### PR TITLE
Remove Inner types from various MultiBrush segments

### DIFF
--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -2202,35 +2202,30 @@ MultiBrushCollections:
 			Template: 14
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
@@ -2251,35 +2246,30 @@ MultiBrushCollections:
 			Template: 21
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@26:
@@ -2300,35 +2290,30 @@ MultiBrushCollections:
 			Template: 28
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@32:
 			Template: 32
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@33:
@@ -2349,35 +2334,30 @@ MultiBrushCollections:
 			Template: 35
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@40:
@@ -2391,91 +2371,78 @@ MultiBrushCollections:
 			Template: 41
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@53:
 			Template: 53
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,0, 3,0, 2,0, 1,0, 0,0
 		MultiBrush@54:
 			Template: 54
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,0, 2,0, 1,0, 0,0
 		MultiBrush@55:
 			Template: 55
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@56:
 			Template: 56
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@78:
 			Template: 78
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@93:
@@ -2944,406 +2911,348 @@ MultiBrushCollections:
 			Template: 149
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2
 		MultiBrush@149reverse:
 			Template: 149
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@150:
 			Template: 150
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2
 		MultiBrush@150reverse:
 			Template: 150
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@151:
 			Template: 151
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 4,3, 4,2, 5,2, 6,2
 		MultiBrush@151reverse:
 			Template: 151
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@152:
 			Template: 152
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 1,3, 2,3, 3,3, 3,4, 4,4, 5,4, 5,5, 6,5
 		MultiBrush@152reverse:
 			Template: 152
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 6,4, 6,3, 5,3, 5,2, 4,2, 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@153:
 			Template: 153
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1, 1,2, 1,3, 1,4
 		MultiBrush@153reverse:
 			Template: 153
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,4, 2,3, 2,2, 2,1, 2,0
 		MultiBrush@154:
 			Template: 154
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3, 2,4
 		MultiBrush@154reverse:
 			Template: 154
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 3,4, 3,3, 3,2, 3,1, 3,0
 		MultiBrush@155:
 			Template: 155
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 4,0, 4,1, 3,1, 3,2, 2,2, 2,3, 2,4, 2,5, 2,6, 1,6, 1,7, 1,8
 		MultiBrush@155reverse:
 			Template: 155
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,8, 2,7, 2,6, 3,6, 3,5, 3,4, 3,3, 4,3, 4,2, 5,2, 5,1, 5,0
 		MultiBrush@156:
 			Template: 156
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1, 2,1, 2,2, 2,3, 2,4, 2,5, 3,5, 3,6, 3,7, 4,7, 4,8
 		MultiBrush@156reverse:
 			Template: 156
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 5,8, 5,7, 5,6, 4,6, 4,5, 4,4, 3,4, 3,3, 3,2, 3,1, 2,1, 2,0
 		MultiBrush@157:
 			Template: 157
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 2,3, 2,2, 3,2
 		MultiBrush@157reverse:
 			Template: 157
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 3,1, 2,1, 1,1, 1,2, 1,3
 		MultiBrush@158:
 			Template: 158
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,2, 1,2, 1,3
 		MultiBrush@158reverse:
 			Template: 158
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 2,3, 2,2, 2,1, 1,1, 0,1
 		MultiBrush@159:
 			Template: 159
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 3,1, 2,1, 2,0
 		MultiBrush@159reverse:
 			Template: 159
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 1,2, 2,2, 3,2
 		MultiBrush@160:
 			Template: 160
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@160reverse:
 			Template: 160
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@174:
 			Template: 174
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@175:
 			Template: 175
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@176:
 			Template: 176
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1, 4,1
 		MultiBrush@177:
 			Template: 177
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@178:
 			Template: 178
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1, 4,1, 5,1, 6,1
 		MultiBrush@179:
 			Template: 179
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@188:
 			Template: 188
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 0,0, 0,1
 		MultiBrush@189:
 			Template: 189
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 1,1, 1,0, 0,0
 		MultiBrush@190:
 			Template: 190
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 0,0, 0,1, 1,1
 		MultiBrush@191:
 			Template: 191
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@192:
 			Template: 192
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 2,0, 1,0, 1,1, 0,1, 0,2, 0,3
 		MultiBrush@193:
 			Template: 193
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 3,0
 		MultiBrush@194:
 			Template: 194
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@195:
 			Template: 195
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 1,0
 		MultiBrush@196:
 			Template: 196
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2, 0,3
 		MultiBrush@197:
 			Template: 197
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2
 		MultiBrush@198:
 			Template: 198
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 2,0, 1,0, 1,1, 1,2, 0,2, 0,3
 		MultiBrush@199:
 			Template: 199
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 3,3, 3,2, 2,2, 1,2, 1,1, 1,0, 0,0
 		MultiBrush@200:
 			Template: 200
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 0,0, 0,1, 0,2, 0,3, 1,3, 2,3, 3,3
 		MultiBrush@201:
 			Template: 201
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 3,0
 		MultiBrush@202:
 			Template: 202
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,3, 1,2, 2,2, 2,1, 3,1, 4,1
 		MultiBrush@203:
 			Template: 203
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 1,2, 1,3, 2,3, 3,3
 		MultiBrush@204:
 			Template: 204
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 4,2, 3,2, 3,1, 4,1, 4,0, 3,0, 2,0, 1,0
 		MultiBrush@205:
 			Template: 205
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 3,0, 3,1, 2,1, 1,1, 1,2, 0,2
 		MultiBrush@208:
 			Template: 208
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1
 		MultiBrush@209:
 			Template: 209
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 0,2, 1,2, 2,2, 3,2
 		MultiBrush@210:
 			Template: 210
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2, 0,3, 1,3
 		MultiBrush@211:
 			Template: 211
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 0,1, 0,2, 0,3
 		MultiBrush@212:
 			Template: 212
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 2,1, 2,0
 		MultiBrush@213:
 			Template: 213
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,3, 2,2, 2,1, 1,1, 1,0
 		MultiBrush@222:
 			Template: 222
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@223:
 			Template: 223
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@224:
 			Template: 224
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@225:
 			Template: 225
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 	Trees:

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1793,49 +1793,42 @@ MultiBrushCollections:
 			Template: 3
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@4:
 			Template: 4
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@7:
 			Template: 7
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@9:
 			Template: 9
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@10:
 			Template: 10
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@11:
 			Template: 11
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@12:
 			Template: 12
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
@@ -1849,35 +1842,30 @@ MultiBrushCollections:
 			Template: 14
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
@@ -1898,35 +1886,30 @@ MultiBrushCollections:
 			Template: 21
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@26:
@@ -1947,35 +1930,30 @@ MultiBrushCollections:
 			Template: 28
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@32:
 			Template: 32
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@33:
@@ -1996,35 +1974,30 @@ MultiBrushCollections:
 			Template: 35
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@40:
@@ -2038,105 +2011,90 @@ MultiBrushCollections:
 			Template: 41
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@51:
 			Template: 51
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@52:
 			Template: 52
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 1,0, 1,1, 1,2, 2,2, 3,2
 		MultiBrush@88:
 			Template: 88
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@89:
 			Template: 89
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@90:
 			Template: 90
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,1, 2,1, 1,1, 1,2, 1,3
 		MultiBrush@91:
 			Template: 91
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 2,3, 2,2, 2,1, 1,1, 0,1
 		MultiBrush@92:
 			Template: 92
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
@@ -2605,196 +2563,168 @@ MultiBrushCollections:
 			Template: 136
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
 		MultiBrush@136reverse:
 			Template: 136
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
 		MultiBrush@137:
 			Template: 137
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
 		MultiBrush@137reverse:
 			Template: 137
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
 		MultiBrush@138:
 			Template: 138
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
 		MultiBrush@138reverse:
 			Template: 138
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@139:
 			Template: 139
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
 		MultiBrush@139reverse:
 			Template: 139
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@140:
 			Template: 140
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@140reverse:
 			Template: 140
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@141:
 			Template: 141
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@141reverse:
 			Template: 141
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@142:
 			Template: 142
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@142reverse:
 			Template: 142
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@143:
 			Template: 143
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@143reverse:
 			Template: 143
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@144:
 			Template: 144
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@144reverse:
 			Template: 144
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@145:
 			Template: 145
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@145reverse:
 			Template: 145
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@146:
 			Template: 146
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@146reverse:
 			Template: 146
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2, 1,3
 		MultiBrush@187:
 			Template: 187
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@190:
 			Template: 190
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@191:
 			Template: 191
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@192:
 			Template: 192
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 		MultiBrush@TopRightBeachCorner:
@@ -2806,7 +2736,6 @@ MultiBrushCollections:
 				Offset: 1,1
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@TopLeftBeachCorner:
@@ -2820,7 +2749,6 @@ MultiBrushCollections:
 				Offset: 0,0,0
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,2, 1,1, 2,1
 	Trees:

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -1794,49 +1794,42 @@ MultiBrushCollections:
 			Template: 3
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@4:
 			Template: 4
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@7:
 			Template: 7
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@9:
 			Template: 9
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@10:
 			Template: 10
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@11:
 			Template: 11
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@12:
 			Template: 12
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
@@ -1850,35 +1843,30 @@ MultiBrushCollections:
 			Template: 14
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
@@ -1899,35 +1887,30 @@ MultiBrushCollections:
 			Template: 21
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@26:
@@ -1948,35 +1931,30 @@ MultiBrushCollections:
 			Template: 28
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@32:
 			Template: 32
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@33:
@@ -1997,35 +1975,30 @@ MultiBrushCollections:
 			Template: 35
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@40:
@@ -2039,105 +2012,90 @@ MultiBrushCollections:
 			Template: 41
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@51:
 			Template: 51
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@52:
 			Template: 52
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 1,0, 1,1, 1,2, 2,2, 3,2
 		MultiBrush@88:
 			Template: 88
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@89:
 			Template: 89
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@90:
 			Template: 90
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,1, 2,1, 1,1, 1,2, 1,3
 		MultiBrush@91:
 			Template: 91
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 2,3, 2,2, 2,1, 1,1, 0,1
 		MultiBrush@92:
 			Template: 92
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
@@ -2606,196 +2564,168 @@ MultiBrushCollections:
 			Template: 136
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
 		MultiBrush@136reverse:
 			Template: 136
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
 		MultiBrush@137:
 			Template: 137
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
 		MultiBrush@137reverse:
 			Template: 137
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
 		MultiBrush@138:
 			Template: 138
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
 		MultiBrush@138reverse:
 			Template: 138
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@139:
 			Template: 139
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
 		MultiBrush@139reverse:
 			Template: 139
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@140:
 			Template: 140
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@140reverse:
 			Template: 140
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@141:
 			Template: 141
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@141reverse:
 			Template: 141
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@142:
 			Template: 142
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@142reverse:
 			Template: 142
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@143:
 			Template: 143
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@143reverse:
 			Template: 143
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@144:
 			Template: 144
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@144reverse:
 			Template: 144
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@145:
 			Template: 145
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@145reverse:
 			Template: 145
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@146:
 			Template: 146
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@146reverse:
 			Template: 146
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2, 1,3
 		MultiBrush@187:
 			Template: 187
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@190:
 			Template: 190
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@191:
 			Template: 191
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@192:
 			Template: 192
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 		MultiBrush@TopRightBeachCorner:
@@ -2807,7 +2737,6 @@ MultiBrushCollections:
 				Offset: 1,1
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@TopLeftBeachCorner:
@@ -2821,7 +2750,6 @@ MultiBrushCollections:
 				Offset: 0,0,0
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,2, 1,1, 2,1
 	Trees:

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1829,49 +1829,42 @@ MultiBrushCollections:
 			Template: 3
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@4:
 			Template: 4
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@7:
 			Template: 7
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@9:
 			Template: 9
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@10:
 			Template: 10
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@11:
 			Template: 11
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@12:
 			Template: 12
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@13:
@@ -1885,35 +1878,30 @@ MultiBrushCollections:
 			Template: 14
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@19:
@@ -1934,35 +1922,30 @@ MultiBrushCollections:
 			Template: 21
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@26:
@@ -1983,35 +1966,30 @@ MultiBrushCollections:
 			Template: 28
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@32:
 			Template: 32
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@33:
@@ -2032,35 +2010,30 @@ MultiBrushCollections:
 			Template: 35
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@40:
@@ -2074,105 +2047,90 @@ MultiBrushCollections:
 			Template: 41
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@51:
 			Template: 51
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@52:
 			Template: 52
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 1,0, 1,1, 1,2, 2,2, 3,2
 		MultiBrush@88:
 			Template: 88
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@89:
 			Template: 89
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@90:
 			Template: 90
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,1, 2,1, 1,1, 1,2, 1,3
 		MultiBrush@91:
 			Template: 91
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 2,3, 2,2, 2,1, 1,1, 0,1
 		MultiBrush@92:
 			Template: 92
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@93:
@@ -2641,196 +2599,168 @@ MultiBrushCollections:
 			Template: 136
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
 		MultiBrush@136reverse:
 			Template: 136
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
 		MultiBrush@137:
 			Template: 137
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
 		MultiBrush@137reverse:
 			Template: 137
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
 		MultiBrush@138:
 			Template: 138
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
 		MultiBrush@138reverse:
 			Template: 138
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@139:
 			Template: 139
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
 		MultiBrush@139reverse:
 			Template: 139
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@140:
 			Template: 140
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@140reverse:
 			Template: 140
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@141:
 			Template: 141
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@141reverse:
 			Template: 141
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@142:
 			Template: 142
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@142reverse:
 			Template: 142
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@143:
 			Template: 143
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@143reverse:
 			Template: 143
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@144:
 			Template: 144
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@144reverse:
 			Template: 144
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@145:
 			Template: 145
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@145reverse:
 			Template: 145
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@146:
 			Template: 146
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@146reverse:
 			Template: 146
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@186:
 			Template: 186
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2, 1,3
 		MultiBrush@187:
 			Template: 187
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@190:
 			Template: 190
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@191:
 			Template: 191
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 		MultiBrush@192:
 			Template: 192
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@TopRightBeachCorner:
@@ -2842,7 +2772,6 @@ MultiBrushCollections:
 				Offset: 1,1
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@TopLeftBeachCorner:
@@ -2856,7 +2785,6 @@ MultiBrushCollections:
 				Offset: 0,0,0
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,2, 1,1, 2,1
 	Trees:

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -6818,322 +6818,276 @@ MultiBrushCollections:
 			Template: 1152
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1
 		MultiBrush@2:
 			Template: 1151
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1
 		MultiBrush@3:
 			Template: 1145
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1
 		MultiBrush@4:
 			Template: 78
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@5:
 			Template: 77
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@6: # Smooth Down
 			Template: 1150
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 1,0, 0,0
 		MultiBrush@7:
 			Template: 1149
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 1,0, 0,0
 		MultiBrush@8:
 			Template: 1143
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 1,0, 0,0
 		MultiBrush@9:
 			Template: 269
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 2,0, 1,0, 0,0
 		MultiBrush@10: # Smooth Left
 			Template: 73
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,1, 1,0
 		MultiBrush@11:
 			Template: 72
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,1, 1,0
 		MultiBrush@12:
 			Template: 71
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,1, 1,0
 		MultiBrush@13:
 			Template: 75
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@14: #smooth Right
 			Template: 1148
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,0, 0,1
 		MultiBrush@15:
 			Template: 76
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,0, 0,1
 		MultiBrush@16:
 			Template: 67
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,0, 0,1
 		MultiBrush@17:
 			Template: 66
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,0, 0,1
 		MultiBrush@18: # smooth inside
 			Template: 259
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 1,0, 0,0, 0,1
 		MultiBrush@19:
 			Template: 260
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 1,1, 1,0, 0,0
 		MultiBrush@20:
 			Template: 261
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@21:
 			Template: 262
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,0, 0,1, 1,1
 		MultiBrush@22: # outside smooth
 			Template: 1147
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,1
 		MultiBrush@23:
 			Template: 1146
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,1
 		MultiBrush@24:
 			Template: 1144
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 0,0
 		MultiBrush@25:
 			Template: 63
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,0
 		MultiBrush@26:
 			Template: 60
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 1,1
 		MultiBrush@27: #SMOOTH DIAGONAL
 			Template: 53
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@28:
 			Template: 37
 			Segment:
 				Start: RockSmooth.U
-				Inner: RockSmooth
 				End: RockSmooth.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@29:
 			Template: 46
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@30:
 			Template: 45
 			Segment:
 				Start: RockSmooth.R
-				Inner: RockSmooth
 				End: RockSmooth.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@31:
 			Template: 44
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 2,0, 1,0, 1,1, 0,1
 		MultiBrush@32:
 			Template: 21
 			Segment:
 				Start: RockSmooth.L
-				Inner: RockSmooth
 				End: RockSmooth.L
 				Points: 2,1, 1,1, 1,0, 0,0
 		MultiBrush@33:
 			Template: 36
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 1,0, 1,1, 0,1, 0,2
 		MultiBrush@34:
 			Template: 32
 			Segment:
 				Start: RockSmooth.D
-				Inner: RockSmooth
 				End: RockSmooth.D
 				Points: 0,0, 0,1, 1,1, 1,2
 		MultiBrush@35: # SandRockCliffs
 			Template: 108
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@36:
 			Template: 187
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@37:
 			Template: 188
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@38:
 			Template: 182
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@39:
 			Template: 200
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@40:
 			Template: 206
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@41: # SandRock DOWN
 			Template: 258
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@42:
 			Template: 194
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@43:
 			Template: 196
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@44:
 			Template: 255
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@45:
 			Template: 256
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@46:
 			Template: 197
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@47:
@@ -7141,7 +7095,6 @@ MultiBrushCollections:
 			Weight: 300
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@48:
@@ -7149,7 +7102,6 @@ MultiBrushCollections:
 			Weight: 500
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@49:
@@ -7157,154 +7109,132 @@ MultiBrushCollections:
 			Weight: 500
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@50: # SandRock RIGHT
 			Template: 110
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@51:
 			Template: 201
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@52:
 			Template: 203
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@53:
 			Template: 223
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@54:
 			Template: 263
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@55:
 			Template: 264
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@56: # SandRock LEFT
 			Template: 111
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,1, 1,0
 		MultiBrush@57:
 			Template: 202
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@58:
 			Template: 204
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@59:
 			Template: 205
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@60:
 			Template: 191
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@61:
 			Template: 192
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@62: # SandRock angles
 			Template: 179
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@63:
 			Template: 180
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@64:
 			Template: 185
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@65:
 			Template: 186
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@66:
 			Template: 210
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@67:
 			Template: 481
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@68:
 			Template: 211
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@69:
 			Template: 212
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@70:
 			Template: 209
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@71: # SandRock ends
@@ -7367,231 +7297,198 @@ MultiBrushCollections:
 			Template: 107
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@80:
 			Template: 29
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@81:
 			Template: 30
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@82:
 			Template: 39
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@83:
 			Template: 34
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@84:
 			Template: 35
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@85: # SAND-SAND DOWN
 			Template: 12
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@86:
 			Template: 13
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@87:
 			Template: 19
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@88:
 			Template: 106
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@89:
 			Template: 31
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@90:
 			Template: 33
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@91: # SAND SAND LEFT
 			Template: 104
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 1,1, 1,0
 		MultiBrush@92:
 			Template: 10
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@93:
 			Template: 11
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@94:
 			Template: 27
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@95:
 			Template: 51
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@96:
 			Template: 52
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@97: # SAND-SAND RIGHT
 			Template: 105
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@98:
 			Template: 26
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@99:
 			Template: 41
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@100:
 			Template: 42
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@101:
 			Template: 49
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@102:
 			Template: 50
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@103: #SAND-SAND ANGLES
 			Template: 14
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@104:
 			Template: 15
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@105:
 			Template: 16
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@106:
 			Template: 17
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@107:
 			Template: 38
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandSandCliff
 				End: SandSandCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@108:
 			Template: 40
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandSandCliff
 				End: SandSandCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@109:
 			Template: 20
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@110:
 			Template: 427
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandSandCliff
 				End: SandSandCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@111:
 			Template: 18
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandSandCliff
 				End: SandSandCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@112: #sand-sand end
@@ -7654,448 +7551,384 @@ MultiBrushCollections:
 			Template: 803
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@121:
 			Template: 804
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@122:
 			Template: 805
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@123:
 			Template: 820
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@124:
 			Template: 827
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@125:
 			Template: 826
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@126: # Rock sand down
 			Template: 800
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@127:
 			Template: 811
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@128:
 			Template: 812
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@129:
 			Template: 821
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@130:
 			Template: 829
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@131:
 			Template: 828
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@132: # ROCK SAND RIGHT
 			Template: 801
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@133:
 			Template: 810
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@134:
 			Template: 813
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@135:
 			Template: 818
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@136:
 			Template: 838
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@137:
 			Template: 839
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@138: #ROCK SAND LEFT
 			Template: 802
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@139:
 			Template: 808
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@140:
 			Template: 809
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@141:
 			Template: 819
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 1,1, 1,0
 		MultiBrush@142:
 			Template: 840
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@143:
 			Template: 841
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@144: #ROCK SAND ANGLES
 			Template: 822
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@145:
 			Template: 823
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@146:
 			Template: 824
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@147:
 			Template: 825
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@148:
 			Template: 814
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockSandCliff
 				End: RockSandCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@149:
 			Template: 815
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockSandCliff
 				End: RockSandCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@150:
 			Template: 816
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockSandCliff
 				End: RockSandCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@151:
 			Template: 817
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockSandCliff
 				End: RockSandCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@152: #ROCK ROCK TOP
 			Template: 608
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@153:
 			Template: 623
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@154:
 			Template: 627
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@155:
 			Template: 628
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@156:
 			Template: 604
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@157:
 			Template: 605
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@158: #ROCK ROCK DOWN
 			Template: 609
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@159:
 			Template: 617
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@160:
 			Template: 618
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@161:
 			Template: 619
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@161:
 			Template: 629
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@162:
 			Template: 630
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@163: # ROCK ROCK RIGHT
 			Template: 606
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@164:
 			Template: 620
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@165:
 			Template: 621
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@166:
 			Template: 622
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@167:
 			Template: 631
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@168:
 			Template: 632
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@169: # ROCK ROCK LEFT
 			Template: 607
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,1, 1,0
 		MultiBrush@170:
 			Template: 624
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@171:
 			Template: 625
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@172:
 			Template: 626
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@173:
 			Template: 633
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@174:
 			Template: 634
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@175: # ROCK ROCK ANGLES
 			Template: 603
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@176:
 			Template: 602
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@177:
 			Template: 601
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@178:
 			Template: 600
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@179:
 			Template: 613
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@180:
 			Template: 614
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@181:
 			Template: 615
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@182:
 			Template: 616
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@183: # ROCK ROCK END
@@ -8158,371 +7991,318 @@ MultiBrushCollections:
 			Template: 1008
 			Segment:
 				Start: SandPlatform.R
-				Inner: SandPlatform
 				End: SandPlatform.R
 				Points: 0,1, 1,1
 		MultiBrush@192:
 			Template: 1009
 			Segment:
 				Start: SandPlatform.R
-				Inner: SandPlatform
 				End: SandPlatform.R
 				Points: 0,1, 1,1
 		MultiBrush@193:
 			Template: 1014
 			Segment:
 				Start: SandPlatform.L
-				Inner: SandPlatform
 				End: SandPlatform.L
 				Points: 1,0, 0,0
 		MultiBrush@194:
 			Template: 1015
 			Segment:
 				Start: SandPlatform.L
-				Inner: SandPlatform
 				End: SandPlatform.L
 				Points: 1,0, 0,0
 		MultiBrush@195:
 			Template: 1005
 			Segment:
 				Start: SandPlatform.D
-				Inner: SandPlatform
 				End: SandPlatform.D
 				Points: 0,0, 0,1
 		MultiBrush@196:
 			Template: 1006
 			Segment:
 				Start: SandPlatform.D
-				Inner: SandPlatform
 				End: SandPlatform.D
 				Points: 0,0, 0,1
 		MultiBrush@197:
 			Template: 1011
 			Segment:
 				Start: SandPlatform.U
-				Inner: SandPlatform
 				End: SandPlatform.U
 				Points: 1,1, 1,0
 		MultiBrush@198:
 			Template: 1012
 			Segment:
 				Start: SandPlatform.U
-				Inner: SandPlatform
 				End: SandPlatform.U
 				Points: 1,1, 1,0
 		MultiBrush@199:
 			Template: 1000
 			Segment:
 				Start: SandPlatform.L
-				Inner: SandPlatform
 				End: SandPlatform.D
 				Points: 1,0, 0,0, 0,1
 		MultiBrush@200:
 			Template: 1001
 			Segment:
 				Start: SandPlatform.U
-				Inner: SandPlatform
 				End: SandPlatform.L
 				Points: 1,1, 1,0, 0,0
 		MultiBrush@201:
 			Template: 1002
 			Segment:
 				Start: SandPlatform.R
-				Inner: SandPlatform
 				End: SandPlatform.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@202:
 			Template: 1003
 			Segment:
 				Start: SandPlatform.D
-				Inner: SandPlatform
 				End: SandPlatform.R
 				Points: 0,0, 0,1, 1,1
 		MultiBrush@203:
 			Template: 1004
 			Segment:
 				Start: SandPlatform.D
-				Inner: SandPlatform
 				End: SandPlatform.L
 				Points: 0,0
 		MultiBrush@204:
 			Template: 1007
 			Segment:
 				Start: SandPlatform.R
-				Inner: SandPlatform
 				End: SandPlatform.D
 				Points: 0,1
 		MultiBrush@205:
 			Template: 1010
 			Segment:
 				Start: SandPlatform.U
-				Inner: SandPlatform
 				End: SandPlatform.R
 				Points: 1,1
 		MultiBrush@206:
 			Template: 1013
 			Segment:
 				Start: SandPlatform.L
-				Inner: SandPlatform
 				End: SandPlatform.U
 				Points: 1,0
 		MultiBrush@207: # dune tiles
 			Template: 1
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@208:
 			Template: 4
 			Segment:
 				Start: Dune.R
-				Inner: Dune
 				End: Dune.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@209:
 			Template: 5
 			Segment:
 				Start: Dune.R
-				Inner: Dune
 				End: Dune.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@210:
 			Template: 6
 			Segment:
 				Start: Dune.L
-				Inner: Dune
 				End: Dune.L
 				Points: 2,0, 1,0, 1,1, 0,1
 		MultiBrush@211:
 			Template: 229
 			Segment:
 				Start: Dune.D
-				Inner: Dune
 				End: Dune.D
 				Points: 0,0, 0,1, 1,1, 1,2
 		MultiBrush@212:
 			Template: 232
 			Segment:
 				Start: Dune.D
-				Inner: Dune
 				End: Dune.D
 				Points: 1,0, 1,1, 0,1, 0,2
 		MultiBrush@213:
 			Template: 233
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.R
 				Points: 1,1
 		MultiBrush@214:
 			Template: 234
 			Segment:
 				Start: Dune.R
-				Inner: Dune
 				End: Dune.R
 				Points: 0,1, 1,1
 		MultiBrush@215:
 			Template: 235
 			Segment:
 				Start: Dune.R
-				Inner: Dune
 				End: Dune.D
 				Points: 0,1
 		MultiBrush@216:
 			Template: 236
 			Segment:
 				Start: Dune.D
-				Inner: Dune
 				End: Dune.D
 				Points: 0,0, 0,1
 		MultiBrush@217:
 			Template: 237
 			Segment:
 				Start: Dune.D
-				Inner: Dune
 				End: Dune.L
 				Points: 0,0
 		MultiBrush@218:
 			Template: 238
 			Segment:
 				Start: Dune.L
-				Inner: Dune
 				End: Dune.L
 				Points: 1,0, 0,0
 		MultiBrush@219:
 			Template: 239
 			Segment:
 				Start: Dune.L
-				Inner: Dune
 				End: Dune.U
 				Points: 1,0
 		MultiBrush@220:
 			Template: 240
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.U
 				Points: 1,1, 1,0
 		MultiBrush@221:
 			Template: 242
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.L
 				Points: 1,1, 1,0, 0,0
 		MultiBrush@222:
 			Template: 243
 			Segment:
 				Start: Dune.R
-				Inner: Dune
 				End: Dune.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@223:
 			Template: 244
 			Segment:
 				Start: Dune.D
-				Inner: Dune
 				End: Dune.R
 				Points: 0,0, 0,1, 1,1
 		MultiBrush@224:
 			Template: 245
 			Segment:
 				Start: Dune.L
-				Inner: Dune
 				End: Dune.D
 				Points: 1,0, 0,0, 0,1
 		MultiBrush@225:
 			Template: 246
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@226:
 			Template: 246
 			Segment:
 				Start: Dune.U
-				Inner: Dune
 				End: Dune.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@227:
 			Template: 7
 			Segment:
 				Start: Dune.L
-				Inner: Dune
 				End: Dune.L
 				Points: 2,1, 1,1, 1,0, 0,0
 		MultiBrush@228: #transition SandRockCliff to Rock
 			Template: 832
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@229:
 			Template: 833
 			Segment:
 				Start: RockRockCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@230:
 			Template: 831
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@231:
 			Template: 830
 			Segment:
 				Start: RockRockCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@232:
 			Template: 837
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@233:
 			Template: 836
 			Segment:
 				Start: RockRockCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@234:
 			Template: 834
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@235:
 			Template: 835
 			Segment:
 				Start: RockRockCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@236: #transition SandRockCliff to SandSandCliff
 			Template: 207
 			Segment:
 				Start: SandRockCliff.R
-				Inner: SandRockCliff
 				End: SandSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@237:
 			Template: 208
 			Segment:
 				Start: SandSandCliff.R
-				Inner: SandRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@238:
 			Template: 8
 			Segment:
 				Start: SandRockCliff.D
-				Inner: SandRockCliff
 				End: SandSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@239:
 			Template: 43
 			Segment:
 				Start: SandSandCliff.D
-				Inner: SandRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@240:
 			Template: 3
 			Segment:
 				Start: SandRockCliff.U
-				Inner: SandRockCliff
 				End: SandSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@241:
 			Template: 2
 			Segment:
 				Start: SandSandCliff.U
-				Inner: SandRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@242:
 			Template: 254
 			Segment:
 				Start: SandRockCliff.L
-				Inner: SandRockCliff
 				End: SandSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@243:
 			Template: 253
 			Segment:
 				Start: SandSandCliff.L
-				Inner: SandRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@244: #transition SandRockCliff to Rock-smooth
@@ -8577,112 +8357,96 @@ MultiBrushCollections:
 			Template: 830
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: SandRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@253:
 			Template: 831
 			Segment:
 				Start: SandRockCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@254:
 			Template: 837
 			Segment:
 				Start: SandRockCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@255:
 			Template: 836
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: SandRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@256:
 			Template: 832
 			Segment:
 				Start: SandRockCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@257:
 			Template: 833
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: SandRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@258:
 			Template: 835
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: SandRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@259:
 			Template: 834
 			Segment:
 				Start: SandRockCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@260: # RockRockCliff transition to sand RockSandCliff
 			Template: 806
 			Segment:
 				Start: RockRockCliff.D
-				Inner: RockRockCliff
 				End: RockSandCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@261:
 			Template: 807
 			Segment:
 				Start: RockSandCliff.D
-				Inner: RockRockCliff
 				End: RockRockCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@262:
 			Template: 843
 			Segment:
 				Start: RockSandCliff.U
-				Inner: RockRockCliff
 				End: RockRockCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@263:
 			Template: 842
 			Segment:
 				Start: RockRockCliff.U
-				Inner: RockRockCliff
 				End: RockSandCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@264:
 			Template: 844
 			Segment:
 				Start: RockSandCliff.R
-				Inner: RockRockCliff
 				End: RockRockCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@265:
 			Template: 847
 			Segment:
 				Start: RockRockCliff.R
-				Inner: RockRockCliff
 				End: RockSandCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@266:
 			Template: 845
 			Segment:
 				Start: RockRockCliff.L
-				Inner: RockRockCliff
 				End: RockSandCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@267:
 			Template: 846
 			Segment:
 				Start: RockSandCliff.L
-				Inner: RockRockCliff
 				End: RockRockCliff.L
 				Points: 2,1, 1,1, 0,1
 	Rough-Sand-Detail:

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -3186,252 +3186,216 @@ MultiBrushCollections:
 			Template: 73
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1
 		MultiBrush@73reverse:
 			Template: 73
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 1,0, 0,0
 		MultiBrush@74:
 			Template: 74
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 0,0, 0,1
 		MultiBrush@74reverse:
 			Template: 74
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 1,1, 1,0
 		MultiBrush@296:
 			Template: 296
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2
 		MultiBrush@296reverse:
 			Template: 296
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@297:
 			Template: 297
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2
 		MultiBrush@297reverse:
 			Template: 297
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 1,1, 0,1
 		MultiBrush@298:
 			Template: 298
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@298reverse:
 			Template: 298
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@299:
 			Template: 299
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1
 		MultiBrush@299reverse:
 			Template: 299
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,1, 2,0
 		MultiBrush@60:
 			Template: 60
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2
 		MultiBrush@60reverse:
 			Template: 60
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@61:
 			Template: 61
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2
 		MultiBrush@61reverse:
 			Template: 61
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@62:
 			Template: 62
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 4,3, 4,2, 5,2, 6,2
 		MultiBrush@62reverse:
 			Template: 62
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@63:
 			Template: 63
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 1,3, 2,3, 3,3, 3,4, 4,4, 5,4, 5,5, 6,5
 		MultiBrush@63reverse:
 			Template: 63
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 6,4, 6,3, 5,3, 5,2, 4,2, 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@64:
 			Template: 64
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1, 1,2, 1,3, 1,4
 		MultiBrush@64reverse:
 			Template: 64
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,4, 2,3, 2,2, 2,1, 2,0
 		MultiBrush@65:
 			Template: 65
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3, 2,4
 		MultiBrush@65reverse:
 			Template: 65
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 3,4, 3,3, 3,2, 3,1, 3,0
 		MultiBrush@66:
 			Template: 66
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 4,0, 4,1, 3,1, 3,2, 2,2, 2,3, 2,4, 2,5, 2,6, 1,6, 1,7, 1,8
 		MultiBrush@66reverse:
 			Template: 66
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,8, 2,7, 2,6, 3,6, 3,5, 3,4, 3,3, 4,3, 4,2, 5,2, 5,1, 5,0
 		MultiBrush@67:
 			Template: 67
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1, 2,1, 2,2, 2,3, 2,4, 2,5, 3,5, 3,6, 3,7, 4,7, 4,8
 		MultiBrush@67reverse:
 			Template: 67
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 5,8, 5,7, 5,6, 4,6, 4,5, 4,4, 3,4, 3,3, 3,2, 3,1, 2,1, 2,0
 		MultiBrush@69:
 			Template: 69
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 2,3, 2,2, 3,2
 		MultiBrush@69reverse:
 			Template: 69
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 3,1, 2,1, 1,1, 1,2, 1,3
 		MultiBrush@70:
 			Template: 70
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,2, 1,2, 1,3
 		MultiBrush@70reverse:
 			Template: 70
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 2,3, 2,2, 2,1, 1,1, 0,1
 		MultiBrush@71:
 			Template: 71
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 3,1, 2,1, 2,0
 		MultiBrush@71reverse:
 			Template: 71
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 1,2, 2,2, 3,2
 		MultiBrush@72:
 			Template: 72
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@72reverse:
 			Template: 72
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,2, 1,2, 2,2, 2,1, 2,0
 		MultiBrush@180:
@@ -3445,35 +3409,30 @@ MultiBrushCollections:
 			Template: 181
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@182:
 			Template: 182
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@183:
 			Template: 183
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@184:
 			Template: 184
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@185:
 			Template: 185
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@186:
@@ -3494,35 +3453,30 @@ MultiBrushCollections:
 			Template: 188
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@189:
 			Template: 189
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@190:
 			Template: 190
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@191:
 			Template: 191
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@192:
 			Template: 192
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@193:
@@ -3543,35 +3497,30 @@ MultiBrushCollections:
 			Template: 195
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@196:
 			Template: 196
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@197:
 			Template: 197
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@198:
 			Template: 198
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@199:
 			Template: 199
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@200:
@@ -3592,35 +3541,30 @@ MultiBrushCollections:
 			Template: 203
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@204:
 			Template: 204
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@205:
 			Template: 205
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@206:
 			Template: 206
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@207:
 			Template: 207
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@208:
@@ -3634,56 +3578,48 @@ MultiBrushCollections:
 			Template: 209
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@210:
 			Template: 210
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@211:
 			Template: 211
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@212:
 			Template: 212
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@213:
 			Template: 213
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@214:
 			Template: 214
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@215:
 			Template: 215
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@216:
 			Template: 216
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@164:
@@ -4186,35 +4122,30 @@ MultiBrushCollections:
 			Template: 301
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@302:
 			Template: 302
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@303:
 			Template: 303
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@304:
 			Template: 304
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@305:
 			Template: 305
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@306:
@@ -4233,35 +4164,30 @@ MultiBrushCollections:
 			Template: 308
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@309:
 			Template: 309
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@310:
 			Template: 310
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@311:
 			Template: 311
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@312:
 			Template: 312
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@313:
@@ -4280,35 +4206,30 @@ MultiBrushCollections:
 			Template: 315
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@316:
 			Template: 316
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@317:
 			Template: 317
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@318:
 			Template: 318
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@319:
 			Template: 319
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@320:
@@ -4327,427 +4248,366 @@ MultiBrushCollections:
 			Template: 322
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@323:
 			Template: 323
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@324:
 			Template: 324
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@325:
 			Template: 325
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@326:
 			Template: 326
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@327:
 			Template: 327
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@328:
 			Template: 328
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@329:
 			Template: 329
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@330:
 			Template: 330
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@331:
 			Template: 331
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@332:
 			Template: 332
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@333:
 			Template: 333
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@334:
 			Template: 334
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@335:
 			Template: 335
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@386:
 			Template: 386
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@387:
 			Template: 387
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@388:
 			Template: 388
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,1, 1,0
 		MultiBrush@389:
 			Template: 389
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@400:
 			Template: 400
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@401:
 			Template: 401
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,0, 3,0, 2,0, 1,0, 0,0
 		MultiBrush@402:
 			Template: 402
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,0, 2,0, 1,0, 0,0
 		MultiBrush@403:
 			Template: 403
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 6,1, 5,1, 4,1, 3,1, 2,1, 1,1, 0,1
 		MultiBrush@404:
 			Template: 404
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@431:
 			Template: 431
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,0, 2,0, 1,0, 1,1, 0,1
 		MultiBrush@432:
 			Template: 432
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 1,0, 0,0
 		MultiBrush@439:
 			Template: 439
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 6,0, 5,0, 4,0, 3,0, 2,0, 1,0, 0,0
 		MultiBrush@440:
 			Template: 440
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,0, 3,0, 2,0, 1,0, 0,0
 		MultiBrush@406:
 			Template: 406
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@407:
 			Template: 407
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@408:
 			Template: 408
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1, 4,1
 		MultiBrush@409:
 			Template: 409
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1
 		MultiBrush@410:
 			Template: 410
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 3,1, 4,1, 5,1, 6,1
 		MultiBrush@411:
 			Template: 411
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@433:
 			Template: 433
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1
 		MultiBrush@434:
 			Template: 434
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 0,2, 1,2, 2,2, 3,2
 		MultiBrush@413:
 			Template: 413
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 0,0, 0,1
 		MultiBrush@414:
 			Template: 414
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 1,1, 1,0, 0,0
 		MultiBrush@415:
 			Template: 415
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 0,0, 0,1, 1,1
 		MultiBrush@416:
 			Template: 416
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@417:
 			Template: 417
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 2,0, 1,0, 1,1, 0,1, 0,2, 0,3
 		MultiBrush@418:
 			Template: 418
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 3,0
 		MultiBrush@423:
 			Template: 423
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 2,0, 1,0, 1,1, 1,2, 0,2, 0,3
 		MultiBrush@424:
 			Template: 424
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 3,3, 3,2, 2,2, 1,2, 1,1, 1,0, 0,0
 		MultiBrush@425:
 			Template: 425
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 0,0, 0,1, 0,2, 0,3, 1,3, 2,3, 3,3
 		MultiBrush@426:
 			Template: 426
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 3,0
 		MultiBrush@427:
 			Template: 427
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,3, 1,2, 2,2, 2,1, 3,1, 4,1
 		MultiBrush@428:
 			Template: 428
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 1,2, 1,3, 2,3, 3,3
 		MultiBrush@429:
 			Template: 429
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 4,2, 3,2, 3,1, 4,1, 4,0, 3,0, 2,0, 1,0
 		MultiBrush@430:
 			Template: 430
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 3,0, 3,1, 2,1, 1,1, 1,2, 0,2
 		MultiBrush@419:
 			Template: 419
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@420:
 			Template: 420
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 1,0
 		MultiBrush@437:
 			Template: 437
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 2,1, 2,0
 		MultiBrush@438:
 			Template: 438
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,3, 2,2, 2,1, 1,1, 1,0
 		MultiBrush@421:
 			Template: 421
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2, 0,3
 		MultiBrush@422:
 			Template: 422
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2
 		MultiBrush@435:
 			Template: 435
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 0,0, 0,1, 0,2, 0,3, 1,3
 		MultiBrush@436:
 			Template: 436
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 0,1, 0,2, 0,3
 		MultiBrush@382:
 			Template: 382
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@383:
 			Template: 383
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@384:
 			Template: 384
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@385:
 			Template: 385
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 	Trees:

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -3229,350 +3229,300 @@ MultiBrushCollections:
 			Template: 3
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,1, 4,2, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@4:
 			Template: 4
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 5,1, 5,2, 4,2, 4,3, 3,3, 3,4, 2,4, 1,4, 1,3, 0,3
 		MultiBrush@5:
 			Template: 5
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@6:
 			Template: 6
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@7:
 			Template: 7
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@8:
 			Template: 8
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@9:
 			Template: 9
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@10:
 			Template: 10
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 1,1, 0,1
 		MultiBrush@12:
 			Template: 12
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 5,4, 4,4, 4,3, 3,3, 2,3, 1,3, 1,2, 0,2, 0,1
 		MultiBrush@13:
 			Template: 13
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,3, 4,4, 3,4, 3,3, 2,3, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@14:
 			Template: 14
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,3, 2,3, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 4,5, 4,4, 3,4, 3,3, 2,3, 1,3, 1,2, 1,1, 1,0
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,4, 1,4, 1,3, 1,2, 0,2, 0,1, 0,0
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 3,3, 2,3, 2,2, 1,2, 1,1, 1,0
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 1,0
 		MultiBrush@19:
 			Template: 19
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 0,1, 0,0
 		MultiBrush@21:
 			Template: 21
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 0,5, 1,5, 1,4, 1,3, 0,3, 0,2, 1,2, 1,1, 2,1, 2,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,4, 0,4, 0,3, 0,2, 0,1, 1,1, 2,1, 3,1, 3,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 0,3, 0,2, 0,1, 1,1, 2,1, 2,0, 3,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 2,3, 3,3, 4,3, 4,4, 5,4, 6,4
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 2,2, 3,2, 3,3, 4,3, 5,3, 5,4
 		MultiBrush@26:
 			Template: 26
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3
 		MultiBrush@27:
 			Template: 27
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@28:
 			Template: 28
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1
 		MultiBrush@33:
 			Template: 33
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 3,2, 4,2, 4,1, 5,1, 6,1
 		MultiBrush@34:
 			Template: 34
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 4,1
 		MultiBrush@35:
 			Template: 35
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,3, 0,2, 1,2, 1,1, 2,1, 3,1
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 5,0, 5,1, 4,1, 4,2, 3,2, 3,3, 3,4, 2,4, 2,5
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 3,1, 3,2, 3,3, 2,3, 2,4
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 3,1, 2,1, 2,2, 1,2, 1,3
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@40:
 			Template: 40
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1, 2,2, 2,3, 3,3, 4,3, 4,4, 4,5
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2, 2,2, 2,3, 3,3, 3,4
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 2,1, 3,1, 3,2, 3,3
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 3,1, 3,2, 2,2, 1,2, 1,3, 0,3, 0,2, 0,1, 0,0, 1,0
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 2,1, 1,1, 0,1, 0,0
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,3, 1,2, 1,1, 1,0, 2,0, 2,1, 2,2, 3,2
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@49:
 			Template: 49
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,2, 1,2, 2,2, 2,3
 		MultiBrush@50:
 			Template: 50
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 2,1, 2,2
 		MultiBrush@51:
 			Template: 51
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 2,0, 2,1, 1,1, 0,1
 		MultiBrush@52:
 			Template: 52
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 2,0, 1,0, 1,1, 0,1
 		MultiBrush@53:
 			Template: 53
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 2,0, 2,1, 3,1, 3,2
 		MultiBrush@54:
 			Template: 54
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,1, 2,1, 2,2, 2,3
 		MultiBrush@55:
 			Template: 55
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 1,3, 1,2, 0,2, 0,1
 		MultiBrush@56:
 			Template: 56
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 0,1, 1,1, 1,0
 		MultiBrush@59:
@@ -3585,35 +3535,30 @@ MultiBrushCollections:
 			Template: 60
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@61:
 			Template: 61
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@62:
 			Template: 62
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@63:
 			Template: 63
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@64:
 			Template: 64
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@65:
@@ -3632,35 +3577,30 @@ MultiBrushCollections:
 			Template: 67
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@68:
 			Template: 68
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@69:
 			Template: 69
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@70:
 			Template: 70
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@71:
 			Template: 71
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@72:
@@ -3679,35 +3619,30 @@ MultiBrushCollections:
 			Template: 74
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@75:
 			Template: 75
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@76:
 			Template: 76
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@77:
 			Template: 77
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@78:
 			Template: 78
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@79:
@@ -3726,252 +3661,216 @@ MultiBrushCollections:
 			Template: 81
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@82:
 			Template: 82
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@83:
 			Template: 83
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@84:
 			Template: 84
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@85:
 			Template: 85
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@86:
 			Template: 86
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@87:
 			Template: 87
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@88:
 			Template: 88
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@89:
 			Template: 89
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@90:
 			Template: 90
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@91:
 			Template: 91
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@92:
 			Template: 92
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@93:
 			Template: 93
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@94:
 			Template: 94
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@112:
 			Template: 112
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
 		MultiBrush@112reverse:
 			Template: 112
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
 		MultiBrush@113:
 			Template: 113
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
 		MultiBrush@113reverse:
 			Template: 113
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
 		MultiBrush@114:
 			Template: 114
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
 		MultiBrush@114reverse:
 			Template: 114
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@115:
 			Template: 115
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
 		MultiBrush@115reverse:
 			Template: 115
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@116:
 			Template: 116
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@116reverse:
 			Template: 116
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@117:
 			Template: 117
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@117reverse:
 			Template: 117
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@118:
 			Template: 118
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@118reverse:
 			Template: 118
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@119:
 			Template: 119
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@119reverse:
 			Template: 119
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@120:
 			Template: 120
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@120reverse:
 			Template: 120
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@121:
 			Template: 121
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@121reverse:
 			Template: 121
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@122:
 			Template: 122
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@122reverse:
 			Template: 122
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@135:
@@ -3985,35 +3884,30 @@ MultiBrushCollections:
 			Template: 136
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@137:
 			Template: 137
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@138:
 			Template: 138
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@139:
 			Template: 139
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@140:
 			Template: 140
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@141:
@@ -4034,35 +3928,30 @@ MultiBrushCollections:
 			Template: 143
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@144:
 			Template: 144
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@145:
 			Template: 145
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@146:
 			Template: 146
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@147:
 			Template: 147
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@148:
@@ -4083,35 +3972,30 @@ MultiBrushCollections:
 			Template: 150
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@151:
 			Template: 151
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@152:
 			Template: 152
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@153:
 			Template: 153
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@154:
 			Template: 154
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@155:
@@ -4132,35 +4016,30 @@ MultiBrushCollections:
 			Template: 157
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@158:
 			Template: 158
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@159:
 			Template: 159
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@160:
 			Template: 160
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@161:
 			Template: 161
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@162:
@@ -4174,56 +4053,48 @@ MultiBrushCollections:
 			Template: 163
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@164:
 			Template: 164
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@165:
 			Template: 165
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@166:
 			Template: 166
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@167:
 			Template: 167
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@168:
 			Template: 168
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@169:
 			Template: 169
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@170:
 			Template: 170
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@173:
@@ -4720,84 +4591,72 @@ MultiBrushCollections:
 			Template: 229
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1
 		MultiBrush@229reverse:
 			Template: 229
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 1,1, 0,1
 		MultiBrush@230:
 			Template: 230
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1
 		MultiBrush@230reverse:
 			Template: 230
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 1,1, 1,0
 		MultiBrush@401:
 			Template: 401
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@402:
 			Template: 402
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@403:
 			Template: 403
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@404:
 			Template: 404
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 		MultiBrush@405:
 			Template: 405
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@406:
 			Template: 406
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@407:
 			Template: 407
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@408:
 			Template: 408
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,1, 1,0
 	Trees:

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -3689,350 +3689,300 @@ MultiBrushCollections:
 			Template: 3
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,1, 4,2, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@4:
 			Template: 4
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 5,1, 5,2, 4,2, 4,3, 3,3, 3,4, 2,4, 1,4, 1,3, 0,3
 		MultiBrush@5:
 			Template: 5
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@6:
 			Template: 6
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@7:
 			Template: 7
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@8:
 			Template: 8
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@9:
 			Template: 9
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,1, 2,1, 1,1, 0,1
 		MultiBrush@10:
 			Template: 10
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 1,1, 0,1
 		MultiBrush@12:
 			Template: 12
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 5,4, 4,4, 4,3, 3,3, 2,3, 1,3, 1,2, 0,2, 0,1
 		MultiBrush@13:
 			Template: 13
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 4,3, 4,4, 3,4, 3,3, 2,3, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@14:
 			Template: 14
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.L
 				Points: 3,3, 2,3, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@15:
 			Template: 15
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 4,5, 4,4, 3,4, 3,3, 2,3, 1,3, 1,2, 1,1, 1,0
 		MultiBrush@16:
 			Template: 16
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 2,4, 1,4, 1,3, 1,2, 0,2, 0,1, 0,0
 		MultiBrush@17:
 			Template: 17
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 3,3, 2,3, 2,2, 1,2, 1,1, 1,0
 		MultiBrush@18:
 			Template: 18
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 1,2, 1,1, 1,0
 		MultiBrush@19:
 			Template: 19
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 0,1, 0,0
 		MultiBrush@21:
 			Template: 21
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 0,5, 1,5, 1,4, 1,3, 0,3, 0,2, 1,2, 1,1, 2,1, 2,0
 		MultiBrush@22:
 			Template: 22
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,4, 0,4, 0,3, 0,2, 0,1, 1,1, 2,1, 3,1, 3,0
 		MultiBrush@23:
 			Template: 23
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.U
 				Points: 1,3, 0,3, 0,2, 0,1, 1,1, 2,1, 2,0, 3,0
 		MultiBrush@24:
 			Template: 24
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 2,3, 3,3, 4,3, 4,4, 5,4, 6,4
 		MultiBrush@25:
 			Template: 25
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 2,1, 2,2, 3,2, 3,3, 4,3, 5,3, 5,4
 		MultiBrush@26:
 			Template: 26
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3
 		MultiBrush@27:
 			Template: 27
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@28:
 			Template: 28
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@29:
 			Template: 29
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@30:
 			Template: 30
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 2,2, 3,2
 		MultiBrush@31:
 			Template: 31
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,1, 1,1
 		MultiBrush@33:
 			Template: 33
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,4, 1,4, 2,4, 3,4, 3,3, 3,2, 4,2, 4,1, 5,1, 6,1
 		MultiBrush@34:
 			Template: 34
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,3, 1,3, 1,2, 2,2, 2,1, 3,1, 4,1
 		MultiBrush@35:
 			Template: 35
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.R
 				Points: 0,3, 0,2, 1,2, 1,1, 2,1, 3,1
 		MultiBrush@36:
 			Template: 36
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 5,0, 5,1, 4,1, 4,2, 3,2, 3,3, 3,4, 2,4, 2,5
 		MultiBrush@37:
 			Template: 37
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 3,1, 3,2, 3,3, 2,3, 2,4
 		MultiBrush@38:
 			Template: 38
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 3,0, 3,1, 2,1, 2,2, 1,2, 1,3
 		MultiBrush@39:
 			Template: 39
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@40:
 			Template: 40
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1
 		MultiBrush@42:
 			Template: 42
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 2,0, 2,1, 2,2, 2,3, 3,3, 4,3, 4,4, 4,5
 		MultiBrush@43:
 			Template: 43
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2, 2,2, 2,3, 3,3, 3,4
 		MultiBrush@44:
 			Template: 44
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.D
 				Points: 1,0, 1,1, 2,1, 3,1, 3,2, 3,3
 		MultiBrush@45:
 			Template: 45
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 3,1, 3,2, 2,2, 1,2, 1,3, 0,3, 0,2, 0,1, 0,0, 1,0
 		MultiBrush@46:
 			Template: 46
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.U
 				Points: 2,1, 1,1, 0,1, 0,0
 		MultiBrush@47:
 			Template: 47
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 1,3, 1,2, 1,1, 1,0, 2,0, 2,1, 2,2, 3,2
 		MultiBrush@48:
 			Template: 48
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@49:
 			Template: 49
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,2, 1,2, 2,2, 2,3
 		MultiBrush@50:
 			Template: 50
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.D
 				Points: 0,1, 1,1, 2,1, 2,2
 		MultiBrush@51:
 			Template: 51
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 2,0, 2,1, 1,1, 0,1
 		MultiBrush@52:
 			Template: 52
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.L
 				Points: 2,0, 1,0, 1,1, 0,1
 		MultiBrush@53:
 			Template: 53
 			Segment:
 				Start: Beach.D
-				Inner: Beach
 				End: Beach.R
 				Points: 2,0, 2,1, 3,1, 3,2
 		MultiBrush@54:
 			Template: 54
 			Segment:
 				Start: Beach.L
-				Inner: Beach
 				End: Beach.D
 				Points: 3,1, 2,1, 2,2, 2,3
 		MultiBrush@55:
 			Template: 55
 			Segment:
 				Start: Beach.U
-				Inner: Beach
 				End: Beach.L
 				Points: 1,3, 1,2, 0,2, 0,1
 		MultiBrush@56:
 			Template: 56
 			Segment:
 				Start: Beach.R
-				Inner: Beach
 				End: Beach.U
 				Points: 0,2, 0,1, 1,1, 1,0
 		MultiBrush@59:
@@ -4045,35 +3995,30 @@ MultiBrushCollections:
 			Template: 60
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@61:
 			Template: 61
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@62:
 			Template: 62
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@63:
 			Template: 63
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@64:
 			Template: 64
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@65:
@@ -4092,35 +4037,30 @@ MultiBrushCollections:
 			Template: 67
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@68:
 			Template: 68
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@69:
 			Template: 69
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@70:
 			Template: 70
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@71:
 			Template: 71
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@72:
@@ -4139,35 +4079,30 @@ MultiBrushCollections:
 			Template: 74
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@75:
 			Template: 75
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@76:
 			Template: 76
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@77:
 			Template: 77
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@78:
 			Template: 78
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@79:
@@ -4186,252 +4121,216 @@ MultiBrushCollections:
 			Template: 81
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@82:
 			Template: 82
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@83:
 			Template: 83
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@84:
 			Template: 84
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@85:
 			Template: 85
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@86:
 			Template: 86
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: Beach.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@87:
 			Template: 87
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@88:
 			Template: 88
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@89:
 			Template: 89
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@90:
 			Template: 90
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@91:
 			Template: 91
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@92:
 			Template: 92
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@93:
 			Template: 93
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@94:
 			Template: 94
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@112:
 			Template: 112
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 3,2, 4,2, 5,2
 		MultiBrush@112reverse:
 			Template: 112
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,2, 4,2, 3,2, 2,2, 1,2, 0,2
 		MultiBrush@113:
 			Template: 113
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,2, 1,2, 2,2, 2,1, 3,1, 4,1, 5,1
 		MultiBrush@113reverse:
 			Template: 113
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 5,1, 4,1, 3,1, 2,1, 2,2, 1,2, 0,2
 		MultiBrush@114:
 			Template: 114
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1, 1,2, 2,2, 3,2, 3,3, 4,3
 		MultiBrush@114reverse:
 			Template: 114
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,3, 3,3, 3,2, 2,2, 1,2, 1,1, 0,1
 		MultiBrush@115:
 			Template: 115
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,3, 1,3, 1,2, 2,2, 3,2, 3,1, 4,1
 		MultiBrush@115reverse:
 			Template: 115
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 4,1, 3,1, 3,2, 2,2, 1,2, 1,3, 0,3
 		MultiBrush@116:
 			Template: 116
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2, 2,3
 		MultiBrush@116reverse:
 			Template: 116
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,3, 2,2, 2,1, 2,0
 		MultiBrush@117:
 			Template: 117
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@117reverse:
 			Template: 117
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@118:
 			Template: 118
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 2,0, 2,1, 2,2
 		MultiBrush@118reverse:
 			Template: 118
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 2,2, 2,1, 2,0
 		MultiBrush@119:
 			Template: 119
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@119reverse:
 			Template: 119
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@120:
 			Template: 120
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@120reverse:
 			Template: 120
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@121:
 			Template: 121
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@121reverse:
 			Template: 121
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@122:
 			Template: 122
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@122reverse:
 			Template: 122
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@135:
@@ -4445,35 +4344,30 @@ MultiBrushCollections:
 			Template: 136
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,2, 1,2, 1,1, 0,1
 		MultiBrush@137:
 			Template: 137
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@138:
 			Template: 138
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@139:
 			Template: 139
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 0,1
 		MultiBrush@140:
 			Template: 140
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.L
 				Points: 2,1, 1,1, 1,2, 0,2
 		MultiBrush@141:
@@ -4494,35 +4388,30 @@ MultiBrushCollections:
 			Template: 143
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,2, 2,1, 1,1, 1,0
 		MultiBrush@144:
 			Template: 144
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@145:
 			Template: 145
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@146:
 			Template: 146
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 1,0
 		MultiBrush@147:
 			Template: 147
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.U
 				Points: 1,2, 1,1, 2,1, 2,0
 		MultiBrush@148:
@@ -4543,35 +4432,30 @@ MultiBrushCollections:
 			Template: 150
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 1,2, 2,2
 		MultiBrush@151:
 			Template: 151
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@152:
 			Template: 152
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@153:
 			Template: 153
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,1, 1,1, 2,1
 		MultiBrush@154:
 			Template: 154
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.R
 				Points: 0,2, 1,2, 1,1, 2,1
 		MultiBrush@155:
@@ -4592,35 +4476,30 @@ MultiBrushCollections:
 			Template: 157
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,0, 2,1, 1,1, 1,2
 		MultiBrush@158:
 			Template: 158
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@159:
 			Template: 159
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@160:
 			Template: 160
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 1,2
 		MultiBrush@161:
 			Template: 161
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.D
 				Points: 1,0, 1,1, 2,1, 2,2
 		MultiBrush@162:
@@ -4634,56 +4513,48 @@ MultiBrushCollections:
 			Template: 163
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.U
 				Points: 2,1, 1,1, 1,0
 		MultiBrush@164:
 			Template: 164
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,2, 1,1, 2,1
 		MultiBrush@165:
 			Template: 165
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.D
 				Points: 0,1, 1,1, 1,2
 		MultiBrush@166:
 			Template: 166
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,0, 1,1, 0,1
 		MultiBrush@167:
 			Template: 167
 			Segment:
 				Start: Cliff.D
-				Inner: Cliff
 				End: Cliff.R
 				Points: 1,0, 1,1, 2,1
 		MultiBrush@168:
 			Template: 168
 			Segment:
 				Start: Cliff.L
-				Inner: Cliff
 				End: Cliff.D
 				Points: 2,1, 1,1, 1,2
 		MultiBrush@169:
 			Template: 169
 			Segment:
 				Start: Cliff.U
-				Inner: Cliff
 				End: Cliff.L
 				Points: 1,2, 1,1, 0,1
 		MultiBrush@170:
 			Template: 170
 			Segment:
 				Start: Cliff.R
-				Inner: Cliff
 				End: Cliff.U
 				Points: 0,1, 1,1, 1,0
 		MultiBrush@173:
@@ -5180,84 +5051,72 @@ MultiBrushCollections:
 			Template: 229
 			Segment:
 				Start: River.R
-				Inner: River
 				End: River.R
 				Points: 0,1, 1,1
 		MultiBrush@229reverse:
 			Template: 229
 			Segment:
 				Start: River.L
-				Inner: River
 				End: River.L
 				Points: 1,1, 0,1
 		MultiBrush@230:
 			Template: 230
 			Segment:
 				Start: River.D
-				Inner: River
 				End: River.D
 				Points: 1,0, 1,1
 		MultiBrush@230reverse:
 			Template: 230
 			Segment:
 				Start: River.U
-				Inner: River
 				End: River.U
 				Points: 1,1, 1,0
 		MultiBrush@401:
 			Template: 401
 			Segment:
 				End: Cliff.L
-				Inner: Cliff
 				Points: 1,1, 0,1
 				Start: Cliff.L
 		MultiBrush@402:
 			Template: 402
 			Segment:
 				End: Cliff.R
-				Inner: Cliff
 				Points: 0,1, 1,1
 				Start: Cliff.R
 		MultiBrush@403:
 			Template: 403
 			Segment:
 				End: Cliff.D
-				Inner: Cliff
 				Points: 1,0, 1,1
 				Start: Cliff.D
 		MultiBrush@404:
 			Template: 404
 			Segment:
 				End: Cliff.U
-				Inner: Cliff
 				Points: 1,1, 1,0
 				Start: Cliff.U
 		MultiBrush@405:
 			Template: 405
 			Segment:
 				Start: WaterCliff.L
-				Inner: WaterCliff
 				End: WaterCliff.L
 				Points: 1,1, 0,1
 		MultiBrush@406:
 			Template: 406
 			Segment:
 				Start: WaterCliff.R
-				Inner: WaterCliff
 				End: WaterCliff.R
 				Points: 0,1, 1,1
 		MultiBrush@407:
 			Template: 407
 			Segment:
 				Start: WaterCliff.D
-				Inner: WaterCliff
 				End: WaterCliff.D
 				Points: 1,0, 1,1
 		MultiBrush@408:
 			Template: 408
 			Segment:
 				Start: WaterCliff.U
-				Inner: WaterCliff
 				End: WaterCliff.U
 				Points: 1,1, 1,0
 	Trees:


### PR DESCRIPTION
Inner types in MultiBrush segment definitions can usually be derived automatically from the start and end types. This is especially important for segments with different starts and ends, where the Inner type match either (e.g. beach to watercliff changers). Inner types are now only needed in two cases:

- The Inner type doesn't match either the start or end. For example, road diagonals.
- The Inner type should only match one of the start or the end. For example, cliffs which end into clear tiles.

This commit cleans up the unneeded or unwanted Inner type definitions in the base mods.
