### PR TITLE
Add Path Tiling developer tool for deriving MultiBrush definitions

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Widgets
 		void IEditorBrush.TickRender(WorldRenderer wr, Actor self) { }
 		IEnumerable<IRenderable> IEditorBrush.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (tool.EditorBlitSource == null)
+			if (tool.EditorBlitSource == null || !tool.ShowPreview)
 				yield break;
 
 			var preview = EditorBlit.PreviewBlitSource(

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -28,11 +28,18 @@ namespace OpenRA.Mods.Common.MapGenerator
 	/// </summary>
 	public sealed class MultiBrushInfo
 	{
+		internal static MiniYamlNode SaveField(string key, MiniYaml value) => new(key, value);
+		internal static MiniYamlNode SaveField(string key, string value) => new(key, new MiniYaml(value));
+		internal static MiniYamlNode SaveField(string key, ushort value) => new(key, new MiniYaml(Exts.ToStringInvariant(value)));
+		internal static MiniYamlNode SaveField(string key, int value) => new(key, new MiniYaml(Exts.ToStringInvariant(value)));
+		internal static MiniYamlNode SaveField(string key, WVec value) => new(key, new MiniYaml(value.ToString()));
+		internal static MiniYamlNode SaveField(string key, CVec value) => new(key, new MiniYaml(value.ToString()));
+
 		public sealed class ActorInfo
 		{
 			[FieldLoader.Ignore]
 			public readonly string Type;
-			public readonly WVec Offset = new(0, 0, 0);
+			public readonly WVec Offset = WVec.Zero;
 
 			public ActorInfo(MiniYaml my)
 			{
@@ -42,13 +49,24 @@ namespace OpenRA.Mods.Common.MapGenerator
 				Type = my.Value;
 				FieldLoader.Load(this, my);
 			}
+
+			public MiniYaml ToMiniYaml()
+			{
+				IEnumerable<MiniYamlNode> Nodes()
+				{
+					if (Offset != WVec.Zero)
+						yield return SaveField("Offset", Offset);
+				}
+
+				return new MiniYaml(Type, Nodes());
+			}
 		}
 
 		public sealed class TemplateInfo
 		{
 			[FieldLoader.Ignore]
 			public readonly ushort Type;
-			public readonly CVec Offset = new(0, 0);
+			public readonly CVec Offset = CVec.Zero;
 
 			public TemplateInfo(ushort type)
 			{
@@ -65,13 +83,24 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 				FieldLoader.Load(this, my);
 			}
+
+			public MiniYaml ToMiniYaml()
+			{
+				IEnumerable<MiniYamlNode> Nodes()
+				{
+					if (Offset != CVec.Zero)
+						yield return SaveField("Offset", Offset);
+				}
+
+				return new MiniYaml(Exts.ToStringInvariant(Type), Nodes());
+			}
 		}
 
 		public sealed class TileInfo
 		{
 			[FieldLoader.Ignore]
 			public readonly TerrainTile Type;
-			public readonly CVec Offset = new(0, 0);
+			public readonly CVec Offset = CVec.Zero;
 
 			public TileInfo(MiniYaml my)
 			{
@@ -83,6 +112,17 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 				FieldLoader.Load(this, my);
 			}
+
+			public MiniYaml ToMiniYaml()
+			{
+				IEnumerable<MiniYamlNode> Nodes()
+				{
+					if (Offset != CVec.Zero)
+						yield return SaveField("Offset", Offset);
+				}
+
+				return new MiniYaml(Type.ToString(), Nodes());
+			}
 		}
 
 		public readonly int Weight;
@@ -93,14 +133,20 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public readonly ImmutableArray<TileInfo> Tiles;
 		public readonly MultiBrushSegment Segment;
 
-		public MultiBrushInfo(TemplateInfo templateInfo)
+		public MultiBrushInfo(
+			int weight = MultiBrush.DefaultWeight,
+			ImmutableArray<ActorInfo>? actors = null,
+			TerrainTile? backingTile = null,
+			ImmutableArray<TemplateInfo>? templates = null,
+			ImmutableArray<TileInfo>? tiles = null,
+			MultiBrushSegment segment = null)
 		{
-			Weight = MultiBrush.DefaultWeight;
-			Actors = [];
-			BackingTile = null;
-			Templates = [templateInfo];
-			Tiles = [];
-			Segment = null;
+			Weight = weight;
+			Actors = actors ?? [];
+			BackingTile = backingTile;
+			Templates = templates ?? [];
+			Tiles = tiles ?? [];
+			Segment = segment;
 		}
 
 		public MultiBrushInfo(MiniYaml my)
@@ -160,7 +206,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 						{
 							if (!Exts.TryParseUshortInvariant(part, out var type))
 								throw new YamlException($"Invalid MultiBrush Template `{part}`");
-							brushes.Add(new MultiBrushInfo(new TemplateInfo(type)));
+							brushes.Add(new MultiBrushInfo(templates: [new TemplateInfo(type)]));
 						}
 
 						break;
@@ -170,6 +216,42 @@ namespace OpenRA.Mods.Common.MapGenerator
 			}
 
 			return brushes.ToImmutableArray();
+		}
+
+		public MiniYaml ToMiniYaml()
+		{
+			// If there's one then name it like "Actor".
+			// If there's multiple then name them like "Actor@0", "Actor@1", ...
+			IEnumerable<MiniYamlNode> AsNodes(string type, IEnumerable<MiniYaml> iEnumerable)
+			{
+				if (iEnumerable.Count() == 1)
+					return [SaveField(type, iEnumerable.First())];
+				else
+					return iEnumerable.Select((e, i) => SaveField($"{type}@{Exts.ToStringInvariant(i)}", e));
+			}
+
+			IEnumerable<MiniYamlNode> Nodes()
+			{
+				if (Weight != MultiBrush.DefaultWeight)
+					yield return SaveField("Weight", Weight);
+
+				if (BackingTile.HasValue)
+					yield return SaveField("BackingTile", BackingTile.Value.ToString());
+
+				IEnumerable<IEnumerable<MiniYamlNode>> repeated =
+					[
+						AsNodes("Actor", Actors.Select(x => x.ToMiniYaml())),
+						AsNodes("Template", Templates.Select(x => x.ToMiniYaml())),
+						AsNodes("Tile", Tiles.Select(x => x.ToMiniYaml()))
+					];
+				foreach (var node in repeated.SelectMany(x => x))
+					yield return node;
+
+				if (Segment != null)
+					yield return SaveField("Segment", Segment.ToMiniYaml());
+			}
+
+			return new MiniYaml(null, Nodes());
 		}
 	}
 
@@ -235,6 +317,21 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 				Points = [.. points];
 			}
+		}
+
+		public MiniYaml ToMiniYaml()
+		{
+			IEnumerable<MiniYamlNode> Nodes()
+			{
+				yield return MultiBrushInfo.SaveField(nameof(Start), Start);
+				if (Inner != null)
+					yield return MultiBrushInfo.SaveField(nameof(Inner), Inner);
+
+				yield return MultiBrushInfo.SaveField(nameof(End), End);
+				yield return MultiBrushInfo.SaveField(nameof(Points), string.Join(", ", Points));
+			}
+
+			return new MiniYaml(null, Nodes());
 		}
 
 		public static bool MatchesType(string type, string matcher)

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Mods.Common.MapGenerator;
 
@@ -100,6 +101,27 @@ namespace OpenRA.Mods.Common.Terrain
 		public bool Contains(int index)
 		{
 			return index >= 0 && index < tileInfo.Length;
+		}
+
+		public bool Contains(CVec offset)
+		{
+			return offset.X >= 0 && offset.Y >= 0 && offset.X < Size.X && offset.Y < Size.Y;
+		}
+
+		public int OffsetToIndex(CVec offset)
+		{
+			if (!Contains(offset))
+				throw new ArgumentException($"offset {offset} is outside of template {Id}");
+
+			return offset.Y * Size.X + offset.X;
+		}
+
+		public CVec IndexToOffset(int index)
+		{
+			if (!Contains(index))
+				throw new ArgumentException($"index {index} not valid for template {Id}");
+
+			return new CVec(index % Size.X, index / Size.Y);
 		}
 
 		public int TilesCount => tileInfo.Length;

--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -32,6 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string[] DefaultInner = [];
 		[Desc("The preferred defaults for the end type.")]
 		public readonly string[] DefaultEnd = [];
+		[Desc("Whether to show developer tools for deriving MultiBrush definitions.")]
+		public readonly bool? Developer;
 
 		public override object Create(ActorInitializer init)
 		{
@@ -43,11 +45,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FluentReference]
 		const string Label = "label-tool-tiling-path";
+		[FluentReference]
+		const string DumpMultiBrushSuccess = "notification-tiling-path-dump-multibrush-success";
 
 		[Desc("The widget tree to open when the tool is selected.")]
 		const string PanelWidget = "TILING_PATH_TOOL_PANEL";
 
 		public bool IsEnabled { get; }
+		public bool IsDeveloper { get; }
 
 		string IEditorTool.Label => Label;
 		string IEditorTool.PanelWidget => PanelWidget;
@@ -332,6 +337,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool ClosedLoops { get; private set; } = true;
 		public int RandomSeed { get; private set; } = 0;
 		public int MaxDeviation { get; private set; } = 5;
+		public bool ShowPreview = true;
 		public EditorBlitSource? EditorBlitSource { get; private set; } = null;
 
 		bool disposed;
@@ -340,6 +346,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			World = self.World;
 			TraitInfo = info;
+
+			IsDeveloper = info.Developer ?? Game.ModData.Manifest.Metadata.Version == "{DEV_VERSION}";
 
 			var templatedTerrainInfo = World.Map.Rules.TerrainInfo as ITemplatedTerrainInfo;
 			SegmentedBrushes =
@@ -536,6 +544,113 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			MaxDeviation = value;
 			Update();
+		}
+
+		public void DumpMultiBrushToClipboard(
+			ushort ignoredTile,
+			string startOverride,
+			string innerOverride,
+			string endOverride,
+			bool explicitInnerType)
+		{
+			var templatedTerrainInfo = World.Map.Rules.TerrainInfo as ITemplatedTerrainInfo;
+
+			var multiBrushInfos = new Dictionary<ushort, MultiBrushInfo>();
+
+			CVec[] corners = [
+				new CVec(0, 0),
+				new CVec(1, 0),
+				new CVec(0, 1),
+				new CVec(1, 1)
+			];
+
+			var planPoints = Plan.Points();
+
+			var templatesToProcess = planPoints
+				.SelectMany(cpos => corners.Select(corner => cpos - corner))
+				.Distinct()
+				.Where(World.Map.Tiles.Contains)
+				.Select(cpos =>
+				{
+					var tile = World.Map.Tiles[cpos];
+					var template = templatedTerrainInfo.Templates[tile.Type];
+					return (CPos: cpos - template.IndexToOffset(tile.Index), Template: template);
+				})
+				.Where(tuple => tuple.Template.Id != ignoredTile)
+				.Distinct()
+				.ToList();
+
+			foreach (var (cpos, tti) in templatesToProcess)
+			{
+				var bounds = new CellCoordsRegion(cpos, cpos + new CVec(tti.Size.X, tti.Size.Y));
+				var points = planPoints
+					.Where(bounds.Contains)
+					.Select(p => p - cpos)
+					.Where(cvec => corners.Any(corner => tti.Contains(cvec - corner) && tti[tti.OffsetToIndex(cvec - corner)] != null))
+					.ToImmutableArray();
+				var pointSet = points.ToHashSet();
+
+				var pointIndices = planPoints
+					.Select((p, i) => (CVec: p - cpos, Index: i))
+					.Where(tuple => pointSet.Contains(tuple.CVec))
+					.Select(tuple => tuple.Index)
+					.ToList();
+
+				var consecutive = pointIndices.Count == pointIndices[^1] - pointIndices[0] + 1;
+
+				if (!consecutive)
+					continue;
+
+				var firstI = pointIndices[0];
+				var lastI = pointIndices[^1];
+
+				var startType =
+					firstI == 0
+						? (startOverride ?? StartType)
+						: (innerOverride ?? InnerType);
+				var innerType =
+					explicitInnerType
+						? (innerOverride ?? InnerType)
+						: null;
+				var endType =
+					lastI == planPoints.Length - 1
+						? (endOverride ?? EndType)
+						: (innerOverride ?? InnerType);
+				var startDirection =
+					firstI == 0
+						? Plan.AutoStart
+						: DirectionExts.FromCVec(planPoints[firstI] - planPoints[firstI - 1]);
+				var endDirection =
+					lastI == planPoints.Length - 1
+						? Plan.AutoEnd
+						: DirectionExts.FromCVec(planPoints[lastI + 1] - planPoints[lastI]);
+
+				multiBrushInfos[tti.Id] = new MultiBrushInfo(
+					templates: [new MultiBrushInfo.TemplateInfo(tti.Id)],
+					segment: new MultiBrushSegment(
+						$"{startType}.{startDirection}",
+						innerType,
+						$"{endType}.{endDirection}",
+						points));
+			}
+
+			IEnumerable<MiniYamlNode> my =
+				[
+					new MiniYamlNode(
+						"MultiBrushCollections", new MiniYaml(null,
+							[
+								new MiniYamlNode("Segmented", new MiniYaml(null,
+									multiBrushInfos
+										.OrderBy(kv => kv.Key)
+										.Select(kv => new MiniYamlNode(
+											$"MultiBrush@{Exts.ToStringInvariant(kv.Key)}",
+											kv.Value.ToMiniYaml()))))
+							]))
+				];
+
+			Game.SetClipboardText(my.WriteToString());
+			TextNotificationsManager.AddFeedbackLine(
+				FluentProvider.GetMessage(DumpMultiBrushSuccess, "count", multiBrushInfos.Count));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
@@ -43,6 +43,49 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			MapToolsLogic.OnSelected += TabSelected;
 
+			var developer_widget = widget.Get<ContainerWidget>("DEVELOPER_TOOLS");
+			if (tool.IsDeveloper)
+			{
+				developer_widget.Visible = true;
+
+				var ignoredTileWidget = developer_widget.Get<TextFieldWidget>("IGNORED_TILE");
+				var validUshort = true;
+				ignoredTileWidget.OnTextEdited = () => validUshort = Exts.TryParseUshortInvariant(ignoredTileWidget.Text, out _);
+				ignoredTileWidget.Text = Exts.ToStringInvariant(world.Map.Rules.TerrainInfo.DefaultTerrainTile.Type);
+				bool CanSave()
+					=> tool.Plan != null && validUshort;
+
+				var startOverrideWidget = developer_widget
+					.Get<ContainerWidget>("START_OVERRIDE")
+					.Get<TextFieldWidget>("INPUT");
+				var innerOverrideWidget = developer_widget
+					.Get<ContainerWidget>("INNER_OVERRIDE")
+					.Get<TextFieldWidget>("INPUT");
+				var endOverrideWidget = developer_widget
+					.Get<ContainerWidget>("END_OVERRIDE")
+					.Get<TextFieldWidget>("INPUT");
+
+				var explicitInnerCheckbox = widget.Get<CheckboxWidget>("EXPLICIT_INNER");
+				var explicitInner = false;
+				explicitInnerCheckbox.IsChecked = () => explicitInner;
+				explicitInnerCheckbox.OnClick = () => explicitInner = !explicitInner;
+
+				string NullIfEmpty(string x) => x == "" ? null : x;
+
+				var dumpButton = widget.Get<ButtonWidget>("DUMP");
+				dumpButton.IsDisabled = () => !CanSave();
+				dumpButton.OnClick = () => tool.DumpMultiBrushToClipboard(
+					Exts.ParseUshortInvariant(ignoredTileWidget.Text),
+					NullIfEmpty(startOverrideWidget.Text),
+					NullIfEmpty(innerOverrideWidget.Text),
+					NullIfEmpty(endOverrideWidget.Text),
+					explicitInner);
+			}
+			else
+			{
+				widget.RemoveChild(developer_widget);
+			}
+
 			((ScrollPanelWidget)widget).Layout.AdjustChildren();
 
 			void SetupDropDown(
@@ -101,6 +144,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var closedLoopsCheckbox = widget.Get<CheckboxWidget>("CLOSED_LOOPS");
 			closedLoopsCheckbox.IsChecked = () => tool.ClosedLoops;
 			closedLoopsCheckbox.OnClick = () => tool.SetClosedLoops(!tool.ClosedLoops);
+
+			var showPreviewCheckbox = widget.Get<CheckboxWidget>("SHOW_PREVIEW");
+			showPreviewCheckbox.IsChecked = () => tool.ShowPreview;
+			showPreviewCheckbox.OnClick = () => tool.ShowPreview = !tool.ShowPreview;
 
 			var resetButton = widget.Get<ButtonWidget>("RESET");
 			resetButton.IsDisabled = () => tool.Plan == null;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -1191,3 +1191,91 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 			Width: PARENT_WIDTH - 35
 			Height: 25
 			Text: button-tiling-path-paint
+		Checkbox@SHOW_PREVIEW:
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 25
+			Text: checkbox-tiling-path-show-preview
+		Container@DEVELOPER_TOOLS:
+			Visible: False
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 295
+			Children:
+				Background@HEADER:
+					Width: PARENT_WIDTH
+					Height: 15
+					Background: separator
+					ClickThrough: True
+					Children:
+						Label@LABEL:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Font: TinyBold
+							Align: Center
+							Text: label-tiling-path-developer
+				LabelForInput@LABEL_IGNORED:
+					Y: 20
+					Width: PARENT_WIDTH
+					Height: 20
+					Text: label-tiling-path-ignored-tile
+					For: IGNORED_TILE
+				TextField@IGNORED_TILE:
+					Y: 45
+					Width: PARENT_WIDTH
+					Height: 25
+				Container@START_OVERRIDE:
+					Y: 75
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-start
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@INNER_OVERRIDE:
+					Y: 130
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-inner
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@END_OVERRIDE:
+					Y: 185
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-end
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Checkbox@EXPLICIT_INNER:
+					Y: 240
+					Width: PARENT_WIDTH - 35
+					Height: 25
+					Text: checkbox-tiling-path-explicit-inner
+				Button@DUMP:
+					Y: 270
+					Width: PARENT_WIDTH
+					Height: 25
+					Text: button-tiling-path-dump

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -87,6 +87,14 @@ button-tiling-path-reverse = Reverse path
 button-tiling-path-reset = Discard path
 button-tiling-path-randomize = Re-randomize tiling
 button-tiling-path-paint = Paint tiling to map
+checkbox-tiling-path-show-preview = Show preview
+label-tiling-path-developer = Developer Tools
+label-tiling-path-ignored-tile = Ignored tile ID
+label-tiling-path-override-start = Start override
+label-tiling-path-override-inner = Inner override
+label-tiling-path-override-end = End override
+checkbox-tiling-path-explicit-inner = Explicit inner type
+button-tiling-path-dump = Dump to clipboard
 
 button-map-editor-tab-container-select-tooltip = Selection
 button-map-editor-tab-container-tiles-tooltip = Tiles

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -1165,3 +1165,91 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 			Width: PARENT_WIDTH - 35
 			Height: 25
 			Text: button-tiling-path-paint
+		Checkbox@SHOW_PREVIEW:
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 25
+			Text: checkbox-tiling-path-show-preview
+		Container@DEVELOPER_TOOLS:
+			Visible: False
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 295
+			Children:
+				Background@HEADER:
+					Width: PARENT_WIDTH
+					Height: 15
+					Background: separator
+					ClickThrough: True
+					Children:
+						Label@LABEL:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Font: TinyBold
+							Align: Center
+							Text: label-tiling-path-developer
+				LabelForInput@LABEL_IGNORED:
+					Y: 20
+					Width: PARENT_WIDTH
+					Height: 20
+					Text: label-tiling-path-ignored-tile
+					For: IGNORED_TILE
+				TextField@IGNORED_TILE:
+					Y: 45
+					Width: PARENT_WIDTH
+					Height: 25
+				Container@START_OVERRIDE:
+					Y: 75
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-start
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@INNER_OVERRIDE:
+					Y: 130
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-inner
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Container@END_OVERRIDE:
+					Y: 185
+					Width: PARENT_WIDTH - 35
+					Height: 50
+					Children:
+						LabelForInput@LABEL:
+							Y: 0
+							Width: PARENT_WIDTH
+							Height: 20
+							Text: label-tiling-path-override-end
+							For: INPUT
+						TextField@INPUT:
+							Y: 20
+							Width: PARENT_WIDTH
+							Height: 25
+				Checkbox@EXPLICIT_INNER:
+					Y: 240
+					Width: PARENT_WIDTH - 35
+					Height: 25
+					Text: checkbox-tiling-path-explicit-inner
+				Button@DUMP:
+					Y: 270
+					Width: PARENT_WIDTH
+					Height: 25
+					Text: button-tiling-path-dump

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -83,6 +83,14 @@ button-tiling-path-reverse = Reverse path
 button-tiling-path-reset = Discard path
 button-tiling-path-randomize = Re-randomize tiling
 button-tiling-path-paint = Paint tiling to map
+checkbox-tiling-path-show-preview = Show preview
+label-tiling-path-developer = Developer Tools
+label-tiling-path-ignored-tile = Ignored tile ID
+label-tiling-path-override-start = Start override
+label-tiling-path-override-inner = Inner override
+label-tiling-path-override-end = End override
+checkbox-tiling-path-explicit-inner = Explicit inner type
+button-tiling-path-dump = Dump to clipboard
 
 button-map-editor-tab-container-select-tooltip = Selection
 button-map-editor-tab-container-tiles-tooltip = Tiles

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -1114,3 +1114,6 @@ notification-tiling-path-started = Started tiling path
 notification-tiling-path-updated = Updated tiling path
 notification-tiling-path-reset = Discarded tiling path
 notification-tiling-path-painted = Painted tiling path
+
+## TilingPathTool
+notification-tiling-path-dump-multibrush-success = Copied { $count } MultiBrush definitions to the clipboard.


### PR DESCRIPTION
Adds a basic in-editor tool for creating segmented MultiBrush definitions by using the Path Tiling Tool. This is primarily focused at modders, but might form the basis of a user-generated MultiBrush system in the future.

1. User places templates down on the map.
2. If needed, user defines the start, inner, and end types.
3. User traces over them using the Path Tiler Tool (perhaps individually or in a batch).
4. User clicks the button to dump the definitions to the OS clipboard.
5. User can then save these definitions to the tileset MiniYaml.

This is much faster and less error prone than trying to create the definitions by hand.

By default, the developer tooling is only shown if the mod version is "{DEV_VERSION}". A user can force the tooling to be shown or hidden via a `Developer` field in world.yaml

Additional related changes:

- Add a checkbox to disable the tiling preview.
- Implement serialization of MultiBrushInfo back to MiniYaml.