### PR TITLE
AI MCV Expansion: accurate expansion

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -139,6 +139,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay (in ticks) between reassigning rally points.")]
 		public readonly int AssignRallyPointsInterval = 100;
 
+		[Desc("Delay (in ticks) between finding a good resource point around conyard to harvest.")]
+		public readonly int CheckBestResourceLocationInterval = 123;
+
 		public override object Create(ActorInitializer init) { return new BaseBuilderBotModule(init.Self, this); }
 	}
 
@@ -166,14 +169,16 @@ namespace OpenRA.Mods.Common.Traits
 		IPathFinder pathFinder;
 		IBotPositionsUpdated[] positionsUpdatedModules;
 		CPos initialBaseCenter;
+		public CPos? ResourceCenter;
 
 		readonly Stack<TraitPair<RallyPoint>> rallyPoints = [];
 		int assignRallyPointsTicks;
+		int checkBestResourceLocationTicks;
 
 		readonly BaseBuilderQueueManager[] builders;
 		int currentBuilderIndex = 0;
 
-		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> refineryBuildings;
+		public readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> RefineryBuildings;
 		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> powerBuildings;
 		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> constructionYardBuildings;
 		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> barracksBuildings;
@@ -184,7 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 			world = self.World;
 			player = self.Owner;
 			builders = new BaseBuilderQueueManager[info.BuildingQueues.Count + info.DefenseQueues.Count];
-			refineryBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.RefineryTypes, player);
+			RefineryBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.RefineryTypes, player);
 			powerBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.PowerTypes, player);
 			constructionYardBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.ConstructionYardTypes, player);
 			barracksBuildings = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.BarracksTypes, player);
@@ -211,6 +216,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
 			assignRallyPointsTicks = world.LocalRandom.Next(0, Info.AssignRallyPointsInterval);
+			checkBestResourceLocationTicks = world.LocalRandom.Next(0, Info.CheckBestResourceLocationInterval);
 		}
 
 		void IBotPositionsUpdated.UpdatedBaseCenter(CPos newLocation)
@@ -243,6 +249,31 @@ namespace OpenRA.Mods.Common.Traits
 					if (rp.Actor.Owner == player && !rp.Actor.Disposed)
 						SetRallyPoint(bot, rp);
 				}
+			}
+
+			if (--checkBestResourceLocationTicks <= 0 && resourceLayer != null)
+			{
+				checkBestResourceLocationTicks = Info.CheckBestResourceLocationInterval;
+
+				Actor bestconyard = null;
+				var best = int.MinValue;
+
+				foreach (var conyard in constructionYardBuildings.Actors.Where(a => !a.IsDead))
+				{
+					if (!world.Map.FindTilesInAnnulus(conyard.Location, Info.MinBaseRadius, Info.MaxBaseRadius).Any(a => resourceLayer.GetResource(a).Type != null))
+						continue;
+
+					var suitable = -world.FindActorsInCircle(conyard.CenterPosition, WDist.FromCells(Info.MaxBaseRadius))
+							.Count(a => (a.Owner.IsAlliedWith(player) && Info.RefineryTypes.Contains(a.Info.Name)) || a.Owner.RelationshipWith(player) == PlayerRelationship.Enemy);
+
+					if (suitable > best)
+					{
+						best = suitable;
+						bestconyard = conyard;
+					}
+				}
+
+				ResourceCenter = bestconyard?.Location;
 			}
 
 			BuildingsBeingProduced.Clear();
@@ -392,7 +423,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Require at least one refinery, unless we can't build it.
 		public bool HasAdequateRefineryCount() =>
 			Info.RefineryTypes.Count == 0 ||
-			AIUtils.CountActorByCommonName(refineryBuildings) >= MinimumRefineryCount() ||
+			AIUtils.CountActorByCommonName(RefineryBuildings) >= MinimumRefineryCount() ||
 			AIUtils.CountActorByCommonName(powerBuildings) == 0 ||
 			AIUtils.CountActorByCommonName(constructionYardBuildings) == 0;
 
@@ -429,7 +460,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyActorDisposing.Disposing(Actor self)
 		{
-			refineryBuildings.Dispose();
+			RefineryBuildings.Dispose();
 			powerBuildings.Dispose();
 			constructionYardBuildings.Dispose();
 			barracksBuildings.Dispose();

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -142,6 +142,21 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay (in ticks) between finding a good resource point around conyard to harvest.")]
 		public readonly int CheckBestResourceLocationInterval = 123;
 
+		[Desc("Interval (in ticks) between checking whether to sell a redundant refinery. Set to -1 to disable.")]
+		public readonly int SellRefineryInterval = 6000;
+
+		[Desc("Distance (in cells) for refineries finding redundant refineries.")]
+		public readonly int SellRefineryCloseCellDistance = 6;
+
+		[Desc("Mixumum distance (in cells) for refineries finding resources around.")]
+		public readonly int SellRefineryNoResourceDistance = 12;
+
+		[Desc("Harvestable and valuable resource types.")]
+		public readonly HashSet<string> ValidResourceTypes = [];
+
+		[Desc("Tells the AI what types are considered resource creator.")]
+		public readonly HashSet<string> ResourceCreatorTypes = [];
+
 		public override object Create(ActorInitializer init) { return new BaseBuilderBotModule(init.Self, this); }
 	}
 
@@ -174,6 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Stack<TraitPair<RallyPoint>> rallyPoints = [];
 		int assignRallyPointsTicks;
 		int checkBestResourceLocationTicks;
+		int sellRefineryTick;
 
 		readonly BaseBuilderQueueManager[] builders;
 		int currentBuilderIndex = 0;
@@ -217,6 +233,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
 			assignRallyPointsTicks = world.LocalRandom.Next(0, Info.AssignRallyPointsInterval);
 			checkBestResourceLocationTicks = world.LocalRandom.Next(0, Info.CheckBestResourceLocationInterval);
+			sellRefineryTick = Info.SellRefineryInterval < 0 ? 0 : world.LocalRandom.Next(0, Info.SellRefineryInterval);
 		}
 
 		void IBotPositionsUpdated.UpdatedBaseCenter(CPos newLocation)
@@ -258,9 +275,10 @@ namespace OpenRA.Mods.Common.Traits
 				Actor bestconyard = null;
 				var best = int.MinValue;
 
-				foreach (var conyard in constructionYardBuildings.Actors.Where(a => !a.IsDead))
+				foreach (var conyard in constructionYardBuildings.Actors)
 				{
-					if (!world.Map.FindTilesInAnnulus(conyard.Location, Info.MinBaseRadius, Info.MaxBaseRadius).Any(a => resourceLayer.GetResource(a).Type != null))
+					if (conyard.IsDead || !world.Map.FindTilesInAnnulus(conyard.Location, Info.MinBaseRadius, Info.MaxBaseRadius)
+						.Any(c => Info.ValidResourceTypes.Contains(resourceLayer.GetResource(c).Type)))
 						continue;
 
 					var suitable = -world.FindActorsInCircle(conyard.CenterPosition, WDist.FromCells(Info.MaxBaseRadius))
@@ -317,6 +335,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			builders[currentBuilderIndex].Tick(bot, queuesByCategory);
+
+			if (Info.SellRefineryInterval >= 0 && --sellRefineryTick <= 0)
+			{
+				SellUselessRefinery(bot);
+				sellRefineryTick = Info.SellRefineryInterval;
+			}
 		}
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
@@ -442,6 +466,36 @@ namespace OpenRA.Mods.Common.Traits
 				new("InitialBaseCenter", FieldSaver.FormatValue(initialBaseCenter)),
 				new("DefenseCenter", FieldSaver.FormatValue(DefenseCenter))
 			];
+		}
+
+		void SellUselessRefinery(IBot bot)
+		{
+			// Sell one refinery each time. Perserve at least one refinery
+			var refineries = world.ActorsHavingTrait<Refinery>().Where(a => a.Owner == player).ToArray();
+
+			if (refineries.Length <= 1)
+				return;
+
+			for (var i = 0; i < refineries.Length; i++)
+			{
+				for (var j = i + 1; j < refineries.Length; j++)
+				{
+					if ((refineries[i].Location - refineries[j].Location).LengthSquared <= Info.SellRefineryCloseCellDistance * Info.SellRefineryCloseCellDistance)
+					{
+						bot.QueueOrder(new Order("Sell", refineries[i], Target.FromActor(refineries[i]), false));
+						return;
+					}
+				}
+
+				if (!world.Map.FindTilesInAnnulus(refineries[i].Location, 0, Info.SellRefineryNoResourceDistance)
+					.Any(c => Info.ValidResourceTypes.Contains(resourceLayer.GetResource(c).Type))
+					&& !world.FindActorsInCircle(refineries[i].CenterPosition, WDist.FromCells(Info.SellRefineryNoResourceDistance))
+					.Any(a => Info.ResourceCreatorTypes.Contains(a.Info.Name)))
+				{
+					bot.QueueOrder(new Order("Sell", refineries[i], Target.FromActor(refineries[i]), false));
+					return;
+				}
+			}
 		}
 
 		void IGameSaveTraitData.ResolveTraitData(Actor self, MiniYaml data)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -496,13 +496,24 @@ namespace OpenRA.Mods.Common.Traits
 					// Try and place the refinery near a resource field
 					if (resourceLayer != null)
 					{
-						var nearbyResources = world.Map.FindTilesInAnnulus(baseCenter, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius)
-							.Where(a => resourceLayer.GetResource(a).Type != null)
-							.Shuffle(world.LocalRandom).Take(baseBuilder.Info.MaxResourceCellsToCheck);
+						// If we have failed to place to the best refinery point, try and place it near the base center
+						var resourceCenter = failCount > 0 ? baseCenter : (baseBuilder.ResourceCenter ?? baseCenter);
 
-						foreach (var r in nearbyResources)
+						var nearbyResources = world.Map
+							.FindTilesInAnnulus(resourceCenter, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius)
+							.Where(a => baseBuilder.Info.ValidResourceTypes.Contains(resourceLayer.GetResource(a).Type));
+
+						var closestRefinery = failCount <= 0
+							? baseBuilder.RefineryBuildings.Actors.Where(a => !a.IsDead)?.ClosestToIgnoringPath(world.Map.CenterOfCell(resourceCenter))
+							: null;
+
+						var resourcesShouldCheck = (closestRefinery == null ?
+							nearbyResources.Shuffle(world.LocalRandom) : nearbyResources.OrderByDescending(c => (c - closestRefinery.Location).LengthSquared))
+							.Take(baseBuilder.Info.MaxResourceCellsToCheck);
+
+						foreach (var r in resourcesShouldCheck)
 						{
-							var found = FindPos(baseCenter, r, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius);
+							var found = FindPos(resourceCenter, r, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius);
 							if (found.Location != null)
 								return found;
 						}

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -1,0 +1,981 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public enum BotMcvExpansionMode { CheckResourceCreator, CheckResource, CheckBase }
+
+	[Desc("Manages AI MCVs and expansion.")]
+	public class McvExpansionManagerBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Actor types that are considered MCVs (deploy into base builders).")]
+		public readonly HashSet<string> McvTypes = [];
+
+		[Desc("Actor types that are considered construction yards (base builders).")]
+		public readonly HashSet<string> ConstructionYardTypes = [];
+
+		[Desc("Actor types that are able to produce MCVs.")]
+		public readonly HashSet<string> McvFactoryTypes = [];
+
+		[Desc("Try to maintain at least this many ConstructionYardTypes, build an MCV if number is below this.")]
+		public readonly int MinimumConstructionYardCount = 2;
+
+		[Desc("Delay (in ticks) between looking for and giving out orders to new MCVs.")]
+		public readonly int ScanForNewMcvInterval = 20;
+
+		[Desc("Delay (in ticks) between check and build a MCV.")]
+		public readonly int BuildMcvInterval = 101;
+
+		[Desc("Move a conyard if have more than 1 conyard, for better expansion.")]
+		public readonly int MoveConyardTick = 4500;
+
+		[Desc($"Tells the AI what building types are considered production. Used by {nameof(FirstMoveConyardTicks)}.")]
+		public readonly HashSet<string> ProductionTypes = [];
+
+		[Desc("Tells the AI what building types are considered refineries.")]
+		public readonly HashSet<string> RefineryTypes = [];
+
+		[Desc("Move a conyard undeploy even if this is the only conyard. only works for once. Add different values so first undeploy can happen at random timming.",
+			"First undeploy requires at least 1 refinery and 2 production buildings, which means bot should not expand when enemy rush and kill some critical base buildings before that.")]
+		public readonly int[] FirstMoveConyardTicks = [-1];
+
+		[Desc("Initial expansion mode chosen by AI.")]
+		public readonly BotMcvExpansionMode InitialExpansionMode = BotMcvExpansionMode.CheckResourceCreator;
+
+		[Desc("Allow Bot switch expansion mode automatically on enough failure or successful attempts.")]
+		public readonly bool ExpansionModeAutoSwitch = true;
+
+		/* those are options shared by two or more modes */
+		[Desc("Tick in update an indice of resource map when." + nameof(BotMcvExpansionMode.CheckResource) + "is inactive.")]
+		public readonly int InactiveUpdateResourceMapInverval = 271;
+
+		[Desc("Tick in update an indice of resource map." + nameof(BotMcvExpansionMode.CheckResource) + "is active.")]
+		public readonly int ActiveUpdateResourceMapInverval = 103;
+
+		[Desc("Distance in cells of half indice of the resource map.")]
+		public readonly int ResourceMapStrideRadius = 12;
+
+		/* those are CheckResourceCreator mode options */
+		[Desc("Minimum distance in cells around the resource creator location when checking for MCV deployment location.")]
+		public readonly int CRCmodeMinDeployRadius = 2;
+
+		[Desc("Maximum distance in cells around the resource creator location when checking for MCV deployment location.")]
+		public readonly int CRCmodeMaxDeployRadius = 12;
+
+		[Desc("Tells the AI what types are considered resource creator.")]
+		public readonly HashSet<string> ResourceCreatorTypes = [];
+
+		[Desc("Distance in cells to a friendly conyard that AI dislike when choose a expanding location.")]
+		public readonly int CRCmodeConyardUnfavorRange = 18;
+
+		[Desc("Distance in cells to a friendly refinery that AI dislike when choose a expanding location.")]
+		public readonly int CRCmodeRefineryUnfavorRange = 12;
+
+		[Desc("Distance in cells that AI try to maintain to the expanding location in deployment.")]
+		public readonly int CRCmodeTryMaintainRange = 8;
+
+		[Desc("Distance in cells from center of the resource creator when checking nearby enemy base buildings for MCV expanding location.")]
+		public readonly int CRCmodeEnemyBaseScanRadius = 16;
+
+		/* those are CheckResource mode options */
+		[Desc("Minimum distance in cells from the found resource creator location when checking for MCV deployment location.")]
+		public readonly int CRmodeMinDeployRadius = 2;
+
+		[Desc("Maximum distance in cells the found resource creator location when checking for MCV deployment location.")]
+		public readonly int CRmodeMaxDeployRadius = 20;
+
+		[Desc("Distance in cells that AI try to maintain to the expanding location in deployment.")]
+		public readonly int CRmodeTryMaintainRange = 8;
+
+		[Desc("Distance in cells from center of the resource indice when checking nearby enemy base buildings for MCV expanding location.",
+			"Recommend to set it equal or bigger than " + nameof(ResourceMapStrideRadius) + "* 1.2.")]
+		public readonly int CRmodeEnemyBaseScanRadius = 18;
+
+		[Desc("Distance in cells to a friendly conyard that AI dislike when choose a expanding location.",
+			"Recommend to set it equal or bigger than " + nameof(ResourceMapStrideRadius) + ".")]
+		public readonly int CRmodeConyardUnfavorRange = 14;
+
+		[Desc("Distance in cells to a friendly refinery that AI dislike when choose a expanding location.",
+			"Recommend to set it equal or bigger than " + nameof(ResourceMapStrideRadius) + "*.")]
+		public readonly int CRmodeRefineryUnfavorRange = 14;
+
+		[Desc("Resource types that are considered can be harvested.")]
+		public readonly HashSet<string> ValidResourceTypes = [];
+
+		/* those are CheckBase mode options */
+		[Desc("Minimum distance in cells from center of the base expansion when checking for MCV deployment location.")]
+		public readonly int CBmodeMinDeployRadius = 2;
+
+		[Desc("Maximum distance in cells from center of the base expansion when checking for MCV deployment location.")]
+		public readonly int CBmodeMaxDeployRadius = 20;
+
+		[Desc("Distance in cells from center of the indice when checking nearby enemy base buildings for MCV expanding location.")]
+		public readonly int CBmodeEnemyBaseScanRadius = 27;
+
+		public override object Create(ActorInitializer init) { return new McvExpansionManagerBotModule(init.Self, this); }
+	}
+
+	public class McvExpansionManagerBotModule : ConditionalTrait<McvExpansionManagerBotModuleInfo>, IBotTick, IBotRespondToAttack, INotifyActorDisposing
+	{
+		// When ExpansionModeAutoSwitch is true, if the AI fails to find a deploy spot enough time even in CheckBase mode
+		// NegativeMaxFailedAttempts is applied to make AI switch bettween modes more frequently until a successful attempt
+		const int PositiveMaxFailedAttempts = 3;
+		const int NegativeMaxFailedAttempts = 1;
+
+		readonly World world;
+		readonly Player player;
+		readonly ActorIndex.OwnerAndNamesAndTrait<TransformsInfo> mcvs;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> constructionYards;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> mcvFactories;
+
+		IBotPositionsUpdated[] notifyPositionsUpdated;
+		IBotRequestUnitProduction[] requestUnitProduction;
+		IResourceLayer resourceLayer;
+		PathFinder pathfinder;
+
+		int updateResourceMapDelay;
+		int scanInterval;
+		int buildMCVInterval;
+		int moveConyardInterval;
+		int updateResourceMapInterval;
+		bool firstTick = true;
+		bool firstUndeploy = true;
+		bool allowfallback;
+
+		BotMcvExpansionMode mcvExpansionMode;
+		int mcvDeploymentMinDeployRadius;
+		int mcvDeploymentMaxDeployRadius;
+		int mcvDeploymentTryMaintainRange;
+
+		int maxFailedAttempts = PositiveMaxFailedAttempts;
+		int failedAttempts;
+		CPos? lastFailedCheckSpot;
+
+		// It is unnecessary to respond every tick, we only need to respond once in a while.
+		int attackrespondcooldown = 20;
+
+		(CPos IndiceCenter, int Value, CPos ResourceCenter)[] resourceMapIndices = null;
+		readonly int indiceSideLength;
+		readonly int indiceResourceScanRadius;
+		int resourceMapIndicesColumnCount;
+		int resourceMapIndicesRowCount;
+
+		int pathDistanceSquareFactor;
+		int updateResourceMapIndex = 0;
+
+		public McvExpansionManagerBotModule(Actor self, McvExpansionManagerBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			mcvs = new ActorIndex.OwnerAndNamesAndTrait<TransformsInfo>(world, info.McvTypes, player);
+			constructionYards = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.ConstructionYardTypes, player);
+			mcvFactories = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.McvFactoryTypes, player);
+			indiceSideLength = info.ResourceMapStrideRadius << 1;
+
+			// FindTilesInAnnulus returns cells in a rough circle shape, and resourceMapIndices are divided in square,
+			// so we need a larger range to cover cells in the indice approximately, but avoid takes too much other indices' cells.
+			indiceResourceScanRadius = info.ResourceMapStrideRadius * 12 / 10; // ≈ * (sqrt(2) + 1) / 2
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			resourceLayer = self.World.WorldActor.TraitOrDefault<IResourceLayer>();
+			notifyPositionsUpdated = self.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			requestUnitProduction = self.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
+			pathfinder = world.WorldActor.Trait<PathFinder>();
+			moveConyardInterval = Info.FirstMoveConyardTicks.RandomOrDefault(world.LocalRandom);
+			if (moveConyardInterval < 0)
+				firstUndeploy = false;
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			scanInterval = world.LocalRandom.Next(Info.ScanForNewMcvInterval, Info.ScanForNewMcvInterval << 1);
+			buildMCVInterval = world.LocalRandom.Next(Info.BuildMcvInterval, Info.BuildMcvInterval << 1);
+			updateResourceMapInterval = world.LocalRandom.Next(Info.ActiveUpdateResourceMapInverval, Info.ActiveUpdateResourceMapInverval << 1);
+		}
+
+		void SwitchExpansionMode(BotMcvExpansionMode nextMode)
+		{
+			mcvExpansionMode = nextMode;
+			switch (nextMode)
+			{
+				case BotMcvExpansionMode.CheckResourceCreator:
+					mcvDeploymentMinDeployRadius = Info.CRCmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CRCmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = Info.CRCmodeTryMaintainRange;
+					updateResourceMapDelay = Info.InactiveUpdateResourceMapInverval;
+					break;
+
+				case BotMcvExpansionMode.CheckResource:
+					mcvDeploymentMinDeployRadius = Info.CRmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CRmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = Info.CRmodeTryMaintainRange;
+					updateResourceMapDelay = Info.ActiveUpdateResourceMapInverval;
+					break;
+
+				case BotMcvExpansionMode.CheckBase:
+					mcvDeploymentMinDeployRadius = Info.CBmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CBmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = (Info.CBmodeMaxDeployRadius + Info.CBmodeMinDeployRadius) >> 1;
+					updateResourceMapDelay = Info.InactiveUpdateResourceMapInverval;
+					break;
+
+				default:
+					break;
+			}
+		}
+
+		void FindBadDeploySpot(CPos? failedSpot)
+		{
+			lastFailedCheckSpot = failedSpot;
+
+			if (!Info.ExpansionModeAutoSwitch)
+			{
+				if (++failedAttempts >= maxFailedAttempts)
+					failedAttempts = maxFailedAttempts;
+				return;
+			}
+
+			if (++failedAttempts >= maxFailedAttempts)
+			{
+				failedAttempts = 0;
+				switch (mcvExpansionMode)
+				{
+					case BotMcvExpansionMode.CheckResourceCreator:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+						break;
+
+					case BotMcvExpansionMode.CheckResource:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckBase);
+						break;
+
+					case BotMcvExpansionMode.CheckBase:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResourceCreator);
+						maxFailedAttempts = NegativeMaxFailedAttempts;
+						break;
+				}
+			}
+		}
+
+		void FindGoodDeploySpot()
+		{
+			lastFailedCheckSpot = null;
+
+			if (!Info.ExpansionModeAutoSwitch)
+			{
+				if (--failedAttempts <= -maxFailedAttempts)
+					failedAttempts = -maxFailedAttempts;
+				return;
+			}
+
+			if (--failedAttempts <= -maxFailedAttempts)
+			{
+				maxFailedAttempts = PositiveMaxFailedAttempts;
+				switch (mcvExpansionMode)
+				{
+					case BotMcvExpansionMode.CheckResourceCreator:
+						failedAttempts = -maxFailedAttempts;
+						break;
+
+					case BotMcvExpansionMode.CheckBase:
+						failedAttempts = maxFailedAttempts - 1;
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+						break;
+
+					case BotMcvExpansionMode.CheckResource:
+						failedAttempts = maxFailedAttempts - 1;
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResourceCreator);
+						break;
+				}
+			}
+		}
+
+		public (CPos? ExpandLocation, int Attraction, CPos? CheckSpot) GetExpansionCenter(Actor mcv, Mobile mobile, bool allowfallback)
+		{
+			/*
+			 * indiceSideLengthSquare (which is equal to indiceSideLength * indiceSideLength) is used as the basic unit to calculate the attraction of a candidate,
+			 * we  compare the attraction on the same scale on different factors, such as candidate's distance to current MCV and ally construction yard & refinery within range, etc:
+			 *
+			 * 1). the weight of candidate's distance-square to current MCV
+			 *
+			 *     a) if not Mobile: range from 0 to -indiceSideLengthSquare.
+			 *
+			 *     The reason why:
+			 *
+			 *     It is calculated as "(candidate - mcv.Location).LengthSquared / pathDistanceSquareFactor".
+			 *     note that: pathDistanceSquareFactor = resourceMapIndicesColumnCount * resourceMapIndicesColumnCount + resourceMapIndicesRowCount * resourceMapIndicesRowCount,
+			 *
+			 *     Consider a map, we divide it at the length of indiceSideLength = r, and then its resourceMapIndicesColumnCount = a, resourceMapIndicesRowCount = b,
+			 *     so the map.width ≈ a*r, map.height ≈ b*r,
+			 *     the maximum euclid distance-square between two points on the map is (a*r)(a*r) + (b*r)(b*r),
+			 *     so the maximum "weight of candidate's distance to current MCV" is from 0 to -((a*r)(a*r) + (b*r)(b*r)) / (a*a + b*b) = -r*r = -indiceSideLengthSquare.
+			 *
+			 *     b) if Mobile: range depends on pathfinding distance in cell.
+			 *
+			 *     It is calculated as "pathfindDistance * pathfindDistance / pathDistanceSquareFactor".
+			 *
+			 * 2). the weight of friendly construction yard within range: -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
+			 *
+			 * 3). the weight of enemy basebuilding within range: -indiceSideLengthSquare*16.
+			 *
+			 * 4). the weight of friendly refinery within range (not for CheckBase mode): -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
+			 *
+			 * 5). the weight of resource amount (only for CheckResource mode): from 0 to +indiceSideLengthSquare/8.
+			 *
+			 *     The reason why:
+			 *
+			 *     The maximum resource amount in a indice of resource map is approximately indiceSideLengthSquare (full of it), but a stride full of resources is less likely to
+			 *     have room for buildings. So we prefer the indice have half of resource cells the most, which may give us enough room to place buildings.
+			 *
+			 *     so the weight can be: (indiceSideLengthSquare/2) - |(indiceResourceCellCount - (indiceSideLengthSquare/2))|, range from (0 to +indiceSideLengthSquare/2).
+			 *
+			 *     Note: In practive resource weight is not very important, we cannot let MCV go a long way just for a rich resource spot.
+			 *     We have to take only 1/4 of it, wich is (0 to +indiceSideLengthSquare/8),
+			 *     and apply some additional method to filter the indice for acceptable resource (not too low).
+			 */
+			var indiceSideLengthSquare = indiceSideLength * indiceSideLength;
+			switch (mcvExpansionMode)
+			{
+				/*
+				 * CheckBase mode only considers the distance to current MCV, ally construction yard within range and enemy buildings within range.
+				 * Attaction has a base value of indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, 1/(2*sqrt(2))≈ 1/2.8 of the maximum distance in map)
+				 */
+				case BotMcvExpansionMode.CheckBase:
+					var cb_conyardlocs = world.ActorsHavingTrait<Building>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.ConstructionYardTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner == player))
+						.ToArray();
+					CPos? cb_suitablespot = null;
+					CPos? cb_checkspot = null;
+					var cb_best = int.MinValue;
+
+					foreach (var (indiceCenter, value, rescenter) in resourceMapIndices)
+					{
+						if (lastFailedCheckSpot == indiceCenter)
+							continue;
+
+						var attraction = indiceSideLengthSquare >> 3;
+
+						attraction -= (indiceCenter - mcv.Location).LengthSquared / pathDistanceSquareFactor;
+
+						if (world.FindActorsInCircle(world.Map.CenterOfCell(indiceCenter), WDist.FromCells(Info.CBmodeEnemyBaseScanRadius)).Any(a => !a.Disposed
+							&& (player.RelationshipWith(a.Owner) == PlayerRelationship.Enemy)
+							&& a.Info.HasTraitInfo<BuildingInfo>()
+							&& a.Info.HasTraitInfo<SellableInfo>()))
+							attraction -= indiceSideLengthSquare << 4;
+
+						foreach (var (location, isAlly) in cb_conyardlocs)
+						{
+							var sdistance = (indiceCenter - location).LengthSquared;
+							if (sdistance <= indiceSideLengthSquare)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						if (!allowfallback)
+						{
+							var sdistance = (indiceCenter - mcv.Location).LengthSquared;
+							if (sdistance <= indiceSideLengthSquare)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (attraction > cb_best)
+						{
+							cb_best = attraction;
+							cb_checkspot = indiceCenter;
+							cb_suitablespot = indiceCenter;
+						}
+					}
+
+					return (cb_suitablespot ?? mcv.Location, cb_best, cb_checkspot);
+
+				/*
+				 * CheckResource mode considers the distance to current MCV, ally construction yard & refinery within range,
+				 * Attaction has a base value of:
+				 * 1. if not Mobile: indiceSideLengthSquare >> 4 (1/16 of the maximum distance weight, = 0.25 of the maximum euclid distance in map)
+				 * 2. if Mobile: indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, ≈ 0.35 of the maximum euclid distance in map)
+				 */
+				case BotMcvExpansionMode.CheckResource:
+
+					var cr_refinarylocs = world.ActorsHavingTrait<Refinery>()
+						.Where(a => a.Owner == player && Info.RefineryTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					var cr_conyardlocs = world.ActorsHavingTrait<Building>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.ConstructionYardTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					// We only take indice has more than half of average indice value (in weight calculation), to skip the indice with very poor resource
+					// when failedAttempts is acceptable.
+					var thresholdRes = (resourceMapIndices.Sum(i => (indiceSideLengthSquare >> 1) - Math.Abs(i.Value - (indiceSideLengthSquare >> 1)))
+						/ resourceMapIndices.Length) >> 1;
+
+					CPos? cr_suitablespot = null;
+					CPos? cr_checkspot = null;
+					var cr_best = int.MinValue;
+
+					foreach (var (indiceCenter, value, rescenter) in resourceMapIndices)
+					{
+						if ((failedAttempts > maxFailedAttempts >> 1 && value <= thresholdRes) || lastFailedCheckSpot == indiceCenter)
+							continue;
+
+						var attraction = 0;
+						if (mobile == null)
+						{
+							attraction = indiceSideLengthSquare >> 4;
+							attraction -= (rescenter - mcv.Location).LengthSquared / pathDistanceSquareFactor;
+						}
+						else
+						{
+							attraction = indiceSideLengthSquare >> 3;
+
+							var path = pathfinder.FindPathToTargetCells(mcv, mcv.Location, [rescenter], BlockedByActor.None);
+
+							if (path == PathFinder.NoPath)
+								continue;
+
+							attraction -= path.Count * path.Count / pathDistanceSquareFactor;
+						}
+
+						// it is better that resource cells takes only half of the indice cells, which give us the place to place building.
+						attraction += ((indiceSideLengthSquare >> 1) - Math.Abs(value - (indiceSideLengthSquare >> 1))) >> 2;
+
+						if (world.FindActorsInCircle(world.Map.CenterOfCell(rescenter), WDist.FromCells(Info.CRmodeEnemyBaseScanRadius)).Any(a => !a.Disposed
+							&& (player.RelationshipWith(a.Owner) == PlayerRelationship.Enemy)
+							&& a.Info.HasTraitInfo<BuildingInfo>()
+							&& a.Info.HasTraitInfo<SellableInfo>()))
+							attraction -= indiceSideLengthSquare << 4;
+
+						foreach (var (location, isAlly) in cr_refinarylocs)
+						{
+							var sdistance = (rescenter - location).LengthSquared;
+							if (sdistance <= Info.CRmodeRefineryUnfavorRange * Info.CRmodeRefineryUnfavorRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						foreach (var (location, isAlly) in cr_conyardlocs)
+						{
+							var sdistance = (rescenter - location).LengthSquared;
+							if (sdistance <= Info.CRmodeConyardUnfavorRange * Info.CRmodeConyardUnfavorRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						if (!allowfallback)
+						{
+							var sdistance = (rescenter - mcv.Location).LengthSquared;
+							if (sdistance <= Info.CRmodeConyardUnfavorRange * Info.CRmodeConyardUnfavorRange)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (attraction > cr_best)
+						{
+							cr_best = attraction;
+							cr_checkspot = indiceCenter;
+							cr_suitablespot = rescenter;
+						}
+					}
+
+					if (cr_suitablespot == null)
+						return (null, int.MinValue, null);
+
+					if (failedAttempts < maxFailedAttempts >> 1)
+						return (cr_suitablespot, cr_best, cr_checkspot);
+					else
+						return (world.Map.FindTilesInAnnulus(cr_suitablespot.Value, 0, indiceResourceScanRadius)
+							.Where(c => Info.ValidResourceTypes.Contains(resourceLayer.GetResource(c).Type))
+							.Random(world.LocalRandom), cr_best, cr_checkspot);
+				/*
+				 * CheckResourceCreator mode considers the distance to current MCV, ally construction yard & refinery within range,
+				 * Attaction has a base value of:
+				 * 1. if not Mobile: (indiceSideLengthSquare >> 3) - (indiceSideLengthSquare >> 5) (3/32 of the maximum distance weight, ≈ 0.31 of the maximum euclid distance in map))
+				 * 2. if Mobile: (indiceSideLengthSquare >> 2)  - (indiceSideLengthSquare >> 4) (3/16 of the maximum distance weight, ≈ 0.43 of the maximum euclid distance in map)
+				 */
+				case BotMcvExpansionMode.CheckResourceCreator:
+
+					var crc_conyardlocs = world.ActorsHavingTrait<Building>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.ConstructionYardTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					var crc_refinarylocs = world.ActorsHavingTrait<Refinery>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.RefineryTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					var crc_rescreators = world.ActorsHavingTrait<SeedsResource>()
+						.Where(a => Info.ResourceCreatorTypes.Contains(a.Info.Name));
+
+					CPos? crc_suitablelocation = null;
+					CPos? crc_checkspot = null;
+					var crc_best = int.MinValue;
+
+					foreach (var rescreator in crc_rescreators)
+					{
+						if (lastFailedCheckSpot == rescreator.Location)
+							continue;
+
+						var attraction = 0;
+						if (mobile == null)
+						{
+							attraction = (indiceSideLengthSquare >> 3) - (indiceSideLengthSquare >> 5);
+							attraction -= (rescreator.Location - mcv.Location).LengthSquared / pathDistanceSquareFactor;
+						}
+						else
+						{
+							attraction = (indiceSideLengthSquare >> 2) - (indiceSideLengthSquare >> 4);
+
+							var path = pathfinder.FindPathToTargetCells(mcv, mcv.Location, [rescreator.Location], BlockedByActor.None);
+
+							if (path == PathFinder.NoPath)
+								continue;
+
+							attraction -= path.Count * path.Count / pathDistanceSquareFactor;
+						}
+
+						if (world.FindActorsInCircle(rescreator.CenterPosition, WDist.FromCells(Info.CRCmodeEnemyBaseScanRadius)).Any(a => !a.Disposed
+							&& (player.RelationshipWith(a.Owner) == PlayerRelationship.Enemy)
+							&& a.Info.HasTraitInfo<BuildingInfo>()
+							&& a.Info.HasTraitInfo<SellableInfo>()))
+							attraction -= indiceSideLengthSquare << 4;
+
+						foreach (var (location, isAlly) in crc_refinarylocs)
+						{
+							var sdistance = (rescreator.Location - location).LengthSquared;
+							if (sdistance <= Info.CRCmodeRefineryUnfavorRange * Info.CRCmodeRefineryUnfavorRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						foreach (var (location, isAlly) in crc_conyardlocs)
+						{
+							var sdistance = (rescreator.Location - location).LengthSquared;
+							if (sdistance <= Info.CRCmodeConyardUnfavorRange * Info.CRCmodeConyardUnfavorRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						if (!allowfallback)
+						{
+							var sdistance = (rescreator.Location - mcv.Location).LengthSquared;
+							if (sdistance <= indiceSideLengthSquare)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (attraction > crc_best)
+						{
+							crc_best = attraction;
+							crc_checkspot = rescreator.Location;
+							crc_suitablelocation = rescreator.Location;
+						}
+					}
+
+					return (crc_suitablelocation, crc_best, crc_checkspot);
+
+				default:
+					return (null, int.MinValue, null);
+			}
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			attackrespondcooldown--;
+
+			if (firstTick)
+			{
+				var resourceSum = 0;
+
+				if (resourceMapIndices == null)
+				{
+					var map = world.Map;
+					var actualMapWidth = map.Bounds.Width;
+					var actualMapHeight = map.Bounds.Height;
+					var xoffset = map.Bounds.X;
+					var yoffset = map.Bounds.Y;
+
+					resourceMapIndicesColumnCount = (actualMapWidth + indiceSideLength - 1) / indiceSideLength;
+					resourceMapIndicesRowCount = (actualMapHeight + indiceSideLength - 1) / indiceSideLength;
+
+					var overallIndiceWidth = resourceMapIndicesColumnCount * indiceSideLength;
+					var overallIndiceHeight = resourceMapIndicesRowCount * indiceSideLength;
+
+					xoffset -= (overallIndiceWidth - actualMapWidth) >> 1;
+					yoffset -= (overallIndiceHeight - actualMapHeight) >> 1;
+
+					resourceMapIndices = Exts.MakeArray(resourceMapIndicesColumnCount * resourceMapIndicesRowCount, i => (new MPos(
+						xoffset + i % resourceMapIndicesColumnCount * indiceSideLength + (indiceSideLength >> 1),
+						yoffset + i / resourceMapIndicesColumnCount * indiceSideLength + (indiceSideLength >> 1)).ToCPos(map), 0, CPos.Zero))
+						.Shuffle(world.LocalRandom).ToArray();
+
+					// Note: we can only get map resource data in IBotTick.BotTick, instead of TraitEnabled or Created.
+					for (var i = 0; i < resourceMapIndices.Length; i++)
+					{
+						UpdateResourceMap(i);
+						resourceSum += resourceMapIndices[i].Value;
+					}
+
+					pathDistanceSquareFactor = resourceMapIndicesColumnCount * resourceMapIndicesColumnCount + resourceMapIndicesRowCount * resourceMapIndicesRowCount;
+				}
+
+				// check which mode we should use in map
+				if (Info.InitialExpansionMode == BotMcvExpansionMode.CheckResourceCreator && world.ActorsHavingTrait<SeedsResource>().Any())
+					SwitchExpansionMode(BotMcvExpansionMode.CheckResourceCreator);
+				else if (Info.InitialExpansionMode != BotMcvExpansionMode.CheckBase && resourceSum > 0)
+					SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+				else
+					SwitchExpansionMode(BotMcvExpansionMode.CheckBase);
+
+				DeployMcvs(bot, false);
+				firstTick = false;
+			}
+
+			if (--scanInterval <= 0)
+			{
+				scanInterval = Info.ScanForNewMcvInterval;
+				DeployMcvs(bot, true);
+			}
+
+			if (--buildMCVInterval <= 0)
+			{
+				buildMCVInterval = Info.BuildMcvInterval;
+				BuildMCV(bot);
+			}
+
+			if (--updateResourceMapInterval <= 0)
+			{
+				updateResourceMapInterval = updateResourceMapDelay;
+				UpdateResourceMap(updateResourceMapIndex);
+				updateResourceMapIndex = (updateResourceMapIndex + 1) % resourceMapIndices.Length;
+			}
+
+			if (--moveConyardInterval <= 0)
+			{
+				moveConyardInterval = Info.MoveConyardTick;
+				UnDeployConyard(bot);
+			}
+		}
+
+		void UpdateResourceMap(int index)
+		{
+			if (resourceLayer == null || resourceMapIndices == null || resourceMapIndices.Length == 0)
+				return;
+
+			var sumCellsX = 0;
+			var sumCellsY = 0;
+			var resTiles = world.Map.FindTilesInAnnulus(resourceMapIndices[index].IndiceCenter, 0, indiceResourceScanRadius).Where(c =>
+			{
+				if (!Info.ValidResourceTypes.Contains(resourceLayer.GetResource(c).Type))
+					return false;
+
+				sumCellsX += c.X;
+				sumCellsY += c.Y;
+				return true;
+			}).ToList();
+
+			if (resTiles.Count != 0)
+			{
+				var resAvgCell = new CPos(sumCellsX / resTiles.Count, sumCellsY / resTiles.Count);
+				var bestCell = resTiles[0];
+				var bestDist = (bestCell - resAvgCell).LengthSquared;
+				foreach (var c in resTiles)
+				{
+					var dist = (c - resAvgCell).LengthSquared;
+					if (dist < bestDist)
+					{
+						bestDist = dist;
+						bestCell = c;
+					}
+				}
+
+				resourceMapIndices[index] = (resourceMapIndices[index].IndiceCenter, resTiles.Count, bestCell);
+			}
+			else
+				resourceMapIndices[index] = (resourceMapIndices[index].IndiceCenter, 0, CPos.Zero);
+		}
+
+		void BuildMCV(IBot bot)
+		{
+			if (Info.McvTypes.Count <= 0)
+				return;
+			if (AIUtils.CountActorByCommonName(mcvFactories) <= 0)
+				return;
+			var mcvNum = AIUtils.CountActorByCommonName(mcvs);
+			var conyardNum = AIUtils.CountActorByCommonName(constructionYards);
+
+			// If we only have 1 MCV and no conyard, we should be allowed to build another MCV.
+			// Otherwise, when an mcv is on the move and we should wait.
+			if ((conyardNum <= 0 && mcvNum > 1) || (conyardNum > 0 && mcvNum > 0))
+				return;
+
+			if (conyardNum + mcvNum >= Info.MinimumConstructionYardCount)
+				return;
+
+			// We have MCV in production queue, let's wait.
+			if (mcvFactories.Actors
+				.Any(a => !a.IsDead && a.TraitsImplementing<ProductionQueue>().Any(t => t.Enabled && t.AllQueued().Any(q => Info.McvTypes.Contains(q.Item)))))
+				return;
+
+			// We have MCV in production queue, let's wait.
+			if (player.PlayerActor.TraitsImplementing<ProductionQueue>()
+				.Any(t => t.Enabled && t.AllQueued().Any(q => Info.McvTypes.Contains(q.Item))))
+				return;
+			var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
+			if (unitBuilder == null)
+				return;
+			var mcvType = Info.McvTypes.Random(world.LocalRandom);
+
+			// Make sure we only request one MCV at a time.
+			if (unitBuilder.RequestedProductionCount(bot, mcvType) <= 0)
+				unitBuilder.RequestUnitProduction(bot, mcvType);
+		}
+
+		void DeployMcvs(IBot bot, bool chooseLocation)
+		{
+			var newMCVs = world.ActorsHavingTrait<Transforms>()
+				.Where(a => a.Owner == player && a.IsIdle && Info.McvTypes.Contains(a.Info.Name));
+
+			foreach (var mcv in newMCVs)
+				DeployMcv(bot, mcv, chooseLocation);
+		}
+
+		void UnDeployConyard(IBot bot)
+		{
+			/*
+			 * TODO: Current BaseBuilderBotModule has very weak control of Build Orders, produces randomly and cannot cooperate well.
+			 * Meaning expanding with 1 MCV has terrible performance: necessary buildings always get interrupted and too much time is spent on the road.
+			 *
+			 * Therefore, the current MCV move is simple and conservative.
+			 */
+			if (firstUndeploy)
+			{
+				// On the first undeploy, we want to make sure the bot player is capable of handling an early game rush.
+				if (world.ActorsHavingTrait<Building>().Count(a => a.Owner == player && Info.ProductionTypes.Contains(a.Info.Name)) >= 2
+					&& world.ActorsHavingTrait<Refinery>().Any(a => a.Owner == player && Info.RefineryTypes.Contains(a.Info.Name)))
+				{
+					var idleconyards = constructionYards.Actors.FirstOrDefault(a => !a.IsDead);
+					if (idleconyards != null)
+					{
+						bot.QueueOrder(new Order("DeployTransform", idleconyards, true));
+						allowfallback = false;
+					}
+				}
+
+				firstUndeploy = false;
+				moveConyardInterval = world.LocalRandom.Next(Info.MoveConyardTick, Info.MoveConyardTick * 2);
+			}
+			else
+			{
+				/*
+				 * On regular undeploy, we only consider that the bot always keep a deployed conyard (so this only works with 2 or more conyards at field),
+				 * and moving MCV should never break the production of refinery.
+				 */
+				var conyards = constructionYards.Actors
+					.Where(a => !a.IsDead).OrderBy(a => a.ActorID)
+					.ToList();
+
+				if (conyards.Count > 1)
+				{
+					// We don't want to interrupt refinery production, otherwise it may cause a dead loop of deploy/undeploy.
+					var movableMCV = conyards.FirstOrDefault(a => !a.TraitsImplementing<ProductionQueue>()
+					.Any(t => t.Enabled && t.AllQueued().Any(q => Info.RefineryTypes.Contains(q.Item))));
+
+					if (movableMCV != null)
+						bot.QueueOrder(new Order("DeployTransform", movableMCV, true));
+				}
+			}
+		}
+
+		// Find any MCV and deploy them at a sensible location.
+		void DeployMcv(IBot bot, Actor mcv, bool move)
+		{
+			CPos? desiredLocation = null;
+			var transformsInfo = mcv.Info.TraitInfo<TransformsInfo>();
+			var actorInfo = world.Map.Rules.Actors[transformsInfo.IntoActor];
+			var bi = actorInfo.TraitInfoOrDefault<BuildingInfo>();
+			if (bi == null)
+				return;
+
+			if (move)
+			{
+				desiredLocation = ChooseMcvDeployLocation(mcv, actorInfo, bi, transformsInfo.Offset, allowfallback);
+				if (desiredLocation == null)
+					return;
+
+				bot.QueueOrder(new Order("Move", mcv, Target.FromCell(world, desiredLocation.Value), true));
+
+				allowfallback = true;
+			}
+			else
+			{
+				if (!world.CanPlaceBuilding(mcv.Location + transformsInfo.Offset, actorInfo, bi, mcv))
+					return;
+				desiredLocation = mcv.Location;
+			}
+
+			bot.QueueOrder(new Order("DeployTransform", mcv, true));
+
+			// When we don't have a construction yard, we notify the new location to other traits for defence,
+			// If not, we only notify sometimes, because we are not sure if mcv can successfully deploy at the desired location.
+			// TODO: This could be addressed via INotifyTransform.
+			if (constructionYards.Actors.All(a => a.IsDead) || world.LocalRandom.Next(2) > 0)
+			{
+				foreach (var n in notifyPositionsUpdated)
+				{
+					n.UpdatedBaseCenter(desiredLocation.Value);
+					n.UpdatedDefenseCenter(desiredLocation.Value);
+				}
+			}
+		}
+
+		// First, find a suitable expansion location according to current mode,
+		// Then, find a deployable cell around it.
+		CPos? ChooseMcvDeployLocation(Actor mcv, ActorInfo transformIntoInfo, BuildingInfo transformIntoBuildingInfo, CVec offset, bool allowfallback)
+		{
+			if (!mcv.Info.HasTraitInfo<IMoveInfo>())
+				return null;
+
+			var mobile = mcv.TraitOrDefault<Mobile>();
+
+			var (expandCenter, attraction, checkspot) = GetExpansionCenter(mcv, mobile, allowfallback);
+
+			// Find the deployable cell
+			CPos? FindDeployCell(CPos? sourceCell, CPos? targetCell, int minRange, int maxRange, int tryMaintainRange)
+			{
+				if (!sourceCell.HasValue || !targetCell.HasValue)
+					return null;
+
+				var target = targetCell.Value;
+				var source = sourceCell.Value;
+
+				var cells = world.Map.FindTilesInAnnulus(target, minRange, maxRange);
+
+				/* First, sort the cells that keep tryMaintainRange to target (meanwhile direction is from center to target) the first to be considered
+				 * by using following code. The idea is to use a linear combination of two distances-square for sorting weight.
+				 *
+				 * See comments in https://github.com/OpenRA/OpenRA/pull/22028#issuecomment-3242518793 for explaination.
+				 */
+				if (source != target)
+				{
+					var theta = tryMaintainRange;
+					var deta = (target - source).Length - tryMaintainRange;
+					cells = cells.OrderBy(c => deta * (c - target).LengthSquared + theta * (c - source).LengthSquared);
+				}
+				else
+					cells = cells.Shuffle(world.LocalRandom);
+
+				CPos? bestcell = null;
+				foreach (var cell in cells)
+				{
+					if (world.CanPlaceBuilding(cell + offset, transformIntoInfo, transformIntoBuildingInfo, null))
+					{
+						bestcell = cell;
+						break;
+					}
+				}
+
+				// If no deployble cell found, return null
+				if (bestcell == null)
+					return null;
+
+				if (source != target && mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, source, bestcell.Value))
+					bestcell = null;
+
+				// If the best deploy cell is not ideal ( >= tryMaintainRange + 2), which means there might be some huge blockers
+				// so we fall back to default behavior, which is the directly closest cell to target
+				if (!bestcell.HasValue || (source != target && (bestcell.Value - target).LengthSquared >= (tryMaintainRange + 2) * (tryMaintainRange + 2)))
+				{
+					cells = cells.OrderBy(c => (c - target).LengthSquared);
+					foreach (var cell in cells)
+					{
+						if (world.CanPlaceBuilding(cell + offset, transformIntoInfo, transformIntoBuildingInfo, null))
+						{
+							if (mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, source, cell))
+								return null;
+
+							return (!bestcell.HasValue) || (cell - target).LengthSquared < (bestcell.Value - target).LengthSquared ? cell : bestcell;
+						}
+					}
+				}
+
+				return bestcell;
+			}
+
+			var bc = FindDeployCell(mcv.Location, expandCenter, mcvDeploymentMinDeployRadius, mcvDeploymentMaxDeployRadius, mcvDeploymentTryMaintainRange);
+
+			// At last, if the attraction of the found expansion location is good enough (>0) and deploy cell found,
+			// we consider it as a good expansion, otherwise, we consider it as a bad expansion.
+			if (bc.HasValue && attraction > 0)
+				FindGoodDeploySpot();
+			else
+				FindBadDeploySpot(bc.HasValue ? null : checkspot);
+
+			return bc;
+		}
+
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
+		{
+			if (attackrespondcooldown <= 0 && Info.McvTypes.Contains(self.Info.Name))
+			{
+				attackrespondcooldown = 20;
+
+				DeployMcv(bot, self, false);
+
+				if (AIUtils.CountActorByCommonName(constructionYards) == 0)
+				{
+					foreach (var n in notifyPositionsUpdated)
+						n.UpdatedBaseCenter(self.Location);
+				}
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			mcvs.Dispose();
+			constructionYards.Dispose();
+			mcvFactories.Dispose();
+		}
+	}
+}

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -86,20 +86,22 @@ Player:
 		RequiresCondition: enable-cabal-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
+		MinimumExcessPower: 0
 		MaximumExcessPower: 150
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 5
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 3
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: nuke, nuk2
 		BarracksTypes: pyle, hand
 		VehiclesFactoryTypes: weap, afld
-		ProductionTypes: pyle, hand, weap, afld, hpad
+		ProductionTypes: pyle, hand, weap, afld
+		NewProductionCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValidResourceTypes: Tiberium, BlueTiberium
 		BuildingLimits:
-			proc: 4
 			pyle: 3
 			hand: 3
 			hq: 1
@@ -111,6 +113,7 @@ Player:
 			fix: 1
 			silo: 1
 		BuildingFractions:
+			nuke: 1
 			proc: 20
 			pyle: 5
 			hand: 5
@@ -126,24 +129,33 @@ Player:
 			tmpl: 1
 			fix: 1
 			hpad: 2
+		BuildingDelays:
+			hq: 4000
+			fix: 4000
+			hpad: 4100
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BaseBuilderBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
+		MinimumExcessPower: 0
 		MaximumExcessPower: 150
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 3
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: nuke,nuk2
 		BarracksTypes: pyle,hand
 		VehiclesFactoryTypes: weap,afld
-		ProductionTypes: pyle,hand,weap,afld,hpad
+		ProductionTypes: pyle,hand,weap,afld
+		NewProductionCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValidResourceTypes: Tiberium, BlueTiberium
 		BuildingLimits:
-			proc: 4
 			pyle: 3
 			hand: 3
 			hq: 1
@@ -155,6 +167,7 @@ Player:
 			fix: 1
 			silo: 1
 		BuildingFractions:
+			nuke: 1
 			proc: 17
 			pyle: 2
 			hand: 2
@@ -170,24 +183,33 @@ Player:
 			tmpl: 1
 			sam: 7
 			fix: 1
+		BuildingDelays:
+			hq: 4000
+			fix: 4000
+			hpad: 4100
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BaseBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
+		MinimumExcessPower: 0
 		MaximumExcessPower: 210
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 2
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: nuke,nuk2
 		BarracksTypes: pyle,hand
 		VehiclesFactoryTypes: weap,afld
-		ProductionTypes: pyle,hand,weap,afld,hpad
+		ProductionTypes: pyle,hand,weap,afld
+		NewProductionCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValidResourceTypes: Tiberium, BlueTiberium
 		BuildingLimits:
-			proc: 4
 			pyle: 4
 			hand: 4
 			hq: 1
@@ -199,6 +221,7 @@ Player:
 			fix: 1
 			silo: 1
 		BuildingFractions:
+			nuke: 1
 			proc: 17
 			pyle: 7
 			hand: 9
@@ -214,6 +237,13 @@ Player:
 			tmpl: 1
 			sam: 7
 			fix: 1
+		BuildingDelays:
+			hq: 4000
+			fix: 4000
+			hpad: 4100
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BuildingRepairBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	SquadManagerBotModule@cabal:
@@ -248,11 +278,28 @@ Player:
 			orca: 5
 		UnitLimits:
 			harv: 8
-	McvManagerBotModule:
-		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
+	McvExpansionManagerBotModule@cabal:
+		RequiresCondition: enable-cabal-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap,afld
+		RefineryTypes: proc
+		ProductionTypes: pyle,hand,weap,afld
+		FirstMoveConyardTicks: 4100, 4500, 5000, 5500
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValidResourceTypes: Tiberium, BlueTiberium
+		MinimumConstructionYardCount: 2
+	McvExpansionManagerBotModule@watson-hal9001:
+		RequiresCondition: enable-watson-ai || enable-hal9001-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap,afld
+		RefineryTypes: proc
+		ProductionTypes: pyle,hand,weap,afld
+		FirstMoveConyardTicks: 4100, 4500, 5000, 5500
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValidResourceTypes: Tiberium, BlueTiberium
+		MinimumConstructionYardCount: 1
 	SquadManagerBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		SquadSize: 15

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -82,6 +82,7 @@ Player:
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4
@@ -141,6 +142,7 @@ Player:
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4
@@ -198,6 +200,7 @@ Player:
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -80,7 +80,7 @@ Player:
 		RefineryTypes: proc
 	BaseBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 160
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
@@ -90,29 +90,32 @@ Player:
 		BarracksTypes: barr,tent
 		VehiclesFactoryTypes: weap
 		ProductionTypes: barr,tent,weap
+		NewProductionCashThreshold: 7000
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
 		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
+			barr: 4
+			tent: 4
 			kenn: 1
 			dome: 1
-			weap: 1
+			weap: 4
 			atek: 1
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 30
-			barr: 1
+			powr: 1
+			proc: 25
+			barr: 3
 			kenn: 1
-			tent: 1
-			weap: 1
-			pbox: 7
-			gun: 7
-			tsla: 5
-			gap: 2
-			ftur: 10
+			tent: 3
+			weap: 4
+			pbox: 3
+			gun: 3
+			tsla: 3
+			gap: 1
+			ftur: 3
 			agun: 5
 			sam: 5
 			atek: 1
@@ -121,10 +124,18 @@ Player:
 			dome: 10
 			mslo: 1
 		BuildingDelays:
-			dome: 4500
+			dome: 7000
+			fix: 3000
+			pbox: 2000
+			gun: 3000
+			ftur: 2000
+			tsla: 3000
+			kenn: 9000
+			atek: 11000
+			stek: 11000
 	BaseBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 200
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
@@ -134,15 +145,17 @@ Player:
 		BarracksTypes: barr,tent
 		VehiclesFactoryTypes: weap
 		ProductionTypes: barr,tent,weap,afld,hpad
+		NewProductionCashThreshold: 8000
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
 		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
+			barr: 4
+			tent: 4
 			dome: 1
-			weap: 1
+			weap: 4
 			spen: 1
 			syrd: 1
 			hpad: 4
@@ -152,19 +165,20 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 15
-			tent: 1
-			barr: 1
+			powr: 1
+			proc: 24
+			tent: 3
+			barr: 3
 			kenn: 1
 			dome: 1
-			weap: 6
-			hpad: 4
+			weap: 4
+			hpad: 1
 			spen: 1
 			syrd: 1
-			afld: 4
-			afld.ukraine: 4
-			pbox: 7
-			gun: 7
+			afld: 1
+			afld.ukraine: 1
+			pbox: 9
+			gun: 9
 			ftur: 10
 			tsla: 5
 			gap: 2
@@ -175,13 +189,23 @@ Player:
 			stek: 1
 			mslo: 1
 		BuildingDelays:
-			dome: 3000
+			dome: 6000
+			fix: 3000
+			pbox: 1500
+			gun: 2000
+			ftur: 1500
+			tsla: 2800
+			kenn: 7000
+			spen: 6000
+			syrd: 6000
+			atek: 9000
+			stek: 9000
 	BaseBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 20
 		MaximumExcessPower: 250
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncrement: 20
+		ExcessPowerIncreaseThreshold: 2
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr,apwr
@@ -191,8 +215,9 @@ Player:
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
 		BuildingLimits:
-			proc: 4
 			barr: 1
 			tent: 1
 			kenn: 1
@@ -207,7 +232,8 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 30
+			powr: 1
+			proc: 23
 			tent: 1
 			barr: 1
 			kenn: 1
@@ -217,9 +243,9 @@ Player:
 			afld.ukraine: 2
 			spen: 1
 			syrd: 1
-			pbox: 10
-			gun: 10
-			ftur: 10
+			pbox: 13
+			gun: 12
+			ftur: 13
 			tsla: 7
 			gap: 3
 			fix: 1
@@ -230,13 +256,16 @@ Player:
 			stek: 1
 			mslo: 1
 		BuildingDelays:
-			dome: 3000
+			dome: 5000
+			atek: 7000
+			stek: 7000
+			kenn: 8000
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 400
 		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncreaseThreshold: 3
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr,apwr
@@ -246,6 +275,8 @@ Player:
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
 		BuildingLimits:
 			proc: 3
 			dome: 1
@@ -261,6 +292,7 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
+			powr: 1
 			proc: 25
 			dome: 1
 			weap: 1
@@ -283,6 +315,7 @@ Player:
 			dome: 3000
 			fix: 20000
 			tsla: 21000
+			kenn: 4000
 	PowerDownBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		PowerDownTypes: dome,tsla,mslo,agun,sam
@@ -298,11 +331,33 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
-	McvManagerBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	McvManagerBotModule@naval:
+		RequiresCondition: enable-naval-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap
+	McvExpansionManagerBotModule@rush-normal:
+		RequiresCondition: enable-rush-ai || enable-normal-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		RefineryTypes: proc
+		ProductionTypes: barr,tent,weap
+		FirstMoveConyardTicks: 4200
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
+		MinimumConstructionYardCount: 2
+	McvExpansionManagerBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		RefineryTypes: proc
+		ProductionTypes: barr,tent,weap
+		ResourceCreatorTypes: mine, gmine
+		ValidResourceTypes: Ore, Gems
+		MoveConyardTick: 5500
+		MinimumConstructionYardCount: 2
 	UnitBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		UnitsToBuild:
@@ -386,8 +441,11 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
+		RushInterval: 100000
+		MinimumAttackForceDelay: 100000
 	UnitBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
+		ProductionMinCashRequirement: 1000
 		UnitsToBuild:
 			e1: 65
 			e2: 15
@@ -418,9 +476,9 @@ Player:
 			pt: 10
 			mnly: 2
 		UnitLimits:
-			dog: 4
+			dog: 3
 			harv: 8
-			jeep: 4
+			jeep: 2
 			ftrk: 4
 			mnly: 2
 	MinelayerBotModule@turtle:

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -23,6 +23,9 @@ Player:
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
 		SiloTypes: gasilo
 		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		ResourceCreatorTypes: tibtre01, tibtre02, tibtre03, bigblue, bigblue3
+		ValidResourceTypes: BlueTiberium, Tiberium, Veins
+		SellRefineryNoResourceDistance: 18
 		BuildingLimits:
 			proc: 4
 			gasilo: 2
@@ -105,8 +108,14 @@ Player:
 			harv: 12
 			medic: 3
 			repair: 3
-	McvManagerBotModule@test:
+	McvExpansionManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		McvTypes: mcv
 		ConstructionYardTypes: gacnst
 		McvFactoryTypes: gaweap, naweap
+		ProductionTypes: gapile, nahand, gaweap, naweap
+		RefineryTypes: proc
+		FirstMoveConyardTicks: 6000
+		MinimumConstructionYardCount: 2
+		ResourceCreatorTypes: tibtre01, tibtre02, tibtre03, bigblue, bigblue3
+		ValidResourceTypes: BlueTiberium, Tiberium, Veins


### PR DESCRIPTION
Supersede #17679

<img width="1877" height="1021" alt="image" src="https://github.com/user-attachments/assets/cedfdc47-b84c-4aff-a58f-b72d11070df9" />

Intrudoce `McvExpansionManagerBotModule`, to accurately expand MCV to near resources.
This bot module has 3 modes to handle different situations:

1. CheckResourceCreator mode (CRC mode): pick location by check the resource creator on map. (Most accurate and perf friendly)

2. CheckResource mode (CR mode): pick location by check the resource tiles on map. (Less accurate and more costly, but can save the day when there is no resource creator for CRC mode). 

3. CheckBase mode (CB mode): pick location by check the near point for expanding base only. (If someone makes map that contains no resource, this mode will do)

Here is also the test version (test on different expansion modes with visualize expansion point)
https://github.com/dnqbob/OpenRA/tree/bot-mcv-expansion-test
<img width="584" height="280" alt="image" src="https://github.com/user-attachments/assets/e7c59c36-99f8-4598-93f3-b329efce26c0" />
