### PR TITLE
AI: Protection squad store idle units, Rework ProtectUnitScanRadius to search squad

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -117,6 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly World World;
 		public readonly Player Player;
+		const int AttackRespondCoolDown = 20;
 
 		readonly Predicate<Actor> unitCannotBeOrdered;
 		Squad protectionSquad;
@@ -136,6 +137,7 @@ namespace OpenRA.Mods.Common.Traits
 		int assignRolesTicks;
 		int attackForceTicks;
 		int minAttackForceDelayTicks;
+		int attackrespondcooldown = AttackRespondCoolDown;
 
 		public SquadManagerBotModule(Actor self, SquadManagerBotModuleInfo info)
 			: base(info)
@@ -201,6 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotTick.BotTick(IBot bot)
 		{
+			attackrespondcooldown--;
 			AssignRolesToIdleUnits(bot);
 		}
 
@@ -469,8 +472,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
-			if (!IsPreferredEnemyUnit(e.Attacker))
+			if (attackrespondcooldown > 0 || !IsPreferredEnemyUnit(e.Attacker))
 				return;
+
+			attackrespondcooldown = AttackRespondCoolDown;
 
 			if (Info.ProtectionTypes.Contains(self.Info.Name))
 			{
@@ -479,6 +484,16 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (protectionSquad.IsValid && !protectionSquad.IsTargetValid(protectionSquad.CenterUnit()))
 					protectionSquad.SetActorToTarget((e.Attacker, WVec.Zero));
+			}
+
+			foreach (var s in Squads)
+			{
+				if (s.IsValid)
+				{
+					var centerUnit = s.CenterUnit();
+					if (centerUnit != null && (centerUnit.Location - e.Attacker.Location).LengthSquared <= Info.ProtectUnitScanRadius * Info.ProtectUnitScanRadius)
+						s.SetActorToTarget((e.Attacker, WVec.Zero));
+				}
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -119,11 +119,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Player Player;
 
 		readonly Predicate<Actor> unitCannotBeOrdered;
-		readonly List<Actor> unitsHangingAroundTheBase = [];
+		Squad protectionSquad;
 
 		// Units that the bot already knows about. Any unit not on this list needs to be given a role.
-		readonly HashSet<Actor> activeUnits = [];
-
 		public List<Squad> Squads = [];
 		readonly Stack<Squad> squadsPendingUpdate = [];
 		readonly ActorIndex.NamesAndTrait<BuildingInfo> constructionYardBuildings;
@@ -198,6 +196,7 @@ namespace OpenRA.Mods.Common.Traits
 		void IBotEnabled.BotEnabled(IBot bot)
 		{
 			this.bot = bot;
+			protectionSquad = new Squad(bot, this, SquadType.Protection);
 		}
 
 		void IBotTick.BotTick(IBot bot)
@@ -319,24 +318,18 @@ namespace OpenRA.Mods.Common.Traits
 			return ret;
 		}
 
-		internal void UnregisterSquad(Squad squad)
-		{
-			activeUnits.ExceptWith(squad.Units);
-			squad.Units.Clear();
-
-			// CleanSquads will remove the squad from the Squads list.
-			// We can't do that here as this is designed to be called from within Squad.Update
-			// and thus would mutate the Squads list we are iterating over.
-		}
+		// CleanSquads will remove the squad from the Squads list.
+		// We can't do that here as this is designed to be called from within Squad.Update
+		// and thus would mutate the Squads list we are iterating over.
+		internal static void UnregisterSquad(Squad squad) => squad.Units.Clear();
 
 		void AssignRolesToIdleUnits(IBot bot)
 		{
 			CleanSquads();
 
-			activeUnits.RemoveWhere(unitCannotBeOrdered);
-			unitsHangingAroundTheBase.RemoveAll(unitCannotBeOrdered);
+			protectionSquad.Units.RemoveWhere(unitCannotBeOrdered);
 			foreach (var n in notifyIdleBaseUnits)
-				n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+				n.UpdatedIdleBaseUnits(protectionSquad.Units);
 
 			if (--rushTicks <= 0)
 			{
@@ -347,6 +340,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (--attackForceTicks <= 0)
 			{
 				attackForceTicks = Info.AttackForceInterval;
+
+				squadsPendingUpdate.Push(protectionSquad);
 				foreach (var s in Squads)
 					squadsPendingUpdate.Push(s);
 			}
@@ -378,7 +373,7 @@ namespace OpenRA.Mods.Common.Traits
 			var newUnits = World.ActorsHavingTrait<IPositionable>()
 				.Where(a => a.Owner == Player &&
 					!Info.ExcludeFromSquadsTypes.Contains(a.Info.Name) &&
-					!activeUnits.Contains(a));
+					!protectionSquad.Units.Contains(a));
 
 			foreach (var a in newUnits)
 			{
@@ -397,14 +392,12 @@ namespace OpenRA.Mods.Common.Traits
 					ships.Units.Add(a);
 				}
 				else
-					unitsHangingAroundTheBase.Add(a);
-
-				activeUnits.Add(a);
+					protectionSquad.Units.Add(a);
 			}
 
 			// Notifying here rather than inside the loop, should be fine and saves a bunch of notification calls
 			foreach (var n in notifyIdleBaseUnits)
-				n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+				n.UpdatedIdleBaseUnits(protectionSquad.Units);
 		}
 
 		void CreateAttackForce(IBot bot)
@@ -413,38 +406,29 @@ namespace OpenRA.Mods.Common.Traits
 			// (don't bother leaving any behind for defense)
 			var randomizedSquadSize = Info.SquadSize + World.LocalRandom.Next(Info.SquadSizeRandomBonus);
 
-			if (unitsHangingAroundTheBase.Count >= randomizedSquadSize)
+			if (protectionSquad.Units.Count >= randomizedSquadSize)
 			{
 				var attackForce = RegisterNewSquad(bot, SquadType.Assault);
 
-				attackForce.Units.UnionWith(unitsHangingAroundTheBase);
+				attackForce.Units.UnionWith(protectionSquad.Units);
 
-				unitsHangingAroundTheBase.Clear();
+				protectionSquad.Units.Clear();
 				foreach (var n in notifyIdleBaseUnits)
-					n.UpdatedIdleBaseUnits(unitsHangingAroundTheBase);
+					n.UpdatedIdleBaseUnits(protectionSquad.Units);
 			}
 		}
 
 		void TryToRushAttack(IBot bot)
 		{
-			var ownUnits = activeUnits
-				.Where(unit =>
-					unit.IsIdle
-					&& unit.Info.HasTraitInfo<AttackBaseInfo>()
-					&& !Info.AirUnitsTypes.Contains(unit.Info.Name)
-					&& !Info.NavalUnitsTypes.Contains(unit.Info.Name)
-					&& !Info.ExcludeFromSquadsTypes.Contains(unit.Info.Name))
-				.ToList();
-
-			if (ownUnits.Count < Info.SquadSize)
+			if (protectionSquad.Units.Count < Info.SquadSize)
 				return;
 
 			var allEnemyBaseBuilder = FindEnemies(
 				constructionYardBuildings.Actors,
-				ownUnits[0])
+				protectionSquad.Units.First())
 				.ToList();
 
-			if (allEnemyBaseBuilder.Count == 0 || ownUnits.Count < Info.SquadSize)
+			if (allEnemyBaseBuilder.Count == 0 || protectionSquad.Units.Count < Info.SquadSize)
 				return;
 
 			foreach (var enemyBaseBuilder in allEnemyBaseBuilder)
@@ -456,41 +440,23 @@ namespace OpenRA.Mods.Common.Traits
 							unit.Info.HasTraitInfo<AttackBaseInfo>()
 							&& !Info.AirUnitsTypes.Contains(unit.Info.Name)
 							&& !Info.NavalUnitsTypes.Contains(unit.Info.Name)),
-					ownUnits[0])
+					protectionSquad.Units.First())
 					.ToList();
 
-				if (AttackOrFleeFuzzy.Rush.CanAttack(ownUnits, enemies.ConvertAll(x => x.Actor)))
+				if (AttackOrFleeFuzzy.Rush.CanAttack(protectionSquad.Units, enemies.ConvertAll(x => x.Actor)))
 				{
 					var target = enemies.Count > 0 ? enemies.Random(World.LocalRandom) : enemyBaseBuilder;
 					var rush = GetSquadOfType(SquadType.Rush);
 					rush ??= RegisterNewSquad(bot, SquadType.Rush, target);
 
-					rush.Units.UnionWith(ownUnits);
+					rush.Units.UnionWith(protectionSquad.Units);
+					protectionSquad.Units.Clear();
+
+					foreach (var n in notifyIdleBaseUnits)
+						n.UpdatedIdleBaseUnits(protectionSquad.Units);
 
 					return;
 				}
-			}
-		}
-
-		void ProtectOwn(IBot bot, Actor attacker)
-		{
-			var protectSq = GetSquadOfType(SquadType.Protection);
-			protectSq ??= RegisterNewSquad(bot, SquadType.Protection, (attacker, WVec.Zero));
-			protectSq.Units.RemoveWhere(unitCannotBeOrdered);
-
-			if (protectSq.IsValid && !protectSq.IsTargetValid(protectSq.CenterUnit()))
-				protectSq.SetActorToTarget((attacker, WVec.Zero));
-
-			if (!protectSq.IsValid)
-			{
-				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(GetRandomBaseCenter()), WDist.FromCells(Info.ProtectUnitScanRadius))
-					.Where(unit =>
-						unit.Owner == Player
-						&& !Info.ProtectionTypes.Contains(unit.Info.Name)
-						&& unit.Info.HasTraitInfo<AttackBaseInfo>())
-					.WithPathTo(World, attacker.CenterPosition);
-
-				protectSq.Units.UnionWith(ownUnits);
 			}
 		}
 
@@ -511,7 +477,8 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var n in notifyPositionsUpdated)
 					n.UpdatedDefenseCenter(e.Attacker.Location);
 
-				ProtectOwn(bot, e.Attacker);
+				if (protectionSquad.IsValid && !protectionSquad.IsTargetValid(protectionSquad.CenterUnit()))
+					protectionSquad.SetActorToTarget((e.Attacker, WVec.Zero));
 			}
 		}
 
@@ -524,11 +491,7 @@ namespace OpenRA.Mods.Common.Traits
 			[
 				new("Squads", "", Squads.ConvertAll(s => new MiniYamlNode("Squad", s.Serialize()))),
 				new("InitialBaseCenter", FieldSaver.FormatValue(initialBaseCenter)),
-				new("UnitsHangingAroundTheBase", FieldSaver.FormatValue(unitsHangingAroundTheBase
-					.Where(a => !unitCannotBeOrdered(a))
-					.Select(a => a.ActorID)
-					.ToArray())),
-				new("ActiveUnits", FieldSaver.FormatValue(activeUnits
+				new("UnitsHangingAroundTheBase", FieldSaver.FormatValue(protectionSquad.Units
 					.Where(a => !unitCannotBeOrdered(a))
 					.Select(a => a.ActorID)
 					.ToArray())),
@@ -551,15 +514,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (nodes.TryGetValue("UnitsHangingAroundTheBase", out var unitsHangingAroundTheBaseNode))
 			{
-				unitsHangingAroundTheBase.Clear();
-				unitsHangingAroundTheBase.AddRange(FieldLoader.GetValue<uint[]>("UnitsHangingAroundTheBase", unitsHangingAroundTheBaseNode.Value)
-					.Select(self.World.GetActorById).Where(a => a != null));
-			}
-
-			if (nodes.TryGetValue("ActiveUnits", out var activeUnitsNode))
-			{
-				activeUnits.Clear();
-				activeUnits.UnionWith(FieldLoader.GetValue<uint[]>("ActiveUnits", activeUnitsNode.Value)
+				protectionSquad.Units.Clear();
+				protectionSquad.Units.Union(FieldLoader.GetValue<uint[]>("UnitsHangingAroundTheBase", unitsHangingAroundTheBaseNode.Value)
 					.Select(self.World.GetActorById).Where(a => a != null));
 			}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -265,6 +265,6 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsIdleState());
 		}
 
-		public void Deactivate(Squad owner) { owner.SquadManager.UnregisterSquad(owner); }
+		public void Deactivate(Squad owner) { SquadManagerBotModule.UnregisterSquad(owner); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -16,7 +16,12 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 	sealed class UnitsForProtectionIdleState : GroundStateBase, IState
 	{
 		public void Activate(Squad owner) { }
-		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState()); }
+		public void Tick(Squad owner)
+		{
+			if (owner.IsValid)
+				owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState());
+		}
+
 		public void Deactivate(Squad owner) { }
 	}
 
@@ -71,10 +76,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			GoToRandomOwnBuilding(owner);
+			GoToRandomOwnBuilding(owner, "AttackMove");
 			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleState());
 		}
 
-		public void Deactivate(Squad owner) { owner.SquadManager.UnregisterSquad(owner); }
+		public void Deactivate(Squad owner) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -19,11 +19,11 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
 	abstract class StateBase
 	{
-		protected static void GoToRandomOwnBuilding(Squad squad)
+		protected static void GoToRandomOwnBuilding(Squad squad, string order = "Move")
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+				squad.Bot.QueueOrder(new Order(order, a, Target.FromCell(squad.World, loc), false));
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
-		void IBotNotifyIdleBaseUnits.UpdatedIdleBaseUnits(List<Actor> idleUnits)
+		void IBotNotifyIdleBaseUnits.UpdatedIdleBaseUnits(HashSet<Actor> idleUnits)
 		{
 			idleUnitCount = idleUnits.Count;
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -618,7 +618,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface IBotNotifyIdleBaseUnits
 	{
-		void UpdatedIdleBaseUnits(List<Actor> idleUnits);
+		void UpdatedIdleBaseUnits(HashSet<Actor> idleUnits);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
This is to solve 
1. when units are not around conyard, they won't join protection squad, unless  ProtectUnitScanRadius is ridiculous high.
<img width="771" height="455" alt="reason" src="https://github.com/user-attachments/assets/25fc89f7-b20f-4dbe-812f-bc2213fc5cb8" />

2. protection squad always contain units from other squad, causing unit behaviours mess up between 2 squad targets.

It brings additional benefits, which removes duplicated storage from ActiveUnits, allow units unregistered from Rush and Assault squads works as idle units.