### PR TITLE
Tiberium damage causes NullReferenceException

### DIFF
--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -150,6 +150,7 @@
 
 World:
 	Inherits: ^BaseWorld
+	AlwaysVisible:
 	ChatCommands:
 	DevCommands:
 	DebugVisualizationCommands:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -233,6 +233,7 @@
 
 World:
 	Inherits: ^BaseWorld
+	AlwaysVisible: 
 	ChatCommands:
 	DevCommands:
 	AutoSave:


### PR DESCRIPTION
Any tiberium damage causes NullReferenceException with stack trace as follows:

Exception of type System.NullReferenceException: Object reference not set to an instance of an object.
   at OpenRA.Actor.CanBeViewedByPlayer(Player player) in /home/user/Programming/git/OpenRA/OpenRA.Game/Actor.cs:line 507
   at OpenRA.Mods.Common.Traits.AutoTarget.OpenRA.Mods.Common.Traits.INotifyDamage.Damaged(Actor self, AttackInfo e) in /home/user/Programming/git/OpenRA/OpenRA.Mods.Common/Traits/AutoTarget.cs:line 244
   at OpenRA.Mods.Common.Traits.Health.InflictDamage(Actor self, Actor attacker, Damage damage, Boolean ignoreModifiers) in /home/user/Programming/git/OpenRA/OpenRA.Mods.Common/Traits/Health.cs:line 200
   at OpenRA.Actor.InflictDamage(Actor attacker, Damage damage) in /home/user/Programming/git/OpenRA/OpenRA.Game/Actor.cs:line 489
   at OpenRA.Mods.Common.Traits.DamagedByTerrain.OpenRA.Traits.ITick.Tick(Actor self) in /home/user/Programming/git/OpenRA/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs:line 59
   at OpenRA.World.<>c.<Tick>b__113_0(Actor actor, ITick trait) in /home/user/Programming/git/OpenRA/OpenRA.Game/World.cs:line 461
   at OpenRA.TraitDictionary.TraitContainer'1.ApplyToAllTimed(Action'2 action, String text) in /home/user/Programming/git/OpenRA/OpenRA.Game/TraitDictionary.cs:line 322
   at OpenRA.TraitDictionary.ApplyToActorsWithTraitTimed[T](Action'2 action, String text) in /home/user/Programming/git/OpenRA/OpenRA.Game/TraitDictionary.cs:line 134
   at OpenRA.World.ApplyToActorsWithTraitTimed[T](Action'2 action, String text) in /home/user/Programming/git/OpenRA/OpenRA.Game/World.cs:line 534
   at OpenRA.World.Tick() in /home/user/Programming/git/OpenRA/OpenRA.Game/World.cs:line 461
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in /home/user/Programming/git/OpenRA/OpenRA.Game/Game.cs:line 661
   at OpenRA.Game.LogicTick() in /home/user/Programming/git/OpenRA/OpenRA.Game/Game.cs:line 685
   at OpenRA.Game.Loop() in /home/user/Programming/git/OpenRA/OpenRA.Game/Game.cs:line 857
   at OpenRA.Game.Run() in /home/user/Programming/git/OpenRA/OpenRA.Game/Game.cs:line 910
   at OpenRA.Game.InitializeAndRun(String[] args) in /home/user/Programming/git/OpenRA/OpenRA.Game/Game.cs:line 339
   at OpenRA.Launcher.Program.Main(String[] args) in /home/user/Programming/git/OpenRA/OpenRA.Launcher/Program.cs:line 46

This PR aims to fix that problem. 