### PR TITLE
Protection squad use idle unit instead of unit around conyard

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -56,7 +56,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				Backoff--;
 			}
 			else
+			{
 				owner.Bot.QueueOrder(new Order("AttackMove", null, owner.Target, false, groupedActors: owner.Units.ToArray()));
+				Backoff = BackoffTicks;
+			}
 		}
 
 		public void Deactivate(Squad owner) { }


### PR DESCRIPTION
Avoid Protection squad takes other squad members, instead we make the target to be all squad target within Info.ProtectUnitScanRadius.