### PR TITLE
Don't count refunds as income and deduct them from expenses.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!self.IsInWorld || self.IsDead)
 				{
-					owner.PlayerActor.Trait<PlayerResources>().GiveCash(refundableValue);
+					owner.PlayerActor.Trait<PlayerResources>().RefundCash(refundableValue);
 					return;
 				}
 
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (!self.IsInWorld || self.IsDead)
 					{
-						owner.PlayerActor.Trait<PlayerResources>().GiveCash(refundableValue);
+						owner.PlayerActor.Trait<PlayerResources>().RefundCash(refundableValue);
 						return;
 					}
 

--- a/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
@@ -291,8 +291,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				foreach (var actorData in ActorsReadyForDelivery)
 				{
-					playerResources.GiveResources(actorData.Resources);
-					playerResources.GiveCash(actorData.Cash);
+					playerResources.RefundResources(actorData.Resources);
+					playerResources.RefundCash(actorData.Cash);
 				}
 
 				ActorsReadyForDelivery.Clear();
@@ -304,8 +304,8 @@ namespace OpenRA.Mods.Common.Traits
 				var actor = ActorsReadyForDelivery.LastOrDefault(actor => actor.Actor.Name == itemName);
 				if (actor.Actor == null)
 					break;
-				playerResources.GiveResources(actor.Resources);
-				playerResources.GiveCash(actor.Cash);
+				playerResources.RefundResources(actor.Resources);
+				playerResources.RefundCash(actor.Cash);
 				ActorsReadyForDelivery.Remove(actor);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -191,11 +191,11 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (item.ResourcesPaid > 0)
 				{
-					playerResources.GiveResources(item.ResourcesPaid);
+					playerResources.RefundResources(item.ResourcesPaid);
 					item.RemainingCost += item.ResourcesPaid;
 				}
 
-				playerResources.GiveCash(item.TotalCost - item.RemainingCost);
+				playerResources.RefundCash(item.TotalCost - item.RemainingCost);
 			}
 
 			Queue.Clear();
@@ -383,12 +383,12 @@ namespace OpenRA.Mods.Common.Traits
 				// Refund spent resources
 				if (Queue[i].ResourcesPaid > 0)
 				{
-					playerResources.GiveResources(Queue[i].ResourcesPaid);
+					playerResources.RefundResources(Queue[i].ResourcesPaid);
 					Queue[i].RemainingCost += Queue[i].ResourcesPaid;
 				}
 
 				// Refund what's been paid so far
-				playerResources.GiveCash(Queue[i].TotalCost - Queue[i].RemainingCost);
+				playerResources.RefundCash(Queue[i].TotalCost - Queue[i].RemainingCost);
 				EndProduction(Queue[i]);
 				cancelledAnItem = true;
 			}
@@ -592,11 +592,11 @@ namespace OpenRA.Mods.Common.Traits
 					// Refund what has been paid
 					if (item.ResourcesPaid > 0)
 					{
-						playerResources.GiveResources(item.ResourcesPaid);
+						playerResources.RefundResources(item.ResourcesPaid);
 						item.RemainingCost += item.ResourcesPaid;
 					}
 
-					playerResources.GiveCash(item.TotalCost - item.RemainingCost);
+					playerResources.RefundCash(item.TotalCost - item.RemainingCost);
 					EndProduction(item);
 				}
 
@@ -649,11 +649,11 @@ namespace OpenRA.Mods.Common.Traits
 				// Refund what has been paid
 				if (queued[i].ResourcesPaid > 0)
 				{
-					playerResources.GiveResources(queued[i].ResourcesPaid);
+					playerResources.RefundResources(queued[i].ResourcesPaid);
 					queued[i].RemainingCost += queued[i].ResourcesPaid;
 				}
 
-				playerResources.GiveCash(queued[i].TotalCost - queued[i].RemainingCost);
+				playerResources.RefundCash(queued[i].TotalCost - queued[i].RemainingCost);
 				EndProduction(queued[i]);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!self.IsInWorld || self.IsDead)
 				{
-					owner.PlayerActor.Trait<PlayerResources>().GiveCash(refundableValue);
+					owner.PlayerActor.Trait<PlayerResources>().RefundCash(refundableValue);
 					return;
 				}
 
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (!self.IsInWorld || self.IsDead)
 					{
-						owner.PlayerActor.Trait<PlayerResources>().GiveCash(refundableValue);
+						owner.PlayerActor.Trait<PlayerResources>().RefundCash(refundableValue);
 						return;
 					}
 


### PR DESCRIPTION
Currently when production of something is cancelled (either by the player or because it's no longer available), you are refunded the cash, and this cash both counts towards income (shown as earnings/income in replays) and also remains counted towards spending (similarly shown in replays).

This change adds an "isRefund" argument to GiveCash and GiveResources which is set to true when called by cancelled production, which prevents them being counted towards earnings, and deducts from spending.