### PR TITLE
Log exceptions for dedicated servers

### DIFF
--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -27,8 +27,10 @@ namespace OpenRA.Server
 			{
 				Run(args);
 			}
-			catch
+			catch (Exception e)
 			{
+				ExceptionHandler.HandleFatalError(e);
+
 				// Flush logs before rethrowing, i.e. allowing the exception to go unhandled.
 				// try-finally won't work - an unhandled exception kills our process without running the finally block!
 				Log.Dispose();


### PR DESCRIPTION
When you don't run your server in an environment where the standard output is logged, there is no way to see stack traces. This adds `exception-$TIMESTAMP.log` files like we have for the client.