### PR TITLE
Replace ProfileID(White|Black)list with a dynamic ProfileIDFilterURL.

### DIFF
--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Network
 			ModWebsite = manifest.Metadata.Website;
 			ModIcon32 = manifest.Metadata.WebIcon32;
 			Protected = !string.IsNullOrEmpty(server.Settings.Password);
-			Authentication = server.Settings.RequireAuthentication || server.Settings.ProfileIDWhitelist.Length > 0;
+			Authentication = server.Settings.RequireAuthentication;
 			Clients = server.LobbyInfo.Clients.Select(c => new GameClient(c)).ToArray();
 			DisabledSpawnPoints = server.LobbyInfo.DisabledSpawnPoints?.ToArray() ?? [];
 		}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -71,14 +71,13 @@ namespace OpenRA
 		[Desc("Takes a comma separated list of IP addresses that are not allowed to join.")]
 		public string[] Ban = [];
 
-		[Desc("For dedicated servers only, allow anonymous clients to join.")]
+		[Desc("For dedicated servers only, controls whether anonymous clients can join.")]
 		public bool RequireAuthentication = false;
 
-		[Desc("For dedicated servers only, if non-empty, only allow authenticated players with these profile IDs to join.")]
-		public int[] ProfileIDWhitelist = [];
-
-		[Desc("For dedicated servers only, if non-empty, always reject players with these user IDs from joining.")]
-		public int[] ProfileIDBlacklist = [];
+		[Desc(
+			"For dedicated servers with RequireAuthentication only, query this URL with a clients ProfileID " +
+			"to determine whether they should be blocked or promoted to game admin.")]
+		public string ProfileIDFilterURL = null;
 
 		[Desc("For dedicated servers only, controls whether a game can be started with just one human player in the lobby.")]
 		public bool EnableSingleplayer = false;

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -12,8 +12,7 @@ set Password=""
 set RecordReplays=False
 
 set RequireAuthentication=False
-set ProfileIDBlacklist=""
-set ProfileIDWhitelist=""
+set ProfileIDFilterURL=""
 
 set EnableSingleplayer=False
 set EnableSyncReports=False
@@ -27,6 +26,6 @@ set SupportDir=""
 
 :loop
 
-bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.Map=%Map% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AdvertiseOnLocalNetwork=%AdvertiseOnLocalNetwork% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Server.FloodLimitJoinCooldown=%FloodLimitJoinCooldown% Engine.SupportDir=%SupportDir%
+bin\OpenRA.Server.exe Engine.EngineDir=".." Game.Mod=%Mod% Server.Name=%Name% Server.Map=%Map% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AdvertiseOnLocalNetwork=%AdvertiseOnLocalNetwork% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDFilterURL=%ProfileIDFilterURL% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.EnableLintChecks=%EnableLintChecks% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Server.FloodLimitJoinCooldown=%FloodLimitJoinCooldown% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -20,8 +20,7 @@ Password="${Password:-""}"
 RecordReplays="${RecordReplays:-"False"}"
 
 RequireAuthentication="${RequireAuthentication:-"False"}"
-ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
-ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
+ProfileIDFilterURL="${ProfileIDFilterURL:-""}"
 
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
@@ -44,8 +43,7 @@ while true; do
      Server.Password="$Password" \
      Server.RecordReplays="$RecordReplays" \
      Server.RequireAuthentication="$RequireAuthentication" \
-     Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
-     Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+     Server.ProfileIDFilterURL="$ProfileIDFilterURL" \
      Server.EnableSyncReports="$EnableSyncReports" \
      Server.EnableGeoIP="$EnableGeoIP" \
      Server.EnableLintChecks="$EnableLintChecks" \


### PR DESCRIPTION
The `ProfileIDBlacklist` and `ProfileIDWhitelist` parameters are limited by the requirement of having to restart the server to update them. These are replaced by a thirdparty REST API that the server will query every time the player joins. Making this a public url gives server operators the ability to pool their moderation resources and form a community blocklist.

This also includes the ability to force specific users to become admin (looking ahead to a future with #17659)

Example server:

```python
import requests
from flask import Flask

ADMIN_PROFILE_IDS = []

# Point this towards a community hosted file that can be trivially updated to block malicious actors
# Sleipnir and Punsho have been naughty
BLOCKLIST_URL = 'https://gist.githubusercontent.com/pchote/c3126734b13ce6603df87dbfb1cc74d9/raw/f5e7bd696bb6dcf735dcfc7732b8270b27d7fb53/blocklist.txt'

app = Flask(__name__)
@app.route('/<int:profile_id>')
def validate(profile_id):
    if profile_id in ADMIN_PROFILE_IDS:
        return 'admin'

    try:
        if profile_id in [int(x) for x in requests.get(BLOCKLIST_URL).text.split(',')]:
            return 'block'
    except:
        pass

    return 'accept'
```