### PR TITLE
Fix aircraft failing to reload

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -134,11 +134,15 @@ namespace OpenRA.Mods.Common.Activities
 				if (source == AttackSource.AttackMove)
 					return true;
 
-				// AbortOnResupply cancels the current activity (after resupplying) plus any queued activities
 				if (attackAircraft.Info.AbortOnResupply)
+				{
+					// AbortOnResupply cancels the current activity (after resupplying) plus any queued activities
 					NextActivity?.Cancel(self);
+					Queue(new ReturnToBase(self));
+				}
+				else
+					QueueChild(new ReturnToBase(self));
 
-				QueueChild(new ReturnToBase(self));
 				returnToBase = true;
 				return attackAircraft.Info.AbortOnResupply;
 			}


### PR DESCRIPTION
Fixes #21893

With the move to `ChildHasPriority = true` now we need to handle child activities with more care