### PR TITLE
Fix editor scalling

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly byte maxDensity;
 		readonly Color veinRadarColor;
 
-		ISpriteSequence veinSequence;
+		readonly ISpriteSequence veinSequence;
 		PaletteReference veinPalette;
 		TerrainSpriteLayer spriteLayer;
 
@@ -177,6 +177,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			renderIndices = new CellLayer<int[]>(world.Map);
 			borders = new CellLayer<Adjacency>(world.Map);
+
+			veinSequence = self.World.Map.Sequences.GetSequence(info.Image, info.Sequence);
 		}
 
 		void AddDirtyCell(CPos cell, string resourceType)
@@ -194,9 +196,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var a in w.Actors)
 				ActorAddedToWorld(a);
 
-			veinSequence = w.Map.Sequences.GetSequence(info.Image, info.Sequence);
 			veinPalette = wr.Palette(info.Palette);
-
 			var first = veinSequence.GetSprite(0);
 			var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
 			spriteLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -116,6 +116,15 @@ namespace OpenRA.Mods.Common.Traits
 			ResourceLayer = self.Trait<IResourceLayer>();
 			ResourceLayer.CellChanged += AddDirtyCell;
 			RenderContents = new CellLayer<RendererCellContents>(self.World.Map);
+
+			var sequences = self.World.Map.Sequences;
+			foreach (var kv in Info.ResourceTypes)
+			{
+				var resourceInfo = kv.Value;
+				var resourceVariants = resourceInfo.Sequences
+					.ToDictionary(v => v, v => sequences.GetSequence(resourceInfo.Image, v));
+				Variants.Add(kv.Key, resourceVariants);
+			}
 		}
 
 		void AddDirtyCell(CPos cell, string resourceType)
@@ -126,14 +135,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void WorldLoaded(World w, WorldRenderer wr)
 		{
-			var sequences = w.Map.Sequences;
-			foreach (var kv in Info.ResourceTypes)
+			foreach (var kv in Variants)
 			{
-				var resourceInfo = kv.Value;
-				var resourceVariants = resourceInfo.Sequences
-					.ToDictionary(v => v, v => sequences.GetSequence(resourceInfo.Image, v));
-				Variants.Add(kv.Key, resourceVariants);
-
+				var resourceVariants = kv.Value;
 				if (spriteLayer == null)
 				{
 					var first = resourceVariants.First().Value.GetSprite(0);

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -22,7 +21,7 @@ namespace OpenRA.Mods.Common.Widgets
 	public class ActorPreviewWidget : Widget
 	{
 		public bool Animate = false;
-		public Func<float> GetScale = () => 1f;
+		public float Scale = 1f;
 
 		readonly WorldRenderer worldRenderer;
 		readonly WorldViewportSizes viewportSizes;
@@ -59,14 +58,17 @@ namespace OpenRA.Mods.Common.Widgets
 			var r = preview.SelectMany(p => p.ScreenBounds(worldRenderer, WPos.Zero));
 			var b = r.Union();
 			IdealPreviewSize = new int2((int)(b.Width * viewportSizes.DefaultScale), (int)(b.Height * viewportSizes.DefaultScale));
-			PreviewOffset = -new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale)) - IdealPreviewSize / 2;
+			var previewTopLeft = new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale));
+			PreviewOffset = previewTopLeft + IdealPreviewSize / 2;
 		}
 
 		IFinalizedRenderable[] renderables;
 		public override void PrepareRenderables()
 		{
-			var scale = GetScale() * viewportSizes.DefaultScale;
-			var origin = RenderOrigin + PreviewOffset + new int2(RenderBounds.Size.Width / 2, RenderBounds.Size.Height / 2);
+			var scale = Scale * viewportSizes.DefaultScale;
+			var origin = RenderOrigin - new int2(
+				(int)(PreviewOffset.X * scale - RenderBounds.Size.Width / 2),
+				(int)(PreviewOffset.Y * scale - RenderBounds.Size.Height / 2));
 
 			renderables = preview
 				.SelectMany(p => p.RenderUI(worldRenderer, origin, scale))

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -198,11 +198,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					preview.SetPreview(actor, td);
 
 					// Scale templates to fit within the panel
-					var scale = 1f;
-					if (scale * preview.IdealPreviewSize.X > ItemTemplate.Bounds.Width)
-						scale = (ItemTemplate.Bounds.Width - Panel.ItemSpacing) / (float)preview.IdealPreviewSize.X;
+					// Preview position is assumed to be a margin
+					var maxPreviewWidth = item.Bounds.Width - 2 * preview.Bounds.X;
+					var maxPreviewHeight = item.Bounds.Height - 2 * preview.Bounds.Y;
 
-					preview.GetScale = () => scale;
+					var scale = 1f;
+					if (preview.IdealPreviewSize.X > maxPreviewWidth)
+						scale = maxPreviewWidth / (float)preview.IdealPreviewSize.X;
+
+					if (preview.IdealPreviewSize.Y * scale > maxPreviewHeight)
+						scale = maxPreviewHeight / (float)preview.IdealPreviewSize.Y;
+
+					preview.Scale = scale;
 					preview.Bounds.Width = (int)(scale * preview.IdealPreviewSize.X);
 					preview.Bounds.Height = (int)(scale * preview.IdealPreviewSize.Y);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -43,25 +43,35 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				foreach (var resourceType in resourceRenderer.ResourceTypes)
 				{
-					var newResourcePreviewTemplate = ScrollItemWidget.Setup(layerPreviewTemplate,
+					var item = ScrollItemWidget.Setup(layerPreviewTemplate,
 						() => editor.CurrentBrush is EditorResourceBrush brush && brush.ResourceType == resourceType,
 						() => editor.SetBrush(new EditorResourceBrush(editor, resourceType, worldRenderer)));
 
-					newResourcePreviewTemplate.Bounds.X = 0;
-					newResourcePreviewTemplate.Bounds.Y = 0;
+					var preview = item.Get<ResourcePreviewWidget>("LAYER_PREVIEW");
+					preview.SetResourceType(resourceType);
 
-					var layerPreview = newResourcePreviewTemplate.Get<ResourcePreviewWidget>("LAYER_PREVIEW");
-					var size = layerPreview.IdealPreviewSize;
-					layerPreview.IsVisible = () => true;
-					layerPreview.ResourceType = resourceType;
-					layerPreview.Bounds.Width = size.Width;
-					layerPreview.Bounds.Height = size.Height;
-					newResourcePreviewTemplate.Bounds.Width = size.Width + layerPreview.Bounds.X * 2;
-					newResourcePreviewTemplate.Bounds.Height = size.Height + layerPreview.Bounds.Y * 2;
-					newResourcePreviewTemplate.IsVisible = () => true;
-					newResourcePreviewTemplate.GetTooltipText = () => resourceType;
+					// Scale templates to fit within the panel
+					// Preview position is assumed to be a margin
+					var maxPreviewWidth = item.Bounds.Width - 2 * preview.Bounds.X;
+					var maxPreviewHeight = item.Bounds.Height - 2 * preview.Bounds.Y;
 
-					layerTemplateList.AddChild(newResourcePreviewTemplate);
+					var scale = 1f;
+					if (preview.IdealPreviewSize.Width > maxPreviewWidth)
+						scale = maxPreviewWidth / (float)preview.IdealPreviewSize.Width;
+
+					if (preview.IdealPreviewSize.Height * scale > maxPreviewHeight)
+						scale = maxPreviewHeight / (float)preview.IdealPreviewSize.Height;
+
+					preview.Scale = scale;
+					preview.Bounds.Width = (int)(scale * preview.IdealPreviewSize.Width);
+					preview.Bounds.Height = (int)(scale * preview.IdealPreviewSize.Height);
+
+					item.Bounds.Width = preview.Bounds.Width + 2 * preview.Bounds.X;
+					item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
+					item.IsVisible = () => true;
+					item.GetTooltipText = () => resourceType;
+
+					layerTemplateList.AddChild(item);
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -116,11 +116,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				preview.SetTemplate(terrainInfo.Templates[tileId]);
 
 				// Scale templates to fit within the panel
-				var scale = 1f;
-				if (scale * preview.IdealPreviewSize.X > ItemTemplate.Bounds.Width)
-					scale = (ItemTemplate.Bounds.Width - Panel.ItemSpacing) / (float)preview.IdealPreviewSize.X;
+				// Preview position is assumed to be a margin
+				var maxPreviewWidth = item.Bounds.Width - 2 * preview.Bounds.X;
+				var maxPreviewHeight = item.Bounds.Height - 2 * preview.Bounds.Y;
 
-				preview.GetScale = () => scale;
+				var scale = 1f;
+				if (preview.IdealPreviewSize.X > maxPreviewWidth)
+					scale = maxPreviewWidth / (float)preview.IdealPreviewSize.X;
+
+				if (preview.IdealPreviewSize.Y * scale > maxPreviewHeight)
+					scale = maxPreviewHeight / (float)preview.IdealPreviewSize.Y;
+
+				preview.Scale = scale;
 				preview.Bounds.Width = (int)(scale * preview.IdealPreviewSize.X);
 				preview.Bounds.Height = (int)(scale * preview.IdealPreviewSize.Y);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					typeDictionary.Add(inits);
 
 			previewWidget.SetPreview(actor, typeDictionary);
-			previewWidget.GetScale = () => selectedInfo.Scale;
+			previewWidget.Scale = selectedInfo.Scale;
 
 			if (portraitWidget != null)
 			{

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Traits;
@@ -19,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class TerrainTemplatePreviewWidget : Widget
 	{
-		public Func<float> GetScale = () => 1f;
+		public float Scale = 1f;
 
 		readonly ITiledTerrainRenderer terrainRenderer;
 		readonly WorldRenderer worldRenderer;
@@ -27,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		TerrainTemplateInfo template;
 
-		public int2 PreviewOffset { get; private set; }
+		public int2 PreviewPos { get; private set; }
 		public int2 IdealPreviewSize { get; private set; }
 
 		[ObjectCreator.UseCtor]
@@ -48,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets
 			viewportSizes = other.viewportSizes;
 			terrainRenderer = other.terrainRenderer;
 			template = other.template;
-			GetScale = other.GetScale;
+			Scale = other.Scale;
 		}
 
 		public override TerrainTemplatePreviewWidget Clone() { return new TerrainTemplatePreviewWidget(this); }
@@ -60,7 +59,7 @@ namespace OpenRA.Mods.Common.Widgets
 			IdealPreviewSize = new int2((int)(b.Width * viewportSizes.DefaultScale), (int)(b.Height * viewportSizes.DefaultScale));
 
 			// Measured from the middle of the widget to the middle of the top-left cell of the template
-			PreviewOffset = -new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale)) - IdealPreviewSize / 2;
+			PreviewPos = new int2((int)(b.Left * viewportSizes.DefaultScale), (int)(b.Top * viewportSizes.DefaultScale));
 		}
 
 		public override void Draw()
@@ -68,8 +67,8 @@ namespace OpenRA.Mods.Common.Widgets
 			if (template == null)
 				return;
 
-			var scale = GetScale() * viewportSizes.DefaultScale;
-			var origin = RenderOrigin + PreviewOffset + new int2(RenderBounds.Size.Width / 2, RenderBounds.Size.Height / 2);
+			var scale = Scale * viewportSizes.DefaultScale;
+			var origin = RenderOrigin - new int2((int)(PreviewPos.X * scale), (int)(PreviewPos.Y * scale));
 
 			foreach (var r in terrainRenderer.RenderUIPreview(worldRenderer, template, origin, scale))
 				r.PrepareRender(worldRenderer).Render(worldRenderer);

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -353,7 +353,6 @@ Container@EDITOR_WORLD_ROOT:
 								ResourcePreview@LAYER_PREVIEW:
 									X: 4
 									Y: 4
-									Visible: false
 		Container@ACTOR_WIDGETS:
 			X: WINDOW_WIDTH - 295
 			Y: 318
@@ -421,7 +420,6 @@ Container@EDITOR_WORLD_ROOT:
 								ActorPreview@ACTOR_PREVIEW:
 									X: 4
 									Y: 4
-									Visible: true
 		Container@TOOLS_WIDGETS:
 			X: WINDOW_WIDTH - 295
 			Y: 318

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -325,7 +325,8 @@ Container@EDITOR_WORLD_ROOT:
 							Children:
 								ScrollItem@TILEPREVIEW_TEMPLATE:
 									Visible: false
-									Width: PARENT_WIDTH - 35
+									Width: (PARENT_WIDTH - 24) / 2 - 6
+									Height: PARENT_WIDTH / 2
 									TooltipContainer: TOOLTIP_CONTAINER
 									Children:
 										TerrainTemplatePreview@TILE_PREVIEW:
@@ -347,6 +348,8 @@ Container@EDITOR_WORLD_ROOT:
 					Children:
 						ScrollItem@LAYERPREVIEW_TEMPLATE:
 							Visible: false
+							Width: (PARENT_WIDTH - 24) / 2 - 6
+							Height: PARENT_WIDTH / 2
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
@@ -412,7 +415,8 @@ Container@EDITOR_WORLD_ROOT:
 					Children:
 						ScrollItem@ACTORPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_WIDTH - 35
+							Width: (PARENT_WIDTH - 24) / 2 - 6
+							Height: PARENT_WIDTH / 2
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 							IgnoreChildMouseOver: true

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -291,7 +291,8 @@ Container@EDITOR_WORLD_ROOT:
 					Children:
 						ScrollItem@TILEPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_WIDTH - 35
+							Width: (PARENT_WIDTH - 24) / 2 - 6
+							Height: PARENT_WIDTH / 2
 							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
 								TerrainTemplatePreview@TILE_PREVIEW:
@@ -315,6 +316,8 @@ Container@EDITOR_WORLD_ROOT:
 					Children:
 						ScrollItem@LAYERPREVIEW_TEMPLATE:
 							Visible: false
+							Width: (PARENT_WIDTH - 24) / 2 - 6
+							Height: PARENT_WIDTH / 2
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
@@ -377,7 +380,8 @@ Container@EDITOR_WORLD_ROOT:
 					Children:
 						ScrollItem@ACTORPREVIEW_TEMPLATE:
 							Visible: false
-							Width: PARENT_WIDTH - 35
+							Width: (PARENT_WIDTH - 24) / 2 - 6
+							Height: PARENT_WIDTH / 2
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 							IgnoreChildMouseOver: true

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -321,7 +321,6 @@ Container@EDITOR_WORLD_ROOT:
 								ResourcePreview@LAYER_PREVIEW:
 									X: 4
 									Y: 4
-									Visible: false
 		Container@ACTOR_WIDGETS:
 			X: WINDOW_WIDTH - 320
 			Y: 354
@@ -386,7 +385,6 @@ Container@EDITOR_WORLD_ROOT:
 								ActorPreview@ACTOR_PREVIEW:
 									X: 4
 									Y: 4
-									Visible: true
 		Container@TOOLS_WIDGETS:
 			X: WINDOW_WIDTH - 320
 			Y: 354


### PR DESCRIPTION
Closes #10138

Various actors bounds were incorrect in actor selector, leading to actor leaking outside of widget bounds, fixed.

Also made sure maximum width of tile / resource / actor is exactly the size where two max size widgets can fit side by side.