### PR TITLE
AI MCV Expansion: MORE accurate expansion

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -1,0 +1,824 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public enum BotMcvExpansionMode { CheckResource, CheckBase, CheckCurrentLocation }
+
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Manages AI MCVs and expansion.")]
+	public class McvExpansionManagerBotModuleInfo : ConditionalTraitInfo, Requires<ResourceMapBotModuleInfo>, NotBefore<ResourceMapBotModuleInfo>
+	{
+		[Desc("Actor types that are considered MCVs (deploy into base builders).")]
+		public readonly HashSet<string> McvTypes = [];
+
+		[Desc("Actor types that are considered construction yards (base builders).")]
+		public readonly HashSet<string> ConstructionYardTypes = [];
+
+		[Desc("Actor types that are able to produce MCVs.")]
+		public readonly HashSet<string> McvFactoryTypes = [];
+
+		[Desc("Try to maintain at least this many ConstructionYardTypes, build an MCV if number is below this.")]
+		public readonly int MinimumConstructionYardCount = 1;
+
+		[Desc("Try to maintain at additional this many ConstructionYardTypes.")]
+		public readonly int AdditionalConstructionYardCount = 0;
+
+		[Desc("Build additional MCV if cash is above this.")]
+		public readonly int BuildAdditionalMCVCashAmount = 5000;
+
+		[Desc("Delay (in ticks) for giving orders to idle MCVs.")]
+		public readonly int ScanForNewMcvInterval = 20;
+
+		[Desc("Delay (in ticks) for checking and building a MCV.")]
+		public readonly int BuildMcvInterval = 101;
+
+		[Desc("Delay (in ticks) for moving a conyard to better expansion. Only work with more than 1 conyard.")]
+		public readonly int MoveConyardTick = 4000;
+
+		[Desc("Should moving the oldest or newest conyard be preferred? Random ordering if unset.")]
+		public readonly bool? MoveOldConyardFirst = null;
+
+		[Desc("Initial expansion mode chosen by AI.")]
+		public readonly BotMcvExpansionMode InitialExpansionMode = BotMcvExpansionMode.CheckResource;
+
+		[Desc("Allow the bot to switch expansion mode automatically on enough failure or successful attempts.")]
+		public readonly bool ExpansionModeAutoSwitch = true;
+
+		/* those are CheckResource mode options */
+		[Desc("Minimum distance (in cells) from the found resource creator location when checking for MCV deployment location.")]
+		public readonly int CRmodeMinDeployRadius = 2;
+
+		[Desc("Maximum distance (in cells) the found resource creator location when checking for MCV deployment location.")]
+		public readonly int CRmodeMaxDeployRadius = 20;
+
+		[Desc("When moving to a resource, what distance (in cells) to resource should we attempt to maintain?")]
+		public readonly int CRmodeTryMaintainRange = 8;
+
+		[Desc("Distance (in cells) to avoid a friendly conyard when choosing an expansion location.",
+					"Recommended to set it equal or larger than ResourceMapStrideRadius.")]
+		public readonly int CRmodeFriendlyConyardDislikeRange = 14;
+
+		[Desc("Distance (in cells) to avoid a friendly refinery when choosing an expansion location.",
+					"Recommended to set it equal or larger than ResourceMapStrideRadius.")]
+		public readonly int CRmodeFriendlyRefineryDislikeRange = 14;
+
+		/* those are CheckBase mode options */
+		[Desc("Minimum distance (in cells) from center of the base expansion when checking for MCV deployment location.")]
+		public readonly int CBmodeMinDeployRadius = 2;
+
+		[Desc("Maximum distance (in cells) from center of the base expansion when checking for MCV deployment location.")]
+		public readonly int CBmodeMaxDeployRadius = 20;
+
+		public override object Create(ActorInitializer init) { return new McvExpansionManagerBotModule(init.Self, this); }
+	}
+
+	public class McvExpansionManagerBotModule :
+		ConditionalTrait<McvExpansionManagerBotModuleInfo>,
+		IBotTick,
+		IBotRespondToAttack,
+		IBotBaseExpansion,
+		INotifyActorDisposing
+	{
+		// When ExpansionModeAutoSwitch is true, if the AI fails to find a deploy spot enough time even in CheckBase mode
+		// NegativeMaxFailedAttempts is applied to make AI switch bettween modes more frequently until a successful attempt
+		const int CRmodPositiveMaxFailedAttempts = 3;
+		const int CBmodPositiveMaxFailedAttempts = 2;
+		const int NegativeMaxFailedAttempts = 0;
+
+		readonly World world;
+		readonly Player player;
+		readonly ActorIndex.OwnerAndNamesAndTrait<TransformsInfo> mcvs;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> constructionYards;
+		readonly ActorIndex.OwnerAndNamesAndTrait<BuildingInfo> mcvFactories;
+
+		IBotPositionsUpdated[] notifyPositionsUpdated;
+		IBotRequestUnitProduction[] requestUnitProduction;
+		IBotSuggestRefineryProduction[] suggestRefineryProduction;
+
+		readonly Dictionary<Actor, CPos> activeMCVs = [];
+
+		PathFinder pathfinder;
+		ResourceMapBotModule resourceMapModule;
+		PlayerResources playerResources;
+		Actor mustUndeployCoyard;
+
+		int scanInterval;
+		int buildMCVInterval;
+		int moveConyardInterval;
+		bool firstTick = true;
+		bool undeployEvenNoBase = false;
+		bool allowfallback = true;
+
+		BotMcvExpansionMode mcvExpansionMode;
+		int mcvDeploymentMinDeployRadius;
+		int mcvDeploymentMaxDeployRadius;
+		int mcvDeploymentTryMaintainRange;
+		int maxFailedAttempts;
+
+		int failedAttempts;
+		CPos? lastFailedCheckSpot;
+
+		// It is unnecessary to respond every tick, we only need to respond once in a while.
+		int attackrespondcooldown = 20;
+
+		int pathDistanceSquareFactor;
+
+		public McvExpansionManagerBotModule(Actor self, McvExpansionManagerBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			mcvs = new ActorIndex.OwnerAndNamesAndTrait<TransformsInfo>(world, info.McvTypes, player);
+			constructionYards = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.ConstructionYardTypes, player);
+			mcvFactories = new ActorIndex.OwnerAndNamesAndTrait<BuildingInfo>(world, info.McvFactoryTypes, player);
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			notifyPositionsUpdated = self.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+			requestUnitProduction = self.TraitsImplementing<IBotRequestUnitProduction>().ToArray();
+			suggestRefineryProduction = self.TraitsImplementing<IBotSuggestRefineryProduction>().ToArray();
+			pathfinder = world.WorldActor.Trait<PathFinder>();
+			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			scanInterval = world.LocalRandom.Next(Info.ScanForNewMcvInterval, Info.ScanForNewMcvInterval << 1);
+			buildMCVInterval = world.LocalRandom.Next(Info.BuildMcvInterval, Info.BuildMcvInterval << 1);
+			moveConyardInterval = world.LocalRandom.Next(Info.MoveConyardTick, Info.MoveConyardTick << 1);
+		}
+
+		void SwitchExpansionMode(BotMcvExpansionMode nextMode)
+		{
+			mcvExpansionMode = nextMode;
+			switch (nextMode)
+			{
+				case BotMcvExpansionMode.CheckResource:
+					mcvDeploymentMinDeployRadius = Info.CRmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CRmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = Info.CRmodeTryMaintainRange;
+					break;
+
+				case BotMcvExpansionMode.CheckBase:
+					mcvDeploymentMinDeployRadius = Info.CBmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CBmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = (Info.CBmodeMaxDeployRadius + Info.CBmodeMinDeployRadius) >> 1;
+					break;
+
+				case BotMcvExpansionMode.CheckCurrentLocation:
+					mcvDeploymentMinDeployRadius = Info.CBmodeMinDeployRadius;
+					mcvDeploymentMaxDeployRadius = Info.CBmodeMaxDeployRadius;
+					mcvDeploymentTryMaintainRange = 0;
+					break;
+
+				default:
+					break;
+			}
+		}
+
+		void FindBadDeploySpot(CPos? failedSpot)
+		{
+			lastFailedCheckSpot = failedSpot;
+
+			if (!Info.ExpansionModeAutoSwitch)
+			{
+				if (++failedAttempts >= maxFailedAttempts)
+					failedAttempts = maxFailedAttempts;
+				return;
+			}
+
+			if (++failedAttempts >= maxFailedAttempts)
+			{
+				failedAttempts = 0;
+				switch (mcvExpansionMode)
+				{
+					case BotMcvExpansionMode.CheckResource:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckBase);
+						break;
+
+					case BotMcvExpansionMode.CheckBase:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+						maxFailedAttempts = NegativeMaxFailedAttempts;
+						break;
+
+					case BotMcvExpansionMode.CheckCurrentLocation:
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+						maxFailedAttempts = NegativeMaxFailedAttempts;
+						break;
+				}
+			}
+		}
+
+		void FindGoodDeploySpot()
+		{
+			lastFailedCheckSpot = null;
+
+			if (!Info.ExpansionModeAutoSwitch)
+			{
+				if (--failedAttempts <= -maxFailedAttempts)
+					failedAttempts = -maxFailedAttempts;
+				return;
+			}
+
+			if (--failedAttempts <= -maxFailedAttempts)
+			{
+				switch (mcvExpansionMode)
+				{
+					case BotMcvExpansionMode.CheckResource:
+						maxFailedAttempts = CRmodPositiveMaxFailedAttempts;
+						failedAttempts = -maxFailedAttempts;
+						break;
+
+					case BotMcvExpansionMode.CheckBase:
+						maxFailedAttempts = CRmodPositiveMaxFailedAttempts;
+						failedAttempts = maxFailedAttempts - 1;
+						SwitchExpansionMode(BotMcvExpansionMode.CheckResource);
+						break;
+
+					case BotMcvExpansionMode.CheckCurrentLocation:
+						maxFailedAttempts = CBmodPositiveMaxFailedAttempts;
+						failedAttempts = maxFailedAttempts - 1;
+						SwitchExpansionMode(BotMcvExpansionMode.CheckBase);
+						break;
+				}
+			}
+		}
+
+		public (CPos? ExpandLocation, int Attraction, CPos? CheckSpot) GetExpansionCenter(Actor mcv, Mobile mobile, bool allowfallback)
+		{
+			/*
+			 * indiceSideLengthSquare (which is equal to indiceSideLength * indiceSideLength) is used as the basic unit to calculate the attraction of a candidate,
+			 * we  compare the attraction on the same scale on different factors, such as candidate's distance to current MCV and ally construction yard & refinery within range, etc:
+			 *
+			 * 1). the weight of candidate's distance-square to current MCV
+			 *
+			 *     a) if not Mobile: range from 0 to -indiceSideLengthSquare.
+			 *
+			 *     The reason why:
+			 *
+			 *     It is calculated as "(candidate - mcv.Location).LengthSquared / pathDistanceSquareFactor".
+			 *     note that: pathDistanceSquareFactor = resourceMapIndicesColumnCount * resourceMapIndicesColumnCount + resourceMapIndicesRowCount * resourceMapIndicesRowCount,
+			 *
+			 *     Consider a map, we divide it at the length of indiceSideLength = r, and then its resourceMapIndicesColumnCount = a, resourceMapIndicesRowCount = b,
+			 *     so the map.width ≈ a*r, map.height ≈ b*r,
+			 *     the maximum euclid distance-square between two points on the map is (a*r)(a*r) + (b*r)(b*r),
+			 *     so the maximum "weight of candidate's distance to current MCV" is from 0 to -((a*r)(a*r) + (b*r)(b*r)) / (a*a + b*b) = -r*r = -indiceSideLengthSquare.
+			 *
+			 *     b) if Mobile: range depends on pathfinding distance in cell.
+			 *
+			 *     It is calculated as "pathfindDistance * pathfindDistance / pathDistanceSquareFactor".
+			 *
+			 * 2). the weight of friendly construction yard within range: -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
+			 *
+			 * 3). the weight of enemy high threat within range: -indiceSideLengthSquare*8, otherwise -indiceSideLengthSquare/64
+			 *
+			 * 4). the weight of friendly refinery within range (not for CheckBase mode): -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
+			 *
+			 * 5). the weight of resource amount (only for CheckResource mode): from 0 to +indiceSideLengthSquare/8.
+			 *
+			 *     The reason why:
+			 *
+			 *     The maximum resource amount in a indice of resource map is approximately indiceSideLengthSquare (full of it), but a stride full of resources is less likely to
+			 *     have room for buildings. So we prefer the indice have half of resource cells the most, which may give us enough room to place buildings.
+			 *
+			 *     so the weight can be: (indiceSideLengthSquare/2) - |(indiceResourceCellCount - (indiceSideLengthSquare/2))|, range from (0 to +indiceSideLengthSquare/2).
+			 *
+			 *     Note: In practive resource weight is not very important, we cannot let MCV go a long way just for a rich resource spot.
+			 *     We have to take only 1/4 of it, wich is (0 to +indiceSideLengthSquare/8),
+			 *     and apply some additional method to filter the indice for acceptable resource (not too low).
+			 */
+			var indiceSideLengthSquare = resourceMapModule.GetIndiceSideLength() * resourceMapModule.GetIndiceSideLength();
+			switch (mcvExpansionMode)
+			{
+				/*
+				 * CheckBase mode only considers the distance to current MCV, ally construction yard within range and enemy buildings within range.
+				 * Attaction has a base value of indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, 1/(2*sqrt(2))≈ 1/2.8 of the maximum distance in map)
+				 */
+				case BotMcvExpansionMode.CheckBase:
+					var cb_conyardlocs = world.ActorsHavingTrait<Building>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.ConstructionYardTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner == player))
+						.ToArray();
+					CPos? cb_suitablespot = null;
+					CPos? cb_checkspot = null;
+					var cb_best = int.MinValue;
+
+					for (var i = 0; i < resourceMapModule.GetIndicesLength(); i++)
+					{
+						var indiceCenter = resourceMapModule.GetIndice(i).IndiceCenter;
+
+						if (lastFailedCheckSpot == indiceCenter)
+							continue;
+
+						var attraction = indiceSideLengthSquare >> 1;
+
+						attraction -= (indiceCenter - mcv.Location).LengthSquared / pathDistanceSquareFactor;
+
+						attraction -= CalculateThreats(indiceSideLengthSquare, i);
+
+						foreach (var (location, isAlly) in cb_conyardlocs)
+						{
+							var sdistance = (indiceCenter - location).LengthSquared;
+							if (sdistance <= indiceSideLengthSquare)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						foreach (var (othermcv, dest) in activeMCVs)
+						{
+							if (dest == indiceCenter && othermcv != mcv)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (!allowfallback)
+						{
+							var sdistance = (indiceCenter - mcv.Location).LengthSquared;
+							if (sdistance <= indiceSideLengthSquare)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (attraction > cb_best)
+						{
+							cb_best = attraction;
+							cb_checkspot = indiceCenter;
+							cb_suitablespot = indiceCenter;
+						}
+					}
+
+					return (cb_suitablespot ?? mcv.Location, cb_best, cb_checkspot);
+
+				/*
+				 * CheckResource mode considers the distance to current MCV, ally construction yard & refinery within range,
+				 * Attaction has a base value of:
+				 * 1. if not Mobile: indiceSideLengthSquare >> 4 (1/16 of the maximum distance weight, = 0.25 of the maximum euclid distance in map)
+				 * 2. if Mobile: indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, ≈ 0.35 of the maximum euclid distance in map)
+				 */
+				case BotMcvExpansionMode.CheckResource:
+
+					var cr_refinarylocs = world.ActorsHavingTrait<Refinery>()
+						.Where(a => a.Owner == player && resourceMapModule.Info.RefineryTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					var cr_conyardlocs = world.ActorsHavingTrait<Building>()
+						.Where(a => a.Owner.IsAlliedWith(player) && Info.ConstructionYardTypes.Contains(a.Info.Name))
+						.Select(a => (a.Location, a.Owner != player))
+						.ToArray();
+
+					// We only take indice has more than half of average indice value (in weight calculation), to skip the indice with very poor resource
+					// when failedAttempts is acceptable.
+					var thresholdRes = 0;
+					for (var i = 0; i < resourceMapModule.GetIndicesLength(); i++)
+					{
+						var resourceCellCounts = resourceMapModule.GetIndice(i).ResourceCellsCount;
+						thresholdRes += (indiceSideLengthSquare >> 1) - Math.Abs(resourceCellCounts - (indiceSideLengthSquare >> 1));
+					}
+
+					thresholdRes = (thresholdRes / resourceMapModule.GetIndicesLength()) >> 1;
+
+					CPos? cr_suitablespot = null;
+					CPos? cr_checkspot = null;
+					var cr_best = int.MinValue;
+
+					for (var i = 0; i < resourceMapModule.GetIndicesLength(); i++)
+					{
+						var indice = resourceMapModule.GetIndice(i);
+						var indiceCenter = indice.IndiceCenter;
+						var resourceCellsCount = indice.ResourceCellsCount;
+						var resourceCellsCenter = indice.ResourceCellsCenter;
+						var resourceCreatorLocs = indice.ResourceCreatorLocs;
+
+						if ((failedAttempts > maxFailedAttempts >> 1 && resourceCellsCount <= thresholdRes) || lastFailedCheckSpot == indiceCenter)
+							continue;
+
+						var attraction = 0;
+						if (mobile == null)
+						{
+							attraction = indiceSideLengthSquare >> 2;
+							attraction -= (resourceCellsCenter - mcv.Location).LengthSquared / pathDistanceSquareFactor;
+						}
+						else
+						{
+							attraction = indiceSideLengthSquare >> 1;
+
+							var path = pathfinder.FindPathToTargetCells(mcv, mcv.Location, [resourceCellsCenter], BlockedByActor.None);
+
+							if (path == PathFinder.NoPath)
+								continue;
+
+							attraction -= path.Count * path.Count / pathDistanceSquareFactor;
+						}
+
+						// it is better that resource cells takes only half of the indice cells, which give us the place to place building.
+						attraction += ((indiceSideLengthSquare >> 1) - Math.Abs(resourceCellsCount - (indiceSideLengthSquare >> 1))) >> 2;
+						attraction += 8 * resourceCreatorLocs.Length;
+
+						var resCenter = resourceCreatorLocs.Length == 0 || world.LocalRandom.Next(2) > 0 ? resourceCellsCenter : resourceCreatorLocs.Random(world.LocalRandom);
+
+						attraction -= CalculateThreats(indiceSideLengthSquare, i);
+
+						foreach (var (location, isAlly) in cr_refinarylocs)
+						{
+							var sdistance = (resCenter - location).LengthSquared;
+							if (sdistance <= Info.CRmodeFriendlyRefineryDislikeRange * Info.CRmodeFriendlyRefineryDislikeRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						foreach (var (location, isAlly) in cr_conyardlocs)
+						{
+							var sdistance = (resCenter - location).LengthSquared;
+							if (sdistance <= Info.CRmodeFriendlyConyardDislikeRange * Info.CRmodeFriendlyConyardDislikeRange)
+							{
+								if (isAlly)
+									attraction -= indiceSideLengthSquare;
+								else
+									attraction -= indiceSideLengthSquare << 1;
+							}
+						}
+
+						foreach (var (othermcv, dest) in activeMCVs)
+						{
+							if (dest == indiceCenter)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (!allowfallback)
+						{
+							var sdistance = (resCenter - mcv.Location).LengthSquared;
+							if (sdistance <= Info.CRmodeFriendlyConyardDislikeRange * Info.CRmodeFriendlyConyardDislikeRange)
+								attraction -= indiceSideLengthSquare << 1;
+						}
+
+						if (attraction > cr_best)
+						{
+							cr_best = attraction;
+							cr_checkspot = indiceCenter;
+							cr_suitablespot = resCenter;
+						}
+					}
+
+					if (cr_suitablespot == null)
+						return (null, int.MinValue, null);
+
+					return (cr_suitablespot, cr_best, cr_checkspot);
+
+				case BotMcvExpansionMode.CheckCurrentLocation:
+					return (mcv.Location, int.MaxValue, null);
+
+				default:
+					return (null, int.MinValue, null);
+			}
+		}
+
+		int CalculateThreats(int indiceSideLengthSquare, int index)
+		{
+			var baseIndice = resourceMapModule.GetIndice(index);
+
+			var (indiceCount, nearbyEnemyBaseThreat, nearbyEnemyThreat) = resourceMapModule.GetNearbyIndicesThreat(index);
+
+			var indiceEnemyBaseThreat = Math.Max(baseIndice.EnemyBaseCount - baseIndice.FriendlyBaseCount, 0);
+
+			var indiceEnemyUnitThreat = Math.Max(baseIndice.EnemyUnitCount - baseIndice.FriendlyUnitCount, 0);
+
+			if (indiceCount == 0)
+				return (indiceEnemyUnitThreat * indiceSideLengthSquare >> 6) + (indiceEnemyBaseThreat * indiceSideLengthSquare << 3);
+
+			return ((indiceEnemyUnitThreat + nearbyEnemyThreat / indiceCount) * indiceSideLengthSquare >> 6) +
+							((indiceEnemyBaseThreat + nearbyEnemyBaseThreat / indiceCount) * indiceSideLengthSquare << 3);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			attackrespondcooldown--;
+
+			if (firstTick)
+			{
+				resourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().First(t => t.IsTraitEnabled());
+				SwitchExpansionMode(Info.InitialExpansionMode);
+
+				pathDistanceSquareFactor = resourceMapModule.GetIndiceRowCount() * resourceMapModule.GetIndiceRowCount()
+					+ resourceMapModule.GetIndiceColumnCount() * resourceMapModule.GetIndiceColumnCount();
+
+				DeployMcvs(bot, false);
+				firstTick = false;
+			}
+
+			if (--scanInterval <= 0)
+			{
+				foreach (var amcv in activeMCVs.Keys.ToList())
+				{
+					if (amcv.IsDead || !amcv.IsInWorld)
+						activeMCVs.Remove(amcv);
+				}
+
+				scanInterval = Info.ScanForNewMcvInterval;
+				DeployMcvs(bot, true);
+			}
+
+			if (--buildMCVInterval <= 0)
+			{
+				buildMCVInterval = Info.BuildMcvInterval;
+				BuildMCV(bot);
+			}
+
+			if (--moveConyardInterval <= 0)
+			{
+				foreach (var amcv in activeMCVs.Keys.ToList())
+				{
+					if (amcv.IsDead || !amcv.IsInWorld)
+						activeMCVs.Remove(amcv);
+				}
+
+				moveConyardInterval = Info.MoveConyardTick;
+				UnDeployConyard(bot);
+			}
+		}
+
+		void BuildMCV(IBot bot)
+		{
+			if (Info.McvTypes.Count <= 0)
+				return;
+			if (AIUtils.CountActorByCommonName(mcvFactories) <= 0)
+				return;
+			var mcvNum = AIUtils.CountActorByCommonName(mcvs);
+			var conyardNum = AIUtils.CountActorByCommonName(constructionYards);
+
+			var mcvShouldHave = playerResources.GetCashAndResources() >= Info.BuildAdditionalMCVCashAmount
+				? Info.MinimumConstructionYardCount + Info.AdditionalConstructionYardCount : Info.MinimumConstructionYardCount;
+
+			// If we only have 1 MCV and no conyard, we should be allowed to build another MCV.
+			// Otherwise, when an mcv is on the move and we should wait.
+			if ((conyardNum <= 0 && mcvNum > 1) || (conyardNum > 0 && mcvNum > 0))
+				return;
+
+			if (conyardNum + mcvNum >= mcvShouldHave)
+				return;
+
+			// We have MCV in production queue, let's wait.
+			if (mcvFactories.Actors
+				.Any(a => !a.IsDead && a.TraitsImplementing<ProductionQueue>().Any(t => t.Enabled && t.AllQueued().Any(q => Info.McvTypes.Contains(q.Item)))))
+				return;
+
+			// We have MCV in production queue, let's wait.
+			if (player.PlayerActor.TraitsImplementing<ProductionQueue>()
+				.Any(t => t.Enabled && t.AllQueued().Any(q => Info.McvTypes.Contains(q.Item))))
+				return;
+			var unitBuilder = requestUnitProduction.FirstEnabledTraitOrDefault();
+			if (unitBuilder == null)
+				return;
+			var mcvType = Info.McvTypes.Random(world.LocalRandom);
+
+			// Make sure we only request one MCV at a time.
+			if (unitBuilder.RequestedProductionCount(bot, mcvType) <= 0)
+				unitBuilder.RequestUnitProduction(bot, mcvType);
+		}
+
+		void DeployMcvs(IBot bot, bool chooseLocation)
+		{
+			var newMCVs = world.ActorsHavingTrait<Transforms>()
+				.Where(a => a.Owner == player && a.IsIdle && Info.McvTypes.Contains(a.Info.Name));
+
+			foreach (var mcv in newMCVs)
+				DeployMcv(bot, mcv, chooseLocation);
+		}
+
+		void UnDeployConyard(IBot bot)
+		{
+			if (mustUndeployCoyard != null && mustUndeployCoyard.IsInWorld && !mustUndeployCoyard.IsDead && mustUndeployCoyard.Owner == player)
+			{
+				bot.QueueOrder(new Order("DeployTransform", mustUndeployCoyard, true));
+				mustUndeployCoyard = null;
+
+				return;
+			}
+
+			if (activeMCVs.Count > 0)
+				return;
+
+			var conyards = constructionYards.Actors
+				.Where(a => !a.IsDead);
+
+			var moveOldConyardFirst = Info.MoveOldConyardFirst ?? world.LocalRandom.Next(2) > 0;
+
+			if (moveOldConyardFirst)
+				conyards = conyards.OrderBy(a => a.ActorID);
+			else
+				conyards = conyards.OrderByDescending(a => a.ActorID);
+
+			var conyardslist = conyards.ToList();
+
+			if (conyardslist.Count > 1 || undeployEvenNoBase)
+			{
+				// We don't want to interrupt refinery production, otherwise it may cause a dead loop of deploy/undeploy.
+				var movableMCV = conyardslist.FirstOrDefault(a => !a.TraitsImplementing<ProductionQueue>()
+				.Any(t => t.Enabled && t.AllQueued().Any(q => resourceMapModule.Info.RefineryTypes.Contains(q.Item))));
+
+				if (movableMCV != null)
+					bot.QueueOrder(new Order("DeployTransform", movableMCV, true));
+
+				undeployEvenNoBase = false;
+			}
+		}
+
+		// Find any MCV and deploy them at a sensible location.
+		void DeployMcv(IBot bot, Actor mcv, bool move)
+		{
+			CPos? desiredLocation = null;
+			var transformsInfo = mcv.Info.TraitInfo<TransformsInfo>();
+			var actorInfo = world.Map.Rules.Actors[transformsInfo.IntoActor];
+			var bi = actorInfo.TraitInfoOrDefault<BuildingInfo>();
+			if (bi == null)
+				return;
+
+			if (move)
+			{
+				var (deployLocation, resLoc, checkloc) = ChooseMcvDeployLocation(mcv, actorInfo, bi, transformsInfo.Offset, allowfallback);
+				allowfallback = true;
+				desiredLocation = deployLocation;
+				if (desiredLocation == null)
+					return;
+
+				activeMCVs[mcv] = checkloc.Value;
+				if (resLoc != null)
+				{
+					foreach (var srp in suggestRefineryProduction)
+						srp.RequestLocation(resLoc.Value, desiredLocation.Value, mcv);
+				}
+
+				bot.QueueOrder(new Order("Move", mcv, Target.FromCell(world, desiredLocation.Value), true));
+			}
+			else
+			{
+				if (!world.CanPlaceBuilding(mcv.Location + transformsInfo.Offset, actorInfo, bi, mcv))
+					return;
+				desiredLocation = mcv.Location;
+			}
+
+			bot.QueueOrder(new Order("DeployTransform", mcv, true));
+
+			// When we don't have a construction yard, we notify the new location to other traits for defence,
+			// If not, we only notify sometimes, because we are not sure if mcv can successfully deploy at the desired location.
+			// TODO: This could be addressed via INotifyTransform.
+			if (constructionYards.Actors.All(a => a.IsDead) || world.LocalRandom.Next(2) > 0)
+			{
+				foreach (var n in notifyPositionsUpdated)
+				{
+					n.UpdatedBaseCenter(desiredLocation.Value);
+					n.UpdatedDefenseCenter(desiredLocation.Value);
+				}
+			}
+		}
+
+		// First, find a suitable expansion location according to current mode,
+		// Then, find a deployable cell around it.
+		(CPos? DeployLoc, CPos? ResourceLoc, CPos? CheckLoc) ChooseMcvDeployLocation(
+			Actor mcv,
+			ActorInfo transformIntoInfo,
+			BuildingInfo transformIntoBuildingInfo,
+			CVec offset,
+			bool allowfallback)
+		{
+			if (!mcv.Info.HasTraitInfo<IMoveInfo>())
+				return (null, null, null);
+
+			var mobile = mcv.TraitOrDefault<Mobile>();
+
+			var (expandCenter, attraction, checkspot) = GetExpansionCenter(mcv, mobile, allowfallback);
+
+			// Find the deployable cell
+			CPos? FindDeployCell(CPos? sourceCell, CPos? targetCell, int minRange, int maxRange, int tryMaintainRange)
+			{
+				if (!sourceCell.HasValue || !targetCell.HasValue)
+					return null;
+
+				var target = targetCell.Value;
+				var source = sourceCell.Value;
+
+				var cells = world.Map.FindTilesInAnnulus(target, minRange, maxRange);
+
+				/* First, sort the cells that keep tryMaintainRange to target (meanwhile direction is from center to target) the first to be considered
+				 * by using following code. The idea is to use a linear combination of two distances-square for sorting weight.
+				 *
+				 * See comments in https://github.com/OpenRA/OpenRA/pull/22028#issuecomment-3242518793 for explaination.
+				 */
+				if (source != target)
+				{
+					var theta = tryMaintainRange;
+					var deta = (target - source).Length - tryMaintainRange;
+					cells = cells.OrderBy(c => deta * (c - target).LengthSquared + theta * (c - source).LengthSquared);
+				}
+				else
+					cells = cells.Shuffle(world.LocalRandom);
+
+				CPos? bestcell = null;
+				foreach (var cell in cells)
+				{
+					if (world.CanPlaceBuilding(cell + offset, transformIntoInfo, transformIntoBuildingInfo, mcv))
+					{
+						bestcell = cell;
+						break;
+					}
+				}
+
+				// If no deployble cell found, return null
+				if (bestcell == null)
+					return null;
+
+				if (source != target && mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, source, bestcell.Value))
+					bestcell = null;
+
+				// If the best deploy cell is not ideal ( >= tryMaintainRange + 2), which means there might be some huge blockers
+				// so we fall back to default behavior, which is the directly closest cell to target
+				if (!bestcell.HasValue || (source != target && (bestcell.Value - target).LengthSquared >= (tryMaintainRange + 2) * (tryMaintainRange + 2)))
+				{
+					cells = cells.OrderBy(c => (c - target).LengthSquared);
+					foreach (var cell in cells)
+					{
+						if (world.CanPlaceBuilding(cell + offset, transformIntoInfo, transformIntoBuildingInfo, mcv))
+						{
+							if (mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, source, cell))
+								return null;
+
+							return (!bestcell.HasValue) || (cell - target).LengthSquared < (bestcell.Value - target).LengthSquared ? cell : bestcell;
+						}
+					}
+				}
+
+				return bestcell;
+			}
+
+			var bc = FindDeployCell(mcv.Location, expandCenter, mcvDeploymentMinDeployRadius, mcvDeploymentMaxDeployRadius, mcvDeploymentTryMaintainRange);
+
+			// At last, if the attraction of the found expansion location is good enough (>0) and deploy cell found,
+			// we consider it as a good expansion, otherwise, we consider it as a bad expansion.
+			if (bc.HasValue && attraction > 0)
+				FindGoodDeploySpot();
+			else
+				FindBadDeploySpot(bc.HasValue ? null : checkspot);
+
+			if (mcvExpansionMode == BotMcvExpansionMode.CheckResource && expandCenter.HasValue && bc.HasValue)
+				return (bc, expandCenter, checkspot);
+
+			return (bc, null, checkspot);
+		}
+
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
+		{
+			if (attackrespondcooldown <= 0 && Info.McvTypes.Contains(self.Info.Name))
+			{
+				attackrespondcooldown = 20;
+
+				DeployMcv(bot, self, false);
+
+				if (AIUtils.CountActorByCommonName(constructionYards) == 0)
+				{
+					foreach (var n in notifyPositionsUpdated)
+						n.UpdatedBaseCenter(self.Location);
+				}
+			}
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			mcvs.Dispose();
+			constructionYards.Dispose();
+			mcvFactories.Dispose();
+		}
+
+		void IBotBaseExpansion.UpdateExpansionParams(IBot bot, bool fallback, bool undeployEvenNoBase, Actor mustUndeploy)
+		{
+			moveConyardInterval = 20; // allow some order latency
+			allowfallback = fallback;
+			this.undeployEvenNoBase = undeployEvenNoBase;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs
@@ -1,0 +1,308 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.Player)]
+	public class ResourceMapBotModuleInfo : ConditionalTraitInfo, NotBefore<IResourceLayerInfo>
+	{
+		[Desc("Harvestable and valuable resource types.")]
+		public readonly HashSet<string> ValuableResourceTypes = [];
+
+		[Desc("Tells the AI what types are considered resource creator.")]
+		public readonly HashSet<string> ResourceCreatorTypes = [];
+
+		[Desc($"Actor types that are considered refineries for {nameof(HarvesterTypes)}.")]
+		public readonly HashSet<string> RefineryTypes = [];
+
+		[Desc($"Actor types that are considered harvesters for {nameof(ValuableResourceTypes)}.")]
+		public readonly HashSet<string> HarvesterTypes = [];
+
+		[Desc("Actor types that are considered to be the base building for expansion. Other enemy units will also be recorded",
+			"Defence and production building is suggested")]
+		public readonly HashSet<string> EnemyBaseBuildingTypes = [];
+
+		[Desc("Delay (in ticks) for updating the indicies.")]
+		public readonly int UpdateResourceMapInverval = 67;
+
+		[Desc("The size (in cells) of half of the side length of the indice (in square).")]
+		public readonly int ResourceMapStrideRadius = 12;
+
+		public override object Create(ActorInitializer init) { return new ResourceMapBotModule(init.Self, this); }
+	}
+
+	public class ResourceIndice
+	{
+		public int2 IndiceIndex;
+		public CPos IndiceCenter;
+		public int ResourceCellsCount;
+		public CPos ResourceCellsCenter;
+		public CPos[] ResourceCreatorLocs;
+		public int PlayerRefineryCount;
+		public int PlayerHarvetserCount;
+
+		public int EnemyUnitCount;
+		public int EnemyBaseCount;
+		public int FriendlyBaseCount;
+		public int FriendlyUnitCount;
+
+		public ResourceIndice(int2 indiceIndex, CPos indiceCenter)
+		{
+			IndiceIndex = indiceIndex;
+			IndiceCenter = indiceCenter;
+			ResourceCreatorLocs = [];
+		}
+	}
+
+	public class ResourceMapBotModule : IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		IResourceLayer resourceLayer;
+		public readonly ResourceMapBotModuleInfo Info;
+
+		ResourceIndice[] resourceMapIndices = null;
+		readonly int indiceSideLength;
+		readonly int indiceResourceScanRadius;
+		int resourceMapIndicesColumnCount;
+		int resourceMapIndicesRowCount;
+
+		int updateResourceMapIndex = 0;
+		int updateResourceMapInterval;
+		bool firstTick = true;
+
+		public ResourceMapBotModule(Actor self, ResourceMapBotModuleInfo info)
+		{
+			world = self.World;
+			player = self.Owner;
+			indiceSideLength = info.ResourceMapStrideRadius << 1;
+			Info = info;
+
+			// FindTilesInAnnulus returns cells in a rough circle shape, and resourceMapIndices are divided in square,
+			// so we need a larger range to cover cells in the indice approximately, but avoid takes too much other indices' cells.
+			indiceResourceScanRadius = info.ResourceMapStrideRadius * 12 / 10; // ≈ * (sqrt(2) + 1) / 2
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (firstTick)
+			{
+				resourceLayer = world.WorldActor.TraitOrDefault<IResourceLayer>();
+				updateResourceMapInterval = world.LocalRandom.Next(Info.UpdateResourceMapInverval, Info.UpdateResourceMapInverval << 1);
+
+				if (resourceMapIndices == null && resourceLayer != null)
+				{
+					var map = world.Map;
+					var actualMapWidth = map.Bounds.Width;
+					var actualMapHeight = map.Bounds.Height;
+					var xoffset = map.Bounds.X;
+					var yoffset = map.Bounds.Y;
+
+					resourceMapIndicesColumnCount = (actualMapWidth + indiceSideLength - 1) / indiceSideLength;
+					resourceMapIndicesRowCount = (actualMapHeight + indiceSideLength - 1) / indiceSideLength;
+
+					var overallIndiceWidth = resourceMapIndicesColumnCount * indiceSideLength;
+					var overallIndiceHeight = resourceMapIndicesRowCount * indiceSideLength;
+
+					xoffset -= (overallIndiceWidth - actualMapWidth) >> 1;
+					yoffset -= (overallIndiceHeight - actualMapHeight) >> 1;
+
+					resourceMapIndices = Exts.MakeArray(resourceMapIndicesColumnCount * resourceMapIndicesRowCount,
+						i => new ResourceIndice(new int2(i % resourceMapIndicesColumnCount, i / resourceMapIndicesColumnCount),
+						new MPos(
+						xoffset + i % resourceMapIndicesColumnCount * indiceSideLength + (indiceSideLength >> 1),
+						yoffset + i / resourceMapIndicesColumnCount * indiceSideLength + (indiceSideLength >> 1)).ToCPos(map)));
+
+					for (var i = 0; i < resourceMapIndices.Length; i++)
+						UpdateResourceMap(i);
+				}
+
+				firstTick = false;
+			}
+
+			if (--updateResourceMapInterval <= 0)
+			{
+				updateResourceMapInterval = Info.UpdateResourceMapInverval;
+				UpdateResourceMap(updateResourceMapIndex);
+				updateResourceMapIndex = (updateResourceMapIndex + 1) % resourceMapIndices.Length;
+			}
+		}
+
+		void UpdateResourceMap(int index)
+		{
+			if (resourceLayer == null || resourceMapIndices == null || resourceMapIndices.Length == 0)
+				return;
+
+			var indice = resourceMapIndices[index];
+			var sumCellsX = 0;
+			var sumCellsY = 0;
+
+			var resTiles = world.Map.FindTilesInAnnulus(indice.IndiceCenter, 0, indiceResourceScanRadius).Where(c =>
+			{
+				if (!Info.ValuableResourceTypes.Contains(resourceLayer.GetResource(c).Type))
+					return false;
+
+				sumCellsX += c.X;
+				sumCellsY += c.Y;
+				return true;
+			}).ToList();
+
+			var resTilesCount = resTiles.Count;
+			var bestCell = CPos.Zero;
+			if (resTilesCount != 0)
+			{
+				var resAvgCell = new CPos(sumCellsX / resTilesCount, sumCellsY / resTilesCount);
+				bestCell = resTiles[0];
+				var bestDist = (bestCell - resAvgCell).LengthSquared;
+				foreach (var c in resTiles)
+				{
+					var dist = (c - resAvgCell).LengthSquared;
+					if (dist < bestDist)
+					{
+						bestDist = dist;
+						bestCell = c;
+					}
+				}
+			}
+
+			var refineryCount = 0;
+			var harvesterCount = 0;
+			var normalEnemyCount = 0;
+			var highThreatEnemyCount = 0;
+
+			var resourceCreatorLocs = world.FindActorsInCircle(world.Map.CenterOfCell(indice.IndiceCenter), WDist.FromCells(indiceResourceScanRadius))
+				.Where(a =>
+				{
+					if (a.Owner.RelationshipWith(player) == PlayerRelationship.Enemy)
+					{
+						if (Info.EnemyBaseBuildingTypes.Contains(a.Info.Name))
+							highThreatEnemyCount++;
+						else
+							normalEnemyCount++;
+					}
+					else if (a.Owner.RelationshipWith(player) == PlayerRelationship.Ally)
+					{
+						if (Info.EnemyBaseBuildingTypes.Contains(a.Info.Name))
+							indice.FriendlyBaseCount++;
+						else
+							indice.FriendlyUnitCount++;
+
+						if (a.Owner == player)
+						{
+							if (Info.RefineryTypes.Contains(a.Info.Name))
+								refineryCount++;
+
+							if (Info.HarvesterTypes.Contains(a.Info.Name))
+								harvesterCount++;
+						}
+					}
+
+					return Info.ResourceCreatorTypes.Contains(a.Info.Name);
+				}).Select(a => a.Location).ToArray();
+
+			indice.ResourceCellsCount = resTilesCount;
+			indice.ResourceCellsCenter = bestCell;
+			indice.ResourceCreatorLocs = resourceCreatorLocs;
+			indice.PlayerRefineryCount = refineryCount;
+			indice.PlayerHarvetserCount = harvesterCount;
+			indice.EnemyUnitCount = normalEnemyCount;
+			indice.EnemyBaseCount = highThreatEnemyCount;
+		}
+
+		public int GetIndicesLength()
+		{
+			return resourceMapIndices?.Length ?? 0;
+		}
+
+		public int GetIndiceSideLength()
+		{
+			return indiceSideLength;
+		}
+
+		public int GetIndiceColumnCount()
+		{
+			return resourceMapIndicesColumnCount;
+		}
+
+		public int GetIndiceRowCount()
+		{
+			return resourceMapIndicesRowCount;
+		}
+
+		public int GetIndiceScanRadius()
+		{
+			return indiceResourceScanRadius;
+		}
+
+		public (int IndiceCount, int EnemyUnitCount, int EnemyBaseCount) GetNearbyIndicesThreat(int index)
+		{
+			var baseIndice = resourceMapIndices[index];
+
+			var indiceCount = 0;
+			var nearbyEnemyBase = 0;
+			var nearbyEnemyUnit = 0;
+
+			var x = baseIndice.IndiceIndex.X;
+			var y = baseIndice.IndiceIndex.Y;
+
+			var offsets = new int[] { -1, 0, 1 };
+
+			for (var i = 0; i < offsets.Length; i++)
+			{
+				for (var j = 0; j < offsets.Length; j++)
+				{
+					var offsetIndex = x + offsets[i] + (y + offsets[j]) * resourceMapIndicesColumnCount;
+					if (offsetIndex != index && offsetIndex >= 0 && offsetIndex < resourceMapIndices.Length)
+					{
+						var indice = resourceMapIndices[offsetIndex];
+						nearbyEnemyBase += indice.EnemyBaseCount - indice.FriendlyBaseCount;
+						nearbyEnemyUnit += indice.EnemyUnitCount - indice.FriendlyUnitCount;
+						indiceCount++;
+					}
+				}
+			}
+
+			return (indiceCount, Math.Max(nearbyEnemyUnit, 0), Math.Max(nearbyEnemyBase, 0));
+		}
+
+		public ResourceIndice GetIndice(int i)
+		{
+			if (resourceMapIndices == null || i >= resourceMapIndices.Length)
+				return null;
+
+			return resourceMapIndices[i];
+		}
+
+		public ResourceIndice FindClosestIndiceFromCPos(CPos cpos)
+		{
+			var maxDist = int.MaxValue;
+			var best = 0;
+
+			for (var i = 0; i < resourceMapIndices.Length; i++)
+			{
+				var index = resourceMapIndices[i];
+				var dist = (index.IndiceCenter - cpos).LengthSquared;
+				if (dist < maxDist)
+				{
+					maxDist = dist;
+					best = i;
+				}
+			}
+
+			return GetIndice(best);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -44,6 +44,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				}
 			}
 
+			owner.Bot.QueueOrder(new Order("AttackMove", null, owner.Target, false, groupedActors: owner.Units.ToArray()));
+
 			if (!owner.IsTargetVisible)
 			{
 				if (Backoff < 0)
@@ -57,7 +59,6 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			}
 			else
 			{
-				owner.Bot.QueueOrder(new Order("AttackMove", null, owner.Target, false, groupedActors: owner.Units.ToArray()));
 				Backoff = BackoffTicks;
 			}
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -635,6 +635,18 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface IBotBaseExpansion
+	{
+		void UpdateExpansionParams(IBot bot, bool fallback, bool undeployEvenNoBase, Actor mustUndeploy);
+	}
+
+	[RequireExplicitImplementation]
+	public interface IBotSuggestRefineryProduction
+	{
+		void RequestLocation(CPos refineryLocation, CPos conyardLocation, Actor expandActor);
+	}
+
+	[RequireExplicitImplementation]
 	public interface IEditorActorOptions : ITraitInfoInterface
 	{
 		IEnumerable<EditorActorOption> ActorOptions(ActorInfo ai, World world);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule.cs
@@ -1,0 +1,32 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	sealed class RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule : UpdateRule
+	{
+		public override string Name => "Remove BarracksTypes and VehiclesTypes in BaseBuilderBotModule";
+		public override string Description => "BarracksTypes and VehiclesTypes were removed and now BaseBuilderBotModule check by using ProductionTypes.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var baseBuilder in actorNode.ChildrenMatching("BaseBuilderBotModule"))
+			{
+				baseBuilder.RemoveNodes("BarracksTypes");
+				baseBuilder.RemoveNodes("VehiclesFactoryTypes");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -72,6 +72,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceBaseAttackNotifier(),
 				new RemoveBuildingInfoAllowPlacementOnResources(),
 				new EditorMarkerTileLabels(),
+				new RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule(),
 			]),
 		];
 

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -82,68 +82,89 @@ Player:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		HarvesterTypes: harv
 		RefineryTypes: proc
+		InitialHarvesters: 3
+	ResourceMapBotModule:
+		RequiresCondition: enable-hal9001-ai || enable-cabal-ai || enable-watson-ai
+		ResourceCreatorTypes: split2, split3, splitblue
+		ValuableResourceTypes: Tiberium, BlueTiberium
+		HarvesterTypes: harv
+		RefineryTypes: proc
+		EnemyBaseBuildingTypes: fact,pyle,hand,weap,afld,gtwr,gun,atwr,obli,hpad,nuke,nuk2,proc
 	BaseBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
-		MaximumExcessPower: 150
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 5
+		MinimumExcessPower: 0
+		MaximumExcessPower: 270
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 3
+		MaxBaseRadius: 18
 		ConstructionYardTypes: fact
+		ExpansionTolerate: 0
+		ForceExpansionTolerate: 1
 		RefineryTypes: proc
 		PowerTypes: nuke, nuk2
-		BarracksTypes: pyle, hand
-		VehiclesFactoryTypes: weap, afld
-		ProductionTypes: pyle, hand, weap, afld, hpad
+		TechTypes: hq, tmpl, fix, eye, hpad
+		ProductionTypes: pyle, hand, weap, afld
+		NewProductionCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:
-			proc: 4
 			pyle: 3
 			hand: 3
 			hq: 1
 			weap: 3
 			afld: 3
-			hpad: 0
+			hpad: 1
 			eye: 1
 			tmpl: 1
 			fix: 1
 			silo: 1
 		BuildingFractions:
-			proc: 20
+			nuke: 1
+			proc: 1
 			pyle: 5
 			hand: 5
 			hq: 4
 			weap: 9
 			afld: 9
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
+			gtwr: 6
+			gun: 6
+			atwr: 20
+			obli: 20
 			sam: 7
 			eye: 1
 			tmpl: 1
 			fix: 1
 			hpad: 2
+		BuildingDelays:
+			hq: 4000
+			fix: 4000
+			hpad: 4100
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BaseBuilderBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
+		MinimumExcessPower: 0
 		MaximumExcessPower: 150
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 3
+		MaxBaseRadius: 18
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: nuke,nuk2
-		BarracksTypes: pyle,hand
-		VehiclesFactoryTypes: weap,afld
-		ProductionTypes: pyle,hand,weap,afld,hpad
+		AdditionalMinimumRefineryCount: 0
+		TechTypes: hq, tmpl, fix, eye, hpad
+		ProductionTypes: pyle,hand,weap,afld
+		ExpansionTolerate: 0
+		ForceExpansionTolerate: 0
+		NewProductionCashThreshold: 6000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:
-			proc: 4
 			pyle: 3
 			hand: 3
 			hq: 1
@@ -155,7 +176,8 @@ Player:
 			fix: 1
 			silo: 1
 		BuildingFractions:
-			proc: 17
+			nuke: 1
+			proc: 1
 			pyle: 2
 			hand: 2
 			hq: 1
@@ -170,24 +192,35 @@ Player:
 			tmpl: 1
 			sam: 7
 			fix: 1
+		BuildingDelays:
+			hq: 5000
+			fix: 5000
+			hpad: 6000
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BaseBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		BuildingQueues: Building.Nod, Building.GDI
 		DefenseQueues: Support.Nod, Support.GDI
-		MinimumExcessPower: 30
-		MaximumExcessPower: 210
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
+		MinimumExcessPower: 0
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 2
 		ConstructionYardTypes: fact
+		MaxBaseRadius: 18
 		RefineryTypes: proc
+		InititalMinimumRefineryCount: 0
+		AdditionalMinimumRefineryCount: 2
 		PowerTypes: nuke,nuk2
-		BarracksTypes: pyle,hand
-		VehiclesFactoryTypes: weap,afld
-		ProductionTypes: pyle,hand,weap,afld,hpad
+		TechTypes: hq, tmpl, fix, eye, hpad
+		ProductionTypes: pyle,hand,weap,afld
+		ExpansionTolerate: 0
+		ForceExpansionTolerate: 0
+		NewProductionCashThreshold: 7000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:
-			proc: 4
 			pyle: 4
 			hand: 4
 			hq: 1
@@ -199,7 +232,8 @@ Player:
 			fix: 1
 			silo: 1
 		BuildingFractions:
-			proc: 17
+			nuke: 1
+			proc: 1
 			pyle: 7
 			hand: 9
 			hq: 1
@@ -214,18 +248,30 @@ Player:
 			tmpl: 1
 			sam: 7
 			fix: 1
+		BuildingDelays:
+			hq: 4000
+			fix: 4000
+			hpad: 4100
+			gun: 2000
+			gtwr: 2000
+			sam: 3000
 	BuildingRepairBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	SquadManagerBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
-		SquadSize: 15
-		ExcludeFromSquadsTypes: harv, mcv, a10
+		SquadSize: 50
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
 		IgnoredEnemyTargetTypes: Air
+		RushInterval: 1000
+		MinimumAttackForceDelay: 1000
+		ProtectUnitScanRadius: 30
+		ProtectionScanRadius: 12
 	UnitBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
+		ProductionMinCashRequirement: 750
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
 		UnitsToBuild:
 			e1: 65
@@ -238,6 +284,7 @@ Player:
 			bike: 40
 			ltnk: 25
 			ftnk: 10
+			apc: 10
 			arty: 60
 			stnk: 40
 			jeep: 5
@@ -246,17 +293,27 @@ Player:
 			htnk: 50
 			heli: 5
 			orca: 5
+			mlrs: 1
 		UnitLimits:
 			harv: 8
-	McvManagerBotModule:
-		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
+			mlrs: 3
+	McvExpansionManagerBotModule@cabal:
+		RequiresCondition: enable-cabal-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap,afld
+		MinimumConstructionYardCount: 1
+		AdditionalConstructionYardCount: 1
+	McvExpansionManagerBotModule@watson-hal9001:
+		RequiresCondition: enable-watson-ai || enable-hal9001-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap,afld
+		MinimumConstructionYardCount: 1
 	SquadManagerBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		SquadSize: 15
-		ExcludeFromSquadsTypes: harv, mcv, a10
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
@@ -275,24 +332,28 @@ Player:
 			ftnk: 10
 			arty: 40
 			bike: 10
-			heli: 10
+			heli: 1
 			ltnk: 40
 			stnk: 40
-			orca: 10
-			msam: 50
+			orca: 1
+			msam: 40
 			htnk: 50
 			jeep: 20
 			mtnk: 50
+			mlrs: 1
 		UnitLimits:
 			harv: 8
+			mlrs: 2
 	SquadManagerBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
-		SquadSize: 8
-		ExcludeFromSquadsTypes: harv, mcv, a10
+		SquadSize: 15
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
 		IgnoredEnemyTargetTypes: Air
+		ProtectUnitScanRadius: 15
+		ProtectionScanRadius: 12
 	UnitBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
@@ -319,3 +380,4 @@ Player:
 			orca: 10
 		UnitLimits:
 			harv: 8
+			mlrs: 3

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -78,10 +78,10 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
-		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4
@@ -137,10 +137,10 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
-		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4
@@ -194,10 +194,10 @@ Player:
 		ConstructionYardTypes: construction_yard
 		RefineryTypes: refinery
 		PowerTypes: wind_trap
-		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
 		DefenseTypes: medium_gun_turret,large_gun_turret
+		SellRefineryInterval: -1
 		BuildingLimits:
 			barracks: 3
 			refinery: 4

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -18,8 +18,6 @@ Player:
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr
-		BarracksTypes: tent
-		VehiclesFactoryTypes: weap
 		ProductionTypes: tent, weap
 		SiloTypes: silo
 		BuildingLimits:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -23,6 +23,13 @@ Player:
 	GrantConditionOnBotOwner@naval:
 		Condition: enable-naval-ai
 		Bots: naval
+	ResourceMapBotModule:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai
+		ResourceCreatorTypes: mine, gmine
+		ValuableResourceTypes: Ore, Gems
+		HarvesterTypes: harv
+		RefineryTypes: proc
+		EnemyBaseBuildingTypes: pbox,gun,ftur,tsla,agun,barr,tent,weap,afld,hpad,fact,powr,apwr,proc
 	SupportPowerBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		Decisions:
@@ -74,45 +81,55 @@ Player:
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
-	HarvesterBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	HarvesterBotModule@rush-naval:
+		RequiresCondition: enable-rush-ai || enable-naval-ai
 		HarvesterTypes: harv
 		RefineryTypes: proc
+		InitialHarvesters: 2
+	HarvesterBotModule@normal-turtle:
+		RequiresCondition: enable-normal-ai || enable-turtle-ai
+		HarvesterTypes: harv
+		RefineryTypes: proc
+		InitialHarvesters: 4
 	BaseBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 160
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
+		ExpansionTolerate: 0
+		ForceExpansionTolerate: 0
+		TechTypes: mslo, dome, atek, stek, fix
+		InititalMinimumRefineryCount: 0
+		AdditionalMinimumRefineryCount: 2
 		ProductionTypes: barr,tent,weap
+		NewProductionCashThreshold: 7000
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
+			barr: 7
+			tent: 7
 			kenn: 1
 			dome: 1
-			weap: 1
+			weap: 4
 			atek: 1
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 30
-			barr: 1
+			powr: 1
+			proc: 1
+			barr: 3
 			kenn: 1
-			tent: 1
-			weap: 1
-			pbox: 7
-			gun: 7
-			tsla: 5
-			gap: 2
-			ftur: 10
+			tent: 3
+			weap: 4
+			pbox: 3
+			gun: 3
+			tsla: 3
+			gap: 1
+			ftur: 3
 			agun: 5
 			sam: 5
 			atek: 1
@@ -121,28 +138,38 @@ Player:
 			dome: 10
 			mslo: 1
 		BuildingDelays:
-			dome: 4500
+			dome: 7000
+			fix: 3000
+			pbox: 2000
+			gun: 3000
+			ftur: 2000
+			tsla: 3000
+			kenn: 9000
+			atek: 11000
+			stek: 11000
 	BaseBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 200
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
+		InititalMinimumRefineryCount: 0
+		AdditionalMinimumRefineryCount: 2
+		ExpansionTolerate: 1,2
 		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad
+		TechTypes: dome, atek, stek, fix, afld, hpad
+		ProductionTypes: barr,tent,weap
+		NewProductionCashThreshold: 8000
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
+			barr: 7
+			tent: 7
 			dome: 1
-			weap: 1
+			weap: 4
 			spen: 1
 			syrd: 1
 			hpad: 4
@@ -152,19 +179,20 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 15
-			tent: 1
-			barr: 1
+			powr: 1
+			proc: 1
+			tent: 3
+			barr: 3
 			kenn: 1
 			dome: 1
-			weap: 6
-			hpad: 4
+			weap: 4
+			hpad: 1
 			spen: 1
 			syrd: 1
-			afld: 4
-			afld.ukraine: 4
-			pbox: 7
-			gun: 7
+			afld: 1
+			afld.ukraine: 1
+			pbox: 9
+			gun: 9
 			ftur: 10
 			tsla: 5
 			gap: 2
@@ -175,24 +203,33 @@ Player:
 			stek: 1
 			mslo: 1
 		BuildingDelays:
-			dome: 3000
+			dome: 6000
+			fix: 3000
+			pbox: 1500
+			gun: 2000
+			ftur: 1500
+			tsla: 2800
+			kenn: 7000
+			spen: 6000
+			syrd: 6000
+			atek: 9000
+			stek: 9000
 	BaseBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 20
 		MaximumExcessPower: 250
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncrement: 20
+		ExcessPowerIncreaseThreshold: 2
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad
+		ForceExpansionTolerate: 6, 7, 8
+		TechTypes: dome, atek, stek, fix, afld, hpad
+		ProductionTypes: barr,tent,weap
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:
-			proc: 4
 			barr: 1
 			tent: 1
 			kenn: 1
@@ -207,7 +244,8 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 30
+			powr: 1
+			proc: 1
 			tent: 1
 			barr: 1
 			kenn: 1
@@ -217,9 +255,9 @@ Player:
 			afld.ukraine: 2
 			spen: 1
 			syrd: 1
-			pbox: 10
-			gun: 10
-			ftur: 10
+			pbox: 13
+			gun: 12
+			ftur: 13
 			tsla: 7
 			gap: 3
 			fix: 1
@@ -230,18 +268,22 @@ Player:
 			stek: 1
 			mslo: 1
 		BuildingDelays:
-			dome: 3000
+			dome: 5000
+			atek: 7000
+			stek: 7000
+			kenn: 8000
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
-		MinimumExcessPower: 60
+		MinimumExcessPower: 0
 		MaximumExcessPower: 400
 		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
+		ExcessPowerIncreaseThreshold: 3
 		ConstructionYardTypes: fact
 		RefineryTypes: proc
 		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
+		ExpansionTolerate: 99
+		ForceExpansionTolerate: 999
+		TechTypes: mslo, dome, atek, stek, fix
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
@@ -261,6 +303,7 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
+			powr: 1
 			proc: 25
 			dome: 1
 			weap: 1
@@ -283,6 +326,7 @@ Player:
 			dome: 3000
 			fix: 20000
 			tsla: 21000
+			kenn: 4000
 	PowerDownBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		PowerDownTypes: dome,tsla,mslo,agun,sam
@@ -298,11 +342,32 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
-	McvManagerBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	McvManagerBotModule@naval:
+		RequiresCondition: enable-naval-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap
+	McvExpansionManagerBotModule@rush:
+		RequiresCondition: enable-rush-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		MoveOldConyardFirst: true
+		MinimumConstructionYardCount: 2
+	McvExpansionManagerBotModule@normal:
+		RequiresCondition: enable-normal-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		MinimumConstructionYardCount: 2
+	McvExpansionManagerBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		MoveOldConyardFirst: false
+		MoveConyardTick: 8000
+		MinimumConstructionYardCount: 2
 	UnitBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		UnitsToBuild:
@@ -310,6 +375,7 @@ Player:
 			e2: 15
 			e3: 30
 			e4: 15
+			e7: 1
 			dog: 15
 			shok: 15
 			harv: 10
@@ -340,6 +406,8 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
+		ProtectUnitScanRadius: 15
+		ProtectionScanRadius: 12
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		UnitsToBuild:
@@ -347,6 +415,7 @@ Player:
 			e2: 15
 			e3: 30
 			e4: 15
+			e7: 1
 			dog: 15
 			shok: 15
 			harv: 15
@@ -386,6 +455,10 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
+		RushInterval: 100000
+		MinimumAttackForceDelay: 100000
+		ProtectUnitScanRadius: 30
+		ProtectionScanRadius: 15
 	UnitBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		UnitsToBuild:
@@ -393,6 +466,7 @@ Player:
 			e2: 15
 			e3: 30
 			e4: 15
+			e7: 1
 			dog: 15
 			shok: 15
 			harv: 15
@@ -418,9 +492,9 @@ Player:
 			pt: 10
 			mnly: 2
 		UnitLimits:
-			dog: 4
+			dog: 3
 			harv: 8
-			jeep: 4
+			jeep: 2
 			ftrk: 4
 			mnly: 2
 	MinelayerBotModule@turtle:

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -9,6 +9,16 @@ Player:
 		RequiresCondition: enable-test-ai
 		HarvesterTypes: harv
 		RefineryTypes: proc
+	PowerDownBotModule:
+		RequiresCondition: enable-test-ai
+		PowerDownTypes:  garadr, naradr, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+	ResourceMapBotModule:
+		RequiresCondition: enable-test-ai
+		ResourceCreatorTypes:  tibtre01, tibtre02, tibtre03, bigblue, bigblue3
+		ValuableResourceTypes: Tiberium, BlueTiberium
+		HarvesterTypes: harv
+		RefineryTypes: proc
+		EnemyBaseBuildingTypes: gacnst, gapowr, gapowrup, napowr, naapwr, gapile, nahand, gaweap, naweap,garadr, naradr, gahpad, nahpad, gatech, natech, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
 	BaseBuilderBotModule@test:
 		RequiresCondition: enable-test-ai
 		MinimumExcessPower: 30
@@ -18,11 +28,11 @@ Player:
 		ConstructionYardTypes: gacnst
 		RefineryTypes: proc
 		PowerTypes: gapowr, gapowrup, napowr, naapwr
-		BarracksTypes: gapile, nahand
-		VehiclesFactoryTypes: gaweap, naweap
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
+		TechTypes: garadr, naradr, gahpad, nahpad, gatech, natech
 		SiloTypes: gasilo
 		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		SellRefineryNoResourceDistance: 18
 		BuildingLimits:
 			proc: 4
 			gasilo: 2
@@ -105,8 +115,9 @@ Player:
 			harv: 12
 			medic: 3
 			repair: 3
-	McvManagerBotModule@test:
+	McvExpansionManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		McvTypes: mcv
 		ConstructionYardTypes: gacnst
 		McvFactoryTypes: gaweap, naweap
+		MinimumConstructionYardCount: 2


### PR DESCRIPTION
Supersedes #22028, base on #22028
Changes many stuffs.

Compares to #22028:

0. ResourceIndiceMap shared by BaseBuilder, harvester module and `McvExpansionManagerBotModule`. (Note: if there is no ResourceIndiceMap, BaseBuilder and harvester module will behave as before, without addition ability on refinery control and expansion control)
1. Expansion controlled by BaseBuilder so basically no more undeploy while building stuff. **So expand with only one MCV is possible now**. Solve https://github.com/OpenRA/OpenRA/pull/22028#discussion_r2367984644 and Solve https://github.com/OpenRA/OpenRA/pull/22028#discussion_r2336925111
2. When there is difficulty to place a building, BaseBuilder can also ordered the conyard undeploy and never fallback to old place. Solve https://github.com/OpenRA/OpenRA/pull/22028#pullrequestreview-3196670334 and other lacking build-area problem.
3. Refinery requested by `McvExpansionManagerBotModule` on each expansion and checked by BaseBuilder by using the resource map that shared, no longer controlled by stupid fraction and limit. Solve https://github.com/OpenRA/OpenRA/pull/22028#discussion_r2379455610
4. Remove VehiclesFactoryTypes (no codes using that)
5. Remove BarracksTypes (it seems senseless for all modes, we can start with ref and wf, and now we can always use ProductionTypes)
6. CheckResource and CheckResourceCreator in `McvExpansionManagerBotModule` merged, as we now have the better and less random technique for CheckResource.
7. harvester module will manage harvesters number in each resource indice.~~(currently not working very good though)~~