### PR TITLE
Fix editor grid overlay height coloring calculation

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Commands;
@@ -57,6 +58,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var map = wr.World.Map;
 			var colors = wr.World.Map.Rules.TerrainInfo.HeightDebugColors;
+			var lastColor = colors.Length - 1;
+			var heightStep = map.Grid.TileScale / 2;
 			var mouseCell = wr.Viewport.ViewToWorld(Viewport.LastMousePos).ToMPos(wr.World.Map);
 
 			foreach (var uv in wr.Viewport.AllVisibleCells.CandidateMapCoords)
@@ -77,8 +80,8 @@ namespace OpenRA.Mods.Common.Traits
 						var j = (i + 1) % p.Length;
 						var start = pos + p[i];
 						var end = pos + p[j];
-						var startColor = colors[height + p[i].Z / 512];
-						var endColor = colors[height + p[j].Z / 512];
+						var startColor = colors[Math.Min(lastColor, height + p[i].Z / heightStep)];
+						var endColor = colors[Math.Min(lastColor, height + p[j].Z / heightStep)];
 						yield return new LineAnnotationRenderable(start, end, width, startColor, endColor);
 					}
 				}


### PR DESCRIPTION
The change fixes two issues with the map editor's height-based grid overlay color calculation:

- If the height exceeded the end of the color scale, the engine would crash due to attempting an out of bounds read. Now, the calculation caps out to using the last color in the scale.
- The calculation assumed the height step was always 512, even for RectangularIsometric maps. Now, the (halved) TileScale of the map's grid type is used.
