### PR TITLE
Fix bot traits crashing on missing ResourceMapBotModule

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -257,7 +257,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (firstTick)
 			{
-				ResourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().First(t => t.IsTraitEnabled());
+				ResourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().FirstOrDefault(t => t.IsTraitEnabled());
 				firstTick = false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (firstTick)
 			{
-				resourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().First(t => t.IsTraitEnabled());
+				resourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().FirstOrDefault(t => t.IsTraitEnabled());
 				firstTick = false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -522,7 +522,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (firstTick)
 			{
-				resourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().First(t => t.IsTraitEnabled());
+				resourceMapModule = bot.Player.PlayerActor.TraitsImplementing<ResourceMapBotModule>().FirstOrDefault(t => t.IsTraitEnabled());
 				SwitchExpansionMode(Info.InitialExpansionMode);
 
 				pathDistanceSquareFactor = resourceMapModule.GetIndiceRowCount() * resourceMapModule.GetIndiceRowCount()


### PR DESCRIPTION
Regression from #22116
Fixes the bug reported in #22126