### PR TITLE
Fix extra prereq for D2k pad/MCV in missions

### DIFF
--- a/mods/d2k/maps/atreides-04/rules.yaml
+++ b/mods/d2k/maps/atreides-04/rules.yaml
@@ -62,13 +62,17 @@ engineer:
 
 repair_pad:
 	Buildable:
-		Prerequisites: heavy_factory, upgrade.heavy
+		Prerequisites: heavy_factory
 
 mcv:
 	Buildable:
-		Prerequisites: repair_pad, upgrade.heavy
+		Prerequisites: repair_pad
 
 upgrade.conyard:
+	Buildable:
+		Prerequisites: ~disabled
+
+upgrade.heavy:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/d2k/maps/harkonnen-04/rules.yaml
+++ b/mods/d2k/maps/harkonnen-04/rules.yaml
@@ -62,13 +62,17 @@ engineer:
 
 repair_pad:
 	Buildable:
-		Prerequisites: heavy_factory, upgrade.heavy
+		Prerequisites: heavy_factory
 
 mcv:
 	Buildable:
-		Prerequisites: repair_pad, upgrade.heavy
+		Prerequisites: repair_pad
 
 upgrade.conyard:
+	Buildable:
+		Prerequisites: ~disabled
+
+upgrade.heavy:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/d2k/maps/ordos-04/rules.yaml
+++ b/mods/d2k/maps/ordos-04/rules.yaml
@@ -58,12 +58,16 @@ engineer:
 
 repair_pad:
 	Buildable:
-		Prerequisites: heavy_factory, upgrade.heavy
+		Prerequisites: heavy_factory
 
 mcv:
 	Buildable:
-		Prerequisites: repair_pad, upgrade.heavy
+		Prerequisites: repair_pad
 
 upgrade.conyard:
+	Buildable:
+		Prerequisites: ~disabled
+
+upgrade.heavy:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
Repair Pads in some missions still require a Heavy Factory upgrade after https://github.com/OpenRA/OpenRA/pull/21930.