### PR TITLE
Fix bot MCV not persisting when failed to deploy.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -193,9 +193,11 @@ namespace OpenRA.Mods.Common.Traits
 			var worstEffectHarvesterCount = int.MaxValue;
 
 			var lackHarvesterIndices = new List<(int Attraction, int LackHarvs, CPos ResoueceCenter)>();
+
 			/*
 			 * indiceSideLengthSquare (which is equal to indiceSideLength * indiceSideLength) is used as the basic unit to calculate the attraction of a candidate,
-			 * we  compare the attraction on the same scale on different factors, such as candidate's distance to current MCV and ally construction yard & refinery within range, etc:
+			 * we compare the attraction on the same scale on different factors, such as ally refinery within range or threats nearby.
+			 * Note: this function requires an enabled resourceMapModule.
 			 */
 
 			var indiceSideLengthSquare = resourceMapModule.GetIndiceSideLength() * resourceMapModule.GetIndiceSideLength();

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -467,7 +467,7 @@ namespace OpenRA.Mods.Common.Traits
 
 						foreach (var (othermcv, dest) in activeMCVs)
 						{
-							if (dest == indiceCenter)
+							if (dest == indiceCenter && othermcv != mcv)
 								attraction -= indiceSideLengthSquare << 1;
 						}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -290,7 +290,7 @@ namespace OpenRA.Mods.Common.Traits
 			 *
 			 * 2). the weight of friendly construction yard within range: -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
 			 *
-			 * 3). the weight of enemy high threat within range: -indiceSideLengthSquare*8, otherwise -indiceSideLengthSquare/64
+			 * 3). the weight of enemy within range: -indiceSideLengthSquare*8 for base building, otherwise -indiceSideLengthSquare/64
 			 *
 			 * 4). the weight of friendly refinery within range (not for CheckBase mode): -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
 			 *
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				/*
 				 * CheckBase mode only considers the distance to current MCV, ally construction yard within range and enemy buildings within range.
-				 * Attaction has a base value of indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, 1/(2*sqrt(2))≈ 1/2.8 of the maximum distance in map)
+				 * Attaction has a base value of indiceSideLengthSquare >> 1 (1/2 of the maximum distance weight, 1/ sqrt(2) ≈ 1/1.4 of maximum euclid distance in map)
 				 */
 				case BotMcvExpansionMode.CheckBase:
 					var cb_conyardlocs = world.ActorsHavingTrait<Building>()
@@ -374,8 +374,8 @@ namespace OpenRA.Mods.Common.Traits
 				/*
 				 * CheckResource mode considers the distance to current MCV, ally construction yard & refinery within range,
 				 * Attaction has a base value of:
-				 * 1. if not Mobile: indiceSideLengthSquare >> 4 (1/16 of the maximum distance weight, = 0.25 of the maximum euclid distance in map)
-				 * 2. if Mobile: indiceSideLengthSquare >> 3 (1/8 of the maximum distance weight, ≈ 0.35 of the maximum euclid distance in map)
+				 * 1. if not Mobile: indiceSideLengthSquare >> 2 (1/4 of the maximum distance weight, = 0.5 of the maximum euclid distance in map)
+				 * 2. if Mobile: indiceSideLengthSquare >> 1 (1/2 of the maximum distance weight, ≈ 0.71 of the maximum euclid distance in map)
 				 */
 				case BotMcvExpansionMode.CheckResource:
 
@@ -389,7 +389,7 @@ namespace OpenRA.Mods.Common.Traits
 						.Select(a => (a.Location, a.Owner != player))
 						.ToArray();
 
-					// We only take indice has more than half of average indice value (in weight calculation), to skip the indice with very poor resource
+					// We only take indice has more than the half of average indice value (in weight calculation), to skip the indice with very poor resource
 					// when failedAttempts is acceptable.
 					var thresholdRes = 0;
 					for (var i = 0; i < resourceMapModule.GetIndicesLength(); i++)


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/OpenRA/OpenRA/pull/22116#issuecomment-3390337716 as
>Nope, even with no changes in the local index. Only later in the game can AI sometimes decide to try again in a location nearby. Maybe deploy checks are broken, as in we consider units that can be nudged as blockers? Transform order should have nudging by default

in the first commit, which is a regression in #22116

Also fix comments that are truly outdated during development of #22116.