### PR TITLE
fix harkonnen logo 

### DIFF
--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -81,7 +81,7 @@ radar-ordos:
 radar-harkonnen:
 	Inherits: ^Chrome
 	Regions:
-		insignia: 227, 127, 100, 100
+		insignia: 227, 127, 100, 90
 
 power-icons:
 	Inherits: ^Glyphs


### PR DESCRIPTION
Fix Harkonnen radar logo slightly overlaps with Purchase button. Regression from #21424
<img width="225" height="270" alt="d2k-2025-10-16T100355696Z" src="https://github.com/user-attachments/assets/19fa94d5-9e14-4faf-bd28-4cad6ccc7a82" />

<img width="224" height="253" alt="d2k-2025-10-16T100334317Z" src="https://github.com/user-attachments/assets/947b0974-71eb-4448-be42-1d35a417b720" />
