### PR TITLE
Move code signing into production

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -121,12 +121,14 @@ jobs:
 
       - name: Upload Installer
         id: unsigned-artifact
+        if: github.repository == 'openra/openra'
         uses: actions/upload-artifact@v5
         with:
           path: build/windows/*.exe
 
       - name: Microsoft Authenticode
         id: signpath
+        if: github.repository == 'openra/openra'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -144,5 +146,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload ${{ github.ref_name }} build/windows/*.zip
-          gh release upload ${{ github.ref_name }} build/windows/signed/*.exe
+          gh release upload "${{ github.ref_name }}" build/windows/*.zip
+
+          if [ "${GITHUB_REPOSITORY}" = "openra/openra" ]; then
+            gh release upload "${{ github.ref_name }}" build/windows/signed/*.exe
+          else
+            gh release upload "${{ github.ref_name }}" build/windows/*.exe
+          fi

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -132,7 +132,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ secrets.SIGNPATH_ORGANISATION_ID }}'
           project-slug: 'OpenRA'
-          signing-policy-slug: 'test-signing'
+          signing-policy-slug: 'release-signing'
           github-artifact-id: '${{ steps.unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'build/windows/signed/'

--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ available to you under the terms of the GNU General Public License
 as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version. For more
 information, see [COPYING](https://github.com/OpenRA/OpenRA/blob/bleed/COPYING).
+
+# Sponsors
+Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).


### PR DESCRIPTION
We have been vetted and got our real certificate. This is a followup to https://github.com/OpenRA/OpenRA/pull/22114.