### PR TITLE
Airstate danger avoidance: check the aircraft nearest target actor

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				}
 			}
 
-			if (!NearToPosSafely(owner, owner.Target.CenterPosition))
+			if (!NearToPosSafely(owner, owner.Units.ClosestToIgnoringPath(owner.TargetActor).CenterPosition))
 			{
 				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState());
 				return;


### PR DESCRIPTION
At `AirAttackState`, we check the danger around the aircraft nearest target actor, instead of the danger around target actor.

This can basically fix https://github.com/OpenRA/OpenRA/pull/22040#pullrequestreview-3341658930.