### PR TITLE
Implement fast WAV ImaAdpcm decoder

### DIFF
--- a/OpenRA.Game/Primitives/SegmentStream.cs
+++ b/OpenRA.Game/Primitives/SegmentStream.cs
@@ -172,5 +172,20 @@ namespace OpenRA.Primitives
 			stream.Seek(offset, SeekOrigin.Begin);
 			return new MemoryStream(stream.ReadBytes(count));
 		}
+
+		public static ReadOnlySpan<byte> GetReadableData(Stream stream, long offset, int size)
+		{
+			if (stream is MemoryStream ms)
+			{
+				// avoid copying where possible
+				var buf = ms.GetBuffer();
+				return new ReadOnlySpan<byte>(buf, (int)offset, Math.Min(size, buf.Length - (int)offset));
+			}
+
+			var buffer = new byte[size];
+			stream.Seek(offset, SeekOrigin.Begin);
+			stream.ReadExactly(buffer);
+			return buffer;
+		}
 	}
 }

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -30,6 +30,7 @@ namespace OpenRA
 		int SampleRate { get; }
 		float LengthInSeconds { get; }
 		Stream GetPCMInputStream();
+		byte[] GetPCMData();
 	}
 
 	public enum SoundType { World, UI }
@@ -93,7 +94,7 @@ namespace OpenRA
 			this.loaders = loaders;
 			this.fileSystem = fileSystem;
 			ISoundSource LoadIntoMemory(ISoundFormat soundFormat) => soundEngine.AddSoundSourceFromMemory(
-				soundFormat.GetPCMInputStream().ReadAllBytes(), soundFormat.Channels, soundFormat.SampleBits, soundFormat.SampleRate);
+				soundFormat.GetPCMData(), soundFormat.Channels, soundFormat.SampleBits, soundFormat.SampleRate);
 			sounds = new Cache<string, ISoundSource>(filename => LoadSound(filename, LoadIntoMemory));
 			currentSounds.Clear();
 			currentNotifications.Clear();

--- a/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
@@ -54,6 +54,12 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 		public int SampleRate => sampleRate;
 		public float LengthInSeconds => lengthInSeconds;
 		public Stream GetPCMInputStream() { return audStreamFactory(); }
+		public byte[] GetPCMData()
+		{
+			using var s = audStreamFactory();
+			return s.ReadAllBytes();
+		}
+
 		public void Dispose() { sourceStream.Dispose(); }
 
 		readonly Stream sourceStream;

--- a/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
@@ -42,6 +42,12 @@ namespace OpenRA.Mods.Cnc.AudioLoaders
 		public int SampleRate { get; }
 		public float LengthInSeconds => (float)totalSamples / SampleRate;
 		public Stream GetPCMInputStream() { return new VocStream(new VocFormat(this)); }
+		public byte[] GetPCMData()
+		{
+			using var pcmStream = GetPCMInputStream();
+			return pcmStream.ReadAllBytes();
+		}
+
 		public void Dispose() { stream.Dispose(); }
 
 		readonly byte[] buffer = new byte[4096];

--- a/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 	public static class AudReader
 	{
-		public static bool LoadSound(Stream s, out Func<Stream> result, out int sampleRate, out int sampleBits, out int channels, out float lengthInSeconds)
+		public static bool LoadSound(Stream s, out Func<Stream> result,
+			out int sampleRate, out int sampleBits, out int channels, out float lengthInSeconds)
 		{
 			result = null;
 			var startPosition = s.Position;

--- a/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
@@ -103,9 +103,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			int dataSize;
 			byte[] inputBuffer;
 
-			int currentSample;
+			short currentSample;
 			int baseOffset;
-			int index;
+			byte index;
 
 			public ImaAdpcmAudStream(Stream stream, int outputSize, int dataSize)
 				: base(stream)

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 		{
 			var audio1 = new MemoryStream(); // left channel / mono
 			var audio2 = new MemoryStream(); // right channel
-			var adpcmIndex = 0;
+			byte adpcmIndex = 0;
 			var compressed = false;
 			for (var i = 0; i < FrameCount; i++)
 			{
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				}
 			}
 
-			static byte[] GetAudioData(bool compressed, MemoryStream audio, ref int adpcmIndex)
+			static byte[] GetAudioData(bool compressed, MemoryStream audio, ref byte adpcmIndex)
 			{
 				var audioArray = audio.ToArray();
 				if (!compressed)

--- a/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/Mp3Loader.cs
@@ -67,6 +67,12 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		public int SampleRate => mp3.Frequency;
 		public float LengthInSeconds { get; }
 		public Stream GetPCMInputStream() { return new MP3Stream(Clone(this)); }
+		public byte[] GetPCMData()
+		{
+			using var pcmStream = GetPCMInputStream();
+			return pcmStream.ReadAllBytes();
+		}
+
 		public void Dispose() { mp3.Dispose(); }
 
 		readonly MP3Stream mp3;

--- a/OpenRA.Mods.Common/AudioLoaders/OggLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/OggLoader.cs
@@ -42,6 +42,12 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		public int SampleRate => reader.SampleRate;
 		public float LengthInSeconds { get; }
 		public Stream GetPCMInputStream() { return new OggStream(new OggFormat(this)); }
+		public byte[] GetPCMData()
+		{
+			using var pcmStream = GetPCMInputStream();
+			return pcmStream.ReadAllBytes();
+		}
+
 		public void Dispose() { reader.Dispose(); }
 
 		readonly VorbisReader reader;

--- a/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
@@ -55,10 +55,12 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		public int SampleRate => sampleRate;
 		public float LengthInSeconds => lengthInSeconds;
 		public Stream GetPCMInputStream() { return wavStreamFactory(); }
+		public byte[] GetPCMData() { return pcmDataFactory(); }
 		public void Dispose() { sourceStream.Dispose(); }
 
 		readonly Stream sourceStream;
 		readonly Func<Stream> wavStreamFactory;
+		readonly Func<byte[]> pcmDataFactory;
 		readonly short channels;
 		readonly int sampleBits;
 		readonly int sampleRate;
@@ -68,7 +70,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		{
 			sourceStream = stream;
 
-			if (!WavReader.LoadSound(stream, out wavStreamFactory, out channels, out sampleBits, out sampleRate, out lengthInSeconds))
+			if (!WavReader.LoadSound(stream, out wavStreamFactory, out pcmDataFactory, out channels, out sampleBits, out sampleRate, out lengthInSeconds))
 				throw new InvalidDataException();
 		}
 	}

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace OpenRA.Mods.Common.FileFormats
 {
@@ -30,39 +31,49 @@ namespace OpenRA.Mods.Common.FileFormats
 			16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
 		];
 
-		public static short DecodeImaAdpcmSample(byte b, ref int index, ref int current)
+		/// <summary>
+		/// Decodes a single IMA ADPCM nibble to a PCM sample.
+		/// </summary>
+		/// <remarks>
+		/// Branchless and only the output variables leave registers.
+		/// </remarks>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static short DecodeImaAdpcmSample(byte nibble, ref byte idx, ref short pred)
 		{
-			var sb = (b & 8) != 0;
-			b &= 7;
+			var step = StepTable[idx];
+			var diff = step >> 3;
 
-			var delta = StepTable[index] * b / 4 + StepTable[index] / 8;
-			if (sb)
-				delta = -delta;
+			var mask = nibble & 7;
+			diff += ((mask >> 2) & 1) * step;
+			diff += ((mask >> 1) & 1) * (step >> 1);
+			diff += (mask & 1) * (step >> 2);
 
-			current += delta;
-			if (current > short.MaxValue)
-				current = short.MaxValue;
+			// branchless negation via bitmask
+			var sign = (nibble & 8) != 0 ? -1 : 1;
+			diff *= sign;
 
-			if (current < short.MinValue)
-				current = short.MinValue;
+			var sample = pred + diff;
 
-			index += IndexAdjust[b];
-			if (index < 0)
-				index = 0;
+			// branchless clamping (fast saturating logic)
+			if ((uint)(sample - short.MinValue) > ushort.MaxValue)
+				sample = sample > 0 ? short.MaxValue : short.MinValue;
 
-			if (index > 88)
-				index = 88;
+			pred = (short)sample;
 
-			return (short)current;
+			var newIdx = idx + IndexAdjust[mask];
+			newIdx = newIdx < 0 ? 0 : newIdx > 88 ? 88 : newIdx;
+			idx = (byte)newIdx;
+
+			return pred;
 		}
 
-		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, Span<byte> output)
+		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref byte index, Span<byte> output)
 		{
-			var currentSample = 0;
+			short currentSample = 0;
 			LoadImaAdpcmSound(raw, ref index, ref currentSample, output);
 		}
 
-		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, ref int currentSample, Span<byte> output)
+		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref byte index, ref short currentSample, Span<byte> output)
 		{
 			var dataSize = raw.Length;
 			if (output.Length != raw.Length * 4)

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -10,7 +10,10 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.FileFormats
 {
@@ -93,6 +96,115 @@ namespace OpenRA.Mods.Common.FileFormats
 				output[offset++] = (byte)t;
 				output[offset++] = (byte)(t >> 8);
 			}
+		}
+
+		public static byte[] ReadData(Stream stream, long dataOffset, int dataSize, short blockAlign, short channels)
+		{
+			const int SamplesPerGroup = 8;
+
+			ArgumentNullException.ThrowIfNull(stream);
+
+			var sourceData = SegmentStream.GetReadableData(stream, dataOffset, dataSize);
+
+			var numBlocks = dataSize / blockAlign;
+
+			var predictorSize = 4 * channels;
+			var blockDataSize = blockAlign - predictorSize;
+
+			// We get two samples per nibble
+			var samplesPerChannel = blockDataSize * 2 / channels;
+
+			// 8 samples from a 4-byte group
+			var groupCount = samplesPerChannel / SamplesPerGroup;
+
+			var predOut = numBlocks * channels * 2;
+			var groupOut = numBlocks * groupCount * channels * SamplesPerGroup * 2;
+			var estimatedOutDataSize = predOut + groupOut;
+
+			var outData = new byte[estimatedOutDataSize];
+
+			// PERF: The output is 16-bit PCM, so we can write bytes as if they were shorts for less CPU churn.
+			var outShorts = MemoryMarshal.Cast<byte, short>(outData.AsSpan());
+
+			// NOTE: decoding a block is sequentually dependent on predictor/index.
+			Span<short> predictor = stackalloc short[channels];
+			Span<byte> index = stackalloc byte[channels];
+
+			// PERF: Avoid bounds checks by using refs.
+			ref var srcRef = ref MemoryMarshal.GetReference(sourceData);
+			ref var outRef = ref MemoryMarshal.GetReference(outShorts);
+			ref var predRef = ref MemoryMarshal.GetReference(predictor);
+			ref var idxRef = ref MemoryMarshal.GetReference(index);
+
+			// Global decoded sample counter
+			var src = 0;
+			var outSample = 0;
+
+			for (var block = 0; block < numBlocks; block++)
+			{
+				// Initial states
+				for (var c = 0; c < channels; c++)
+				{
+					var offset = src + c * 4;
+
+					// Load initial values.
+					var pred = (short)(Unsafe.Add(ref srcRef, offset) | (Unsafe.Add(ref srcRef, offset + 1) << 8));
+					var idx = Unsafe.Add(ref srcRef, offset + 2);
+
+					Unsafe.Add(ref predRef, c) = pred;
+					Unsafe.Add(ref idxRef, c) = idx;
+				}
+
+				src += predictorSize;
+
+				// Write initial predictor samples interleaved
+				for (var c = 0; c < channels; c++)
+					Unsafe.Add(ref outRef, outSample + c) = Unsafe.Add(ref predRef, c);
+
+				outSample += channels;
+
+				for (var iter = 0; iter < groupCount; iter++)
+				{
+					// Decode 8 samples sequentially per channel
+					for (var c = 0; c < channels; c++)
+					{
+						ref var pred = ref Unsafe.Add(ref predRef, c);
+						ref var idx = ref Unsafe.Add(ref idxRef, c);
+
+						var b0 = Unsafe.Add(ref srcRef, src + 0);
+						var b1 = Unsafe.Add(ref srcRef, src + 1);
+						var b2 = Unsafe.Add(ref srcRef, src + 2);
+						var b3 = Unsafe.Add(ref srcRef, src + 3);
+
+						src += 4;
+
+						// PERF: Decode into temporary variables so they could be easily inlined directly to output.
+						var s0 = DecodeImaAdpcmSample((byte)(b0 & 0x0F), ref idx, ref pred);
+						var s1 = DecodeImaAdpcmSample((byte)(b0 >> 4), ref idx, ref pred);
+						var s2 = DecodeImaAdpcmSample((byte)(b1 & 0x0F), ref idx, ref pred);
+						var s3 = DecodeImaAdpcmSample((byte)(b1 >> 4), ref idx, ref pred);
+						var s4 = DecodeImaAdpcmSample((byte)(b2 & 0x0F), ref idx, ref pred);
+						var s5 = DecodeImaAdpcmSample((byte)(b2 >> 4), ref idx, ref pred);
+						var s6 = DecodeImaAdpcmSample((byte)(b3 & 0x0F), ref idx, ref pred);
+						var s7 = DecodeImaAdpcmSample((byte)(b3 >> 4), ref idx, ref pred);
+
+						// Write interleaved samples (one sample per channel)
+						var basePos = outSample + c;
+						Unsafe.Add(ref outRef, basePos + channels * 0) = s0;
+						Unsafe.Add(ref outRef, basePos + channels * 1) = s1;
+						Unsafe.Add(ref outRef, basePos + channels * 2) = s2;
+						Unsafe.Add(ref outRef, basePos + channels * 3) = s3;
+						Unsafe.Add(ref outRef, basePos + channels * 4) = s4;
+						Unsafe.Add(ref outRef, basePos + channels * 5) = s5;
+						Unsafe.Add(ref outRef, basePos + channels * 6) = s6;
+						Unsafe.Add(ref outRef, basePos + channels * 7) = s7;
+					}
+
+					outSample += channels * 8;
+				}
+			}
+
+			return outData;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -21,9 +21,11 @@ namespace OpenRA.Mods.Common.FileFormats
 	{
 		enum WaveType : short { Pcm = 0x1, MsAdpcm = 0x2, ImaAdpcm = 0x11 }
 
-		public static bool LoadSound(Stream s, out Func<Stream> result, out short channels, out int sampleBits, out int sampleRate, out float lengthInSeconds)
+		public static bool LoadSound(Stream s, out Func<Stream> result, out Func<byte[]> pcmDataFactory,
+		out short channels, out int sampleBits, out int sampleRate, out float lengthInSeconds)
 		{
 			result = null;
+			pcmDataFactory = null;
 			channels = -1;
 			sampleBits = -1;
 			sampleRate = -1;
@@ -103,6 +105,13 @@ namespace OpenRA.Mods.Common.FileFormats
 					return new WavStreamMsAdpcm(audioStream, dataSize, blockAlign, chan);
 
 				return audioStream; // Data is already PCM format.
+			};
+
+			var func = result;
+			pcmDataFactory = () =>
+			{
+				using var funcStream = func();
+				return funcStream.ReadAllBytes();
 			};
 
 			return true;

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			return true;
 		}
 
-		sealed class WavStreamImaAdpcm : ReadOnlyAdapterStream
+		sealed class WavStreamImaAdpcm : Stream
 		{
 			const int SamplesPerGroup = 8;
 			const int BytesPerSample = 2;
@@ -145,15 +145,29 @@ namespace OpenRA.Mods.Common.FileFormats
 			readonly short channels;
 			readonly int numBlocks;
 			readonly int inBlockDataSize;
-			readonly int outputSize;
-			readonly byte[] blockData;
+			readonly int outGroupSize;
 
-			int outOffset;
+			// NOTE: decoding a block is sequentually dependent on predictor/index.
+			readonly short[] predictor;
+			readonly byte[] index;
+
 			int currentBlock;
+			int inBlockOffset;
+
+			readonly byte[] ringBuf = new byte[8192];
+			int head, tail, count;
+
+			bool baseStreamEmpty;
+			readonly Stream baseStream;
 
 			public WavStreamImaAdpcm(Stream stream, int dataSize, short blockAlign, short channels)
-				: base(stream)
 			{
+				ArgumentNullException.ThrowIfNull(stream);
+				if (!stream.CanRead)
+					throw new ArgumentException("stream must be readable.", nameof(stream));
+
+				baseStream = stream;
+
 				this.channels = channels;
 
 				var inHeaderSize = 4 * channels;
@@ -162,78 +176,203 @@ namespace OpenRA.Mods.Common.FileFormats
 				numBlocks = dataSize / blockAlign;
 				var numGroupsPerBlock = inBlockDataSize / channels / SamplesPerGroup * BytesPerSample;
 
-				var outGroupSize = SamplesPerGroup * BytesPerSample * channels;
+				outGroupSize = SamplesPerGroup * BytesPerSample * channels;
 				var outHead = channels * BytesPerSample;
 				var outGroups = numGroupsPerBlock * outGroupSize;
-				outputSize = numBlocks * (outHead + outGroups);
+				Length = numBlocks * (outHead + outGroups);
 
-				blockData = new byte[inBlockDataSize];
+				predictor = new short[channels];
+				index = new byte[channels];
 			}
 
-			protected override bool BufferData(Stream baseStream, Queue<byte> data)
+			/// <summary>
+			/// Reads and decodes blocks from the base stream into the ring buffer.
+			/// </summary>
+			bool ReadBlocks()
 			{
-				// Decode each block of IMA ADPCM data
-				// Each block starts with a initial state per-channel
-				Span<int> predictor = stackalloc int[channels];
-				Span<int> index = stackalloc int[channels];
+				// Check if we have enough space for a group. Ask for a flush if not.
+				// If ring buffer size were too small this could loop forever, however
+				// we know our buffer will always be large enough.
+				var availableBytes = ringBuf.Length - count;
+				if (availableBytes < outGroupSize + 2)
+					return false;
 
-				Span<byte> channelData = stackalloc byte[channels * 4];
-				baseStream.ReadBytes(channelData);
-				var cd = 0;
-				for (var c = 0; c < channels; c++)
+				// PERF: The output is 16-bit PCM, so we can write bytes as if they were shorts for less CPU churn.
+				var outShorts = MemoryMarshal.Cast<byte, short>(ringBuf.AsSpan());
+
+				// PERF: Used for batch reading data from stream.
+				Span<byte> header = stackalloc byte[4];
+				Span<byte> group = stackalloc byte[4 * channels];
+
+				// Fill the ring buffer instead decoding just one group.
+				while (ringBuf.Length - count >= outGroupSize + 2 && currentBlock < numBlocks)
 				{
-					predictor[c] = (short)(channelData[cd++] | channelData[cd++] << 8);
-					index[c] = channelData[cd++];
-					cd++; // Unknown/Reserved
-
-					// Output first sample from input
-					data.Enqueue((byte)predictor[c]);
-					data.Enqueue((byte)(predictor[c] >> 8));
-					outOffset += 2;
-
-					if (outOffset >= outputSize)
-						return true;
-				}
-
-				// Decode and output remaining data in this block
-				Span<byte> decoded = stackalloc byte[16];
-				Span<byte> interleaveBuffer = stackalloc byte[channels * 16];
-				var blockDataSpan = blockData.AsSpan();
-				baseStream.ReadBytes(blockDataSpan);
-				var blockOffset = 0;
-				Span<byte> chunk = stackalloc byte[4];
-				while (blockOffset < inBlockDataSize)
-				{
-					for (var c = 0; c < channels; c++)
+					// If we are at the start of a block, read the header
+					if (inBlockOffset == 0)
 					{
-						// Decode 4 bytes (to 16 bytes of output) per channel
-						ImaAdpcmReader.LoadImaAdpcmSound(blockDataSpan.Slice(blockOffset, 4), ref index[c], ref predictor[c], decoded);
-
-						// Interleave output, one sample per channel
-						var interleaveChannelOffset = 2 * c;
-						for (var i = 0; i < decoded.Length; i += 2)
+						for (var c = 0; c < channels; c++)
 						{
-							var interleaveSampleOffset = interleaveChannelOffset + i;
-							interleaveBuffer[interleaveSampleOffset] = decoded[i];
-							interleaveBuffer[interleaveSampleOffset + 1] = decoded[i + 1];
-							interleaveChannelOffset += 2 * (channels - 1);
-						}
+							baseStream.ReadExactly(header);
 
-						blockOffset += 4;
+							// Load initial values.
+							predictor[c] = (short)(header[0] | (header[1] << 8));
+							index[c] = header[2];
+
+							// header[3] is unknown/reserved
+
+							// Write initial predictor samples interleaved
+							var pos = tail / 2;
+							outShorts[pos] = predictor[c];
+							tail = (tail + 2) % ringBuf.Length;
+							count += 2;
+						}
 					}
 
-					var outputRemaining = outputSize - outOffset;
-					var toCopy = Math.Min(outputRemaining, interleaveBuffer.Length);
-					for (var i = 0; i < toCopy; i++)
-						data.Enqueue(interleaveBuffer[i]);
+					// Writing into a single buffer to improve cache locality, making sure data is serial.
+					for (var c = 0; c < channels; c++)
+						baseStream.ReadExactly(group.Slice(c * 4, 4));
 
-					outOffset += 16 * channels;
+					// Decode the group sequentially.
+					for (var c = 0; c < channels; c++)
+					{
+						ref var pred = ref predictor[c];
+						ref var idx = ref index[c];
 
-					if (outOffset >= outputSize)
-						return true;
+						var offset = c * 4;
+						var b0 = group[offset + 0];
+						var b1 = group[offset + 1];
+						var b2 = group[offset + 2];
+						var b3 = group[offset + 3];
+
+						// Decode into temporary variables so they could be easily turned into registers.
+						var s0 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b0 & 0x0F), ref idx, ref pred);
+						var s1 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b0 >> 4), ref idx, ref pred);
+						var s2 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b1 & 0x0F), ref idx, ref pred);
+						var s3 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b1 >> 4), ref idx, ref pred);
+						var s4 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b2 & 0x0F), ref idx, ref pred);
+						var s5 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b2 >> 4), ref idx, ref pred);
+						var s6 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b3 & 0x0F), ref idx, ref pred);
+						var s7 = ImaAdpcmReader.DecodeImaAdpcmSample((byte)(b3 >> 4), ref idx, ref pred);
+
+						// Write interleaved samples (one sample per channel).
+						// Handle ring buffer wrap-around.
+						var basePos = tail / 2 + c;
+						outShorts[(basePos + 0 * channels) % outShorts.Length] = s0;
+						outShorts[(basePos + 1 * channels) % outShorts.Length] = s1;
+						outShorts[(basePos + 2 * channels) % outShorts.Length] = s2;
+						outShorts[(basePos + 3 * channels) % outShorts.Length] = s3;
+						outShorts[(basePos + 4 * channels) % outShorts.Length] = s4;
+						outShorts[(basePos + 5 * channels) % outShorts.Length] = s5;
+						outShorts[(basePos + 6 * channels) % outShorts.Length] = s6;
+						outShorts[(basePos + 7 * channels) % outShorts.Length] = s7;
+					}
+
+					tail = (tail + outGroupSize) % ringBuf.Length;
+					count += outGroupSize;
+
+					// We don't decode the entire block at once.
+					inBlockOffset += 4 * channels;
+					if (inBlockOffset >= inBlockDataSize)
+					{
+						inBlockOffset = 0;
+						currentBlock++;
+
+						// The file is done.
+						if (currentBlock >= numBlocks)
+							return true;
+					}
 				}
 
-				return ++currentBlock >= numBlocks;
+				return false;
+			}
+
+			public override bool CanSeek => false;
+			public override bool CanRead => true;
+			public override bool CanWrite => false;
+
+			public override long Length { get; }
+
+			public override long Position
+			{
+				get => throw new NotSupportedException();
+				set => throw new NotSupportedException();
+			}
+
+			public override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+			public override void SetLength(long value) { throw new NotSupportedException(); }
+			public override void WriteByte(byte value) { throw new NotSupportedException(); }
+			public override void Write(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+			public override void Write(ReadOnlySpan<byte> buffer) { throw new NotSupportedException(); }
+			public override void Flush() { throw new NotSupportedException(); }
+
+			public override int ReadByte()
+			{
+				while (true)
+				{
+					if (count > 0)
+					{
+						var b = ringBuf[head++];
+						if (head >= ringBuf.Length)
+							head = 0;
+
+						count--;
+						return b;
+					}
+
+					if (baseStreamEmpty)
+						return -1;
+
+					// Try to fill buffer
+					baseStreamEmpty = ReadBlocks();
+				}
+			}
+
+			public override int Read(byte[] buffer, int offset, int count)
+			{
+				return Read(buffer.AsSpan(offset, count));
+			}
+
+			public override int Read(Span<byte> buffer)
+			{
+				var copied = 0;
+
+				while (copied < buffer.Length)
+				{
+					if (count == 0)
+					{
+						if (baseStreamEmpty)
+							break;
+
+						baseStreamEmpty = ReadBlocks();
+						if (count == 0 && baseStreamEmpty)
+							break;
+
+						if (count == 0)
+							continue;
+					}
+
+					// Copy contiguous chunk to avoid per-byte copies
+					var contiguous = Math.Min(count, ringBuf.Length - head);
+					var toCopy = Math.Min(contiguous, buffer.Length - copied);
+
+					// memcpy-like copy
+					new Span<byte>(ringBuf, head, toCopy).CopyTo(buffer[copied..]);
+
+					head += toCopy;
+					if (head >= ringBuf.Length)
+						head -= ringBuf.Length;
+					count -= toCopy;
+					copied += toCopy;
+				}
+
+				return copied;
+			}
+
+			protected override void Dispose(bool disposing)
+			{
+				if (disposing)
+					baseStream.Dispose();
+				base.Dispose(disposing);
 			}
 		}
 

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -21,11 +21,11 @@ namespace OpenRA.Mods.Common.FileFormats
 	{
 		enum WaveType : short { Pcm = 0x1, MsAdpcm = 0x2, ImaAdpcm = 0x11 }
 
-		public static bool LoadSound(Stream s, out Func<Stream> result, out Func<byte[]> pcmDataFactory,
-		out short channels, out int sampleBits, out int sampleRate, out float lengthInSeconds)
+		public static bool LoadSound(Stream s, out Func<Stream> result, out Func<byte[]> data,
+			out short channels, out int sampleBits, out int sampleRate, out float lengthInSeconds)
 		{
 			result = null;
-			pcmDataFactory = null;
+			data = null;
 			channels = -1;
 			sampleBits = -1;
 			sampleRate = -1;
@@ -107,11 +107,31 @@ namespace OpenRA.Mods.Common.FileFormats
 				return audioStream; // Data is already PCM format.
 			};
 
-			var func = result;
-			pcmDataFactory = () =>
+			data = () =>
 			{
-				using var funcStream = func();
-				return funcStream.ReadAllBytes();
+				var currentPosition = s.Position;
+				byte[] data;
+				switch (audioType)
+				{
+					case WaveType.ImaAdpcm:
+						data = ImaAdpcmReader.ReadData(s, dataOffset, dataSize, blockAlign, chan);
+						break;
+					case WaveType.MsAdpcm:
+						var msStream = new WavStreamMsAdpcm(s, dataSize, blockAlign, chan);
+						data = msStream.ReadAllBytes();
+
+						break;
+					default:
+						s.Position = dataOffset;
+
+						// Data is already PCM format.
+						data = s.ReadBytes(dataSize);
+						break;
+				}
+
+				s.Position = currentPosition;
+
+				return data;
 			};
 
 			return true;

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Mods.Common.FileFormats
 			WaveType audioType = 0;
 			var dataOffset = -1L;
 			var dataSize = -1;
-			var uncompressedSize = -1;
 			short blockAlign = -1;
 			while (s.Position < s.Length)
 			{
@@ -53,7 +52,6 @@ namespace OpenRA.Mods.Common.FileFormats
 
 				var blockType = s.ReadASCII(4);
 				var chunkSize = s.ReadUInt32();
-
 				switch (blockType)
 				{
 					case "fmt ":
@@ -71,18 +69,15 @@ namespace OpenRA.Mods.Common.FileFormats
 						lengthInSeconds = (float)(s.Length * 8) / (channels * sampleRate * sampleBits);
 						s.Position += chunkSize - 16; // Ignoring any optional extra params
 						break;
-					case "fact":
-						uncompressedSize = s.ReadInt32();
-						s.Position += chunkSize - 4; // Ignoring other formats than ADPCM, fact chunk not in standard PCM files
-						break;
 					case "data":
 						if (s.Position + chunkSize > s.Length)
 							chunkSize = (uint)(s.Length - s.Position); // Handle defective data chunk size by assuming it's the remainder of the file
 
-						dataOffset = s.Position;
 						dataSize = (int)chunkSize;
-						s.Position += chunkSize;
+						dataOffset = s.Position;
+						s.Position += dataSize;
 						break;
+					case "fact": // This chunk is often wrong, we will recalculate sample count ourselves
 					case "LIST":
 					case "cue ":
 					default:
@@ -103,7 +98,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			{
 				var audioStream = SegmentStream.CreateWithoutOwningStream(s, dataOffset, dataSize);
 				if (audioType == WaveType.ImaAdpcm)
-					return new WavStreamImaAdpcm(audioStream, dataSize, blockAlign, chan, uncompressedSize);
+					return new WavStreamImaAdpcm(audioStream, dataSize, blockAlign, chan);
 				if (audioType == WaveType.MsAdpcm)
 					return new WavStreamMsAdpcm(audioStream, dataSize, blockAlign, chan);
 
@@ -115,24 +110,35 @@ namespace OpenRA.Mods.Common.FileFormats
 
 		sealed class WavStreamImaAdpcm : ReadOnlyAdapterStream
 		{
+			const int SamplesPerGroup = 8;
+			const int BytesPerSample = 2;
+
 			readonly short channels;
 			readonly int numBlocks;
-			readonly int blockDataSize;
+			readonly int inBlockDataSize;
 			readonly int outputSize;
 			readonly byte[] blockData;
 
 			int outOffset;
 			int currentBlock;
 
-			public WavStreamImaAdpcm(Stream stream, int dataSize, short blockAlign, short channels, int uncompressedSize)
+			public WavStreamImaAdpcm(Stream stream, int dataSize, short blockAlign, short channels)
 				: base(stream)
 			{
 				this.channels = channels;
-				numBlocks = dataSize / blockAlign;
-				blockDataSize = blockAlign - channels * 4;
-				outputSize = uncompressedSize * channels * 2;
 
-				blockData = new byte[blockDataSize];
+				var inHeaderSize = 4 * channels;
+				inBlockDataSize = blockAlign - inHeaderSize;
+
+				numBlocks = dataSize / blockAlign;
+				var numGroupsPerBlock = inBlockDataSize / channels / SamplesPerGroup * BytesPerSample;
+
+				var outGroupSize = SamplesPerGroup * BytesPerSample * channels;
+				var outHead = channels * BytesPerSample;
+				var outGroups = numGroupsPerBlock * outGroupSize;
+				outputSize = numBlocks * (outHead + outGroups);
+
+				blockData = new byte[inBlockDataSize];
 			}
 
 			protected override bool BufferData(Stream baseStream, Queue<byte> data)
@@ -166,7 +172,8 @@ namespace OpenRA.Mods.Common.FileFormats
 				var blockDataSpan = blockData.AsSpan();
 				baseStream.ReadBytes(blockDataSpan);
 				var blockOffset = 0;
-				while (blockOffset < blockDataSize)
+				Span<byte> chunk = stackalloc byte[4];
+				while (blockOffset < inBlockDataSize)
 				{
 					for (var c = 0; c < channels; c++)
 					{


### PR DESCRIPTION
Fixed some music files being interpreted as having half the leangth.

Added a fast audio data load API, for when we want all data immediately
Also improved parsing speeds on streaming audio.

We load audio during gameplay, so it is important for it to be fast. Otherwise with larger files we stutter.

Loading small files is about 2x faster and uses 2x less memory.
Loading large files is 10x and faster, and uses 10x or even less memory
Streaming is slower and more resource intensive when measuring the full roundtrip. But we seldom stream.

25220.36 KB -> 4271.8 KB
-> 16683.79 KB for streaming

1963.08 KB -> 201.24 KB
-> 580.8 KB for streaming

873.94 KB -> 81.77 KB
-> 274.73 KB for streaming

8.28 KB -> 4.14 KB
-> 4.14 KB for streaming

Full parse trip goes from miliseconds or close to a milisecond to microseconds. The provided numbers are when the files are hot in cache and jit is warmed up.

29736 µs -> 4211 µs
-> 13212 µs for streaming

1421 µs ->  259 µs
-> 718 µs for streaming

573 µs -> 95 µs
-> 282 µs for streaming

4 µs -> 2 µs
-> 2 µs  for streaming

For some reason even with this PR `DEVASTATORMELTDOWN.WAV` still managed to idle for 6ms. In testing it is one of the heaviest files, in the provided numbers shown as the second largest. The heaviest is a two channel 4 minute music file.

Unrelated, AUD files also decode slowly and pops up in random places when profiling