### PR TITLE
Encapsulates StartProduction order to fix infinite production bug

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -448,85 +448,13 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Enabled)
 				return;
 
-			var rules = self.World.Map.Rules;
 			switch (order.OrderString)
 			{
 				case "StartProduction":
-					var unit = rules.Actors[order.TargetString];
-					var bi = unit.TraitInfo<BuildableInfo>();
-
-					// Not built by this queue
-					if (!bi.Queue.Contains(Info.Type))
-						return;
-
-					// You can't build that
-					if (BuildableItems().All(b => b.Name != order.TargetString))
-						return;
-
-					// Check if the player is trying to build more units that they are allowed
-					var fromLimit = int.MaxValue;
-					if (!developerMode.AllTech)
-					{
-						if (Info.QueueLimit > 0)
-							fromLimit = Info.QueueLimit - Queue.Count;
-
-						if (Info.ItemLimit > 0)
-							fromLimit = Math.Min(fromLimit, Info.ItemLimit - Queue.Count(i => i.Item == order.TargetString));
-
-						if (bi.BuildLimit > 0)
-						{
-							var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
-							fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
-						}
-
-						if (fromLimit <= 0)
-							return;
-					}
-
-					var cost = GetProductionCost(unit);
-					var time = GetBuildTime(unit, bi);
-					var amountToBuild = Math.Min(fromLimit, order.ExtraData);
-					for (var n = 0; n < amountToBuild; n++)
-					{
-						if (Info.PayUpFront && cost > playerResources.GetCashAndResources())
-							return;
-						var hasPlayedSound = false;
-						BeginProduction(new ProductionItem(this, order.TargetString, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
-						{
-							// Make sure the item hasn't been invalidated between the ProductionItem ticking and this FrameEndTask running
-							if (!Queue.Any(i => i.Done && i.Item == unit.Name))
-							{
-								hasPlayedSound = false;
-								return;
-							}
-
-							var isBuilding = unit.HasTraitInfo<BuildingInfo>();
-							if (isBuilding && !hasPlayedSound)
-							{
-								hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
-								TextNotificationsManager.AddTransientLine(self.Owner, Info.ReadyTextNotification);
-							}
-							else if (!isBuilding)
-							{
-								if (BuildUnit(unit))
-								{
-									Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.ReadyAudio, self.Owner.Faction.InternalName);
-									TextNotificationsManager.AddTransientLine(self.Owner, Info.ReadyTextNotification);
-								}
-								else if (!hasPlayedSound && time > 0)
-								{
-									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
-									TextNotificationsManager.AddTransientLine(self.Owner, Info.BlockedTextNotification);
-								}
-							}
-						})), !order.Queued);
-					}
-
+					StartProduction(order.TargetString, order.ExtraData, !order.Queued);
 					break;
 				case "PauseProduction":
 					PauseProduction(order.TargetString, order.ExtraData != 0);
-
 					break;
 				case "CancelProduction":
 					CancelProduction(order.TargetString, order.ExtraData);
@@ -563,6 +491,86 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.ApplyPercentageModifiers(valued.Cost, modifiers);
 		}
 
+		protected virtual void StartProduction(string itemName, uint amount, bool hasPriority = false)
+		{
+			var rules = Actor.World.Map.Rules;
+			var unit = rules.Actors[itemName];
+			var bi = unit.TraitInfo<BuildableInfo>();
+
+			// Not built by this queue
+			if (!bi.Queue.Contains(Info.Type))
+				return;
+
+			// You can't build that
+			if (BuildableItems().All(b => b.Name != itemName))
+				return;
+
+			var fromLimit = int.MaxValue;
+			var isInfinite = false;
+			if (Info.InfiniteBuildLimit >= 0 && amount > Info.InfiniteBuildLimit)
+			{
+				isInfinite = true;
+				fromLimit = 1;
+			}
+
+			// Check if the player is trying to build more units that they are allowed
+			else if (!developerMode.AllTech)
+			{
+				if (Info.QueueLimit > 0)
+					fromLimit = Info.QueueLimit - Queue.Count;
+
+				if (Info.ItemLimit > 0)
+					fromLimit = Math.Min(fromLimit, Info.ItemLimit - Queue.Count(i => i.Item == itemName));
+
+				if (bi.BuildLimit > 0)
+				{
+					var inQueue = Queue.Count(pi => pi.Item == itemName);
+					var owned = Actor.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == itemName && a.Owner == Actor.Owner);
+					fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
+				}
+
+				if (fromLimit <= 0)
+					return;
+			}
+
+			var cost = GetProductionCost(unit);
+			var time = GetBuildTime(unit, bi);
+			var amountToBuild = Math.Min(fromLimit, amount);
+			for (var n = 0; n < amountToBuild; n++)
+			{
+				if (Info.PayUpFront && cost > playerResources.GetCashAndResources() && !isInfinite)
+					return;
+				var hasPlayedSound = false;
+				BeginProduction(new ProductionItem(this, itemName, cost, playerPower, () => Actor.World.AddFrameEndTask(_ =>
+				{
+					// Make sure the item hasn't been invalidated between the ProductionItem ticking and this FrameEndTask running
+					if (!Queue.Any(i => i.Done && i.Item == unit.Name))
+						return;
+
+					var isBuilding = unit.HasTraitInfo<BuildingInfo>();
+					if (isBuilding && !hasPlayedSound)
+					{
+						hasPlayedSound = Game.Sound.PlayNotification(rules, Actor.Owner, "Speech", Info.ReadyAudio, Actor.Owner.Faction.InternalName);
+						TextNotificationsManager.AddTransientLine(Actor.Owner, Info.ReadyTextNotification);
+					}
+					else if (!isBuilding)
+					{
+						if (BuildUnit(unit))
+						{
+							Game.Sound.PlayNotification(rules, Actor.Owner, "Speech", Info.ReadyAudio, Actor.Owner.Faction.InternalName);
+							TextNotificationsManager.AddTransientLine(Actor.Owner, Info.ReadyTextNotification);
+						}
+						else if (!hasPlayedSound && time > 0)
+						{
+							hasPlayedSound = Game.Sound.PlayNotification(rules, Actor.Owner, "Speech", Info.BlockedAudio, Actor.Owner.Faction.InternalName);
+							TextNotificationsManager.AddTransientLine(Actor.Owner, Info.BlockedTextNotification);
+						}
+					}
+				}))
+				{ Infinite = isInfinite }, hasPriority);
+			}
+		}
+
 		protected virtual void PauseProduction(string itemName, bool paused)
 		{
 			Queue.FirstOrDefault(a => a.Item == itemName)?.Pause(paused);
@@ -584,8 +592,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (item.Infinite)
 				{
 					item.Infinite = false;
-					for (var i = 1; i < Info.InfiniteBuildLimit; i++)
-						Queue.Add(new ProductionItem(this, item.Item, item.TotalCost, playerPower, item.OnComplete));
+					StartProduction(item.Item, (uint)Info.InfiniteBuildLimit - 1);
 				}
 				else
 				{
@@ -611,7 +618,7 @@ namespace OpenRA.Mods.Common.Traits
 			Queue.Remove(item);
 
 			if (item.Infinite)
-				Queue.Add(new ProductionItem(this, item.Item, item.TotalCost, playerPower, item.OnComplete) { Infinite = true });
+				StartProduction(item.Item, (uint)Info.InfiniteBuildLimit + 1);
 		}
 
 		protected virtual void BeginProduction(ProductionItem item, bool hasPriority)

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -592,7 +592,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (item.Infinite)
 				{
 					item.Infinite = false;
-					StartProduction(item.Item, (uint)Info.InfiniteBuildLimit - 1);
+					var amount = Math.Max(0, Info.InfiniteBuildLimit - 1);
+					StartProduction(item.Item, (uint)amount);
 				}
 				else
 				{


### PR DESCRIPTION
Encapsulated `StartProduction` order into its own method so that each production item goes through the initialization in the `ResolveOrder` method. This solves the infinite production prerequisite bug (OpenHV/OpenHV#1316).

This approach does not regress #21983, as the proper initialization for each item removes the need for that change.