### PR TITLE
Fix McvExpansionManagerBotModule on CheckCurrentLocation mode.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 		IBotRequestUnitProduction[] requestUnitProduction;
 		IBotSuggestRefineryProduction[] suggestRefineryProduction;
 
-		readonly Dictionary<Actor, CPos> activeMCVs = [];
+		readonly Dictionary<Actor, CPos?> activeMCVs = [];
 
 		PathFinder pathfinder;
 		ResourceMapBotModule resourceMapModule;
@@ -667,7 +667,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (desiredLocation == null)
 					return;
 
-				activeMCVs[mcv] = checkloc.Value;
+				activeMCVs[mcv] = checkloc;
 				if (resLoc != null)
 				{
 					foreach (var srp in suggestRefineryProduction)


### PR DESCRIPTION
fix #22138

Another regression from #22116, try get value from nullable.

just did some tests with `InitialExpansionMode: CheckCurrentLocation` and disallow auto-switching modes, which run without crashing. 

Thanks @Porenutak for debugging!

