### PR TITLE
Try to avoid ordering dead actors in AI squads

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -492,8 +492,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var s in Squads)
 			{
-				if (s.IsValid && FindEnemies([attacker], s.Units.First()).Any()
-					&& (s.Units.First().Location - attacker.Location).LengthSquared <= Info.ProtectUnitScanRadius * Info.ProtectUnitScanRadius)
+				var livingUnitInSquad = s.Units.FirstOrDefault(x => !x.IsDead);
+				if (livingUnitInSquad == null)
+					continue;
+				if (s.IsValid && FindEnemies([attacker], livingUnitInSquad).Any()
+					&& (livingUnitInSquad.Location - attacker.Location).LengthSquared <= Info.ProtectUnitScanRadius * Info.ProtectUnitScanRadius)
 					s.SetActorToTarget((attacker, WVec.Zero));
 			}
 


### PR DESCRIPTION
Possible fix for #21438

I believe this error occurs when the `sourceActor` parameter for the `FindEnemies` method calls the `TraitsImplementing` method and is somehow disposed.

This change ensures that the unit `sourceActor` being passed to `FindEnemies` method is still alive (and thus not able to be disposed at that time), or if not, then there is no need to set the squad to target the attacker since all the members of the squad are dead.

