### PR TITLE
Revert type of resource values back to int

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
+++ b/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly string Type = null;
 
 		[Desc("Resource density threshold which is required.")]
-		public readonly byte Density = 1;
+		public readonly int Density = 1;
 
 		[Desc("This many adjacent resource tiles are required.")]
 		public readonly int Adjacency = 1;

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly HashSet<CPos> dirty = [];
 		readonly Queue<CPos> cleanDirty = [];
 		readonly HashSet<CPos> veinholeCells = [];
-		readonly byte maxDensity;
+		readonly int maxDensity;
 		readonly Color veinRadarColor;
 
 		ISpriteSequence veinSequence;

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -2110,7 +2110,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				var oldValue = CheckValue3By3(cpos);
 				Map.Resources[mpos] = new ResourceTile(
 					resourceType.ResourceIndex,
-					resourceType.MaxDensity);
+					(byte)resourceType.MaxDensity);
 				var newValue = CheckValue3By3(cpos);
 				return newValue - oldValue;
 			}

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -81,14 +81,14 @@ namespace OpenRA.Mods.Common.Traits
 		public event Action<CPos, string> CellChanged;
 
 		ResourceLayerContents IResourceLayer.GetResource(CPos cell) { return Tiles.Contains(cell) ? Tiles[cell] : default; }
-		byte IResourceLayer.GetMaxDensity(string resourceType)
+		int IResourceLayer.GetMaxDensity(string resourceType)
 		{
-			return info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo) ? resourceInfo.MaxDensity : (byte)0;
+			return info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo) ? resourceInfo.MaxDensity : 0;
 		}
 
-		bool IResourceLayer.CanAddResource(string resourceType, CPos cell, byte amount) { return CanAddResource(resourceType, cell, amount); }
-		int IResourceLayer.AddResource(string resourceType, CPos cell, byte amount) { return AddResource(resourceType, cell, amount); }
-		int IResourceLayer.RemoveResource(string resourceType, CPos cell, byte amount) { return RemoveResource(resourceType, cell, amount); }
+		bool IResourceLayer.CanAddResource(string resourceType, CPos cell, int amount) { return CanAddResource(resourceType, cell, amount); }
+		int IResourceLayer.AddResource(string resourceType, CPos cell, int amount) { return AddResource(resourceType, cell, amount); }
+		int IResourceLayer.RemoveResource(string resourceType, CPos cell, int amount) { return RemoveResource(resourceType, cell, amount); }
 		void IResourceLayer.ClearResources(CPos cell) { ClearResources(cell); }
 		bool IResourceLayer.IsVisible(CPos cell) { return Map.Contains(cell); }
 		bool IResourceLayer.IsEmpty => false;
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void UpdateNetWorth(string oldResourceType, byte oldDensity, string newResourceType, byte newDensity)
+		void UpdateNetWorth(string oldResourceType, int oldDensity, string newResourceType, int newDensity)
 		{
 			if (oldResourceType != null && oldDensity > 0 && resourceValues.TryGetValue(oldResourceType, out var oldResourceValue))
 				NetWorth -= oldDensity * oldResourceValue;
@@ -197,14 +197,14 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>
 		/// Matches the logic in <see cref="ResourceLayer"/> trait.
 		/// </summary>
-		protected virtual byte CalculateCellDensity(ResourceLayerContents contents, CPos cell)
+		protected virtual int CalculateCellDensity(ResourceLayerContents contents, CPos cell)
 		{
 			var resources = Map.Resources;
 			if (contents.Type == null || !info.ResourceTypes.TryGetValue(contents.Type, out var resourceInfo) || resources[cell].Type != resourceInfo.ResourceIndex)
 				return 0;
 
 			if (!info.RecalculateResourceDensity)
-				return contents.Density.Clamp((byte)1, resourceInfo.MaxDensity);
+				return contents.Density.Clamp(1, resourceInfo.MaxDensity);
 
 			// Set density based on the number of neighboring resources.
 			var adjacent = 0;
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 			// We need to have at least one resource in the cell.
 			// HACK: we should not be lerping to 9, as maximum adjacent resources is 8.
 			// HACK: it's too disruptive to fix.
-			return (byte)Math.Max(int2.Lerp(0, resourceInfo.MaxDensity, adjacent, 9), 1);
+			return Math.Max(int2.Lerp(0, resourceInfo.MaxDensity, adjacent, 9), 1);
 		}
 
 		protected virtual bool AllowResourceAt(string resourceType, CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -17,11 +17,11 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public readonly struct ResourceLayerContents(string type, byte density)
+	public readonly struct ResourceLayerContents(string type, int density)
 	{
 		public static readonly ResourceLayerContents Empty = default;
 		public readonly string Type = type;
-		public readonly byte Density = density;
+		public readonly int Density = density;
 	}
 
 	[TraitLocation(SystemActors.World)]
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly HashSet<string> AllowedTerrainTypes = null;
 
 			[Desc("Maximum number of resource units allowed in a single cell.")]
-			public readonly byte MaxDensity = 10;
+			public readonly int MaxDensity = 10;
 
 			public ResourceTypeInfo(MiniYaml yaml)
 			{
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 				// We need to have at least one resource in the cell.
 				// HACK: we should not be lerping to 9, as maximum adjacent resources is 8.
 				// HACK: it's too disruptive to fix.
-				var density = (byte)Math.Max(int2.Lerp(0, resourceInfo.MaxDensity, adjacent, 9), 1);
+				var density = Math.Max(int2.Lerp(0, resourceInfo.MaxDensity, adjacent, 9), 1);
 				Content[cell] = new ResourceLayerContents(resource.Type, density);
 			}
 		}
@@ -190,10 +190,10 @@ namespace OpenRA.Mods.Common.Traits
 			world.Map.CustomTerrain[cell] = world.Map.Rules.TerrainInfo.GetTerrainIndex(resourceInfo.TerrainType);
 			++resCells;
 
-			return new ResourceLayerContents(resourceType, (byte)density.Clamp(1, resourceInfo.MaxDensity));
+			return new ResourceLayerContents(resourceType, density.Clamp(1, resourceInfo.MaxDensity));
 		}
 
-		bool CanAddResource(string resourceType, CPos cell, byte amount = 1)
+		bool CanAddResource(string resourceType, CPos cell, int amount = 1)
 		{
 			if (!world.Map.Contains(cell))
 				return false;
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Traits
 			return content.Density + amount <= resourceInfo.MaxDensity;
 		}
 
-		int AddResource(string resourceType, CPos cell, byte amount = 1)
+		int AddResource(string resourceType, CPos cell, int amount = 1)
 		{
 			if (!Content.Contains(cell))
 				return 0;
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Common.Traits
 				return 0;
 
 			var oldDensity = content.Density;
-			var density = (byte)Math.Min(resourceInfo.MaxDensity, oldDensity + amount);
+			var density = Math.Min(resourceInfo.MaxDensity, oldDensity + amount);
 			Content[cell] = new ResourceLayerContents(content.Type, density);
 
 			CellChanged?.Invoke(cell, content.Type);
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Traits
 			return density - oldDensity;
 		}
 
-		int RemoveResource(string resourceType, CPos cell, byte amount = 1)
+		int RemoveResource(string resourceType, CPos cell, int amount = 1)
 		{
 			if (!Content.Contains(cell))
 				return 0;
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Traits
 				return 0;
 
 			var oldDensity = content.Density;
-			var density = (byte)Math.Max(0, oldDensity - amount);
+			var density = Math.Max(0, oldDensity - amount);
 
 			if (density == 0)
 			{
@@ -282,7 +282,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		ResourceLayerContents IResourceLayer.GetResource(CPos cell) { return Content.Contains(cell) ? Content[cell] : default; }
-		byte IResourceLayer.GetMaxDensity(string resourceType)
+		int IResourceLayer.GetMaxDensity(string resourceType)
 		{
 			if (!info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo))
 				return 0;
@@ -290,9 +290,9 @@ namespace OpenRA.Mods.Common.Traits
 			return resourceInfo.MaxDensity;
 		}
 
-		bool IResourceLayer.CanAddResource(string resourceType, CPos cell, byte amount) { return CanAddResource(resourceType, cell, amount); }
-		int IResourceLayer.AddResource(string resourceType, CPos cell, byte amount) { return AddResource(resourceType, cell, amount); }
-		int IResourceLayer.RemoveResource(string resourceType, CPos cell, byte amount) { return RemoveResource(resourceType, cell, amount); }
+		bool IResourceLayer.CanAddResource(string resourceType, CPos cell, int amount) { return CanAddResource(resourceType, cell, amount); }
+		int IResourceLayer.AddResource(string resourceType, CPos cell, int amount) { return AddResource(resourceType, cell, amount); }
+		int IResourceLayer.RemoveResource(string resourceType, CPos cell, int amount) { return RemoveResource(resourceType, cell, amount); }
 		void IResourceLayer.ClearResources(CPos cell) { ClearResources(cell); }
 		bool IResourceLayer.IsVisible(CPos cell) { return !world.FogObscures(cell); }
 		bool IResourceLayer.IsEmpty => resCells < 1;

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -353,12 +353,11 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly ResourceRendererInfo.ResourceTypeInfo Info;
 			public readonly ISpriteSequence Sequence;
 			public readonly PaletteReference Palette;
-			public readonly byte Density;
+			public readonly int Density;
 
 			public static readonly RendererCellContents Empty = default;
 
-			public RendererCellContents(string resourceType, byte density, ResourceRendererInfo.ResourceTypeInfo info,
-				ISpriteSequence sequence, PaletteReference palette)
+			public RendererCellContents(string resourceType, int density, ResourceRendererInfo.ResourceTypeInfo info, ISpriteSequence sequence, PaletteReference palette)
 			{
 				Type = resourceType;
 				Density = density;
@@ -367,7 +366,7 @@ namespace OpenRA.Mods.Common.Traits
 				Palette = palette;
 			}
 
-			public RendererCellContents(RendererCellContents contents, byte density)
+			public RendererCellContents(RendererCellContents contents, int density)
 			{
 				Type = contents.Type;
 				Density = density;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -820,10 +820,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		event Action<CPos, string> CellChanged;
 		ResourceLayerContents GetResource(CPos cell);
-		byte GetMaxDensity(string resourceType);
-		bool CanAddResource(string resourceType, CPos cell, byte amount = 1);
-		int AddResource(string resourceType, CPos cell, byte amount = 1);
-		int RemoveResource(string resourceType, CPos cell, byte amount = 1);
+		int GetMaxDensity(string resourceType);
+		bool CanAddResource(string resourceType, CPos cell, int amount = 1);
+		int AddResource(string resourceType, CPos cell, int amount = 1);
+		int RemoveResource(string resourceType, CPos cell, int amount = 1);
 		void ClearResources(CPos cell);
 
 		bool IsVisible(CPos cell);

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Warheads
 				if (!resourceLayer.CanAddResource(AddsResourceType, cell))
 					continue;
 
-				var splash = (byte)world.SharedRandom.Next(1, maxDensity - resourceLayer.GetResource(cell).Density);
+				var splash = world.SharedRandom.Next(1, maxDensity - resourceLayer.GetResource(cell).Density);
 				resourceLayer.AddResource(AddsResourceType, cell, splash);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Size of the area. The resources are removed within this area.", "Provide 2 values for a ring effect (outer/inner).")]
 		public readonly int[] Size = [0, 0];
 
-		[Desc("Amount of resources to be removed. If zero, all resources within the area will be removed.")]
-		public readonly byte ResourceAmount = 0;
+		[Desc("Amount of resources to be removed. If negative or zero, all resources within the area will be removed.")]
+		public readonly int ResourceAmount = 0;
 
 		[Desc("Resource types to remove with this warhead.", "If empty, all resource types will be removed.")]
 		public readonly HashSet<string> ResourceTypes = [];


### PR DESCRIPTION
The byte (255) limit for resource amounts is too restrictive and feels artificial. It puts unnecessary burden on third-party mods to workaround this limit.

This PR reverts #21779 entirely.