### PR TITLE
Fix custom map loading from relative Engine.SupportDir paths.

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -221,6 +221,9 @@ namespace OpenRA
 			if (!Directory.Exists(path))
 				throw new DirectoryNotFoundException(path);
 
+			// Ensure that userSupportPath is an absolute path
+			path = Path.GetFullPath(path);
+
 			if (!path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) &&
 					!path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
 				path += Path.DirectorySeparatorChar;


### PR DESCRIPTION
If the game is launched using the `Engine.SupportDir` commandline argument with a relative path (unpackaged) maps with custom rules will fail to load. This fixes the issue by ensuring that the path is absolute.

Repro case: launch the game with `Engine.SupportDir=foo` and move the `evacuation` mission from `mods/ra/maps` to `foo/maps/ra/{DEV_VERSION}`. Attempt to select map ingame.