### PR TITLE
Fix lobby option handling when unknown maps become available.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -601,7 +601,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool OptionsTabDisabled()
 		{
-			return !MapIsPlayable || panel == PanelType.Kick || panel == PanelType.ForceStart;
+			return map.Status == MapStatus.Unavailable || map.Status == MapStatus.Searching ||
+				!MapIsPlayable || panel == PanelType.Kick || panel == PanelType.ForceStart;
 		}
 
 		public override void Tick()

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly OrderManager orderManager;
 		readonly Func<bool> configurationDisabled;
 		MapPreview mapPreview;
+		MapStatus mapStatus;
 
 		[ObjectCreator.UseCtor]
 		internal LobbyOptionsLogic(Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled)
@@ -49,13 +50,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdownRowTemplate = optionsContainer.Get("DROPDOWN_ROW_TEMPLATE");
 
 			mapPreview = getMap();
+			mapStatus = mapPreview.Status;
 			RebuildOptions();
 		}
 
 		public override void Tick()
 		{
 			var newMapPreview = getMap();
-			if (newMapPreview == mapPreview)
+			if (newMapPreview == mapPreview && mapStatus == mapPreview.Status)
 				return;
 
 			// We are currently enumerating the widget tree and so can't modify any layout
@@ -63,6 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.RunAfterTick(() =>
 			{
 				mapPreview = newMapPreview;
+				mapStatus = mapPreview.Status;
 				RebuildOptions();
 			});
 		}


### PR DESCRIPTION
Fixes the two issues demonstrated by the following repro case:

1. start client 1 and host a local multiplayer server with the Evacuation mission

2. move evacuation out of the RA maps folder

3. start client 2 and join client 1's server

4. wait for the "This map was not found on the OpenRA Resource Center" to appear

Notice that the options panel can be selected, but is empty.

5. Restore evacuation to the RA maps folder

6. Click the Retry Search button

Notice that the options panel remains empty.