### PR TITLE
Fix ambiguous call that might make the application unbuildable in Arch Linux

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -96,6 +96,7 @@ Also thanks to:
     * John Turner (whinis)
     * Jonas A. Lind (SoScared)
     * Joppy Furr
+    * Julio Cesar B. O. Sampaio (Mega2223)
     * Kanar
     * Kenny Hoxworth (hoxworth)
     * Kevin Azzam (ChaoticMind)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,8 +282,12 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
+#pragma warning disable ide0004
+					// Although code analysis marks this cast as redundant, without it
+					// some versions of dotnet 8 may yield a compilation error
+					// alledgely due to method call ambiguity, this is likely undesired behavior
 					return CryptoUtil.SHA1Hash((byte[])[]);
-
+#pragma warning restore ide0004
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)
 					merged = new MergedStream(merged, streams[i]);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,7 +282,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash((byte[]) []);
+					return CryptoUtil.SHA1Hash((byte[])[]);
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,7 +282,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash([]);
+					return CryptoUtil.SHA1Hash((byte[]) []);
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,12 +282,12 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-#pragma warning disable ide0004
+#pragma warning disable IDE0004
 					// Although code analysis marks this cast as redundant, without it
 					// some versions of dotnet 8 may yield a compilation error
 					// alledgely due to method call ambiguity, this is likely undesired behavior
 					return CryptoUtil.SHA1Hash((byte[])[]);
-#pragma warning restore ide0004
+#pragma warning restore IDE0004
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)
 					merged = new MergedStream(merged, streams[i]);


### PR DESCRIPTION
As mentioned in #21840 , older versions of the dotnet framework might give give an error while executing the make action, making the application unbuildable. This error is due to an ambiguous method call in Map.cs

The obvious fix would be to use an newer version of the dotnet framework, however, as of writing, the latest version of the [dotnet-sdk module in the Arch Extra repository](https://archlinux.org/packages/extra/x86_64/dotnet-sdk-8.0/) is version 8.0.120 , which means that all Arch Linux users (and possibly users from other distros) are unable to build OpenRA without also building a newer version of the dotnet framework themselves.

There is only one line of code in which this happens, so this simple cast makes the application buildable again in older dotnet frameworks.
