### PR TITLE
Fixed up lobby map generator

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget dropdownSettingTemplate;
 		readonly Widget tilesetSetting;
 		readonly Widget sizeSetting;
+		readonly Widget parentWidget;
 		readonly ZipFileLoader.ReadWriteZipFile package;
 
 		ITerrainInfo selectedTerrain;
@@ -84,12 +85,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		volatile bool generating;
 		volatile bool failed;
+		bool initialGenerationDone;
 
 		[ObjectCreator.UseCtor]
 		internal MapGeneratorLogic(Widget widget, ModData modData, MapGenerationArgs initialSettings, Action<MapGenerationArgs, IReadWritePackage> onGenerate)
 		{
 			this.modData = modData;
 			this.onGenerate = onGenerate;
+			parentWidget = widget.Parent;
 			package = new ZipFileLoader.ReadWriteZipFile();
 
 			generator = modData.DefaultRules.Actors[SystemActors.EditorWorld].TraitInfos<IEditorMapGeneratorInfo>().First();
@@ -217,10 +220,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (map.Status == MapStatus.Available)
 				{
 					preview.Update(map);
+					initialGenerationDone = true;
 					onGenerate(initialSettings, null);
 				}
-				else
-					GenerateMap();
 			}
 			else
 			{
@@ -228,6 +230,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				settings.Randomize(Game.CosmeticRandom);
 				RandomizeSize();
 				RefreshSettings();
+			}
+		}
+
+		public override void Tick()
+		{
+			if (!initialGenerationDone && !generating && parentWidget.IsVisible())
+			{
+				initialGenerationDone = true;
 				GenerateMap();
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget dropdownSettingTemplate;
 		readonly Widget tilesetSetting;
 		readonly Widget sizeSetting;
-		readonly IReadWritePackage package;
+		readonly ZipFileLoader.ReadWriteZipFile package;
 
 		ITerrainInfo selectedTerrain;
 		string selectedSize;

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -188,6 +188,7 @@ Container@MAPCHOOSER_PANEL:
 					Width: 140
 					Height: 35
 					Text: button-bg-ok
+				Container@DROPDOWN_PANEL_ROOT:
 				TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@MAPCHOOSER_GENERATE_PANEL:
@@ -287,5 +288,4 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 							Y: 20
 							Width: PARENT_WIDTH - 20
 							Height: 25
-							PanelRoot: GENERATOR_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
-		Container@GENERATOR_DROPDOWN_PANEL_ROOT:
+							PanelRoot: DROPDOWN_PANEL_ROOT

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -187,6 +187,7 @@ Background@MAPCHOOSER_PANEL:
 			Text: button-back
 			Font: Bold
 			Key: escape
+		Container@DROPDOWN_PANEL_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 
@@ -288,5 +289,4 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 							Y: 20
 							Width: PARENT_WIDTH - 20
 							Height: 25
-							PanelRoot: GENERATOR_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
-		Container@GENERATOR_DROPDOWN_PANEL_ROOT:
+							PanelRoot: DROPDOWN_PANEL_ROOT


### PR DESCRIPTION
- Fixes a crash when a player leves the map selector before a map was sucessfuly generated.
- Now handles race conditions gracefully.
- No longer generates maps when not in map generation tab.
- Fixed large dropdowns overlapping buttons.