### PR TITLE
Fix rare PointsChirality infinite loop

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
@@ -1078,7 +1078,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				if (prop == FirstPassSentinel)
 					return chirality[point];
 
-				if (chirality[point] != 0)
+				if (chirality[point] != 0 || prop == 0)
 					return null;
 				chirality[point] = prop;
 				return prop;


### PR DESCRIPTION
Under some inputs, MatrixUtils.PointsChirality could enter into an infinite loop consuming memory until an OOM occurs. This was due to the FloodFill-based operation endlessly propagate zero values.

This adds a defensive check to prevent propagating zero values.
