### PR TITLE
Add FieldLoader/Saver support for ImmutableArray, FrozenSet, FrozenDictionary.

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
@@ -28,7 +29,7 @@ namespace OpenRA
 		public readonly string Id;
 		public readonly string Version;
 		public readonly string LaunchPath;
-		public readonly string[] LaunchArgs;
+		public readonly ImmutableArray<string> LaunchArgs;
 		public Sprite Icon { get; internal set; }
 		public Sprite Icon2x { get; internal set; }
 		public Sprite Icon3x { get; internal set; }

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -78,7 +79,7 @@ namespace OpenRA
 			return Math.Sign((v1.X - v0.X) * (p.Y - v0.Y) - (p.X - v0.X) * (v1.Y - v0.Y));
 		}
 
-		public static bool PolygonContains(this int2[] polygon, int2 p)
+		public static bool PolygonContains(this ImmutableArray<int2> polygon, int2 p)
 		{
 			var windingNumber = 0;
 

--- a/OpenRA.Game/FluentBundle.cs
+++ b/OpenRA.Game/FluentBundle.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using Linguini.Bundle;
@@ -87,19 +88,19 @@ namespace OpenRA
 	{
 		readonly Linguini.Bundle.FluentBundle bundle;
 
-		public FluentBundle(string culture, string[] paths, IReadOnlyFileSystem fileSystem)
+		public FluentBundle(string culture, ImmutableArray<string> paths, IReadOnlyFileSystem fileSystem)
 			: this(culture, paths, fileSystem, error => Log.Write("debug", error.Message)) { }
 
-		public FluentBundle(string culture, string[] paths, IReadOnlyFileSystem fileSystem, string text)
+		public FluentBundle(string culture, ImmutableArray<string> paths, IReadOnlyFileSystem fileSystem, string text)
 			: this(culture, paths, fileSystem, text, error => Log.Write("debug", error.Message)) { }
 
-		public FluentBundle(string culture, string[] paths, IReadOnlyFileSystem fileSystem, Action<ParseError> onError)
+		public FluentBundle(string culture, ImmutableArray<string> paths, IReadOnlyFileSystem fileSystem, Action<ParseError> onError)
 			: this(culture, paths, fileSystem, null, onError) { }
 
 		public FluentBundle(string culture, string text, Action<ParseError> onError)
-			: this(culture, null, null, text, onError) { }
+			: this(culture, default, null, text, onError) { }
 
-		public FluentBundle(string culture, string[] paths, IReadOnlyFileSystem fileSystem, string text, Action<ParseError> onError)
+		public FluentBundle(string culture, ImmutableArray<string> paths, IReadOnlyFileSystem fileSystem, string text, Action<ParseError> onError)
 		{
 			bundle = LinguiniBuilder.Builder()
 				.CultureInfo(new CultureInfo(culture))

--- a/OpenRA.Game/FluentProvider.cs
+++ b/OpenRA.Game/FluentProvider.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Text;
 using OpenRA.FileSystem;
 
@@ -29,9 +30,9 @@ namespace OpenRA
 				modFluentBundle = new FluentBundle(modData.Manifest.FluentCulture, modData.Manifest.FluentMessages, fileSystem);
 				if (fileSystem is Map map && map.FluentMessageDefinitions != null)
 				{
-					var files = Array.Empty<string>();
+					var files = ImmutableArray<string>.Empty;
 					if (map.FluentMessageDefinitions.Value != null)
-						files = FieldLoader.GetValue<string[]>("value", map.FluentMessageDefinitions.Value);
+						files = FieldLoader.GetValue<ImmutableArray<string>>("value", map.FluentMessageDefinitions.Value);
 
 					string text = null;
 					if (map.FluentMessageDefinitions.Nodes.Length > 0)

--- a/OpenRA.Game/Fonts.cs
+++ b/OpenRA.Game/Fonts.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 
 namespace OpenRA
@@ -23,15 +24,15 @@ namespace OpenRA
 	public class Fonts : IGlobalModData
 	{
 		[FieldLoader.LoadUsing(nameof(LoadFonts))]
-		public readonly Dictionary<string, FontData> FontList;
+		public readonly FrozenDictionary<string, FontData> FontList;
 
 		static object LoadFonts(MiniYaml y)
 		{
-			var ret = new Dictionary<string, FontData>();
+			var ret = new Dictionary<string, FontData>(y.Nodes.Length);
 			foreach (var node in y.Nodes)
 				ret.Add(node.Key, FieldLoader.Load<FontData>(node.Value));
 
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 	}
 }

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -415,7 +416,7 @@ namespace OpenRA
 
 			var modSearchArg = args.GetValue("Engine.ModSearchPaths", null);
 			var modSearchPaths = modSearchArg != null ?
-				FieldLoader.GetValue<string[]>("Engine.ModsPath", modSearchArg) :
+				FieldLoader.GetValue<ImmutableArray<string>>("Engine.ModsPath", modSearchArg) :
 				[Path.Combine(Platform.EngineDir, "mods")];
 
 			Mods = new InstalledMods(modSearchPaths, explicitModPaths);

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileSystem;
@@ -41,7 +42,7 @@ namespace OpenRA
 		public TimeSpan Duration => EndTimeUtc > StartTimeUtc ? EndTimeUtc - StartTimeUtc : TimeSpan.Zero;
 
 		public IList<Player> Players { get; }
-		public HashSet<int> DisabledSpawnPoints = [];
+		public FrozenSet<int> DisabledSpawnPoints = FrozenSet<int>.Empty;
 
 		public MapPreview MapPreview
 		{

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using OpenRA.FileSystem;
@@ -268,7 +269,7 @@ namespace OpenRA
 
 			if (mapRules.Value != null)
 			{
-				var mapFiles = FieldLoader.GetValue<string[]>("value", mapRules.Value);
+				var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", mapRules.Value);
 				foreach (var f in mapFiles)
 					if (AnyFlaggedTraits(modData, MiniYaml.FromStream(fileSystem.Open(f), f)))
 						return true;

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Primitives;
@@ -82,13 +83,13 @@ namespace OpenRA.GameRules
 		public readonly WVec FollowingBurstTargetOffset = WVec.Zero;
 
 		[Desc("The sound played each time the weapon is fired.")]
-		public readonly string[] Report = null;
+		public readonly ImmutableArray<string> Report = default;
 
 		[Desc("Sound played only on first burst in a salvo.")]
-		public readonly string[] StartBurstReport = null;
+		public readonly ImmutableArray<string> StartBurstReport = default;
 
 		[Desc("The sound played when the weapon is reloaded.")]
-		public readonly string[] AfterFireSound = null;
+		public readonly ImmutableArray<string> AfterFireSound = default;
 
 		[Desc("Delay in ticks to play reloading sound.")]
 		public readonly int AfterFireSoundDelay = 0;
@@ -116,7 +117,7 @@ namespace OpenRA.GameRules
 
 		[Desc("Delay in ticks between firing shots from the same ammo magazine. If one entry, it will be used for all bursts.",
 			"If multiple entries, their number needs to match Burst - 1.")]
-		public readonly int[] BurstDelays = [5];
+		public readonly ImmutableArray<int> BurstDelays = [5];
 
 		[Desc("The minimum range the weapon can fire.")]
 		public readonly WDist MinRange = WDist.Zero;
@@ -128,7 +129,7 @@ namespace OpenRA.GameRules
 		public readonly IProjectileInfo Projectile;
 
 		[FieldLoader.LoadUsing(nameof(LoadWarheads))]
-		public readonly List<IWarhead> Warheads = [];
+		public readonly ImmutableArray<IWarhead> Warheads = [];
 
 		/// <summary>
 		/// This constructor is used solely for documentation generation.
@@ -170,7 +171,7 @@ namespace OpenRA.GameRules
 				retList.Add(ret);
 			}
 
-			return retList;
+			return retList.ToImmutableArray();
 		}
 
 		public bool IsValidTarget(BitSet<TargetableType> targetTypes)

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -250,7 +251,7 @@ namespace OpenRA.Graphics
 			return sequences.GetSequence(Name, sequenceName);
 		}
 
-		public string GetRandomExistingSequence(string[] sequences, MersenneTwister random)
+		public string GetRandomExistingSequence(ImmutableArray<string> sequences, MersenneTwister random)
 		{
 			return sequences.Where(HasSequence).RandomOrDefault(random);
 		}

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Primitives;
@@ -47,9 +49,9 @@ namespace OpenRA.Graphics
 			public readonly string Image2x = null;
 			public readonly string Image3x = null;
 
-			public readonly int[] PanelRegion = null;
+			public readonly ImmutableArray<int> PanelRegion = default;
 			public readonly PanelSides PanelSides = PanelSides.All;
-			public readonly Dictionary<string, Rectangle> Regions = [];
+			public readonly FrozenDictionary<string, Rectangle> Regions = FrozenDictionary<string, Rectangle>.Empty;
 		}
 
 		public static IReadOnlyDictionary<string, Collection> Collections => collections;

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using OpenRA.Primitives;
 
@@ -64,18 +65,18 @@ namespace OpenRA.Graphics
 			Buffer.BlockCopy(colors, 0, destination, destinationOffset * 4, Palette.Size * 4);
 		}
 
-		public ImmutablePalette(string filename, int[] remapTransparent, int[] remap)
+		public ImmutablePalette(string filename, ImmutableArray<int> remapTransparent, ImmutableArray<int> remap)
 		{
 			using (var s = File.OpenRead(filename))
 				LoadFromStream(s, remapTransparent, remap);
 		}
 
-		public ImmutablePalette(Stream s, int[] remapTransparent, int[] remapShadow)
+		public ImmutablePalette(Stream s, ImmutableArray<int> remapTransparent, ImmutableArray<int> remapShadow)
 		{
 			LoadFromStream(s, remapTransparent, remapShadow);
 		}
 
-		void LoadFromStream(Stream s, int[] remapTransparent, int[] remapShadow)
+		void LoadFromStream(Stream s, ImmutableArray<int> remapTransparent, ImmutableArray<int> remapShadow)
 		{
 			using (var reader = new BinaryReader(s))
 				for (var i = 0; i < Palette.Size; i++)

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -135,7 +135,7 @@ namespace OpenRA
 		void SetVec(string name, float x);
 		void SetVec(string name, float x, float y);
 		void SetVec(string name, float x, float y, float z);
-		void SetVec(string name, float[] vec, int length);
+		void SetVec(string name, ReadOnlyMemory<float> vec, int length);
 		void SetTexture(string param, ITexture texture);
 		void SetMatrix(string param, float[] mtx);
 		void PrepareRender();

--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -10,19 +10,19 @@
 #endregion
 
 using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 
 namespace OpenRA.Graphics
 {
 	public class PlayerColorRemap : IPaletteRemap
 	{
-		readonly int[] remapIndices;
+		readonly ImmutableArray<int> remapIndices;
 		readonly float hue;
 		readonly float saturation;
 		readonly float value;
 
-		public PlayerColorRemap(int[] remapIndices, Color color)
+		public PlayerColorRemap(ImmutableArray<int> remapIndices, Color color)
 		{
 			this.remapIndices = remapIndices;
 

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 
@@ -268,7 +269,7 @@ namespace OpenRA.Graphics
 				{
 					var ramp = map.Grid.Ramps[map.Ramp.Contains(uv) ? map.Ramp[uv] : 0];
 					var pos = map.CenterOfCell(uv.ToCPos(map)) - new WVec(0, 0, ramp.CenterHeightOffset);
-					var screen = ramp.Corners.Select(c => worldRenderer.ScreenPxPosition(pos + c)).ToArray();
+					var screen = ramp.Corners.Select(c => worldRenderer.ScreenPxPosition(pos + c)).ToImmutableArray();
 					if (screen.PolygonContains(world))
 						return uv.ToCPos(map);
 				}

--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace OpenRA
@@ -24,10 +25,10 @@ namespace OpenRA
 		[FluentReference]
 		public readonly string Description = "";
 
-		public readonly HashSet<string> Types = [];
+		public readonly FrozenSet<string> Types = FrozenSet<string>.Empty;
 
 		[FluentReference]
-		public readonly HashSet<string> Contexts = [];
+		public readonly FrozenSet<string> Contexts = FrozenSet<string>.Empty;
 
 		public readonly bool Readonly = false;
 		public bool HasDuplicates { get; internal set; }
@@ -45,11 +46,11 @@ namespace OpenRA
 				Description = descriptionYaml.Value;
 
 			if (nodeDict.TryGetValue("Types", out var typesYaml))
-				Types = FieldLoader.GetValue<HashSet<string>>("Types", typesYaml.Value);
+				Types = FieldLoader.GetValue<FrozenSet<string>>("Types", typesYaml.Value);
 
 			if (nodeDict.TryGetValue("Contexts", out var contextYaml))
-				Contexts = FieldLoader.GetValue<HashSet<string>>("Contexts", contextYaml.Value)
-					.Select(c => ContextFluentPrefix + "." + c).ToHashSet();
+				Contexts = FieldLoader.GetValue<ImmutableArray<string>>("Contexts", contextYaml.Value)
+					.Select(c => ContextFluentPrefix + "." + c).ToFrozenSet();
 
 			if (nodeDict.TryGetValue("Platform", out var platformYaml))
 			{

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -192,7 +193,7 @@ namespace OpenRA
 		public bool LockPreview;
 		public Rectangle Bounds;
 		public MapVisibility Visibility = MapVisibility.Lobby;
-		public string[] Categories = ["Conquest"];
+		public ImmutableArray<string> Categories = ["Conquest"];
 
 		public Size MapSize { get; private set; }
 

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -117,7 +117,7 @@ namespace OpenRA
 
 		public readonly bool EnableDepthBuffer = false;
 
-		public readonly WVec[] SubCellOffsets =
+		public readonly ImmutableArray<WVec> SubCellOffsets =
 		[
 			new(0, 0, 0),       // full cell - index 0
 			new(-299, -256, 0), // top left - index 1
@@ -127,9 +127,9 @@ namespace OpenRA
 			new(256, 256, 0),   // bottom right - index 5
 		];
 
-		public CellRamp[] Ramps { get; }
+		public ImmutableArray<CellRamp> Ramps { get; }
 
-		internal readonly CVec[][] TilesByDistance;
+		internal readonly ImmutableArray<ImmutableArray<CVec>> TilesByDistance;
 
 		public int TileScale { get; }
 
@@ -202,7 +202,7 @@ namespace OpenRA
 			TilesByDistance = CreateTilesByDistance();
 		}
 
-		CVec[][] CreateTilesByDistance()
+		ImmutableArray<ImmutableArray<CVec>> CreateTilesByDistance()
 		{
 			var ts = new List<CVec>[MaximumTileSearchRange + 1];
 			for (var i = 0; i < MaximumTileSearchRange + 1; i++)
@@ -238,7 +238,7 @@ namespace OpenRA
 				});
 			}
 
-			return ts.Select(list => list.ToArray()).ToArray();
+			return ts.Select(list => list.ToImmutableArray()).ToImmutableArray();
 		}
 
 		public WVec OffsetOfSubCell(SubCell subCell)

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -54,7 +55,7 @@ namespace OpenRA
 						Name = "Creeps",
 						Faction = firstFaction,
 						NonCombatant = true,
-						Enemies = Exts.MakeArray(playerCount, i => $"Multi{i}")
+						Enemies = Exts.MakeArray(playerCount, i => $"Multi{i}").ToImmutableArray()
 					}
 				}
 			};

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -49,10 +50,10 @@ namespace OpenRA
 	{
 		public readonly string title;
 		public readonly string author;
-		public readonly string[] categories;
+		public readonly ImmutableArray<string> categories;
 		public readonly int players;
 		public readonly Rectangle bounds;
-		public readonly short[] spawnpoints = [];
+		public readonly ImmutableArray<short> spawnpoints = [];
 		public readonly MapGridType map_grid_type;
 		public readonly string minimap;
 		public readonly bool downloading;
@@ -70,12 +71,12 @@ namespace OpenRA
 		{
 			public int MapFormat;
 			public string Title;
-			public string[] Categories;
+			public ImmutableArray<string> Categories;
 			public string Author;
 			public string TileSet;
 			public MapPlayers Players;
 			public int PlayerCount;
-			public CPos[] SpawnPoints;
+			public ImmutableArray<CPos> SpawnPoints;
 			public MapGridType GridType;
 			public Rectangle Bounds;
 			public Png Preview;
@@ -129,9 +130,9 @@ namespace OpenRA
 				{
 					if (FluentMessageDefinitions != null)
 					{
-						var files = Array.Empty<string>();
+						var files = ImmutableArray<string>.Empty;
 						if (FluentMessageDefinitions.Value != null)
-							files = FieldLoader.GetValue<string[]>("value", FluentMessageDefinitions.Value);
+							files = FieldLoader.GetValue<ImmutableArray<string>>("value", FluentMessageDefinitions.Value);
 
 						string text = null;
 						if (FluentMessageDefinitions.Nodes.Length > 0)
@@ -157,8 +158,8 @@ namespace OpenRA
 						var files = Enumerable.Empty<string>();
 						if (RuleDefinitions.Value != null)
 						{
-							var mapFiles = FieldLoader.GetValue<string[]>("value", RuleDefinitions.Value);
-							files = files.Append(mapFiles);
+							var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", RuleDefinitions.Value);
+							files = files.Concat(mapFiles);
 						}
 
 						var stringPool = new HashSet<string>(); // Reuse common strings in YAML
@@ -196,7 +197,6 @@ namespace OpenRA
 			}
 		}
 
-		static readonly CPos[] NoSpawns = [];
 		readonly object syncRoot = new();
 		readonly MapCache cache;
 		readonly ModData modData;
@@ -238,12 +238,12 @@ namespace OpenRA
 
 		public int MapFormat => innerData.MapFormat;
 		public string Title => innerData.Title;
-		public string[] Categories => innerData.Categories;
+		public ImmutableArray<string> Categories => innerData.Categories;
 		public string Author => innerData.Author;
 		public string TileSet => innerData.TileSet;
 		public MapPlayers Players => innerData.Players;
 		public int PlayerCount => innerData.PlayerCount;
-		public CPos[] SpawnPoints => innerData.SpawnPoints;
+		public ImmutableArray<CPos> SpawnPoints => innerData.SpawnPoints;
 		public MapGridType GridType => innerData.GridType;
 		public Rectangle Bounds => innerData.Bounds;
 		public Png Preview => innerData.Preview;
@@ -341,7 +341,7 @@ namespace OpenRA
 				TileSet = "unknown",
 				Players = null,
 				PlayerCount = 0,
-				SpawnPoints = NoSpawns,
+				SpawnPoints = [],
 				GridType = gridType,
 				Bounds = Rectangle.Empty,
 				Preview = null,
@@ -397,7 +397,7 @@ namespace OpenRA
 				newData.Title = temp.Value;
 
 			if (yaml.TryGetValue("Categories", out temp))
-				newData.Categories = FieldLoader.GetValue<string[]>("Categories", temp.Value);
+				newData.Categories = FieldLoader.GetValue<ImmutableArray<string>>("Categories", temp.Value);
 
 			if (yaml.TryGetValue("Tileset", out temp))
 				newData.TileSet = temp.Value;
@@ -433,7 +433,7 @@ namespace OpenRA
 						spawns.Add(s.Get<LocationInit>().Value);
 					}
 
-					newData.SpawnPoints = spawns.ToArray();
+					newData.SpawnPoints = spawns.ToImmutableArray();
 				}
 				else
 					newData.SpawnPoints = [];
@@ -526,7 +526,7 @@ namespace OpenRA
 					var spawns = new CPos[r.spawnpoints.Length / 2];
 					for (var j = 0; j < r.spawnpoints.Length; j += 2)
 						spawns[j / 2] = new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]);
-					newData.SpawnPoints = spawns;
+					newData.SpawnPoints = spawns.ToImmutableArray();
 					newData.GridType = r.map_grid_type;
 					if (cache.LoadPreviewImages)
 					{

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -53,8 +54,8 @@ namespace OpenRA
 		public bool LockHandicap = false;
 		public int Handicap = 0;
 
-		public string[] Allies = [];
-		public string[] Enemies = [];
+		public ImmutableArray<string> Allies = [];
+		public ImmutableArray<string> Enemies = [];
 
 		public PlayerReference() { }
 		public PlayerReference(MiniYaml my) { FieldLoader.Load(this, my); }

--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileSystem;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -27,14 +28,14 @@ namespace OpenRA
 		string Id { get; }
 		string Name { get; }
 		Size TileSize { get; }
-		TerrainTypeInfo[] TerrainTypes { get; }
+		ImmutableArray<TerrainTypeInfo> TerrainTypes { get; }
 		TerrainTileInfo GetTerrainInfo(TerrainTile r);
 		bool TryGetTerrainInfo(TerrainTile r, out TerrainTileInfo info);
 		byte GetTerrainIndex(string type);
 		byte GetTerrainIndex(TerrainTile r);
 		TerrainTile DefaultTerrainTile { get; }
 
-		Color[] HeightDebugColors { get; }
+		ImmutableArray<Color> HeightDebugColors { get; }
 		IEnumerable<Color> RestrictedPlayerColors { get; }
 		float MinHeightColorBrightness { get; }
 		float MaxHeightColorBrightness { get; }
@@ -62,7 +63,7 @@ namespace OpenRA
 	{
 		public readonly string Type;
 		public readonly BitSet<TargetableType> TargetTypes;
-		public readonly HashSet<string> AcceptsSmudgeType = [];
+		public readonly ImmutableArray<string> AcceptsSmudgeType = [];
 		public readonly Color Color;
 		public readonly bool RestrictPlayerColor = false;
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -678,8 +678,8 @@ namespace OpenRA
 		{
 			if (mapRules != null && mapRules.Value != null)
 			{
-				var mapFiles = FieldLoader.GetValue<string[]>("value", mapRules.Value);
-				files = files.Append(mapFiles);
+				var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", mapRules.Value);
+				files = files.Concat(mapFiles);
 			}
 
 			var stringPool = new HashSet<string>(); // Reuse common strings in YAML

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -40,7 +41,7 @@ namespace OpenRA.Network
 		public bool AuthenticationFailed = false;
 
 		// The default null means "no map restriction" while an empty set means "all maps restricted"
-		public HashSet<string> ServerMapPool = null;
+		public FrozenSet<string> ServerMapPool = null;
 
 		public int NetFrameNumber { get; private set; }
 		public int LocalFrameNumber;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Server;
@@ -67,11 +68,11 @@ namespace OpenRA.Network
 					{
 						var message = new FluentMessage(node.Value);
 						if (message.Key == Joined)
-							TextNotificationsManager.AddPlayerJoinedLine(message.Key, message.Arguments);
+							TextNotificationsManager.AddPlayerJoinedLine(message.Key, message.Arguments.ToArray());
 						else if (message.Key == Left)
-							TextNotificationsManager.AddPlayerLeftLine(message.Key, message.Arguments);
+							TextNotificationsManager.AddPlayerLeftLine(message.Key, message.Arguments.ToArray());
 						else
-							TextNotificationsManager.AddSystemLine(message.Key, message.Arguments);
+							TextNotificationsManager.AddSystemLine(message.Key, message.Arguments.ToArray());
 					}
 
 					break;
@@ -385,7 +386,7 @@ namespace OpenRA.Network
 
 				case "SyncMapPool":
 				{
-					orderManager.ServerMapPool = FieldLoader.GetValue<HashSet<string>>("SyncMapPool", order.TargetString);
+					orderManager.ServerMapPool = FieldLoader.GetValue<FrozenSet<string>>("SyncMapPool", order.TargetString);
 					break;
 				}
 

--- a/OpenRA.Game/Primitives/Polygon.cs
+++ b/OpenRA.Game/Primitives/Polygon.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace OpenRA.Primitives
@@ -19,7 +20,7 @@ namespace OpenRA.Primitives
 		public static readonly Polygon Empty = new(Rectangle.Empty);
 
 		public readonly Rectangle BoundingRect;
-		public readonly int2[] Vertices;
+		public readonly ImmutableArray<int2> Vertices;
 		readonly bool isRectangle;
 
 		public Polygon(Rectangle bounds)
@@ -29,7 +30,7 @@ namespace OpenRA.Primitives
 			isRectangle = true;
 		}
 
-		public Polygon(int2[] vertices)
+		public Polygon(ImmutableArray<int2> vertices)
 		{
 			if (vertices != null && vertices.Length > 0)
 			{
@@ -53,7 +54,7 @@ namespace OpenRA.Primitives
 			{
 				isRectangle = true;
 				BoundingRect = Rectangle.Empty;
-				Vertices = Exts.MakeArray(4, _ => int2.Zero);
+				Vertices = Exts.MakeArray(4, _ => int2.Zero).ToImmutableArray();
 			}
 		}
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -132,7 +133,7 @@ namespace OpenRA.Server
 		public MapPreview Map;
 		public readonly MapStatusCache MapStatusCache;
 		public GameSave GameSave;
-		public HashSet<string> MapPool;
+		public FrozenSet<string> MapPool;
 
 		// Default to the next frame for ServerType.Local - MP servers take the value from the selected GameSpeed.
 		public int OrderLatency = 1;
@@ -661,9 +662,9 @@ namespace OpenRA.Server
 
 						events.Add(new CallbackEvent(() =>
 						{
-							var notAuthenticated = Type == ServerType.Dedicated && profile == null && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Length > 0);
+							var notAuthenticated = Type == ServerType.Dedicated && profile == null && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Count > 0);
 							var blacklisted = Type == ServerType.Dedicated && profile != null && Settings.ProfileIDBlacklist.Contains(profile.ProfileID);
-							var notWhitelisted = Type == ServerType.Dedicated && Settings.ProfileIDWhitelist.Length > 0 &&
+							var notWhitelisted = Type == ServerType.Dedicated && Settings.ProfileIDWhitelist.Count > 0 &&
 								(profile == null || !Settings.ProfileIDWhitelist.Contains(profile.ProfileID));
 
 							if (notAuthenticated)
@@ -689,7 +690,7 @@ namespace OpenRA.Server
 				}
 				else
 				{
-					if (Type == ServerType.Dedicated && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Length > 0))
+					if (Type == ServerType.Dedicated && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Count > 0))
 					{
 						Log.Write("server", $"Rejected connection from {newConn.EndPoint}; Not authenticated.");
 						SendOrderTo(newConn, "ServerError", RequiresAuthentication);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Primitives;
@@ -69,16 +71,16 @@ namespace OpenRA
 		public string Map = null;
 
 		[Desc("Takes a comma separated list of IP addresses that are not allowed to join.")]
-		public string[] Ban = [];
+		public FrozenSet<string> Ban = FrozenSet<string>.Empty;
 
 		[Desc("For dedicated servers only, allow anonymous clients to join.")]
 		public bool RequireAuthentication = false;
 
 		[Desc("For dedicated servers only, if non-empty, only allow authenticated players with these profile IDs to join.")]
-		public int[] ProfileIDWhitelist = [];
+		public FrozenSet<int> ProfileIDWhitelist = FrozenSet<int>.Empty;
 
 		[Desc("For dedicated servers only, if non-empty, always reject players with these user IDs from joining.")]
-		public int[] ProfileIDBlacklist = [];
+		public FrozenSet<int> ProfileIDBlacklist = FrozenSet<int>.Empty;
 
 		[Desc("For dedicated servers only, controls whether a game can be started with just one human player in the lobby.")]
 		public bool EnableSingleplayer = false;
@@ -105,7 +107,7 @@ namespace OpenRA
 		public bool EnableLintChecks = true;
 
 		[Desc("For dedicated servers only, a comma separated list of map uids that are allowed to be used.")]
-		public string[] MapPool = [];
+		public FrozenSet<string> MapPool = FrozenSet<string>.Empty;
 
 		[Desc("Delay in milliseconds before newly joined players can send chat messages.")]
 		public int FloodLimitJoinCooldown = 5000;
@@ -251,7 +253,7 @@ namespace OpenRA
 		public string Name = "Commander";
 		public Color Color = Color.FromArgb(200, 32, 32);
 		public string LastServer = "localhost:1234";
-		public Color[] CustomColors = [];
+		public ImmutableArray<Color> CustomColors = [];
 	}
 
 	public class SinglePlayerGameSettings

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using OpenRA.FileSystem;
 using OpenRA.GameRules;
@@ -165,12 +166,12 @@ namespace OpenRA
 		public ISound PlayLooped(SoundType type, string name) { return Play(type, null, name, true, WPos.Zero, 1f, true); }
 		public ISound PlayLooped(SoundType type, string name, WPos pos) { return Play(type, null, name, false, pos, 1f, true); }
 
-		public ISound Play(SoundType type, string[] names, World world, Player player = null, float volumeModifier = 1f)
+		public ISound Play(SoundType type, ImmutableArray<string> names, World world, Player player = null, float volumeModifier = 1f)
 		{
 			return Play(type, player, names.Random(world.LocalRandom), true, WPos.Zero, volumeModifier);
 		}
 
-		public ISound Play(SoundType type, string[] names, World world, WPos pos, Player player = null, float volumeModifier = 1f)
+		public ISound Play(SoundType type, ImmutableArray<string> names, World world, WPos pos, Player player = null, float volumeModifier = 1f)
 		{
 			return Play(type, player, names.Random(world.LocalRandom), false, pos, volumeModifier);
 		}
@@ -399,9 +400,9 @@ namespace OpenRA
 			if (variant != null)
 			{
 				if (rules.Variants.TryGetValue(variant, out var v) && !rules.DisableVariants.Contains(definition))
-					suffix = v[id % v.Length];
+					suffix = v[(int)(id % v.Length)];
 				if (rules.Prefixes.TryGetValue(variant, out var p) && !rules.DisablePrefixes.Contains(definition))
-					prefix = p[id % p.Length];
+					prefix = p[(int)(id % p.Length)];
 			}
 
 			var name = prefix + clip + suffix;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -175,7 +176,7 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface IStoresResourcesInfo : ITraitInfoInterface
 	{
-		string[] ResourceTypes { get; }
+		ImmutableArray<string> ResourceTypes { get; }
 	}
 
 	public interface IStoresResources
@@ -505,12 +506,12 @@ namespace OpenRA.Traits
 
 	public interface IControlGroupsInfo : ITraitInfoInterface
 	{
-		string[] Groups { get; }
+		ImmutableArray<string> Groups { get; }
 	}
 
 	public interface IControlGroups
 	{
-		string[] Groups { get; }
+		ImmutableArray<string> Groups { get; }
 
 		void SelectControlGroup(int group);
 		void CreateControlGroup(int group);

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 
 namespace OpenRA.Traits
 {
@@ -25,7 +25,7 @@ namespace OpenRA.Traits
 		public readonly string InternalName = null;
 
 		[Desc("Pick a random faction as the player's faction out of this list.")]
-		public readonly HashSet<string> RandomFactionMembers = [];
+		public readonly FrozenSet<string> RandomFactionMembers = FrozenSet<string>.Empty;
 
 		[Desc("The side that the faction belongs to. For example, England belongs to the 'Allies' side.")]
 		public readonly string Side = null;

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using OpenRA.Graphics;
@@ -208,8 +209,8 @@ namespace OpenRA.Widgets
 		public IntegerExpression Y;
 		public IntegerExpression Width;
 		public IntegerExpression Height;
-		public string[] Logic = [];
-		public ChromeLogic[] LogicObjects { get; private set; }
+		public ImmutableArray<string> Logic = [];
+		public ImmutableArray<ChromeLogic> LogicObjects { get; private set; }
 		public bool Visible = true;
 		public bool IgnoreMouseOver;
 		public bool IgnoreChildMouseOver;
@@ -307,7 +308,7 @@ namespace OpenRA.Widgets
 			args["widget"] = this;
 
 			LogicObjects = Logic.Select(l => Game.ModData.ObjectCreator.CreateObject<ChromeLogic>(l, args))
-				.ToArray();
+				.ToImmutableArray();
 
 			foreach (var logicObject in LogicObjects)
 				Ui.Subscribe(logicObject);

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -302,7 +303,7 @@ namespace OpenRA
 			foreach (var player in Players)
 				gameInfo.AddPlayer(player, OrderManager.LobbyInfo);
 
-			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints;
+			gameInfo.DisabledSpawnPoints = OrderManager.LobbyInfo.DisabledSpawnPoints.ToFrozenSet();
 
 			gameInfo.StartTimeUtc = DateTime.UtcNow;
 

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -33,15 +35,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 	public class ClassicTilesetSpecificSpriteSequence : ClassicSpriteSequence
 	{
 		[Desc("Dictionary of <tileset name>: filename to override the Filename key.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenames = new(nameof(TilesetFilenames), null);
+		static readonly SpriteSequenceField<FrozenDictionary<string, string>> TilesetFilenames = new(nameof(TilesetFilenames), null);
 
 		[Desc("Dictionary of <tileset name>: <filename pattern> to override the FilenamePattern key.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenamesPattern = new(nameof(TilesetFilenamesPattern), null);
+		static readonly SpriteSequenceField<FrozenDictionary<string, string>> TilesetFilenamesPattern = new(nameof(TilesetFilenamesPattern), null);
 
 		public ClassicTilesetSpecificSpriteSequence(SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
 			: base(cache, loader, image, sequence, data, defaults) { }
 
-		protected override IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, int[] frames, MiniYaml data, MiniYaml defaults)
+		protected override IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, ImmutableArray<int> frames, MiniYaml data, MiniYaml defaults)
 		{
 			var tilesetFilenamesPatternNode = data.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key) ?? defaults.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key);
 			if (tilesetFilenamesPatternNode != null)
@@ -71,7 +73,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 			return base.ParseFilenames(modData, tileset, frames, data, defaults);
 		}
 
-		protected override IEnumerable<ReservationInfo> ParseCombineFilenames(ModData modData, string tileset, int[] frames, MiniYaml data)
+		protected override IEnumerable<ReservationInfo> ParseCombineFilenames(ModData modData, string tileset, ImmutableArray<int> frames, MiniYaml data)
 		{
 			var node = data.NodeWithKeyOrDefault(TilesetFilenames.Key);
 			if (node != null)
@@ -83,7 +85,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 					{
 						var subStart = LoadField("Start", 0, data);
 						var subLength = LoadField("Length", 1, data);
-						frames = Exts.MakeArray(subLength, i => subStart + i);
+						frames = Exts.MakeArray(subLength, i => subStart + i).ToImmutableArray();
 					}
 
 					return [new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location)];

--- a/OpenRA.Mods.Cnc/Graphics/ModelActorPreview.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelActorPreview.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Mods.Common.Graphics;
@@ -22,8 +23,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly ModelRenderer renderer;
 		readonly ModelAnimation[] components;
 		readonly float scale;
-		readonly float[] lightAmbientColor;
-		readonly float[] lightDiffuseColor;
+		readonly ImmutableArray<float> lightAmbientColor;
+		readonly ImmutableArray<float> lightDiffuseColor;
 		readonly WRot lightSource;
 		readonly WRot camera;
 		readonly PaletteReference colorPalette;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly int zOffset;
 
 		public ModelPreview(ModelRenderer renderer, ModelAnimation[] components, in WVec offset, int zOffset, float scale, WAngle lightPitch, WAngle lightYaw,
-			float[] lightAmbientColor, float[] lightDiffuseColor, WAngle cameraPitch,
+			ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor, WAngle cameraPitch,
 			PaletteReference colorPalette, PaletteReference normalsPalette, PaletteReference shadowPalette)
 		{
 			this.renderer = renderer;

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
@@ -24,15 +25,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly IEnumerable<ModelAnimation> models;
 		readonly WRot camera;
 		readonly WRot lightSource;
-		readonly float[] lightAmbientColor;
-		readonly float[] lightDiffuseColor;
+		readonly ImmutableArray<float> lightAmbientColor;
+		readonly ImmutableArray<float> lightDiffuseColor;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
 
 		public ModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos pos, int zOffset, in WRot camera, float scale,
-			in WRot lightSource, float[] lightAmbientColor, float[] lightDiffuseColor,
+			in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow)
 			: this(renderer, models, pos, zOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		public ModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos pos, int zOffset, in WRot camera, float scale,
-			in WRot lightSource, float[] lightAmbientColor, float[] lightDiffuseColor,
+			in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow,
 			float alpha, in float3 tint, TintModifiers tintModifiers)
 		{

--- a/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
@@ -25,15 +26,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly int2 screenPos;
 		readonly WRot camera;
 		readonly WRot lightSource;
-		readonly float[] lightAmbientColor;
-		readonly float[] lightDiffuseColor;
+		readonly ImmutableArray<float> lightAmbientColor;
+		readonly ImmutableArray<float> lightDiffuseColor;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
 
 		public UIModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos effectiveWorldPos, int2 screenPos, int zOffset,
-			in WRot camera, float scale, in WRot lightSource, float[] lightAmbientColor, float[] lightDiffuseColor,
+			in WRot camera, float scale, in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow)
 		{
 			this.renderer = renderer;

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Orders;
@@ -87,7 +88,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when disguised as specified actor.",
 			"A dictionary of [actor id]: [condition].")]
-		public readonly Dictionary<string, string> DisguisedAsConditions = [];
+		public readonly FrozenDictionary<string, string> DisguisedAsConditions = FrozenDictionary<string, string>.Empty;
 
 		[CursorReference]
 		[Desc("Cursor to display when hovering over a valid actor to disguise as.")]

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -20,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	sealed class LightPaletteRotatorInfo : TraitInfo
 	{
 		[Desc("Palettes this effect should not apply to.")]
-		public readonly HashSet<string> ExcludePalettes = [];
+		public readonly FrozenSet<string> ExcludePalettes = FrozenSet<string>.Empty;
 
 		[Desc("'Speed' at which the effect cycles through palette indices.")]
 		public readonly float TimeStep = .5f;
@@ -29,7 +31,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int ModifyIndex = 103;
 
 		[Desc("Palette indices to rotate through.")]
-		public readonly int[] RotationIndices = [230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 238, 237, 236, 235, 234, 233, 232, 231];
+		public readonly ImmutableArray<int> RotationIndices = [230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 238, 237, 236, 235, 234, 233, 232, 231];
 
 		public override object Create(ActorInitializer init) { return new LightPaletteRotator(this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderVoxels.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Graphics;
@@ -52,8 +53,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public readonly WAngle LightPitch = WAngle.FromDegrees(50);
 		public readonly WAngle LightYaw = WAngle.FromDegrees(240);
-		public readonly float[] LightAmbientColor = [0.6f, 0.6f, 0.6f];
-		public readonly float[] LightDiffuseColor = [0.4f, 0.4f, 0.4f];
+		public readonly ImmutableArray<float> LightAmbientColor = [0.6f, 0.6f, 0.6f];
+		public readonly ImmutableArray<float> LightDiffuseColor = [0.4f, 0.4f, 0.4f];
 
 		public override object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common;
@@ -24,10 +26,10 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	public class WithCargoInfo : TraitInfo, Requires<CargoInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Cargo position relative to turret or body in (forward, right, up) triples. The default offset should be in the middle of the list.")]
-		public readonly WVec[] LocalOffset = [WVec.Zero];
+		public readonly ImmutableArray<WVec> LocalOffset = [WVec.Zero];
 
 		[Desc("Passenger CargoType to display.")]
-		public readonly HashSet<string> DisplayTypes = [];
+		public readonly FrozenSet<string> DisplayTypes = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new WithCargo(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithHarvesterSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithHarvesterSpriteBody.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
@@ -18,7 +19,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	public class WithHarvesterSpriteBodyInfo : WithFacingSpriteBodyInfo, Requires<HarvesterInfo>
 	{
 		[Desc("Images switched between depending on fullness of harvester. Overrides RenderSprites.Image.")]
-		public readonly string[] ImageByFullness = [];
+		public readonly ImmutableArray<string> ImageByFullness = [];
 
 		public override object Create(ActorInitializer init) { return new WithHarvesterSpriteBody(init, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
@@ -19,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	public class WithLandingCraftAnimationInfo : TraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>
 	{
-		public readonly HashSet<string> OpenTerrainTypes = ["Clear"];
+		public readonly FrozenSet<string> OpenTerrainTypes = new HashSet<string> { "Clear" }.ToFrozenSet();
 
 		[SequenceReference]
 		public readonly string OpenSequence = "open";

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Cnc.Effects;
@@ -26,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[FieldLoader.Require]
 		[Desc("Drop pod unit")]
 		[ActorReference([typeof(AircraftInfo), typeof(FallsToEarthInfo)])]
-		public readonly string[] UnitTypes = null;
+		public readonly ImmutableArray<string> UnitTypes = default;
 
 		[Desc("Number of drop pods spawned.")]
 		public readonly int2 Drops = new(5, 8);
@@ -82,7 +84,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly DropPodsPowerInfo info;
 		readonly string[] unitTypes;
 		readonly Dictionary<string, Func<CPos, WPos>> getLaunchLocation = [];
-		readonly Dictionary<string, HashSet<string>> landableTerrainTypes = [];
+		readonly Dictionary<string, FrozenSet<string>> landableTerrainTypes = [];
 
 		public DropPodsPower(Actor self, DropPodsPowerInfo info)
 			: base(self, info)

--- a/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
+++ b/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int Adjacency = 1;
 
 		[Desc("The range of time (in ticks) until the transformation starts.")]
-		public readonly int[] Delay = [1000, 3000];
+		public readonly ImmutableArray<int> Delay = [1000, 3000];
 
 		public override object Create(ActorInitializer init) { return new TransformsNearResources(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/JumpjetLocomotor.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/JumpjetLocomotor.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly short JumpjetTransitionCost = 0;
 
 		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
-		public readonly HashSet<string> JumpjetTransitionTerrainTypes = [];
+		public readonly FrozenSet<string> JumpjetTransitionTerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Can this actor transition on slopes?")]
 		public readonly bool JumpjetTransitionOnRamps = true;

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -44,8 +45,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	public sealed class ModelRenderer : IDisposable, IRenderer, INotifyActorDisposing
 	{
 		// Static constants
-		static readonly float[] ShadowDiffuse = [0, 0, 0];
-		static readonly float[] ShadowAmbient = [1, 1, 1];
+		static readonly ImmutableArray<float> ShadowDiffuse = [0, 0, 0];
+		static readonly ImmutableArray<float> ShadowAmbient = [1, 1, 1];
 		static readonly float2 SpritePadding = new(2, 2);
 		static readonly float[] ZeroVector = [0, 0, 0, 1];
 		static readonly float[] ZVector = [0, 0, 1, 1];
@@ -94,7 +95,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public ModelRenderProxy RenderAsync(
 			WorldRenderer wr, IEnumerable<ModelAnimation> models, in WRot camera, float scale,
-			in WRot groundOrientation, in WRot lightSource, float[] lightAmbientColor, float[] lightDiffuseColor,
+			in WRot groundOrientation, in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadowPalette)
 		{
 			if (!isInFrame)
@@ -281,15 +282,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			ModelRenderData renderData,
 			IModelCache cache,
 			float[] t, float[] lightDirection,
-			float[] ambientLight, float[] diffuseLight,
+			ImmutableArray<float> ambientLight, ImmutableArray<float> diffuseLight,
 			float colorPaletteTextureIndex, float normalsPaletteTextureIndex)
 		{
 			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
 			shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
 			shader.SetMatrix("TransformMatrix", t);
 			shader.SetVec("LightDirection", lightDirection, 4);
-			shader.SetVec("AmbientLight", ambientLight, 3);
-			shader.SetVec("DiffuseLight", diffuseLight, 3);
+			shader.SetVec("AmbientLight", ambientLight.AsMemory(), 3);
+			shader.SetVec("DiffuseLight", diffuseLight.AsMemory(), 3);
 
 			shader.PrepareRender();
 			renderer.DrawBatch(cache.VertexBuffer, shader, renderData.Start, renderData.Count, PrimitiveType.TriangleList);

--- a/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSEditorResourceLayer.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = [];
+		public readonly FrozenSet<string> VeinholeActors = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new TSEditorResourceLayer(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSResourceLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = [];
+		public readonly FrozenSet<string> VeinholeActors = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new TSResourceLayer(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/TSTiberiumRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSTiberiumRenderer.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -22,16 +24,16 @@ namespace OpenRA.Mods.Cnc.Traits
 	public class TSTiberiumRendererInfo : ResourceRendererInfo
 	{
 		[Desc("Sequences to use for ramp type 1.", "Dictionary of [resource type]: [list of sequences].")]
-		public readonly Dictionary<string, string[]> Ramp1Sequences = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> Ramp1Sequences = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		[Desc("Sequences to use for ramp type 2.", "Dictionary of [resource type]: [list of sequences].")]
-		public readonly Dictionary<string, string[]> Ramp2Sequences = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> Ramp2Sequences = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		[Desc("Sequences to use for ramp type 3.", "Dictionary of [resource type]: [list of sequences].")]
-		public readonly Dictionary<string, string[]> Ramp3Sequences = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> Ramp3Sequences = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		[Desc("Sequences to use for ramp type 4.", "Dictionary of [resource type]: [list of sequences].")]
-		public readonly Dictionary<string, string[]> Ramp4Sequences = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> Ramp4Sequences = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		public override object Create(ActorInitializer init) { return new TSTiberiumRenderer(init.Self, this); }
 	}
@@ -52,7 +54,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			world = self.World;
 		}
 
-		void LoadVariants(Dictionary<string, string[]> rampSequences, Dictionary<string, Dictionary<string, ISpriteSequence>> rampVariants)
+		void LoadVariants(FrozenDictionary<string, ImmutableArray<string>> rampSequences, Dictionary<string, Dictionary<string, ISpriteSequence>> rampVariants)
 		{
 			var sequences = world.Map.Sequences;
 			foreach (var kv in rampSequences)

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[ActorReference]
 		[Desc("Actor types that should be treated as veins for adjacency.")]
-		public readonly HashSet<string> VeinholeActors = [];
+		public readonly FrozenSet<string> VeinholeActors = FrozenSet<string>.Empty;
 
 		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)
 		{

--- a/OpenRA.Mods.Cnc/Traits/World/WithResourceAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/WithResourceAnimation.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common;
@@ -26,13 +28,13 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Resource types to animate.")]
-		public readonly HashSet<string> Types = null;
+		public readonly FrozenSet<string> Types = null;
 
 		[Desc("The percentage of resource cells to play the animation on.", "Use two values to randomize between them.")]
-		public readonly int[] Ratio = [1, 10];
+		public readonly ImmutableArray<int> Ratio = [1, 10];
 
 		[Desc("Tick interval between two animation spawning.", "Use two values to randomize between them.")]
-		public readonly int[] Interval = [200, 500];
+		public readonly ImmutableArray<int> Interval = [200, 500];
 
 		[FieldLoader.Require]
 		[Desc("Animation image.")]
@@ -40,7 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[SequenceReference(nameof(Image))]
 		[Desc("Randomly select one of these sequences to render.")]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[PaletteReference]
 		[Desc("Animation palette.")]

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportGen1MapCommand.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -394,8 +395,8 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				switch (s.Key)
 				{
 					case "Allies":
-						pr.Allies = s.Value.Split(',').Intersect(players).Except(neutral).ToArray();
-						pr.Enemies = s.Value.Split(',').SymmetricDifference(players).Except(neutral).ToArray();
+						pr.Allies = s.Value.Split(',').Intersect(players).Except(neutral).ToImmutableArray();
+						pr.Enemies = s.Value.Split(',').SymmetricDifference(players).Except(neutral).ToImmutableArray();
 						break;
 					default:
 						Console.WriteLine("Ignoring unknown {0}={1} for player {2}", s.Key, s.Value, pr.Name);

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -50,7 +51,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			Game.ModData = destModData;
 			var destPaletteInfo = destModData.DefaultRules.Actors[SystemActors.Player].TraitInfo<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
-			var shadowIndex = Array.Empty<int>();
+			var shadowIndex = ImmutableArray<int>.Empty;
 
 			// the remap range is always 16 entries, but their location and order changes
 			for (var i = 0; i < 16; i++)

--- a/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Graphics;
 using OpenRA.Mods.Cnc.Traits;
@@ -26,8 +27,8 @@ namespace OpenRA.Mods.Cnc.Widgets
 		public float Scale = 10f;
 		public int LightPitch = 142;
 		public int LightYaw = 682;
-		public float[] LightAmbientColor = [0.6f, 0.6f, 0.6f];
-		public float[] LightDiffuseColor = [0.4f, 0.4f, 0.4f];
+		public ImmutableArray<float> LightAmbientColor = [0.6f, 0.6f, 0.6f];
+		public ImmutableArray<float> LightDiffuseColor = [0.4f, 0.4f, 0.4f];
 		public WRot Rotation = WRot.None;
 		public WAngle CameraAngle = WAngle.FromDegrees(40);
 
@@ -35,8 +36,8 @@ namespace OpenRA.Mods.Cnc.Widgets
 		public Func<string> GetPlayerPalette;
 		public Func<string> GetNormalsPalette;
 		public Func<string> GetShadowPalette;
-		public Func<float[]> GetLightAmbientColor;
-		public Func<float[]> GetLightDiffuseColor;
+		public Func<ImmutableArray<float>> GetLightAmbientColor;
+		public Func<ImmutableArray<float>> GetLightDiffuseColor;
 		public Func<float> GetScale;
 		public Func<int> GetLightPitch;
 		public Func<int> GetLightYaw;

--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common
 
 	public static class AIUtils
 	{
-		public static bool IsAreaAvailable<T>(World world, Player player, Map map, int radius, HashSet<string> terrainTypes)
+		public static bool IsAreaAvailable<T>(World world, Player player, Map map, int radius, FrozenSet<string> terrainTypes)
 		{
 			var cells = world.ActorsHavingTrait<T>().Where(a => a.Owner == player);
 

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		public readonly string ToActor;
 		public CVec Offset = CVec.Zero;
 		public WAngle Facing = new(384);
-		public string[] Sounds = [];
+		public ImmutableArray<string> Sounds = [];
 		public string Notification = null;
 		public string TextNotification = null;
 		public int ForceHealthPercentage = 0;

--- a/OpenRA.Mods.Common/AssetBrowser.cs
+++ b/OpenRA.Mods.Common/AssetBrowser.cs
@@ -9,13 +9,15 @@
  */
 #endregion
 
+using System.Collections.Immutable;
+
 namespace OpenRA
 {
 	public class AssetBrowser : IGlobalModData
 	{
-		public readonly string[] SpriteExtensions = [];
-		public readonly string[] ModelExtensions = [];
-		public readonly string[] AudioExtensions = [];
-		public readonly string[] VideoExtensions = [];
+		public readonly ImmutableArray<string> SpriteExtensions = [];
+		public readonly ImmutableArray<string> ModelExtensions = [];
+		public readonly ImmutableArray<string> AudioExtensions = [];
+		public readonly ImmutableArray<string> VideoExtensions = [];
 	}
 }

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -234,13 +235,13 @@ namespace OpenRA.Mods.Common.Widgets
 		public string Text { get; }
 
 		readonly MarkerLayerOverlay markerLayerOverlay;
-		readonly ImmutableDictionary<int, ImmutableArray<CPos>> tiles;
+		readonly FrozenDictionary<int, ImmutableArray<CPos>> tiles;
 
 		public ClearAllMarkerTilesEditorAction(
 			MarkerLayerOverlay markerLayerOverlay)
 		{
 			this.markerLayerOverlay = markerLayerOverlay;
-			tiles = markerLayerOverlay.Tiles.ToImmutableDictionary(t => t.Key, t => t.Value.ToImmutableArray());
+			tiles = markerLayerOverlay.Tiles.ToFrozenDictionary(t => t.Key, t => t.Value.ToImmutableArray());
 			var allTilesCount = tiles.Values.Sum(x => x.Length);
 
 			Text = FluentProvider.GetMessage(ClearedAllMarkerTiles, "count", allTilesCount);

--- a/OpenRA.Mods.Common/Effects/FloatingSprite.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingSprite.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 
@@ -17,8 +18,8 @@ namespace OpenRA.Mods.Common.Effects
 {
 	public sealed class FloatingSprite : IEffect, ISpatiallyPartitionable
 	{
-		readonly WDist[] speed;
-		readonly WDist[] gravity;
+		readonly ImmutableArray<WDist> speed;
+		readonly ImmutableArray<WDist> gravity;
 		readonly Animation anim;
 
 		readonly bool visibleThroughFog;
@@ -32,8 +33,8 @@ namespace OpenRA.Mods.Common.Effects
 		int ticks;
 		WAngle facing;
 
-		public FloatingSprite(Actor emitter, string image, string[] sequences, string palette, bool isPlayerPalette,
-			int[] lifetime, WDist[] speed, WDist[] gravity, int turnRate, int randomRate, WPos pos, WAngle facing,
+		public FloatingSprite(Actor emitter, string image, ImmutableArray<string> sequences, string palette, bool isPlayerPalette,
+			ImmutableArray<int> lifetime, ImmutableArray<WDist> speed, ImmutableArray<WDist> gravity, int turnRate, int randomRate, WPos pos, WAngle facing,
 			bool visibleThroughFog = false)
 		{
 			var world = emitter.World;

--- a/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
+++ b/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.FileSystem
@@ -22,7 +23,21 @@ namespace OpenRA.Mods.Common.FileSystem
 
 	public class DefaultFileSystemLoader : IFileSystemLoader
 	{
-		public readonly Dictionary<string, string> Packages = null;
+		[FieldLoader.LoadUsing(nameof(LoadPackages))]
+		public readonly ImmutableArray<KeyValuePair<string, string>> Packages = default;
+
+		static object LoadPackages(MiniYaml yaml)
+		{
+			var packageNode = yaml.NodeWithKeyOrDefault(nameof(Packages));
+			if (packageNode == null)
+				return default(ImmutableArray<KeyValuePair<string, string>>);
+
+			var packages = new List<KeyValuePair<string, string>>(packageNode.Value.Nodes.Length);
+			foreach (var node in packageNode.Value.Nodes)
+				packages.Add(KeyValuePair.Create(node.Key, node.Value.Value));
+
+			return packages.ToImmutableArray();
+		}
 
 		public void Mount(OpenRA.FileSystem.FileSystem fileSystem, ObjectCreator objectCreator)
 		{

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 
@@ -31,15 +33,15 @@ namespace OpenRA.Mods.Common.Graphics
 	public class TilesetSpecificSpriteSequence : DefaultSpriteSequence
 	{
 		[Desc("Dictionary of <tileset name>: filename to override the Filename key.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenames = new(nameof(TilesetFilenames), null);
+		static readonly SpriteSequenceField<FrozenDictionary<string, string>> TilesetFilenames = new(nameof(TilesetFilenames), null);
 
 		[Desc("Dictionary of <tileset name>: <filename pattern> to override the FilenamePattern key.")]
-		static readonly SpriteSequenceField<Dictionary<string, string>> TilesetFilenamesPattern = new(nameof(TilesetFilenamesPattern), null);
+		static readonly SpriteSequenceField<FrozenDictionary<string, string>> TilesetFilenamesPattern = new(nameof(TilesetFilenamesPattern), null);
 
 		public TilesetSpecificSpriteSequence(SpriteCache cache, ISpriteSequenceLoader loader, string image, string sequence, MiniYaml data, MiniYaml defaults)
 			: base(cache, loader, image, sequence, data, defaults) { }
 
-		protected override IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, int[] frames, MiniYaml data, MiniYaml defaults)
+		protected override IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, ImmutableArray<int> frames, MiniYaml data, MiniYaml defaults)
 		{
 			var tilesetFilenamesPatternNode = data.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key) ?? defaults.NodeWithKeyOrDefault(TilesetFilenamesPattern.Key);
 			if (tilesetFilenamesPatternNode != null)
@@ -69,7 +71,7 @@ namespace OpenRA.Mods.Common.Graphics
 			return base.ParseFilenames(modData, tileset, frames, data, defaults);
 		}
 
-		protected override IEnumerable<ReservationInfo> ParseCombineFilenames(ModData modData, string tileset, int[] frames, MiniYaml data)
+		protected override IEnumerable<ReservationInfo> ParseCombineFilenames(ModData modData, string tileset, ImmutableArray<int> frames, MiniYaml data)
 		{
 			var node = data.NodeWithKeyOrDefault(TilesetFilenames.Key);
 			if (node != null)
@@ -81,7 +83,7 @@ namespace OpenRA.Mods.Common.Graphics
 					{
 						var subStart = LoadField("Start", 0, data);
 						var subLength = LoadField("Length", 1, data);
-						frames = Exts.MakeArray(subLength, i => subStart + i);
+						frames = Exts.MakeArray(subLength, i => subStart + i).ToImmutableArray();
 					}
 
 					return [new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location)];

--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.HitShapes
 		public WDist OuterRadius { get; private set; }
 
 		[FieldLoader.Require]
-		public readonly int2[] Points;
+		public readonly ImmutableArray<int2> Points;
 
 		[Desc("Defines the top offset relative to the actor's center.")]
 		public readonly int VerticalTopOffset = 0;
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.HitShapes
 
 		public PolygonShape() { }
 
-		public PolygonShape(int2[] points) { Points = points; }
+		public PolygonShape(ImmutableArray<int2> points) { Points = points; }
 
 		public void Initialize()
 		{

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Lint
 				// Logic classes can declare the data key names that specify hotkeys.
 				if (node.Key == "Logic" && node.Value.Nodes.Length > 0)
 				{
-					var typeNames = FieldLoader.GetValue<string[]>(node.Key, node.Value.Value);
+					var typeNames = FieldLoader.GetValue<ImmutableArray<string>>(node.Key, node.Value.Value);
 					var checkArgKeys = new List<string>();
 					foreach (var typeName in typeNames)
 					{

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Lint
@@ -32,7 +33,7 @@ namespace OpenRA.Mods.Common.Lint
 
 				if (node.Key == "Logic")
 				{
-					var typeNames = FieldLoader.GetValue<string[]>(node.Key, node.Value.Value);
+					var typeNames = FieldLoader.GetValue<ImmutableArray<string>>(node.Key, node.Value.Value);
 					foreach (var typeName in typeNames)
 					{
 						var type = Game.ModData.ObjectCreator.FindType(typeName);

--- a/OpenRA.Mods.Common/Lint/CheckFluentReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckFluentReferences.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var context in usedKeys.EmptyKeyContexts)
 				emitWarning($"Empty key in map ftl files required by {context}");
 
-			var mapMessages = FieldLoader.GetValue<string[]>("value", map.FluentMessageDefinitions.Value);
+			var mapMessages = FieldLoader.GetValue<ImmutableArray<string>>("value", map.FluentMessageDefinitions.Value);
 			var modMessages = modData.Manifest.FluentMessages;
 
 			// For maps we don't warn on unused keys. They might be unused on *this* map,
@@ -363,7 +364,7 @@ namespace OpenRA.Mods.Common.Lint
 			{
 				if (childNode.Key == "Logic")
 				{
-					foreach (var logicName in FieldLoader.GetValue<string[]>(childNode.Key, childNode.Value.Value))
+					foreach (var logicName in FieldLoader.GetValue<ImmutableArray<string>>(childNode.Key, childNode.Value.Value))
 					{
 						var logicType = modData.ObjectCreator.FindType(logicName);
 						if (logicType == null)

--- a/OpenRA.Mods.Common/Lint/CheckFluentSyntax.cs
+++ b/OpenRA.Mods.Common/Lint/CheckFluentSyntax.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using Linguini.Syntax.Ast;
 using Linguini.Syntax.Parser;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Lint
 			if (map.FluentMessageDefinitions == null)
 				return;
 
-			Run(emitError, emitWarning, map, FieldLoader.GetValue<string[]>("value", map.FluentMessageDefinitions.Value));
+			Run(emitError, emitWarning, map, FieldLoader.GetValue<ImmutableArray<string>>("value", map.FluentMessageDefinitions.Value));
 		}
 
 		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)

--- a/OpenRA.Mods.Common/Lint/CheckInteractable.cs
+++ b/OpenRA.Mods.Common/Lint/CheckInteractable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -60,7 +61,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		static bool HasInvalidBounds(WDist[] bounds, Size tileSize, int tileScale)
+		static bool HasInvalidBounds(ImmutableArray<WDist> bounds, Size tileSize, int tileScale)
 		{
 			if (bounds == null)
 				return false;

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using OpenRA.Server;
 
 namespace OpenRA.Mods.Common.Lint
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 			Run(emitError, map.MapFormat, map.Author, map.Title, map.Categories);
 		}
 
-		static void Run(Action<string> emitError, int mapFormat, string author, string title, string[] categories)
+		static void Run(Action<string> emitError, int mapFormat, string author, string title, ImmutableArray<string> categories)
 		{
 			if (mapFormat < Map.SupportedMapFormat)
 				emitError($"Map format `{mapFormat}` does not match the supported version `{Map.CurrentMapFormat}`.");

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Server;
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Lint
 				spawns.Add(s.Get<LocationInit>().Value);
 			}
 
-			Run(emitError, emitWarning, players, map.Visibility, map.Rules.Actors[SystemActors.World], spawns.ToArray());
+			Run(emitError, emitWarning, players, map.Visibility, map.Rules.Actors[SystemActors.World], spawns.ToImmutableArray());
 		}
 
 		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		static void Run(Action<string> emitError, Action<string> emitWarning,
-			MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, CPos[] spawnPoints)
+			MapPlayers players, MapVisibility visibility, ActorInfo worldActorInfo, ImmutableArray<CPos> spawnPoints)
 		{
 			if (players.Players.Count > 64)
 				emitError("Defining more than 64 players is not allowed.");

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileSystem;
 using OpenRA.Server;
 
@@ -94,7 +95,7 @@ namespace OpenRA.Mods.Common.Lint
 			if (ruleDefinitions == null)
 				return;
 
-			var mapFiles = FieldLoader.GetValue<string[]>("value", ruleDefinitions.Value);
+			var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", ruleDefinitions.Value);
 			foreach (var f in mapFiles)
 				CheckActors(MiniYaml.FromStream(fileSystem.Open(f), f), emitError, modData);
 

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileSystem;
 using OpenRA.GameRules;
 using OpenRA.Server;
@@ -115,7 +116,7 @@ namespace OpenRA.Mods.Common.Lint
 			if (weaponDefinitions == null)
 				return;
 
-			var mapFiles = FieldLoader.GetValue<string[]>("value", weaponDefinitions.Value);
+			var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", weaponDefinitions.Value);
 			foreach (var f in mapFiles)
 				CheckWeapons(MiniYaml.FromStream(fileSystem.Open(f), f), emitError, emitWarning, modData);
 

--- a/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
+++ b/OpenRA.Mods.Common/Lint/CheckWorldAndPlayerInherits.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Mods.Common.UpdateRules;
@@ -47,8 +48,8 @@ namespace OpenRA.Mods.Common.Lint
 			var files = modData.Manifest.Rules.AsEnumerable();
 			if (ruleDefinitions.Value != null)
 			{
-				var mapFiles = FieldLoader.GetValue<string[]>("value", ruleDefinitions.Value);
-				files = files.Append(mapFiles);
+				var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", ruleDefinitions.Value);
+				files = files.Concat(mapFiles);
 			}
 
 			var nodes = new List<MiniYamlNode>();

--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -36,19 +36,26 @@ namespace OpenRA.Mods.Common.Lint
 				return expr != null ? expr.Variables : [];
 			}
 
-			if (type.IsGenericType &&
-				(type.GetGenericTypeDefinition() == typeof(Dictionary<,>) ||
-				type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)))
+			Type dictionaryInterface = null;
+			if (type.IsGenericType)
+			{
+				if (type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>))
+					dictionaryInterface = type;
+				else
+					dictionaryInterface = type.GetInterface(typeof(IReadOnlyDictionary<,>).FullName);
+			}
+
+			if (dictionaryInterface != null)
 			{
 				// Use an intermediate list to cover the unlikely case where both keys and values are lintable.
 				var dictionaryValues = new List<string>();
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Keys) && type.GenericTypeArguments[0] == typeof(string))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Keys) && dictionaryInterface.GenericTypeArguments[0] == typeof(string))
 					dictionaryValues.AddRange((IEnumerable<string>)((IDictionary)fieldInfo.GetValue(ruleInfo)).Keys);
 
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && type.GenericTypeArguments[1] == typeof(string))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && dictionaryInterface.GenericTypeArguments[1] == typeof(string))
 					dictionaryValues.AddRange((IEnumerable<string>)((IDictionary)fieldInfo.GetValue(ruleInfo)).Values);
 
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && type.GenericTypeArguments[1] == typeof(IEnumerable<string>))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && dictionaryInterface.GenericTypeArguments[1] == typeof(IEnumerable<string>))
 					foreach (var row in (IEnumerable<IEnumerable<string>>)((IDictionary)fieldInfo.GetValue(ruleInfo)).Values)
 						dictionaryValues.AddRange(row);
 
@@ -58,9 +65,6 @@ namespace OpenRA.Mods.Common.Lint
 			var supportedTypes = new[]
 			{
 				"string", "IEnumerable<string>",
-				"Dictionary<string, T> (LintDictionaryReference.Keys)",
-				"Dictionary<T, string> (LintDictionaryReference.Values)",
-				"Dictionary<T, IEnumerable<string>> (LintDictionaryReference.Values)",
 				"IReadOnlyDictionary<string, T> (LintDictionaryReference.Keys)",
 				"IReadOnlyDictionary<T, string> (LintDictionaryReference.Values)",
 				"IReadOnlyDictionary<T, IEnumerable<string>> (LintDictionaryReference.Values)",
@@ -88,17 +92,26 @@ namespace OpenRA.Mods.Common.Lint
 				return expr != null ? expr.Variables : [];
 			}
 
-			if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+			Type dictionaryInterface = null;
+			if (type.IsGenericType)
+			{
+				if (type.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>))
+					dictionaryInterface = type;
+				else
+					dictionaryInterface = type.GetInterface(typeof(IReadOnlyDictionary<,>).FullName);
+			}
+
+			if (dictionaryInterface != null)
 			{
 				// Use an intermediate list to cover the unlikely case where both keys and values are lintable.
 				var dictionaryValues = new List<string>();
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Keys) && type.GenericTypeArguments[0] == typeof(string))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Keys) && dictionaryInterface.GenericTypeArguments[0] == typeof(string))
 					dictionaryValues.AddRange((IEnumerable<string>)((IDictionary)propertyInfo.GetValue(ruleInfo)).Keys);
 
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && type.GenericTypeArguments[1] == typeof(string))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && dictionaryInterface.GenericTypeArguments[1] == typeof(string))
 					dictionaryValues.AddRange((IEnumerable<string>)((IDictionary)propertyInfo.GetValue(ruleInfo)).Values);
 
-				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && type.GenericTypeArguments[1] == typeof(IEnumerable<string>))
+				if (dictionaryReference.HasFlag(LintDictionaryReference.Values) && dictionaryInterface.GenericTypeArguments[1] == typeof(IEnumerable<string>))
 					foreach (var row in (IEnumerable<IEnumerable<string>>)((IDictionary)propertyInfo.GetValue(ruleInfo)).Values)
 						dictionaryValues.AddRange(row);
 
@@ -108,9 +121,9 @@ namespace OpenRA.Mods.Common.Lint
 			var supportedTypes = new[]
 			{
 				"string", "IEnumerable<string>",
-				"Dictionary<string, T> (LintDictionaryReference.Keys)",
-				"Dictionary<T, string> (LintDictionaryReference.Values)",
-				"Dictionary<T, IEnumerable<string>> (LintDictionaryReference.Values)",
+				"IReadOnlyDictionary<string, T> (LintDictionaryReference.Keys)",
+				"IReadOnlyDictionary<T, string> (LintDictionaryReference.Values)",
+				"IReadOnlyDictionary<T, IEnumerable<string>> (LintDictionaryReference.Values)",
 				"BooleanExpression", "IntegerExpression"
 			};
 

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -1951,7 +1951,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			var allowedTerrainResourceCombos = resourceTypes
 				.SelectMany(resourceTypeInfo => resourceTypeInfo.AllowedTerrainTypes
 					.Select(terrainName => (resourceTypeInfo, terrainInfo.GetTerrainIndex(terrainName))))
-				.ToImmutableHashSet();
+				.ToHashSet();
 
 			var strengths = new Dictionary<ResourceTypeInfo, CellLayer<int>>();
 			foreach (var resourceType in resourceTypes)

--- a/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
+++ b/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
@@ -597,10 +597,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 			var pathStart = points[0];
 			var pathEnd = points[^1];
 			var orderedPermittedBrushes = Brushes.All.ToImmutableArray();
-			var permittedBrushes = orderedPermittedBrushes.ToImmutableHashSet();
-			var permittedStartBrushes = Brushes.Start.ToImmutableHashSet();
-			var permittedInnerBrushes = Brushes.Inner.ToImmutableHashSet();
-			var permittedEndBrushes = Brushes.End.ToImmutableHashSet();
+			var permittedStartBrushes = Brushes.Start.ToHashSet();
+			var permittedInnerBrushes = Brushes.Inner.ToHashSet();
+			var permittedEndBrushes = Brushes.End.ToHashSet();
 
 			const int MaxCost = int.MaxValue;
 			var segmentTypeToId = new Dictionary<string, int>();

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -24,8 +25,8 @@ namespace OpenRA.Mods.Common
 			[FluentReference]
 			public readonly string Title;
 			public readonly string Identifier;
-			public readonly string[] TestFiles = [];
-			public readonly string[] Sources = [];
+			public readonly ImmutableArray<string> TestFiles = [];
+			public readonly ImmutableArray<string> Sources = [];
 			public readonly bool Required;
 			public readonly string Download;
 
@@ -46,7 +47,7 @@ namespace OpenRA.Mods.Common
 			public readonly MiniYaml Type;
 
 			// Used to find installation locations for SourceType.Install
-			public readonly string[] RegistryPrefixes = [string.Empty];
+			public readonly ImmutableArray<string> RegistryPrefixes = [string.Empty];
 			public readonly string RegistryKey;
 			public readonly string RegistryValue;
 
@@ -87,7 +88,7 @@ namespace OpenRA.Mods.Common
 			public readonly string MirrorList;
 			public readonly string SHA1;
 			public readonly string Type;
-			public readonly Dictionary<string, string> Extract;
+			public readonly FrozenDictionary<string, string> Extract;
 
 			public ModDownload(MiniYaml yaml)
 			{
@@ -103,35 +104,35 @@ namespace OpenRA.Mods.Common
 
 		[IncludeFluentReferences(LintDictionaryReference.Values)]
 		[FieldLoader.LoadUsing(nameof(LoadPackages))]
-		public readonly Dictionary<string, ModPackage> Packages = [];
+		public readonly ImmutableArray<KeyValuePair<string, ModPackage>> Packages = [];
 
 		static object LoadPackages(MiniYaml yaml)
 		{
-			var packages = new Dictionary<string, ModPackage>();
+			var packages = new List<KeyValuePair<string, ModPackage>>();
 			var packageNode = yaml.NodeWithKeyOrDefault("Packages");
 			if (packageNode != null)
 				foreach (var node in packageNode.Value.Nodes)
-					packages.Add(node.Key, new ModPackage(node.Value));
+					packages.Add(KeyValuePair.Create(node.Key, new ModPackage(node.Value)));
 
-			return packages;
+			return packages.ToImmutableArray();
 		}
 
 		[FieldLoader.LoadUsing(nameof(LoadDownloads))]
-		public readonly string[] Downloads = [];
+		public readonly ImmutableArray<string> Downloads = [];
 
 		static object LoadDownloads(MiniYaml yaml)
 		{
 			var downloadNode = yaml.NodeWithKeyOrDefault("Downloads");
-			return downloadNode != null ? downloadNode.Value.Nodes.Select(n => n.Key).ToArray() : [];
+			return downloadNode != null ? downloadNode.Value.Nodes.Select(n => n.Key).ToImmutableArray() : [];
 		}
 
 		[FieldLoader.LoadUsing(nameof(LoadSources))]
-		public readonly string[] Sources = [];
+		public readonly ImmutableArray<string> Sources = [];
 
 		static object LoadSources(MiniYaml yaml)
 		{
 			var sourceNode = yaml.NodeWithKeyOrDefault("Sources");
-			return sourceNode != null ? sourceNode.Value.Nodes.Select(n => n.Key).ToArray() : [];
+			return sourceNode != null ? sourceNode.Value.Nodes.Select(n => n.Key).ToImmutableArray() : [];
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Projectiles
 	public class AreaBeamInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate a randomly picked velocity per beam.")]
-		public readonly WDist[] Speed = [new(128)];
+		public readonly ImmutableArray<WDist> Speed = [new(128)];
 
 		[Desc("The maximum duration (in ticks) of each beam burst.")]
 		public readonly int Duration = 10;
@@ -46,10 +47,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly WDist MinDistance = WDist.Zero;
 
 		[Desc("Damage modifier applied at each range step.")]
-		public readonly int[] Falloff = [100, 100];
+		public readonly ImmutableArray<int> Falloff = [100, 100];
 
 		[Desc("Ranges at which each Falloff step is defined.")]
-		public readonly WDist[] Range = [WDist.Zero, new(int.MaxValue)];
+		public readonly ImmutableArray<WDist> Range = [WDist.Zero, new(int.MaxValue)];
 
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
@@ -25,7 +27,7 @@ namespace OpenRA.Mods.Common.Projectiles
 	public class BulletInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]
-		public readonly WDist[] Speed = [new(17)];
+		public readonly ImmutableArray<WDist> Speed = [new(17)];
 
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
@@ -41,7 +43,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("The palette used to draw this projectile.")]
@@ -61,7 +63,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		public readonly string[] TrailSequences = ["idle"];
+		public readonly ImmutableArray<string> TrailSequences = ["idle"];
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 2;
@@ -83,7 +85,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly WDist Width = new(1);
 
 		[Desc("Arc in WAngles, two values indicate variable arc.")]
-		public readonly WAngle[] LaunchAngle = [WAngle.Zero];
+		public readonly ImmutableArray<WAngle> LaunchAngle = [WAngle.Zero];
 
 		[Desc("Up to how many times does this bullet bounce when touching ground without hitting a target.",
 			"0 implies exploding on contact with the originally targeted position.")]
@@ -96,7 +98,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly string BounceSound = null;
 
 		[Desc("Terrain where the projectile explodes instead of bouncing.")]
-		public readonly HashSet<string> InvalidBounceTerrain = [];
+		public readonly FrozenSet<string> InvalidBounceTerrain = FrozenSet<string>.Empty;
 
 		[Desc("Trigger the explosion if the projectile touches an actor thats owner has these player relationships.")]
 		public readonly PlayerRelationship ValidBounceBlockerRelationships = PlayerRelationship.Enemy | PlayerRelationship.Neutral;

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while falling.")]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Sequence to play when launched. Skipped if null or empty.")]

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Palette used to render the projectile sequence.")]
@@ -118,7 +119,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		public readonly string[] TrailSequences = ["idle"];
+		public readonly ImmutableArray<string> TrailSequences = ["idle"];
 
 		[PaletteReference(nameof(TrailUsePlayerPalette))]
 		[Desc("Palette used to render the trail sequence.")]

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Effects
 		readonly int impactDelay;
 		readonly int turn;
 		readonly string trailImage;
-		readonly string[] trailSequences;
+		readonly ImmutableArray<string> trailSequences;
 		readonly string trailPalette;
 		readonly int trailInterval;
 		readonly int trailDelay;
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.Common.Effects
 		public NukeLaunch(Player firedBy, string image, WeaponInfo weapon, string weaponPalette, string upSequence, string downSequence,
 			WPos launchPos, WPos targetPos, WDist detonationAltitude, bool removeOnDetonation, WDist velocity, int launchDelay, int impactDelay,
 			bool skipAscent,
-			string trailImage, string[] trailSequences, string trailPalette, bool trailUsePlayerPalette, int trailDelay, int trailInterval)
+			string trailImage, ImmutableArray<string> trailSequences, string trailPalette, bool trailUsePlayerPalette, int trailDelay, int trailInterval)
 		{
 			this.firedBy = firedBy;
 			this.weapon = weapon;

--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Scripting
 	public class LuaScriptInfo : TraitInfo, Requires<SpawnMapActorsInfo>, NotBefore<SpawnStartingUnitsInfo>
 	{
 		[Desc("File names with location relative to the map.")]
-		public readonly HashSet<string> Scripts = [];
+		public readonly FrozenSet<string> Scripts = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new LuaScript(this); }
 	}

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -1298,13 +1299,13 @@ namespace OpenRA.Mods.Common.Server
 				return;
 
 			var mapCache = server.ModData.MapCache;
-			if (server.Settings.MapPool.Length > 0)
-				server.MapPool = server.Settings.MapPool.ToHashSet();
+			if (server.Settings.MapPool.Count > 0)
+				server.MapPool = server.Settings.MapPool;
 			else if (!server.Settings.QueryMapRepository)
 				server.MapPool = mapCache
 					.Where(p => p.Status == MapStatus.Available && p.Visibility.HasFlag(MapVisibility.Lobby))
 					.Select(p => p.Uid)
-					.ToHashSet();
+					.ToFrozenSet();
 			else
 				return;
 

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -83,7 +84,7 @@ namespace OpenRA.Mods.Common.Terrain
 					}
 
 					var frameCount = terrainInfo.EnableDepth && depthFrames == null ? allFrames.Length / 2 : allFrames.Length;
-					var indices = templateInfo.Frames ?? Exts.MakeArray(t.Value.TilesCount, j => j);
+					var indices = templateInfo.Frames != null ? templateInfo.Frames : Exts.MakeArray(t.Value.TilesCount, j => j).ToImmutableArray();
 
 					var start = indices.Min();
 					var end = indices.Max();

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -9,16 +9,17 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.MapGenerator;
 
 namespace OpenRA.Mods.Common.Terrain
 {
 	public interface ITemplatedTerrainInfo : ITerrainInfo
 	{
-		string[] EditorTemplateOrder { get; }
-		IReadOnlyDictionary<ushort, TerrainTemplateInfo> Templates { get; }
-		IReadOnlyDictionary<string, IEnumerable<MultiBrushInfo>> MultiBrushCollections { get; }
+		ImmutableArray<string> EditorTemplateOrder { get; }
+		FrozenDictionary<ushort, TerrainTemplateInfo> Templates { get; }
+		FrozenDictionary<string, ImmutableArray<MultiBrushInfo>> MultiBrushCollections { get; }
 	}
 
 	public interface ITerrainInfoNotifyMapCreated : ITerrainInfo
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Terrain
 		public readonly ushort Id;
 		public readonly int2 Size;
 		public readonly bool PickAny;
-		public readonly string[] Categories;
+		public readonly ImmutableArray<string> Categories;
 
 		readonly TerrainTileInfo[] tileInfo;
 

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,13 +19,13 @@ namespace OpenRA.Mods.Common.Traits
 	public class AcceptsDeliveredCashInfo : TraitInfo
 	{
 		[Desc("Accepted `DeliversCash` types. Leave empty to accept all types.")]
-		public readonly HashSet<string> ValidTypes = [];
+		public readonly FrozenSet<string> ValidTypes = FrozenSet<string>.Empty;
 
 		[Desc("Player relationships the owner of the delivering actor needs.")]
 		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Ally;
 
 		[Desc("Play a randomly selected sound from this list when accepting cash.")]
-		public readonly string[] Sounds = [];
+		public readonly ImmutableArray<string> Sounds = [];
 
 		public override object Create(ActorInitializer init) { return new AcceptsDeliveredCash(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AcceptsDeliveredExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		[Desc("Accepted `DeliversExperience` types. Leave empty to accept all types.")]
-		public readonly HashSet<string> ValidTypes = [];
+		public readonly FrozenSet<string> ValidTypes = FrozenSet<string>.Empty;
 
 		[Desc("Player relationships the owner of the delivering actor needs.")]
 		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Ally;

--- a/OpenRA.Mods.Common/Traits/ActorSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/ActorSpawner.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ActorSpawnerInfo : ConditionalTraitInfo
 	{
 		[Desc("Type of ActorSpawner with which it connects.")]
-		public readonly HashSet<string> Types = [];
+		public readonly FrozenSet<string> Types = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new ActorSpawner(this); }
 	}
@@ -27,6 +27,6 @@ namespace OpenRA.Mods.Common.Traits
 		public ActorSpawner(ActorSpawnerInfo info)
 			: base(info) { }
 
-		public HashSet<string> Types => Info.Types;
+		public FrozenSet<string> Types => Info.Types;
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
@@ -83,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Minimum altitude where this aircraft is considered airborne.")]
 		public readonly int MinAirborneAltitude = 1;
 
-		public readonly HashSet<string> LandableTerrainTypes = [];
+		public readonly FrozenSet<string> LandableTerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;
@@ -142,10 +144,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WDist AltitudeVelocity = new(43);
 
 		[Desc("Sounds to play when the actor is taking off.")]
-		public readonly string[] TakeoffSounds = [];
+		public readonly ImmutableArray<string> TakeoffSounds = [];
 
 		[Desc("Sounds to play when the actor is landing.")]
-		public readonly string[] LandingSounds = [];
+		public readonly ImmutableArray<string> LandingSounds = [];
 
 		[Desc("The distance of the resupply base that the aircraft will wait for its turn.")]
 		public readonly WDist WaitDistanceFromResupplyBase = new(3072);

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Name = "primary";
 
 		[Desc("Name(s) of armament(s) that use this pool.")]
-		public readonly string[] Armaments = ["primary", "secondary"];
+		public readonly ImmutableArray<string> Armaments = ["primary", "secondary"];
 
 		[Desc("How much ammo does this pool contain when fully loaded.")]
 		public readonly int Ammo = 1;

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits.Render;
@@ -42,10 +43,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Muzzle position relative to turret or body, (forward, right, up) triples.",
 			"If weapon Burst = 1, it cycles through all listed offsets, otherwise the offset corresponding to current burst is used.")]
-		public readonly WVec[] LocalOffset = [];
+		public readonly ImmutableArray<WVec> LocalOffset = [];
 
 		[Desc("Muzzle yaw relative to turret or body.")]
-		public readonly WAngle[] LocalYaw = [];
+		public readonly ImmutableArray<WAngle> LocalYaw = [];
 
 		[Desc("Move the turret backwards when firing.")]
 		public readonly WDist Recoil = WDist.Zero;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	public abstract class AttackBaseInfo : PausableConditionalTraitInfo
 	{
 		[Desc("Armament names")]
-		public readonly string[] Armaments = ["primary", "secondary"];
+		public readonly ImmutableArray<string> Armaments = ["primary", "secondary"];
 
 		[CursorReference]
 		[Desc("Cursor to display when hovering over a valid target.")]

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
@@ -32,17 +33,17 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Fire port offsets in local coordinates.")]
-		public readonly WVec[] PortOffsets = null;
+		public readonly ImmutableArray<WVec> PortOffsets = default;
 
 		[FieldLoader.Require]
 		[Desc("Fire port yaw angles.")]
-		public readonly WAngle[] PortYaws = null;
+		public readonly ImmutableArray<WAngle> PortYaws = default;
 
 		[FieldLoader.Require]
 		[Desc("Fire port yaw cone angle.")]
-		public readonly WAngle[] PortCones = null;
+		public readonly ImmutableArray<WAngle> PortCones = default;
 
-		public FirePort[] Ports { get; private set; }
+		public ImmutableArray<FirePort> Ports { get; private set; }
 
 		[PaletteReference]
 		public readonly string MuzzlePalette = "effect";
@@ -59,17 +60,19 @@ namespace OpenRA.Mods.Common.Traits
 			if (PortCones.Length != PortOffsets.Length)
 				throw new YamlException("PortCones must define an angle for each port.");
 
-			Ports = new FirePort[PortOffsets.Length];
+			var ports = new FirePort[PortOffsets.Length];
 
 			for (var i = 0; i < PortOffsets.Length; i++)
 			{
-				Ports[i] = new FirePort
+				ports[i] = new FirePort
 				{
 					Offset = PortOffsets[i],
 					Yaw = PortYaws[i],
 					Cone = PortCones[i],
 				};
 			}
+
+			Ports = ports.ToImmutableArray();
 
 			base.RulesetLoaded(rules, ai);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -18,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>
 	{
 		[Desc("Turret names")]
-		public readonly string[] Turrets = ["primary"];
+		public readonly ImmutableArray<string> Turrets = ["primary"];
 
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string AttackAnythingCondition = null;
 
 		[FieldLoader.Ignore]
-		public readonly Dictionary<UnitStance, string> ConditionByStance = [];
+		public FrozenDictionary<UnitStance, string> ConditionByStance = FrozenDictionary<UnitStance, string>.Empty;
 
 		[Desc("Allow the player to change the unit stance.")]
 		public readonly bool EnableStances = true;
@@ -89,17 +90,20 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.RulesetLoaded(rules, info);
 
+			var conditionByStance = new Dictionary<UnitStance, string>();
 			if (HoldFireCondition != null)
-				ConditionByStance[UnitStance.HoldFire] = HoldFireCondition;
+				conditionByStance[UnitStance.HoldFire] = HoldFireCondition;
 
 			if (ReturnFireCondition != null)
-				ConditionByStance[UnitStance.ReturnFire] = ReturnFireCondition;
+				conditionByStance[UnitStance.ReturnFire] = ReturnFireCondition;
 
 			if (DefendCondition != null)
-				ConditionByStance[UnitStance.Defend] = DefendCondition;
+				conditionByStance[UnitStance.Defend] = DefendCondition;
 
 			if (AttackAnythingCondition != null)
-				ConditionByStance[UnitStance.AttackAnything] = AttackAnythingCondition;
+				conditionByStance[UnitStance.AttackAnything] = AttackAnythingCondition;
+
+			ConditionByStance = conditionByStance.ToFrozenDictionary();
 		}
 
 		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -21,34 +23,34 @@ namespace OpenRA.Mods.Common.Traits
 	public class BaseBuilderBotModuleInfo : ConditionalTraitInfo, NotBefore<ResourceMapBotModuleInfo>, NotBefore<IResourceLayerInfo>
 	{
 		[Desc("Tells the AI what building types are considered construction yards.")]
-		public readonly HashSet<string> ConstructionYardTypes = [];
+		public readonly FrozenSet<string> ConstructionYardTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered refineries.")]
-		public readonly HashSet<string> RefineryTypes = [];
+		public readonly FrozenSet<string> RefineryTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered power plants.")]
-		public readonly HashSet<string> PowerTypes = [];
+		public readonly FrozenSet<string> PowerTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered production facilities.")]
-		public readonly HashSet<string> ProductionTypes = [];
+		public readonly FrozenSet<string> ProductionTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered tech buildings.")]
-		public readonly HashSet<string> TechTypes = [];
+		public readonly FrozenSet<string> TechTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered naval production facilities.")]
-		public readonly HashSet<string> NavalProductionTypes = [];
+		public readonly FrozenSet<string> NavalProductionTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered silos (resource storage).")]
-		public readonly HashSet<string> SiloTypes = [];
+		public readonly FrozenSet<string> SiloTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what building types are considered defenses.")]
-		public readonly HashSet<string> DefenseTypes = [];
+		public readonly FrozenSet<string> DefenseTypes = FrozenSet<string>.Empty;
 
 		[Desc("Production queues AI uses for buildings.")]
-		public readonly HashSet<string> BuildingQueues = ["Building"];
+		public readonly FrozenSet<string> BuildingQueues = new HashSet<string> { "Building" }.ToFrozenSet();
 
 		[Desc("Production queues AI uses for defenses.")]
-		public readonly HashSet<string> DefenseQueues = ["Defense"];
+		public readonly FrozenSet<string> DefenseQueues = new HashSet<string> { "Defense" }.ToFrozenSet();
 
 		[Desc("Minimum distance in cells from center of the base when checking for building placement.")]
 		public readonly int MinBaseRadius = 2;
@@ -122,16 +124,16 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int CheckForWaterRadius = 8;
 
 		[Desc("Terrain types which are considered water for base building purposes.")]
-		public readonly HashSet<string> WaterTerrainTypes = ["Water"];
+		public readonly FrozenSet<string> WaterTerrainTypes = new HashSet<string> { "Water" }.ToFrozenSet();
 
 		[Desc("What buildings to the AI should build.", "What integer percentage of the total base must be this type of building.")]
-		public readonly Dictionary<string, int> BuildingFractions = null;
+		public readonly FrozenDictionary<string, int> BuildingFractions = null;
 
 		[Desc("What buildings should the AI have a maximum limit to build.")]
-		public readonly Dictionary<string, int> BuildingLimits = null;
+		public readonly FrozenDictionary<string, int> BuildingLimits = null;
 
 		[Desc("When should the AI start building specific buildings.")]
-		public readonly Dictionary<string, int> BuildingDelays = null;
+		public readonly FrozenDictionary<string, int> BuildingDelays = null;
 
 		[Desc("Only queue construction of a new structure when above this requirement.")]
 		public readonly int ProductionMinCashRequirement = 500;
@@ -155,10 +157,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MaxRefineryPerIndice = 2;
 
 		[Desc($"AI will move mcv when those numbers of refinery <= productions + tech - {nameof(ExpansionTolerate)}.")]
-		public readonly int[] ExpansionTolerate = [0, 1];
+		public readonly ImmutableArray<int> ExpansionTolerate = [0, 1];
 
 		[Desc($"AI will move the only mcv when those numbers of refinery <= productions + tech - {nameof(ForceExpansionTolerate)}.")]
-		public readonly int[] ForceExpansionTolerate = [2, 3];
+		public readonly ImmutableArray<int> ForceExpansionTolerate = [2, 3];
 
 		public override object Create(ActorInitializer init) { return new BaseBuilderBotModule(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -261,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		ActorInfo GetProducibleBuilding(HashSet<string> actors, IEnumerable<ActorInfo> buildables, Func<ActorInfo, int> orderBy = null)
+		ActorInfo GetProducibleBuilding(FrozenSet<string> actors, IEnumerable<ActorInfo> buildables, Func<ActorInfo, int> orderBy = null)
 		{
 			var available = buildables.Where(actor =>
 			{

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/MinelayerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference(typeof(MinelayerInfo))]
 		[Desc("Actors with " + nameof(Minelayer) + "trait.")]
-		public readonly HashSet<string> MinelayingActorTypes = default;
+		public readonly FrozenSet<string> MinelayingActorTypes = default;
 
 		[Desc("Find this amount of suitable actors and lay mine to a location.")]
 		public readonly int MaxPerAssign = 1;

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.LoadUsing(nameof(LoadConsiderations))]
 		[Desc("The decisions associated with this power")]
-		public readonly List<Consideration> Considerations = [];
+		public readonly ImmutableArray<Consideration> Considerations = [];
 
 		[Desc("Minimum ticks to wait until next Decision scan attempt.")]
 		public readonly int MinimumScanTimeInterval = 250;
@@ -58,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (d.Key.Split('@')[0] == "Consideration")
 					ret.Add(new Consideration(d.Value));
 
-			return ret;
+			return ret.ToImmutableArray();
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -22,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Actor types that can capture other actors (via `Captures`).",
 			"Leave this empty to disable capturing.")]
-		public readonly HashSet<string> CapturingActorTypes = [];
+		public readonly FrozenSet<string> CapturingActorTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that can be targeted for capturing.",
 			"Leave this empty to include all actors.")]
-		public readonly HashSet<string> CapturableActorTypes = [];
+		public readonly FrozenSet<string> CapturableActorTypes = FrozenSet<string>.Empty;
 
 		[Desc("Minimum delay (in ticks) between trying to capture with CapturingActorTypes.")]
 		public readonly int MinimumCaptureDelay = 375;

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -24,10 +25,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Actor types that are considered harvesters. If harvester count drops below RefineryTypes count, a new harvester is built.",
 			"Leave empty to disable harvester replacement. Currently only needed by harvester replacement system.")]
-		public readonly HashSet<string> HarvesterTypes = [];
+		public readonly FrozenSet<string> HarvesterTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are counted as refineries. Currently only needed by harvester replacement system.")]
-		public readonly HashSet<string> RefineryTypes = [];
+		public readonly FrozenSet<string> RefineryTypes = FrozenSet<string>.Empty;
 
 		[Desc("Interval (in ticks) between giving out orders to idle harvesters.")]
 		public readonly int ScanForIdleHarvestersInterval = 50;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -23,13 +24,13 @@ namespace OpenRA.Mods.Common.Traits
 	public class McvExpansionManagerBotModuleInfo : ConditionalTraitInfo, Requires<ResourceMapBotModuleInfo>, NotBefore<ResourceMapBotModuleInfo>
 	{
 		[Desc("Actor types that are considered MCVs (deploy into base builders).")]
-		public readonly HashSet<string> McvTypes = [];
+		public readonly FrozenSet<string> McvTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are considered construction yards (base builders).")]
-		public readonly HashSet<string> ConstructionYardTypes = [];
+		public readonly FrozenSet<string> ConstructionYardTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are able to produce MCVs.")]
-		public readonly HashSet<string> McvFactoryTypes = [];
+		public readonly FrozenSet<string> McvFactoryTypes = FrozenSet<string>.Empty;
 
 		[Desc("Try to maintain at least this many ConstructionYardTypes, build an MCV if number is below this.")]
 		public readonly int MinimumConstructionYardCount = 1;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -20,13 +21,13 @@ namespace OpenRA.Mods.Common.Traits
 	public class McvManagerBotModuleInfo : ConditionalTraitInfo
 	{
 		[Desc("Actor types that are considered MCVs (deploy into base builders).")]
-		public readonly HashSet<string> McvTypes = [];
+		public readonly FrozenSet<string> McvTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are considered construction yards (base builders).")]
-		public readonly HashSet<string> ConstructionYardTypes = [];
+		public readonly FrozenSet<string> ConstructionYardTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are able to produce MCVs.")]
-		public readonly HashSet<string> McvFactoryTypes = [];
+		public readonly FrozenSet<string> McvFactoryTypes = FrozenSet<string>.Empty;
 
 		[Desc("Try to maintain at least this many ConstructionYardTypes, build an MCV if number is below this.")]
 		public readonly int MinimumConstructionYardCount = 1;

--- a/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Interval = 150;
 
 		[Desc("Actors that allow this module to toggle")]
-		public readonly HashSet<string> PowerDownTypes = [];
+		public readonly FrozenSet<string> PowerDownTypes = FrozenSet<string>.Empty;
 
 		[Desc("Order used by " + nameof(ToggleConditionOnOrderInfo) + " for powerdown on toggled actor.")]
 		public readonly string PowerDownOrder = "PowerDown";

--- a/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/ResourceMapBotModule.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -20,20 +20,20 @@ namespace OpenRA.Mods.Common.Traits
 	public class ResourceMapBotModuleInfo : ConditionalTraitInfo, NotBefore<IResourceLayerInfo>
 	{
 		[Desc("Harvestable and valuable resource types.")]
-		public readonly HashSet<string> ValuableResourceTypes = [];
+		public readonly FrozenSet<string> ValuableResourceTypes = FrozenSet<string>.Empty;
 
 		[Desc("Tells the AI what types are considered resource creator.")]
-		public readonly HashSet<string> ResourceCreatorTypes = [];
+		public readonly FrozenSet<string> ResourceCreatorTypes = FrozenSet<string>.Empty;
 
 		[Desc($"Actor types that are considered refineries for {nameof(HarvesterTypes)}.")]
-		public readonly HashSet<string> RefineryTypes = [];
+		public readonly FrozenSet<string> RefineryTypes = FrozenSet<string>.Empty;
 
 		[Desc($"Actor types that are considered harvesters for {nameof(ValuableResourceTypes)}.")]
-		public readonly HashSet<string> HarvesterTypes = [];
+		public readonly FrozenSet<string> HarvesterTypes = FrozenSet<string>.Empty;
 
 		[Desc("Actor types that are considered to be the base building for expansion. Other enemy units will also be recorded",
 			"Defence and production building is suggested")]
-		public readonly HashSet<string> EnemyBaseBuildingTypes = [];
+		public readonly FrozenSet<string> EnemyBaseBuildingTypes = FrozenSet<string>.Empty;
 
 		[Desc("Delay (in ticks) for updating the indicies.")]
 		public readonly int UpdateResourceMapInverval = 67;

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits.BotModules.Squads;
@@ -24,27 +25,27 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[Desc("Actor types that are valid for naval squads.")]
-		public readonly HashSet<string> NavalUnitsTypes = [];
+		public readonly FrozenSet<string> NavalUnitsTypes = FrozenSet<string>.Empty;
 
 		[ActorReference]
 		[Desc("Actor types that are excluded from ground attacks.")]
-		public readonly HashSet<string> AirUnitsTypes = [];
+		public readonly FrozenSet<string> AirUnitsTypes = FrozenSet<string>.Empty;
 
 		[ActorReference]
 		[Desc("Actor types that should generally be excluded from attack squads.")]
-		public readonly HashSet<string> ExcludeFromSquadsTypes = [];
+		public readonly FrozenSet<string> ExcludeFromSquadsTypes = FrozenSet<string>.Empty;
 
 		[ActorReference]
 		[Desc("Actor types that are considered construction yards (base builders).")]
-		public readonly HashSet<string> ConstructionYardTypes = [];
+		public readonly FrozenSet<string> ConstructionYardTypes = FrozenSet<string>.Empty;
 
 		[ActorReference]
 		[Desc("Enemy building types around which to scan for targets for naval squads.")]
-		public readonly HashSet<string> NavalProductionTypes = [];
+		public readonly FrozenSet<string> NavalProductionTypes = FrozenSet<string>.Empty;
 
 		[ActorReference]
 		[Desc("Own actor types that are prioritized when defending.")]
-		public readonly HashSet<string> ProtectionTypes = [];
+		public readonly FrozenSet<string> ProtectionTypes = FrozenSet<string>.Empty;
 
 		[Desc("Target types are used for identifying aircraft.")]
 		public readonly BitSet<TargetableType> AircraftTargetType = new("Air");

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AI.Fuzzy.Library;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Tells the AI how to use its support powers.")]
 		[FieldLoader.LoadUsing(nameof(LoadDecisions))]
-		public readonly List<SupportPowerDecision> Decisions = [];
+		public readonly ImmutableArray<SupportPowerDecision> Decisions = [];
 
 		static object LoadDecisions(MiniYaml yaml)
 		{
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var d in decisions.Value.Nodes)
 					ret.Add(new SupportPowerDecision(d.Value));
 
-			return ret;
+			return ret.ToImmutableArray();
 		}
 
 		public override object Create(ActorInitializer init) { return new SupportPowerBotModule(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -28,16 +30,16 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int IdleBaseUnitsMaximum = -1;
 
 		[Desc("Production queues AI uses for producing units.")]
-		public readonly string[] UnitQueues = ["Vehicle", "Infantry", "Plane", "Ship", "Aircraft"];
+		public readonly ImmutableArray<string> UnitQueues = ["Vehicle", "Infantry", "Plane", "Ship", "Aircraft"];
 
 		[Desc("What units to the AI should build.", "What relative share of the total army must be this type of unit.")]
-		public readonly Dictionary<string, int> UnitsToBuild = null;
+		public readonly FrozenDictionary<string, int> UnitsToBuild = null;
 
 		[Desc("What units should the AI have a maximum limit to train.")]
-		public readonly Dictionary<string, int> UnitLimits = null;
+		public readonly FrozenDictionary<string, int> UnitLimits = null;
 
 		[Desc("When should the AI start train specific units.")]
-		public readonly Dictionary<string, int> UnitDelays = null;
+		public readonly FrozenDictionary<string, int> UnitDelays = null;
 
 		[Desc("Only queue construction of a new unit when above this requirement.")]
 		public readonly int ProductionMinCashRequirement = 500;
@@ -253,7 +255,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (queuedBuildRequestsNode != null)
 			{
 				queuedBuildRequests.Clear();
-				queuedBuildRequests.AddRange(FieldLoader.GetValue<string[]>("QueuedBuildRequests", queuedBuildRequestsNode.Value.Value));
+				queuedBuildRequests.AddRange(FieldLoader.GetValue<ImmutableArray<string>>("QueuedBuildRequests", queuedBuildRequestsNode.Value.Value));
 			}
 
 			var idleUnitCountNode = data.NodeWithKeyOrDefault("IdleUnitCount");

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -20,10 +21,10 @@ namespace OpenRA.Mods.Common.Traits
 			"This can be prefixed with ! to invert the prerequisite (disabling production if the prerequisite is available)",
 			"and/or ~ to hide the actor from the production palette if the prerequisite is not available.",
 			"Prerequisites are granted by actors with the ProvidesPrerequisite trait.")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		[Desc("Production queue(s) that can produce this.")]
-		public readonly HashSet<string> Queue = [];
+		public readonly FrozenSet<string> Queue = FrozenSet<string>.Empty;
 
 		[Desc("Override the production structure type (from the Production Produces list) that this unit should be built at.")]
 		public readonly string BuildAtProductionType = null;

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Terrain;
@@ -37,9 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly ushort DestroyedPlusSouthTemplate = 0;
 		public readonly ushort DestroyedPlusBothTemplate = 0;
 
-		public readonly string[] ShorePieces = ["br1", "br2"];
-		public readonly int[] NorthOffset = null;
-		public readonly int[] SouthOffset = null;
+		public readonly ImmutableArray<string> ShorePieces = ["br1", "br2"];
+		public readonly ImmutableArray<int> NorthOffset = default;
+		public readonly ImmutableArray<int> SouthOffset = default;
 
 		[WeaponReference]
 		[Desc("The name of the weapon to use when demolishing the bridge")]
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public LegacyBridgeHut GetHut(int index) { return huts[index]; }
-		public Bridge GetNeighbor(int[] offset, LegacyBridgeLayer bridges)
+		public Bridge GetNeighbor(ImmutableArray<int> offset, LegacyBridgeLayer bridges)
 		{
 			if (offset == null)
 				return null;

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Primitives;
@@ -22,10 +22,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class BridgeHutInfo : TraitInfo, IDemolishableInfo
 	{
 		[Desc("Bridge types to act on")]
-		public readonly string[] Types = ["GroundLevelBridge"];
+		public readonly ImmutableArray<string> Types = ["GroundLevelBridge"];
 
 		[Desc("Offsets to look for adjacent bridges to act on")]
-		public readonly CVec[] NeighbourOffsets = [];
+		public readonly ImmutableArray<CVec> NeighbourOffsets = [];
 
 		[Desc("Delay between each segment repair step")]
 		public readonly int RepairPropagationDelay = 20;

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Actor type to replace with on repair.")]
 		public readonly string ReplaceWithActor = null;
 
-		public readonly CVec[] NeighbourOffsets = [];
+		public readonly ImmutableArray<CVec> NeighbourOffsets = [];
 
 		public override object Create(ActorInitializer init) { return new BridgePlaceholder(init.Self, this); }
 	}
@@ -78,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 		string IBridgeSegment.Type => Info.Type;
 		DamageState IBridgeSegment.DamageState => Info.DamageState;
 		bool IBridgeSegment.Valid => self.IsInWorld;
-		CVec[] IBridgeSegment.NeighbourOffsets => Info.NeighbourOffsets;
+		ImmutableArray<CVec> IBridgeSegment.NeighbourOffsets => Info.NeighbourOffsets;
 		CPos IBridgeSegment.Location => self.Location;
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -29,12 +31,12 @@ namespace OpenRA.Mods.Common.Traits
 	public class BuildingInfo : TraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Where you are allowed to place the building (Water, Clear, ...)")]
-		public readonly HashSet<string> TerrainTypes = [];
+		public readonly FrozenSet<string> TerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("x means cell is blocked, capital X means blocked but not counting as targetable, ",
 			"= means part of the footprint but passable, _ means completely empty.")]
 		[FieldLoader.LoadUsing(nameof(LoadFootprint))]
-		public readonly Dictionary<CVec, FootprintCellType> Footprint;
+		public readonly FrozenDictionary<CVec, FootprintCellType> Footprint;
 
 		public readonly CVec Dimensions = new(1, 1);
 
@@ -54,9 +56,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Clear smudges from underneath the building footprint on transform.")]
 		public readonly bool RemoveSmudgesOnTransform = true;
 
-		public readonly string[] BuildSounds = [];
+		public readonly ImmutableArray<string> BuildSounds = [];
 
-		public readonly string[] UndeploySounds = [];
+		public readonly ImmutableArray<string> UndeploySounds = [];
 
 		public override object Create(ActorInitializer init) { return new Building(init, this); }
 
@@ -76,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var index = 0;
-			var ret = new Dictionary<CVec, FootprintCellType>();
+			var ret = new Dictionary<CVec, FootprintCellType>(dim.X * dim.Y);
 			for (var y = 0; y < dim.Y; y++)
 			{
 				for (var x = 0; x < dim.X; x++)
@@ -89,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 
 		public IEnumerable<CPos> FootprintTiles(CPos location, FootprintCellType type)

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WAngle? Facing = null;
 
 		[Desc("Type tags on this exit.")]
-		public readonly HashSet<string> ProductionTypes = [];
+		public readonly FrozenSet<string> ProductionTypes = FrozenSet<string>.Empty;
 
 		[Desc("Number of ticks to wait before moving into the world.")]
 		public readonly int ExitDelay = 0;

--- a/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Types of buildable area this actor gives.")]
-		public readonly HashSet<string> AreaTypes = [];
+		public readonly FrozenSet<string> AreaTypes = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new GivesBuildableArea(this); }
 	}
@@ -28,8 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 		public GivesBuildableArea(GivesBuildableAreaInfo info)
 			: base(info) { }
 
-		readonly HashSet<string> noAreaTypes = [];
-
-		public HashSet<string> AreaTypes => !IsTraitDisabled ? Info.AreaTypes : noAreaTypes;
+		public FrozenSet<string> AreaTypes => !IsTraitDisabled ? Info.AreaTypes : FrozenSet<string>.Empty;
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string Type = "GroundLevelBridge";
 
-		public readonly CVec[] NeighbourOffsets = [];
+		public readonly ImmutableArray<CVec> NeighbourOffsets = [];
 
 		[WeaponReference]
 		[Desc("The name of the weapon to use when demolishing the bridge")]
@@ -118,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 		string IBridgeSegment.Type => Info.Type;
 		DamageState IBridgeSegment.DamageState => self.GetDamageState();
 		bool IBridgeSegment.Valid => self.IsInWorld;
-		CVec[] IBridgeSegment.NeighbourOffsets => Info.NeighbourOffsets;
+		ImmutableArray<CVec> IBridgeSegment.NeighbourOffsets => Info.NeighbourOffsets;
 		CPos IBridgeSegment.Location => self.Location;
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -55,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Range = 5;
 
 		[Desc("LineBuildNode 'Types' to attach to.")]
-		public readonly HashSet<string> NodeTypes = ["wall"];
+		public readonly FrozenSet<string> NodeTypes = new HashSet<string> { "wall" }.ToFrozenSet();
 
 		[ActorReference(typeof(LineBuildInfo))]
 		[Desc("Actor type for line-built segments (defaults to same actor).")]

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuildNode.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuildNode.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,10 +20,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class LineBuildNodeInfo : TraitInfo<LineBuildNode>
 	{
 		[Desc("This actor is of LineBuild 'NodeType'...")]
-		public readonly HashSet<string> Types = ["wall"];
+		public readonly FrozenSet<string> Types = new HashSet<string> { "wall" }.ToFrozenSet();
 
 		[Desc("Cells (outside the footprint) that contain cells that can connect to this actor.")]
-		public readonly CVec[] Connections = [new CVec(1, 0), new CVec(0, 1), new CVec(-1, 0), new CVec(0, -1)];
+		public readonly ImmutableArray<CVec> Connections = [new CVec(1, 0), new CVec(0, 1), new CVec(-1, 0), new CVec(0, -1)];
 	}
 
 	public class LineBuildNode { }

--- a/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -19,10 +20,10 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		[ActorReference(typeof(BuildingInfo))]
 		[Desc("Variant actors that can be cycled between when placing a structure.")]
-		public readonly string[] Actors = null;
+		public readonly ImmutableArray<string> Actors = default;
 
 		[Desc("Facing of the non-variant actor, followed by facings for each variant actor. The length equals the length of Actors + 1.")]
-		public readonly WAngle[] Facings = null;
+		public readonly ImmutableArray<WAngle> Facings = default;
 
 		public override object Create(ActorInitializer init) { return new PlaceBuildingVariants(); }
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("List of production queues for which the primary flag should be set.",
 			"If empty, the list given in the `Produces` property of the `" + nameof(Production) + "` trait will be used.")]
-		public readonly string[] ProductionQueues = [];
+		public readonly ImmutableArray<string> ProductionQueues = [];
 
 		[CursorReference]
 		[Desc("Cursor to display when setting the primary building.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool IsPlayerPalette = true;
 
 		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
-		public readonly CVec[] Path = [];
+		public readonly ImmutableArray<CVec> Path = [];
 
 		[NotificationReference("Speech")]
 		[Desc("Speech notification to play when setting a new rallypoint.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly BitSet<DamageType> RepairDamageTypes = default;
 
 		[Desc("The percentage repair bonus applied with increasing numbers of repairers.")]
-		public readonly int[] RepairBonuses = [100, 150, 175, 200, 220, 240, 260, 280, 300];
+		public readonly ImmutableArray<int> RepairBonuses = [100, 150, 175, 200, 220, 240, 260, 280, 300];
 
 		// TODO: This should be replaced with a pause condition
 		[Desc("Cancel the repair state when the trait is disabled.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RequiresBuildableArea.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RequiresBuildableArea.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Types of buildable are this actor requires.")]
-		public readonly HashSet<string> AreaTypes = [];
+		public readonly FrozenSet<string> AreaTypes = FrozenSet<string>.Empty;
 
 		[Desc("Maximum range from the actor with 'GivesBuildableArea' this can be placed at.")]
 		public readonly int Adjacent = 2;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> DockActors = [];
+		public readonly FrozenSet<string> DockActors = FrozenSet<string>.Empty;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		[CursorReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Cursor overrides to display for specific terrain types.",
 			"A dictionary of [terrain type]: [cursor name].")]
-		public readonly Dictionary<string, string> TerrainCursors = [];
+		public readonly FrozenDictionary<string, string> TerrainCursors = FrozenDictionary<string, string>.Empty;
 
 		[CursorReference]
 		[Desc("Cursor to display when a move order cannot be issued at target location.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = [];
+		public readonly FrozenSet<string> RepairActors = FrozenSet<string>.Empty;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
@@ -26,10 +28,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MaxWeight = 0;
 
 		[Desc("`Passenger.CargoType`s that can be loaded into this actor.")]
-		public readonly HashSet<string> Types = [];
+		public readonly FrozenSet<string> Types = FrozenSet<string>.Empty;
 
 		[Desc("A list of actor types that are initially spawned into this actor.")]
-		public readonly string[] InitialUnits = [];
+		public readonly ImmutableArray<string> InitialUnits = [];
 
 		[Desc("When this actor is sold should all of its passengers be unloaded?")]
 		public readonly bool EjectOnSell = true;
@@ -38,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool EjectOnDeath = false;
 
 		[Desc("Terrain types that this actor is allowed to eject actors onto. Leave empty for all terrain types.")]
-		public readonly HashSet<string> UnloadTerrainTypes = [];
+		public readonly FrozenSet<string> UnloadTerrainTypes = FrozenSet<string>.Empty;
 
 		[VoiceReference]
 		[Desc("Voice to play when ordered to unload the passengers.")]
@@ -82,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when specified actors are loaded inside the transport.",
 			"A dictionary of [actor name]: [condition].")]
-		public readonly Dictionary<string, string> PassengerConditions = [];
+		public readonly FrozenDictionary<string, string> PassengerConditions = FrozenDictionary<string, string>.Empty;
 
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterPassengerConditions => PassengerConditions.Values;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when a specified actor is being carried.",
 			"A dictionary of [actor name]: [condition].")]
-		public readonly Dictionary<string, string> CarryableConditions = [];
+		public readonly FrozenDictionary<string, string> CarryableConditions = FrozenDictionary<string, string>.Empty;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -107,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		WAngle cachedFacing;
 		IActorPreview[] carryablePreview;
-		HashSet<string> landableTerrainTypes;
+		FrozenSet<string> landableTerrainTypes;
 		int carryConditionToken = Actor.InvalidConditionToken;
 		int carryableConditionToken = Actor.InvalidConditionToken;
 
@@ -197,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		HashSet<string> IOverrideAircraftLanding.LandableTerrainTypes => landableTerrainTypes ?? aircraft.Info.LandableTerrainTypes;
+		FrozenSet<string> IOverrideAircraftLanding.LandableTerrainTypes => landableTerrainTypes ?? aircraft.Info.LandableTerrainTypes;
 
 		public virtual bool AttachCarryable(Actor self, Actor carryable)
 		{
@@ -214,7 +215,7 @@ namespace OpenRA.Mods.Common.Traits
 				carryableConditionToken = self.GrantCondition(carryableCondition);
 
 			CarryableOffset = OffsetForCarryable(self, carryable);
-			landableTerrainTypes = Carryable.Trait<Mobile>().Info.LocomotorInfo.TerrainSpeeds.Keys.ToHashSet();
+			landableTerrainTypes = Carryable.Trait<Mobile>().Info.LocomotorInfo.TerrainSpeeds.Keys.ToFrozenSet();
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantChargedConditionOnToggle.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantChargedConditionOnToggle.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
@@ -58,10 +59,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string BlockedCursor = "deploy-blocked";
 
 		[Desc("Play a randomly selected sound from this list when turning on.")]
-		public readonly string[] ActivationSounds = null;
+		public readonly ImmutableArray<string> ActivationSounds = default;
 
 		[Desc("Play a randomly selected sound from this list when turning off.")]
-		public readonly string[] DeactivattionSounds = null;
+		public readonly ImmutableArray<string> DeactivattionSounds = default;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,11 +24,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Condition = null;
 
 		[Desc("Name of the armaments that grant this condition.")]
-		public readonly HashSet<string> ArmamentNames = ["primary"];
+		public readonly FrozenSet<string> ArmamentNames = new HashSet<string> { "primary" }.ToFrozenSet();
 
 		[Desc("Shots required to apply an instance of the condition. If there are more instances of the condition granted than values listed,",
 			"the last value is used for all following instances beyond the defined range.")]
-		public readonly int[] RequiredShotsPerInstance = [1];
+		public readonly ImmutableArray<int> RequiredShotsPerInstance = [1];
 
 		[Desc("Maximum instances of the condition to grant.")]
 		public readonly int MaximumInstances = 1;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -9,8 +9,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -25,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Bot types that trigger the condition.")]
-		public readonly string[] Bots = [];
+		public readonly ImmutableArray<string> Bots = [];
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnBotOwner(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnClientDock.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnClientDock.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int AfterDockDuration = 0;
 
 		[Desc("Host actor type(s) leading to the condition being granted. Leave empty for allowing all hosts by default.")]
-		public readonly HashSet<string> DockHostNames = null;
+		public readonly FrozenSet<string> DockHostNames = null;
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnClientDock(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Condition = null;
 
 		[Desc("Play a random sound from this list when enabled.")]
-		public readonly string[] EnabledSounds = [];
+		public readonly ImmutableArray<string> EnabledSounds = [];
 
 		[Desc("Play a random sound from this list when disabled.")]
-		public readonly string[] DisabledSounds = [];
+		public readonly ImmutableArray<string> DisabledSounds = [];
 
 		[Desc("Levels of damage at which to grant the condition.")]
 		public readonly DamageState ValidDamageStates = DamageState.Heavy | DamageState.Critical;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
@@ -32,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string DeployedCondition = null;
 
 		[Desc("The terrain types that this actor can deploy on. Leave empty to allow any.")]
-		public readonly HashSet<string> AllowedTerrainTypes = [];
+		public readonly FrozenSet<string> AllowedTerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Can this actor deploy on slopes?")]
 		public readonly bool CanDeployOnRamps = false;
@@ -52,10 +54,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WAngle? Facing = null;
 
 		[Desc("Play a randomly selected sound from this list when deploying.")]
-		public readonly string[] DeploySounds = null;
+		public readonly ImmutableArray<string> DeploySounds = default;
 
 		[Desc("Play a randomly selected sound from this list when undeploying.")]
-		public readonly string[] UndeploySounds = null;
+		public readonly ImmutableArray<string> UndeploySounds = default;
 
 		[Desc("Skip make/deploy animation?")]
 		public readonly bool SkipMakeAnimation = false;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Condition = null;
 
 		[Desc("Only grant this condition for certain factions.")]
-		public readonly HashSet<string> Factions = [];
+		public readonly FrozenSet<string> Factions = FrozenSet<string>.Empty;
 
 		[Desc("Should it recheck everything when it is captured?")]
 		public readonly bool ResetOnOwnerChange = false;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Condition = null;
 
 		[Desc("Play a random sound from this list when enabled.")]
-		public readonly string[] EnabledSounds = [];
+		public readonly ImmutableArray<string> EnabledSounds = [];
 
 		[Desc("Play a random sound from this list when disabled.")]
-		public readonly string[] DisabledSounds = [];
+		public readonly ImmutableArray<string> DisabledSounds = [];
 
 		[Desc("Minimum level of health at which to grant the condition.")]
 		public readonly int MinHP = 0;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHostDock.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHostDock.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int AfterDockDuration = 0;
 
 		[Desc("Client actor type(s) leading to the condition being granted. Leave empty for allowing all clients by default.")]
-		public readonly HashSet<string> DockClientNames = null;
+		public readonly FrozenSet<string> DockClientNames = null;
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnHostDock(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("List of required prerequisites.")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnPrerequisite(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference]
 		[Desc("The actors to grant condition for. If empty condition will be granted for all actors.")]
-		public readonly HashSet<string> Actors = [];
+		public readonly FrozenSet<string> Actors = FrozenSet<string>.Empty;
 
 		[Desc("How long condition is applies for. Use -1 for infinite.")]
 		public readonly int Duration = -1;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -9,8 +9,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Terrain names to trigger the condition.")]
-		public readonly string[] TerrainTypes = [];
+		public readonly ImmutableArray<string> TerrainTypes = [];
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnTerrain(init, this); }
 	}
@@ -32,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class GrantConditionOnTerrain : ITick
 	{
 		readonly GrantConditionOnTerrainInfo info;
-		readonly TerrainTypeInfo[] terrainTypes;
+		readonly ImmutableArray<TerrainTypeInfo> terrainTypes;
 
 		int conditionToken = Actor.InvalidConditionToken;
 		string cachedTerrain;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTileSet.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTileSet.cs
@@ -9,8 +9,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -24,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Tile set IDs to trigger the condition.")]
-		public readonly string[] TileSets = [];
+		public readonly ImmutableArray<string> TileSets = [];
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnTileSet(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Conditions
@@ -19,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Conditions
 		[FieldLoader.Require]
 		[GrantedConditionReference]
 		[Desc("List of conditions to grant from.")]
-		public readonly string[] Conditions = null;
+		public readonly ImmutableArray<string> Conditions = default;
 
 		public override object Create(ActorInitializer init) { return new GrantRandomCondition(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Duration = 0;
 
 		[Desc("Allowed to land on.")]
-		public readonly HashSet<string> TerrainTypes = [];
+		public readonly FrozenSet<string> TerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Define actors that can collect crates by setting this into the Crushes field from the Mobile trait.")]
 		public readonly string CrushClass = "crate";

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -9,8 +9,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -47,11 +46,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int TimeDelay = 0;
 
 		[Desc("Only allow this crate action when the collector has these prerequisites")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		[ActorReference]
 		[Desc("Actor types that this crate action will not occur for.")]
-		public readonly string[] ExcludedActorTypes = [];
+		public readonly ImmutableArray<string> ExcludedActorTypes = [];
 
 		public override object Create(ActorInitializer init) { return new CrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly BitSet<TargetableType> ValidTargets = new("Ground", "Water");
 
 		[Desc("Which factions this crate action can occur for.")]
-		public readonly HashSet<string> ValidFactions = [];
+		public readonly FrozenSet<string> ValidFactions = FrozenSet<string>.Empty;
 
 		[Desc("Is the new duplicates given to a specific owner, regardless of whom collected it?")]
 		public readonly string Owner = null;

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -21,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("The list of units to spawn.")]
-		public readonly string[] Units = [];
+		public readonly ImmutableArray<string> Units = [];
 
 		[Desc("Factions that are allowed to trigger this action.")]
-		public readonly HashSet<string> ValidFactions = [];
+		public readonly FrozenSet<string> ValidFactions = FrozenSet<string>.Empty;
 
 		[Desc("Override the owner of the newly spawned unit: e.g. Creeps or Neutral")]
 		public readonly string Owner = null;

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -9,8 +9,7 @@
  */
 #endregion
 
-using System;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -31,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Terrain types where the actor will take damage.")]
-		public readonly string[] Terrain = [];
+		public readonly ImmutableArray<string> Terrain = [];
 
 		public override object Create(ActorInitializer init) { return new DamagedByTerrain(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Type = null;
 
 		[Desc("Sound to play when delivering cash")]
-		public readonly string[] Sounds = [];
+		public readonly ImmutableArray<string> Sounds = [];
 
 		[CursorReference]
 		[Desc("Cursor to display when hovering over a valid actor to deliver cash to.")]

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -40,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		[CursorReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc($"Cursor to display when able to dock at target actor. Overrides the default cursor specified in {nameof(EnterCursor)}",
 			"A dictionary of [DockType]: [cursor name].")]
-		public readonly Dictionary<string, string> EnterCursorOverrides = [];
+		public readonly FrozenDictionary<string, string> EnterCursorOverrides = FrozenDictionary<string, string>.Empty;
 
 		[CursorReference]
 		[Desc("Cursor to display when unable to dock at target actor.")]

--- a/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Primitives;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[WeaponReference]
 		[FieldLoader.Require]
 		[Desc("The weapons used for shrapnel.")]
-		public readonly string[] Weapons = [];
+		public readonly ImmutableArray<string> Weapons = [];
 
 		[Desc("What damage type needs to kill the actor to trigger the firing of projectiles? " +
 			"Leave empty to ignore damage types.")]
@@ -35,12 +36,12 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MaximumDamage = int.MaxValue;
 
 		[Desc("The amount of pieces of shrapnel to expel. Two values indicate a range.")]
-		public readonly int[] Pieces = [3, 10];
+		public readonly ImmutableArray<int> Pieces = [3, 10];
 
 		[Desc("The minimum and maximum distances the shrapnel may travel.")]
-		public readonly WDist[] Range = [WDist.FromCells(2), WDist.FromCells(5)];
+		public readonly ImmutableArray<WDist> Range = [WDist.FromCells(2), WDist.FromCells(5)];
 
-		public WeaponInfo[] WeaponInfos { get; private set; }
+		public ImmutableArray<WeaponInfo> WeaponInfos { get; private set; }
 
 		public override object Create(ActorInitializer actor) { return new FireProjectilesOnDeath(this); }
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!rules.Weapons.TryGetValue(weaponToLower, out var weapon))
 					throw new YamlException($"Weapons Ruleset does not contain an entry '{weaponToLower}'");
 				return weapon;
-			}).ToArray();
+			}).ToImmutableArray();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/FireWarheads.cs
+++ b/OpenRA.Mods.Common/Traits/FireWarheads.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Traits;
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[WeaponReference]
 		[FieldLoader.Require]
 		[Desc("Weapons to fire.")]
-		public readonly string[] Weapons = [];
+		public readonly ImmutableArray<string> Weapons = [];
 
 		[Desc("How long (in ticks) to wait before the first detonation.")]
 		public readonly int StartCooldown = 0;
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init) { return new FireWarheads(this); }
 
-		public WeaponInfo[] WeaponInfos { get; private set; }
+		public ImmutableArray<WeaponInfo> WeaponInfos { get; private set; }
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!rules.Weapons.TryGetValue(weaponToLower, out var weapon))
 					throw new YamlException($"Weapons Ruleset does not contain an entry '{weaponToLower}'");
 				return weapon;
-			}).ToArray();
+			}).ToImmutableArray();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Condition to grant at each level.",
 			"Key is the XP requirements for each level as a percentage of our own value.",
 			"Value is the condition to grant.")]
-		public readonly Dictionary<int, string> Conditions = null;
+		public readonly FrozenDictionary<int, string> Conditions = null;
 
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterConditions => Conditions.Values;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int HarvestFacings = 0;
 
 		[Desc("Which resources it can harvest.")]
-		public readonly string[] Resources = [];
+		public readonly ImmutableArray<string> Resources = [];
 
 		[Desc("Percentage of maximum speed when fully loaded.")]
 		public readonly int FullyLoadedSpeed = 85;

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Turret = null;
 
 		[Desc("Create a targetable position for each offset listed here (relative to CenterPosition).")]
-		public readonly WVec[] TargetableOffsets = [WVec.Zero];
+		public readonly ImmutableArray<WVec> TargetableOffsets = [WVec.Zero];
 
 		[Desc("Create a targetable position at the center of each occupied cell. Stacks with TargetableOffsets.")]
 		public readonly bool UseTargetableCellsOffsets = false;

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Spawns remains of a husk actor with the correct facing.")]
 	public class HuskInfo : TraitInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo, IRulesetLoaded
 	{
-		public readonly HashSet<string> AllowedTerrain = [];
+		public readonly FrozenSet<string> AllowedTerrain = FrozenSet<string>.Empty;
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly WAngle PreviewFacing = new(384);

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int AttackPanicChance = 20;
 
 		[Desc("The terrain types that this actor should avoid running on to while panicking.")]
-		public readonly HashSet<string> AvoidTerrainTypes = [];
+		public readonly FrozenSet<string> AvoidTerrainTypes = FrozenSet<string>.Empty;
 
 		[SequenceReference(prefix: true)]
 		public readonly string PanicSequencePrefix = "panic-";

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly BitSet<DamageType> DamageTriggers = default;
 
 		[Desc("Damage modifiers for each damage type (defined on the warheads) while the unit is prone.")]
-		public readonly Dictionary<string, int> DamageModifiers = [];
+		public readonly FrozenDictionary<string, int> DamageModifiers = FrozenDictionary<string, int>.Empty;
 
 		[Desc("Muzzle offset modifier to apply while prone.")]
 		public readonly WVec ProneOffset = new(500, 0, 0);

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Damage percentage for specific terrain types. 120 = 120%, 80 = 80%, etc.")]
-		public readonly Dictionary<string, int> TerrainModifier = null;
+		public readonly FrozenDictionary<string, int> TerrainModifier = null;
 
 		[Desc("Modify healing damage? For example: A friendly medic.")]
 		public readonly bool ModifyHealing = false;

--- a/OpenRA.Mods.Common/Traits/Interactable.cs
+++ b/OpenRA.Mods.Common/Traits/Interactable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -23,16 +24,16 @@ namespace OpenRA.Mods.Common.Traits
 			"If null, the engine will guess an appropriate size based on the With*Body trait.",
 			"The first two numbers define the width and height of the rectangle as a world distance.",
 			"The (optional) second two numbers define an x and y offset from the actor center.")]
-		public readonly WDist[] Bounds = null;
+		public readonly ImmutableArray<WDist> Bounds = default;
 
 		[Desc("Defines a custom rectangle for Decorations (e.g. the selection box).",
 			"If null, Bounds will be used instead")]
-		public readonly WDist[] DecorationBounds = null;
+		public readonly ImmutableArray<WDist> DecorationBounds = default;
 
 		[Desc("Defines a custom 2D polygon for mouse interaction with the actor.",
 			"If null, Bounds will be used instead",
 			"Each vertex has two components (so two numbers), which define an x and y offset from the actor center.")]
-		public readonly int2[] Polygon = null;
+		public readonly ImmutableArray<int2> Polygon = default;
 
 		public override object Create(ActorInitializer init) { return new Interactable(this); }
 	}
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			return autoBounds.Select(s => s.AutoMouseoverBounds(self, wr)).FirstOrDefault(r => !r.IsEmpty);
 		}
 
-		int2[] PolygonBounds(Actor self, WorldRenderer wr)
+		ImmutableArray<int2> PolygonBounds(Actor self, WorldRenderer wr)
 		{
 			var screenVertices = new int2[info.Polygon.Length];
 
@@ -78,10 +79,10 @@ namespace OpenRA.Mods.Common.Traits
 				screenVertices[i] = wr.ScreenPxPosition(self.CenterPosition) + offset;
 			}
 
-			return screenVertices;
+			return screenVertices.ToImmutableArray();
 		}
 
-		Polygon Bounds(Actor self, WorldRenderer wr, WDist[] bounds)
+		Polygon Bounds(Actor self, WorldRenderer wr, ImmutableArray<WDist> bounds)
 		{
 			if (bounds == null)
 				return new Polygon(AutoBounds(self, wr));
@@ -107,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Rectangle DecorationBounds(Actor self, WorldRenderer wr)
 		{
-			return Bounds(self, wr, info.DecorationBounds ?? info.Bounds).BoundingRect;
+			return Bounds(self, wr, info.DecorationBounds != null ? info.DecorationBounds : info.Bounds).BoundingRect;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
+++ b/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -23,14 +24,14 @@ namespace OpenRA.Mods.Common.Traits
 			"If null, the engine will guess an appropriate size based on the building's footprint.",
 			"The first two numbers define the width and depth of the footprint rectangle.",
 			"The (optional) second two numbers define an x and y offset from the actor center.")]
-		public readonly int[] Bounds = null;
+		public readonly ImmutableArray<int> Bounds = default;
 
 		[Desc("Height above the footprint for the top of the interaction rectangle.")]
 		public readonly int Height = 24;
 
 		[Desc("Defines a custom rectangle for Decorations (e.g. the selection box).",
 			"If null, Bounds will be used instead.")]
-		public readonly int[] DecorationBounds = null;
+		public readonly ImmutableArray<int> DecorationBounds = default;
 
 		[Desc("Defines a custom height for Decorations (e.g. the selection box).",
 			"If < 0, Height will be used instead.",
@@ -82,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			buildingInfo = self.Info.TraitInfo<BuildingInfo>();
 		}
 
-		Polygon Bounds(Actor self, WorldRenderer wr, int[] bounds, int height)
+		Polygon Bounds(Actor self, WorldRenderer wr, ImmutableArray<int> bounds, int height)
 		{
 			int2 left, right, top, bottom;
 			if (bounds != null)
@@ -129,7 +130,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Polygon DecorationBounds(Actor self, WorldRenderer wr)
 		{
-			return Bounds(self, wr, info.DecorationBounds ?? info.Bounds, info.DecorationHeight >= 0 ? info.DecorationHeight : info.Height);
+			return Bounds(
+				self,
+				wr,
+				info.DecorationBounds != null ? info.DecorationBounds : info.Bounds,
+				info.DecorationHeight >= 0 ? info.DecorationHeight : info.Height);
 		}
 
 		Polygon IMouseBounds.MouseoverBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool RemoveInstead = false;
 
 		[Desc("The amount of time (in ticks) before the actor dies. Two values indicate a range between which a random value is chosen.")]
-		public readonly int[] Delay = [0];
+		public readonly ImmutableArray<int> Delay = [0];
 
 		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default;

--- a/OpenRA.Mods.Common/Traits/MapEditorData.cs
+++ b/OpenRA.Mods.Common/Traits/MapEditorData.cs
@@ -9,16 +9,17 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	public class MapEditorDataInfo : TraitInfo<MapEditorData>
 	{
-		public readonly HashSet<string> RequireTilesets = null;
-		public readonly HashSet<string> ExcludeTilesets = null;
-		public readonly string[] Categories;
+		public readonly FrozenSet<string> RequireTilesets = null;
+		public readonly FrozenSet<string> ExcludeTilesets = null;
+		public readonly ImmutableArray<string> Categories;
 	}
 
 	public class MapEditorData { }

--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -46,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string TileUnknownName = "build-unknown";
 
 		[Desc("Only allow laying mines on listed terrain types. Leave empty to allow all terrain types.")]
-		public readonly HashSet<string> TerrainTypes = [];
+		public readonly FrozenSet<string> TerrainTypes = FrozenSet<string>.Empty;
 
 		[CursorReference]
 		[Desc("Cursor to display when able to lay a mine.")]

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
@@ -50,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		[CursorReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Cursor overrides to display for specific terrain types.",
 			"A dictionary of [terrain type]: [cursor name].")]
-		public readonly Dictionary<string, string> TerrainCursors = [];
+		public readonly FrozenDictionary<string, string> TerrainCursors = FrozenDictionary<string, string>.Empty;
 
 		[CursorReference]
 		[Desc("Cursor to display when a move order cannot be issued at target location.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/ProductionCostMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ProductionCostMultiplier.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -21,10 +22,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Multiplier = 100;
 
 		[Desc("Only apply this cost change if owner has these prerequisites.")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		[Desc("Queues that this cost will apply.")]
-		public readonly HashSet<string> Queue = [];
+		public readonly FrozenSet<string> Queue = FrozenSet<string>.Empty;
 
 		int IProductionCostModifierInfo.GetProductionCostModifier(TechTree techTree, string queue)
 		{

--- a/OpenRA.Mods.Common/Traits/Multipliers/ProductionTimeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ProductionTimeMultiplier.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -21,10 +22,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Multiplier = 100;
 
 		[Desc("Only apply this time change if owner has these prerequisites.")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		[Desc("Queues that this time will apply.")]
-		public readonly HashSet<string> Queue = [];
+		public readonly FrozenSet<string> Queue = FrozenSet<string>.Empty;
 
 		int IProductionTimeModifierInfo.GetProductionTimeModifier(TechTree techTree, string queue)
 		{

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -22,17 +23,17 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Defines to which palettes this effect should be applied to.",
 			"If none specified, it applies to all palettes not explicitly excluded.")]
-		public readonly HashSet<string> Palettes = [];
+		public readonly FrozenSet<string> Palettes = FrozenSet<string>.Empty;
 
 		[Desc("Defines for which tileset IDs this effect should be loaded.",
 			"If none specified, it applies to all tileset IDs not explicitly excluded.")]
-		public readonly HashSet<string> Tilesets = [];
+		public readonly FrozenSet<string> Tilesets = FrozenSet<string>.Empty;
 
 		[Desc("Defines which palettes should be excluded from this effect.")]
-		public readonly HashSet<string> ExcludePalettes = [];
+		public readonly FrozenSet<string> ExcludePalettes = FrozenSet<string>.Empty;
 
 		[Desc("Don't apply the effect for these tileset IDs.")]
-		public readonly HashSet<string> ExcludeTilesets = [];
+		public readonly FrozenSet<string> ExcludeTilesets = FrozenSet<string>.Empty;
 
 		[Desc("Palette index of first RotationRange color.")]
 		public readonly int RotationBase = 0x60;
@@ -107,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		static bool StartsWithAny(string name, HashSet<string> prefixes)
+		static bool StartsWithAny(string name, FrozenSet<string> prefixes)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var pref in prefixes)

--- a/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/ColorPickerPalette.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -32,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string BasePalette = null;
 
 		[Desc("Remap these indices to player colors.")]
-		public readonly int[] RemapIndex = [];
+		public readonly ImmutableArray<int> RemapIndex = [];
 
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
@@ -59,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 		void ILoadsPalettes.LoadPalettes(WorldRenderer wr)
 		{
 			color = preferredColor;
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, color);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap), info.AllowModifiers);
 		}
 
@@ -71,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			color = preferredColor;
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, color);
 			wr.ReplacePalette(info.Name, new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap));
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Name = "resources";
 
 		[Desc("Remap these indices to pre-defined colors.")]
-		public readonly int[] RemapIndex = [];
+		public readonly ImmutableArray<int> RemapIndex = [];
 
 		[Desc("The fixed color to remap.")]
 		public readonly Color Color;
@@ -52,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPalettes(WorldRenderer wr)
 		{
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, info.Color);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, info.Color);
 			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.Base).Palette, remap), info.AllowModifiers);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Palettes/FixedPlayerColorShift.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/FixedPlayerColorShift.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The name of the palette to base off.")]
 		public readonly string BasePalette = null;
 
-		public readonly Dictionary<string, float[]> PlayerIndex;
+		public readonly FrozenDictionary<string, ImmutableArray<float>> PlayerIndex;
 
 		public override object Create(ActorInitializer init) { return new FixedPlayerColorShift(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPalette.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -32,11 +33,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Indices from BasePalette to be swapped with ReplaceIndex.")]
-		public readonly int[] Index = [];
+		public readonly ImmutableArray<int> Index = [];
 
 		[FieldLoader.Require]
 		[Desc("Indices from BasePalette to replace from Index.")]
-		public readonly int[] ReplaceIndex = [];
+		public readonly ImmutableArray<int> ReplaceIndex = [];
 
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
@@ -72,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<int, int> replacements = [];
 		readonly IPalette basePalette;
 
-		public IndexedColorRemap(IPalette basePalette, int[] ramp, int[] remap)
+		public IndexedColorRemap(IPalette basePalette, ImmutableArray<int> ramp, ImmutableArray<int> remap)
 		{
 			this.basePalette = basePalette;
 			if (ramp.Length != remap.Length)

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -30,12 +31,12 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string BaseName = "player";
 
 		[Desc("Remap these indices to player colors.")]
-		public readonly int[] RemapIndex = [];
+		public readonly ImmutableArray<int> RemapIndex = [];
 
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public readonly Dictionary<string, int[]> PlayerIndex;
+		public readonly FrozenDictionary<string, ImmutableArray<int>> PlayerIndex;
 
 		public override object Create(ActorInitializer init) { return new IndexedPlayerPalette(this); }
 
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.PlayerIndex.TryGetValue(playerName, out var remap))
 				pal = new ImmutablePalette(
 					basePalette,
-					new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, remap));
+					new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, remap));
 			else
 				pal = new ImmutablePalette(basePalette);
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -34,10 +35,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Filename = null;
 
 		[Desc("Map listed indices to transparent. Ignores previous color.")]
-		public readonly int[] TransparentIndex = [0];
+		public readonly ImmutableArray<int> TransparentIndex = [0];
 
 		[Desc("Map listed indices to shadow. Ignores previous color.")]
-		public readonly int[] ShadowIndex = [];
+		public readonly ImmutableArray<int> ShadowIndex = [];
 
 		public readonly bool AllowModifiers = true;
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromGimpOrJascFile.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.FileSystem;
@@ -30,10 +31,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Defines for which tileset IDs this palette should be loaded.",
 			"If none specified, it applies to all tileset IDs not explicitly excluded.")]
-		public readonly HashSet<string> Tilesets = [];
+		public readonly FrozenSet<string> Tilesets = FrozenSet<string>.Empty;
 
 		[Desc("Don't load palette for these tileset IDs.")]
-		public readonly HashSet<string> ExcludeTilesets = [];
+		public readonly FrozenSet<string> ExcludeTilesets = FrozenSet<string>.Empty;
 
 		[FieldLoader.Require]
 		[Desc("Name of the file to load.")]

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromPng.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Filename = null;
 
 		[Desc("Map listed indices to shadow. Ignores previous color.")]
-		public readonly int[] ShadowIndex = [];
+		public readonly ImmutableArray<int> ShadowIndex = [];
 
 		public readonly bool AllowModifiers = true;
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PlayerColorPalette.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string BaseName = "player";
 
 		[Desc("Remap these indices to player colors.")]
-		public readonly int[] RemapIndex = [];
+		public readonly ImmutableArray<int> RemapIndex = [];
 
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
@@ -48,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPlayerPalettes(WorldRenderer wr, string playerName, Color color, bool replaceExisting)
 		{
-			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToArray() : info.RemapIndex, color);
+			var remap = new PlayerColorRemap(info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, color);
 			var pal = new ImmutablePalette(wr.Palette(info.BasePalette).Palette, remap);
 			wr.AddPalette(info.BaseName + playerName, pal, info.AllowModifiers, replaceExisting);
 		}

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
@@ -44,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string WaterCorpsePalette = "effect";
 
 		[Desc("Terrain types on which to display WaterCorpseSequence.")]
-		public readonly HashSet<string> WaterTerrainTypes = ["Water"];
+		public readonly FrozenSet<string> WaterTerrainTypes = new HashSet<string> { "Water" }.ToFrozenSet();
 
 		public readonly string WaterImpactSound = null;
 

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when this actor is loaded inside specified transport.",
 			"A dictionary of [actor name]: [condition].")]
-		public readonly Dictionary<string, string> CargoConditions = [];
+		public readonly FrozenDictionary<string, string> CargoConditions = FrozenDictionary<string, string>.Empty;
 
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterCargoConditions => CargoConditions.Values;

--- a/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[NotificationReference("Speech")]
 		[Desc("Notifications to play when the delivery actor is on its way. Last notification is played when the actors to deliver are spawned on the map.")]
-		public readonly string[] DeliveryProgressNotifications = [];
+		public readonly ImmutableArray<string> DeliveryProgressNotifications = [];
 
 		public override object Create(ActorInitializer init) { return new BulkProductionQueue(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -30,10 +31,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Every time another production building of the same queue is",
 			"constructed, the build times of all actors in the queue",
 			"modified by a percentage of the original time.")]
-		public readonly int[] BuildingCountBuildTimeMultipliers = [100, 86, 75, 67, 60, 55, 50];
+		public readonly ImmutableArray<int> BuildingCountBuildTimeMultipliers = [100, 86, 75, 67, 60, 55, 50];
 
 		[Desc("Build time modifier multiplied by the number of parallel production for producing different actors at the same time.")]
-		public readonly int[] ParallelPenaltyBuildTimeMultipliers = [100, 116, 133, 150, 166, 183, 200, 216, 233, 250];
+		public readonly ImmutableArray<int> ParallelPenaltyBuildTimeMultipliers = [100, 116, 133, 150, 166, 183, 200, 216, 233, 250];
 
 		public override object Create(ActorInitializer init) { return new ClassicParallelProductionQueue(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Every time another production building of the same queue is",
 			"constructed, the build times of all actors in the queue",
 			"decreased by a percentage of the original time.")]
-		public readonly int[] BuildTimeSpeedReduction = [100, 86, 75, 67, 60, 55, 50];
+		public readonly ImmutableArray<int> BuildTimeSpeedReduction = [100, 86, 75, 67, 60, 55, 50];
 
 		public override object Create(ActorInitializer init) { return new ClassicProductionQueue(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -34,12 +35,12 @@ namespace OpenRA.Mods.Common.Traits
 			techTree = self.Trait<TechTree>();
 		}
 
-		static string MakeKey(string[] prerequisites)
+		static string MakeKey(ImmutableArray<string> prerequisites)
 		{
 			return "condition_" + string.Join("_", prerequisites.Order());
 		}
 
-		public void Register(Actor actor, GrantConditionOnPrerequisite u, string[] prerequisites)
+		public void Register(Actor actor, GrantConditionOnPrerequisite u, ImmutableArray<string> prerequisites)
 		{
 			var key = MakeKey(prerequisites);
 			if (!upgradables.TryGetValue(key, out var list))
@@ -54,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			u.PrerequisitesUpdated(actor, techTree.HasPrerequisites(prerequisites));
 		}
 
-		public void Unregister(Actor actor, GrantConditionOnPrerequisite u, string[] prerequisites)
+		public void Unregister(Actor actor, GrantConditionOnPrerequisite u, ImmutableArray<string> prerequisites)
 		{
 			var key = MakeKey(prerequisites);
 			var list = upgradables[key];

--- a/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/Player/LobbyPrerequisiteCheckbox.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using OpenRA.Traits;
 
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Prerequisites to grant when this checkbox is enabled.")]
-		public readonly HashSet<string> Prerequisites = [];
+		public readonly FrozenSet<string> Prerequisites = FrozenSet<string>.Empty;
 
 		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
 
@@ -61,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class LobbyPrerequisiteCheckbox : INotifyCreated, ITechTreePrerequisite
 	{
 		readonly LobbyPrerequisiteCheckboxInfo info;
-		HashSet<string> prerequisites = [];
+		FrozenSet<string> prerequisites = FrozenSet<string>.Empty;
 
 		public LobbyPrerequisiteCheckbox(LobbyPrerequisiteCheckboxInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Traits;
@@ -27,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string DefaultCashDropdownDescription = "The amount of cash that players start with";
 
 		[Desc("Starting cash options that are available in the lobby options.")]
-		public readonly int[] SelectableCash = [2500, 5000, 10000, 20000];
+		public readonly ImmutableArray<int> SelectableCash = [2500, 5000, 10000, 20000];
 
 		[Desc("Default starting cash option: should be one of the SelectableCash options.")]
 		public readonly int DefaultCash = 5000;
@@ -59,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string CashTickDownNotification = null;
 
 		[Desc("Monetary value of each resource type.", "Dictionary of [resource type]: [value per unit].")]
-		public readonly Dictionary<string, int> ResourceValues = [];
+		public readonly FrozenDictionary<string, int> ResourceValues = FrozenDictionary<string, int>.Empty;
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Group = null;
 
 		[Desc("Only enable this queue for certain factions.")]
-		public readonly HashSet<string> Factions = [];
+		public readonly FrozenSet<string> Factions = FrozenSet<string>.Empty;
 
 		[Desc("Should the prerequisite remain enabled if the owner changes?")]
 		public readonly bool Sticky = true;

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -21,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Prerequisite = null;
 
 		[Desc("Only grant this prerequisite when you have these prerequisites.")]
-		public readonly string[] RequiresPrerequisites = [];
+		public readonly ImmutableArray<string> RequiresPrerequisites = [];
 
 		[Desc("Only grant this prerequisite for certain factions.")]
-		public readonly HashSet<string> Factions = [];
+		public readonly FrozenSet<string> Factions = FrozenSet<string>.Empty;
 
 		[Desc("Should it recheck everything when it is captured?")]
 		public readonly bool ResetOnOwnerChange = false;

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Name;
 
 		[Desc("Prerequisites to grant when this tech level is active.")]
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
 

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 				w.Update(ownedPrerequisites);
 		}
 
-		public void Add(string key, string[] prerequisites, int limit, ITechTreeElement tte)
+		public void Add(string key, ImmutableArray<string> prerequisites, int limit, ITechTreeElement tte)
 		{
 			watchers.Add(new Watcher(key, prerequisites, limit, tte));
 		}
@@ -119,13 +120,13 @@ namespace OpenRA.Mods.Common.Traits
 			public ITechTreeElement RegisteredBy { get; }
 
 			// Strings may be either actor type, or "alternate name" key
-			readonly string[] prerequisites;
+			readonly ImmutableArray<string> prerequisites;
 			bool hasPrerequisites;
 			readonly int limit;
 			bool hidden;
 			bool initialized = false;
 
-			public Watcher(string key, string[] prerequisites, int limit, ITechTreeElement watcher)
+			public Watcher(string key, ImmutableArray<string> prerequisites, int limit, ITechTreeElement watcher)
 			{
 				Key = key;
 				this.prerequisites = prerequisites;

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Support;
@@ -25,17 +26,17 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Conditions to grant for each accepted plug type.",
 			"Key is the plug type.",
 			"Value is the condition that is granted when the plug is enabled.")]
-		public readonly Dictionary<string, string> Conditions = null;
+		public readonly FrozenDictionary<string, string> Conditions = null;
 
 		[Desc("Requirements for accepting a plug type.",
 			"Key is the plug type that the requirements applies to.",
 			"Value is the condition expression defining the requirements to place the plug.")]
-		public readonly Dictionary<string, BooleanExpression> Requirements = [];
+		public readonly FrozenDictionary<string, BooleanExpression> Requirements = FrozenDictionary<string, BooleanExpression>.Empty;
 
 		[Desc("Options to display in the map editor.",
 			"Key is the plug type that the requirements applies to.",
 			"Value is the label that is displayed in the actor editor dropdown.")]
-		public readonly Dictionary<string, string> EditorOptions = [];
+		public readonly FrozenDictionary<string, string> EditorOptions = FrozenDictionary<string, string>.Empty;
 
 		[Desc("Label to use for an empty plug socket.")]
 		public readonly string EmptyOption = "Empty";
@@ -58,8 +59,9 @@ namespace OpenRA.Mods.Common.Traits
 				yield break;
 
 			// Make sure the no-plug option is always available
-			EditorOptions[""] = EmptyOption;
-			yield return new EditorActorDropdown("Plug", EditorDisplayOrder, _ => EditorOptions,
+			var editorOptions = EditorOptions.ToDictionary();
+			editorOptions[""] = EmptyOption;
+			yield return new EditorActorDropdown("Plug", EditorDisplayOrder, _ => editorOptions,
 				(actor, _) =>
 				{
 					var init = actor.GetInitOrDefault<PlugInit>(this);

--- a/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
+++ b/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -17,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 		"this trait grants a level-up to newly spawned actors.")]
 	public class ProducibleWithLevelInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		[Desc("Number of levels to give to the actor on creation.")]
 		public readonly int InitialLevels = 1;

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]
-		public readonly string[] Produces = [];
+		public readonly ImmutableArray<string> Produces = [];
 
 		[Desc("When owner is changed, should the Faction be updated to the new owner's faction?")]
 		public readonly bool UpdateFactionOnOwnerChange = false;

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -20,10 +21,10 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("Actors that this actor can dock to and get rearmed by.")]
-		public readonly HashSet<string> RearmActors = [];
+		public readonly FrozenSet<string> RearmActors = FrozenSet<string>.Empty;
 
 		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
-		public readonly HashSet<string> AmmoPools = ["primary"];
+		public readonly FrozenSet<string> AmmoPools = new HashSet<string> { "primary" }.ToFrozenSet();
 
 		public override object Create(ActorInitializer init) { return new Rearmable(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/RegionProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/RegionProximityCapturable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -22,20 +23,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Set of cell offsets (relative to the actor's Location) the " + nameof(ProximityCaptor) + " needs to be in to initiate the capture. ",
 			"A 'Region' ActorInit can be used to override this value per actor. If either is empty or non-existent, ",
 			"the immediately neighboring cells of the actor will be used.")]
-		public readonly CVec[] Region = [];
+		public readonly ImmutableArray<CVec> Region = [];
 
 		public override object Create(ActorInitializer init) { return new RegionProximityCapturable(init, this); }
 	}
 
 	public class RegionProximityCapturable : ProximityCapturableBase
 	{
-		readonly CVec[] offsets;
+		readonly ImmutableArray<CVec> offsets;
 		CPos[] region;
 
 		public RegionProximityCapturable(ActorInitializer init, RegionProximityCapturableInfo info)
 			: base(init, info)
 		{
-			offsets = init.GetValue<RegionInit, CVec[]>(info, info.Region);
+			offsets = init.GetValue<RegionInit, ImmutableArray<CVec>>(info, info.Region);
 		}
 
 		protected override int CreateTrigger(Actor self)
@@ -61,9 +62,9 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class RegionInit : ValueActorInit<CVec[]>
+	public class RegionInit : ValueActorInit<ImmutableArray<CVec>>
 	{
-		public RegionInit(CVec[] value)
+		public RegionInit(ImmutableArray<CVec> value)
 			: base(value) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,11 +18,11 @@ namespace OpenRA.Mods.Common.Traits
 	public class RejectsOrdersInfo : ConditionalTraitInfo
 	{
 		[Desc("Explicit list of rejected orders. Leave empty to reject all minus those listed under Except.")]
-		public readonly HashSet<string> Reject = [];
+		public readonly FrozenSet<string> Reject = FrozenSet<string>.Empty;
 
 		[Desc("List of orders that should *not* be rejected.",
 			"Also overrides other instances of this trait's Reject fields.")]
-		public readonly HashSet<string> Except = [];
+		public readonly FrozenSet<string> Except = FrozenSet<string>.Empty;
 
 		[Desc("Remove current and all queued orders from the actor when this trait is enabled.")]
 		public readonly bool RemoveOrders = false;
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class RejectsOrders : ConditionalTrait<RejectsOrdersInfo>
 	{
-		public HashSet<string> Reject => Info.Reject;
-		public HashSet<string> Except => Info.Except;
+		public FrozenSet<string> Reject => Info.Reject;
+		public FrozenSet<string> Except => Info.Except;
 
 		public RejectsOrders(RejectsOrdersInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
+++ b/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -19,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("The time between individual particle creation. Two values mean actual lifetime will vary between them.")]
-		public readonly int[] Lifetime;
+		public readonly ImmutableArray<int> Lifetime;
 
 		[FieldLoader.Require]
 		[Desc("The time in ticks until stop spawning. -1 means forever.")]
@@ -29,13 +30,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool ResetOnDamaged = true;
 
 		[Desc("Randomised offset for the particle emitter.")]
-		public readonly WVec[] Offset = [WVec.Zero];
+		public readonly ImmutableArray<WVec> Offset = [WVec.Zero];
 
 		[Desc("Randomized particle forward movement.")]
-		public readonly WDist[] Speed = [WDist.Zero];
+		public readonly ImmutableArray<WDist> Speed = [WDist.Zero];
 
 		[Desc("Randomized particle gravity.")]
-		public readonly WDist[] Gravity = [WDist.Zero];
+		public readonly ImmutableArray<WDist> Gravity = [WDist.Zero];
 
 		[Desc("Randomize particle facing.")]
 		public readonly bool RandomFacing = true;
@@ -47,14 +48,14 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RandomRate = 4;
 
 		[Desc("How many particles should spawn. Two values for a random range.")]
-		public readonly int[] SpawnFrequency = [1];
+		public readonly ImmutableArray<int> SpawnFrequency = [1];
 
 		[Desc("Which image to use.")]
 		public readonly string Image = "smoke";
 
 		[Desc("Which sequence to use.")]
 		[SequenceReference(nameof(Image))]
-		public readonly string[] Sequences = ["particles"];
+		public readonly ImmutableArray<string> Sequences = ["particles"];
 
 		[Desc("Which palette to use.")]
 		[PaletteReference(nameof(IsPlayerPalette))]

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -24,13 +25,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[SequenceReference(nameof(Image))]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[PaletteReference]
 		public readonly string Palette = "effect";
 
 		[Desc("Only leave trail on listed terrain types. Leave empty to leave trail on all terrain types.")]
-		public readonly HashSet<string> TerrainTypes = [];
+		public readonly FrozenSet<string> TerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Accepts values: Cell to draw the trail sprite in the center of the current cell,",
 			"CenterPosition to draw the trail sprite at the current position.")]
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly int StartDelay = 0;
 
 		[Desc("Trail spawn positions relative to actor position. (forward, right, up) triples")]
-		public readonly WVec[] Offsets = [WVec.Zero];
+		public readonly ImmutableArray<WVec> Offsets = [WVec.Zero];
 
 		[Desc("Should the trail spawn relative to last position or current position?")]
 		public readonly bool SpawnAtLastPosition = true;

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	sealed class ReloadArmamentsBarInfo : TraitInfo
 	{
 		[Desc("Armament names")]
-		public readonly string[] Armaments = ["primary", "secondary"];
+		public readonly ImmutableArray<string> Armaments = ["primary", "secondary"];
 
 		public readonly Color Color = Color.Red;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -31,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[Desc("A dictionary of faction-specific image overrides.")]
-		public readonly Dictionary<string, string> FactionImages = null;
+		public readonly FrozenDictionary<string, string> FactionImages = null;
 
 		[PaletteReference]
 		[Desc("Custom palette name")]

--- a/OpenRA.Mods.Common/Traits/Render/WithAircraftLandingEffect.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAircraftLandingEffect.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[SequenceReference(nameof(Image))]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[PaletteReference]
 		public readonly string Palette = "effect";
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly WDist DistanceAboveTerrain = new(756);
 
 		[Desc("Only play on these terrain types.")]
-		public readonly HashSet<string> TerrainTypes = [];
+		public readonly FrozenSet<string> TerrainTypes = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new WithAircraftLandingEffect(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Palette = "chrome";
 
 		[Desc("Name(s) of AmmoPool(s) that use this decoration. Leave empty to include all pools.")]
-		public readonly string[] AmmoPools = [];
+		public readonly ImmutableArray<string> AmmoPools = [];
 
 		public override object Create(ActorInitializer init) { return new WithAmmoPipsDecoration(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
@@ -28,16 +29,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[SequenceReference]
 		[Desc("Sequences to use when both neighbours are alive.")]
-		public readonly string[] Sequences = ["idle"];
+		public readonly ImmutableArray<string> Sequences = ["idle"];
 
 		[SequenceReference]
-		public readonly string[] ADestroyedSequences = ["adestroyed"];
+		public readonly ImmutableArray<string> ADestroyedSequences = ["adestroyed"];
 
 		[SequenceReference]
-		public readonly string[] BDestroyedSequences = ["bdestroyed"];
+		public readonly ImmutableArray<string> BDestroyedSequences = ["bdestroyed"];
 
 		[SequenceReference]
-		public readonly string[] ABDestroyedSequences = ["abdestroyed"];
+		public readonly ImmutableArray<string> ABDestroyedSequences = ["abdestroyed"];
 
 		public override object Create(ActorInitializer init) { return new WithBridgeSpriteBody(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -36,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[SequenceReference(nameof(Image), dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific passenger actors.")]
-		public readonly Dictionary<string, string> CustomPipSequences = [];
+		public readonly FrozenDictionary<string, string> CustomPipSequences = FrozenDictionary<string, string>.Empty;
 
 		[PaletteReference]
 		public readonly string Palette = "chrome";

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
@@ -21,10 +23,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 	sealed class WithCrateBodyInfo : TraitInfo, Requires<RenderSpritesInfo>, IRenderActorPreviewSpritesInfo
 	{
 		[Desc("Easteregg sequences to use in December.")]
-		public readonly string[] XmasImages = [];
+		public readonly ImmutableArray<string> XmasImages = [];
 
 		[Desc("Terrain types on which to display WaterSequence.")]
-		public readonly HashSet<string> WaterTerrainTypes = ["Water"];
+		public readonly FrozenSet<string> WaterTerrainTypes = new HashSet<string> { "Water" }.ToFrozenSet();
 
 		[SequenceReference]
 		public readonly string IdleSequence = "idle";

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -34,11 +35,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("How many times should " + nameof(LoopSequence),
 			" be played? A range can be provided to be randomly chosen from.")]
-		public readonly int[] LoopCount = [1, 3];
+		public readonly ImmutableArray<int> LoopCount = [1, 3];
 
 		[Desc("Initial delay before animation is enabled",
 			"Two values indicate a random delay range.")]
-		public readonly int[] InitialDelay = [0];
+		public readonly ImmutableArray<int> InitialDelay = [0];
 
 		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -9,9 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
@@ -21,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	sealed class WithDeadBridgeSpriteBodyInfo : WithSpriteBodyInfo
 	{
 		[ActorReference]
-		public readonly string[] RampActors = [];
+		public readonly ImmutableArray<string> RampActors = [];
 
 		[Desc("Offset to search for the 'A' neighbour")]
 		public readonly CVec AOffset = CVec.Zero;
@@ -30,13 +29,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly CVec BOffset = CVec.Zero;
 
 		[SequenceReference]
-		public readonly string[] ARampSequences = ["aramp"];
+		public readonly ImmutableArray<string> ARampSequences = ["aramp"];
 
 		[SequenceReference]
-		public readonly string[] BRampSequences = ["bramp"];
+		public readonly ImmutableArray<string> BRampSequences = ["bramp"];
 
 		[SequenceReference]
-		public readonly string[] ABRampSequences = ["abramp"];
+		public readonly ImmutableArray<string> ABRampSequences = ["abramp"];
 
 		[SequenceReference]
 		[Desc("Placeholder sequence to use in the map editor.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("Death animations to use for each damage type (defined on the warheads).",
 			"Is only used if UseDeathTypeSuffix is `True`.")]
-		public readonly Dictionary<string, string[]> DeathTypes = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> DeathTypes = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		[SequenceReference]
 		[Desc("Sequence to use when the actor is killed by some non-standard means (e.g. suicide).")]

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Support;
@@ -35,17 +37,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("Screen-space offsets to apply when defined conditions are enabled.",
 			"A dictionary of [condition string]: [x, y offset].")]
-		public readonly Dictionary<BooleanExpression, int2> Offsets = [];
+		public readonly FrozenDictionary<BooleanExpression, int2> Offsets = FrozenDictionary<BooleanExpression, int2>.Empty;
 
 		[Desc("The number of ticks that each step in the blink pattern in active.")]
 		public readonly int BlinkInterval = 5;
 
 		[Desc("A pattern of ticks (BlinkInterval long) where the decoration is visible or hidden.")]
-		public readonly BlinkState[] BlinkPattern = [];
+		public readonly ImmutableArray<BlinkState> BlinkPattern = [];
 
 		[Desc("Override blink conditions to use when defined conditions are enabled.",
 			"A dictionary of [condition string]: [pattern].")]
-		public readonly Dictionary<BooleanExpression, BlinkState[]> BlinkPatterns = [];
+		public readonly FrozenDictionary<BooleanExpression, ImmutableArray<BlinkState>> BlinkPatterns =
+			FrozenDictionary<BooleanExpression, ImmutableArray<BlinkState>>.Empty;
 
 		[ConsumedConditionReference]
 		public IEnumerable<string> ConsumedConditions
@@ -58,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		protected readonly Actor Self;
 		int2 conditionalOffset;
-		BlinkState[] blinkPattern;
+		ImmutableArray<BlinkState> blinkPattern;
 
 		protected WithDecorationBase(Actor self, InfoType info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	sealed class WithGateSpriteBodyInfo : WithSpriteBodyInfo, IWallConnectorInfo, Requires<GateInfo>
 	{
 		[Desc("Cells (outside the gate footprint) that contain wall cells that can connect to the gate")]
-		public readonly CVec[] WallConnections = [];
+		public readonly ImmutableArray<CVec> WallConnections = [];
 
 		[Desc("Wall type for connections")]
 		public readonly string Type = "wall";

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -19,10 +20,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[SequenceReference]
 		[Desc("Sequence names to use.")]
-		public readonly string[] Sequences = ["active"];
+		public readonly ImmutableArray<string> Sequences = ["active"];
 
 		[Desc("The amount of time (in ticks) between animations. Two values indicate a range between which a random value is chosen.")]
-		public readonly int[] Interval = [750];
+		public readonly ImmutableArray<int> Interval = [750];
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
@@ -31,13 +33,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Attack sequence to use for each armament.",
 			"A dictionary of [armament name]: [sequence name(s)].",
 			"Multiple sequence names can be defined to specify per-burst animations.")]
-		public readonly Dictionary<string, string[]> AttackSequences = [];
+		public readonly FrozenDictionary<string, ImmutableArray<string>> AttackSequences = FrozenDictionary<string, ImmutableArray<string>>.Empty;
 
 		[SequenceReference]
-		public readonly string[] IdleSequences = [];
+		public readonly ImmutableArray<string> IdleSequences = [];
 
 		[SequenceReference]
-		public readonly string[] StandSequences = ["stand"];
+		public readonly ImmutableArray<string> StandSequences = ["stand"];
 
 		[PaletteReference(nameof(IsPlayerPalette))]
 		[Desc("Custom palette name")]

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Traits;
@@ -28,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Condition = null;
 
 		[Desc("Apply to sprite bodies with these names.")]
-		public readonly string[] BodyNames = ["body"];
+		public readonly ImmutableArray<string> BodyNames = ["body"];
 
 		public override object Create(ActorInitializer init) { return new WithMakeAnimation(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionIconOverlay.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithProductionIconOverlayInfo : TraitInfo<WithProductionIconOverlay>, IRulesetLoaded
 	{
 		[FieldLoader.Require]
-		public readonly string[] Types = [];
+		public readonly ImmutableArray<string> Types = [];
 
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithProductionOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>, Requires<ProductionInfo>
 	{
 		[Desc("Queues that should be producing for this overlay to render.")]
-		public readonly HashSet<string> Queues = [];
+		public readonly FrozenSet<string> Queues = FrozenSet<string>.Empty;
 
 		[SequenceReference]
 		[Desc("Sequence name to use")]

--- a/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[SequenceReference(nameof(Image), dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Pip sequence to use for specific resource types.")]
-		public readonly Dictionary<string, string> ResourceSequences = [];
+		public readonly FrozenDictionary<string, string> ResourceSequences = FrozenDictionary<string, string>.Empty;
 
 		[PaletteReference]
 		public readonly string Palette = "chrome";

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = [];
+		public readonly FrozenSet<string> RepairActors = FrozenSet<string>.Empty;
 
 		[VoiceReference]
 		public readonly string Voice = "Action";

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[ActorReference]
 		[FieldLoader.Require]
-		public readonly HashSet<string> RepairActors = [];
+		public readonly FrozenSet<string> RepairActors = FrozenSet<string>.Empty;
 
 		public readonly WDist CloseEnough = WDist.FromCells(4);
 

--- a/OpenRA.Mods.Common/Traits/Replaceable.cs
+++ b/OpenRA.Mods.Common/Traits/Replaceable.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Replacement types this Replaceable actor accepts.")]
-		public readonly HashSet<string> Types = [];
+		public readonly FrozenSet<string> Types = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new Replaceable(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Replacement.cs
+++ b/OpenRA.Mods.Common/Traits/Replacement.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[FieldLoader.Require]
 		[Desc("Replacement type (matched against Types in Replaceable).")]
-		public readonly HashSet<string> ReplaceableTypes = [];
+		public readonly FrozenSet<string> ReplaceableTypes = FrozenSet<string>.Empty;
 	}
 
 	public class Replacement { }

--- a/OpenRA.Mods.Common/Traits/RequiresSpecificOwners.cs
+++ b/OpenRA.Mods.Common/Traits/RequiresSpecificOwners.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Only allow players listed here as owners.")]
 		[FieldLoader.Require]
-		public readonly HashSet<string> ValidOwnerNames = [];
+		public readonly FrozenSet<string> ValidOwnerNames = FrozenSet<string>.Empty;
 	}
 
 	public class RequiresSpecificOwners { }

--- a/OpenRA.Mods.Common/Traits/RevealOnFire.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnFire.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class RevealOnFireInfo : ConditionalTraitInfo
 	{
 		[Desc("The armament types which trigger revealing.")]
-		public readonly string[] ArmamentNames = ["primary", "secondary"];
+		public readonly ImmutableArray<string> ArmamentNames = ["primary", "secondary"];
 
 		[Desc("Player relationships relative to the target player this actor will be revealed to during firing.")]
 		public readonly PlayerRelationship RevealForRelationships = PlayerRelationship.Ally;

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits.Render;
@@ -24,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RefundPercent = 50;
 
 		[Desc("List of audio clips to play when the actor is being sold.")]
-		public readonly string[] SellSounds = [];
+		public readonly ImmutableArray<string> SellSounds = [];
 
 		[NotificationReference("Speech")]
 		[Desc("Speech notification to play.")]

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
@@ -18,15 +19,15 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	sealed class AmbientSoundInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
-		public readonly string[] SoundFiles = null;
+		public readonly ImmutableArray<string> SoundFiles = default;
 
 		[Desc("Initial delay (in ticks) before playing the sound for the first time.",
 			"Two values indicate a random delay range.")]
-		public readonly int[] Delay = [0];
+		public readonly ImmutableArray<int> Delay = [0];
 
 		[Desc("Interval between playing the sound (in ticks).",
 			"Two values indicate a random delay range.")]
-		public readonly int[] Interval = [0];
+		public readonly ImmutableArray<int> Interval = [0];
 
 		public override object Create(ActorInitializer init) { return new AmbientSound(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
@@ -17,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	public class AttackSoundsInfo : ConditionalTraitInfo
 	{
 		[Desc("Play a randomly selected sound from this list when preparing for an attack or attacking.")]
-		public readonly string[] Sounds = [];
+		public readonly ImmutableArray<string> Sounds = [];
 
 		[Desc("Delay in ticks before sound starts, either relative to attack preparation or attack.")]
 		public readonly int Delay = 0;

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -17,10 +18,10 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	public class SoundOnDamageTransitionInfo : TraitInfo
 	{
 		[Desc("Play a random sound from this list when damaged.")]
-		public readonly string[] DamagedSounds = [];
+		public readonly ImmutableArray<string> DamagedSounds = [];
 
 		[Desc("Play a random sound from this list when destroyed.")]
-		public readonly string[] DestroyedSounds = [];
+		public readonly ImmutableArray<string> DestroyedSounds = [];
 
 		[Desc("DamageType(s) that trigger the sounds. Leave empty to always trigger a sound.")]
 		public readonly BitSet<DamageType> DamageTypes = default;

--- a/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -24,15 +25,15 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("Actor types to spawn on sell, amount and type based on ValuePercent. Be sure to use lowercase.")]
-		public readonly string[] ActorTypes = null;
+		public readonly ImmutableArray<string> ActorTypes = default;
 
 		[ActorReference]
 		[Desc("Actors to spawn on sell. Be sure to use lowercase.")]
-		public readonly string[] GuaranteedActorTypes = [];
+		public readonly ImmutableArray<string> GuaranteedActorTypes = [];
 
 		[Desc("Spawns actors only if the selling player's faction is in this list. " +
 			"Leave empty to allow all factions by default.")]
-		public readonly HashSet<string> Factions = [];
+		public readonly FrozenSet<string> Factions = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new SpawnActorsOnSell(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -9,10 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -25,9 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Capacity = 28;
 
 		[Desc("Which resources can be stored.")]
-		public readonly string[] Resources = [];
+		public readonly ImmutableArray<string> Resources = [];
 
-		string[] IStoresResourcesInfo.ResourceTypes => Resources;
+		ImmutableArray<string> IStoresResourcesInfo.ResourceTypes => Resources;
 
 		public override object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/DirectionalSupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/DirectionalSupportPower.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -19,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool UseDirectionalTarget = false;
 
 		[SequenceReference(nameof(DirectionArrowAnimation), allowNullImage: true)]
-		public readonly string[] Arrows = ["arrow-t", "arrow-tl", "arrow-l", "arrow-bl", "arrow-b", "arrow-br", "arrow-r", "arrow-tr"];
+		public readonly ImmutableArray<string> Arrows = ["arrow-t", "arrow-tl", "arrow-l", "arrow-bl", "arrow-b", "arrow-br", "arrow-r", "arrow-tr"];
 
 		[Desc("Animation used to render the direction arrows.")]
 		public readonly string DirectionArrowAnimation = null;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		public readonly string[] TrailSequences = [];
+		public readonly ImmutableArray<string> TrailSequences = [];
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 1;
@@ -117,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly float CircleBorderWidth = 3;
 
 		[Desc("Render circles based on these distance ranges while targeting.")]
-		public readonly WDist[] CircleRanges = null;
+		public readonly ImmutableArray<WDist> CircleRanges = default;
 
 		public WeaponInfo WeaponInfo { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[ActorReference(typeof(PassengerInfo))]
 		[Desc("Troops to be delivered.  They will be distributed between the planes if SquadSize > 1.")]
-		public readonly string[] DropItems = [];
+		public readonly ImmutableArray<string> DropItems = [];
 
 		[Desc("Risks stuck units when they don't have the Paratrooper trait.")]
 		public readonly bool AllowImpassableCells = false;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference]
 		[FieldLoader.Require]
 		[Desc("Actors to produce.")]
-		public readonly string[] Actors = null;
+		public readonly ImmutableArray<string> Actors = default;
 
 		[FieldLoader.Require]
 		[Desc("Production queue type to use")]

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int LifeTime = 250;
 
 		[Desc("Only allow this to be spawned on this terrain.")]
-		public readonly string[] Terrain = null;
+		public readonly ImmutableArray<string> Terrain = default;
 
 		public readonly bool AllowUnderShroud = true;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Normal rules apply for subsequent charges.")]
 		public readonly bool StartFullyCharged = false;
 
-		public readonly string[] Prerequisites = [];
+		public readonly ImmutableArray<string> Prerequisites = [];
 
 		public readonly string DetectedSound = null;
 

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
@@ -33,10 +34,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WAngle Facing = new(384);
 
 		[Desc("Sounds to play when transforming.")]
-		public readonly string[] TransformSounds = [];
+		public readonly ImmutableArray<string> TransformSounds = [];
 
 		[Desc("Sounds to play when the transformation is blocked.")]
-		public readonly string[] NoTransformSounds = [];
+		public readonly ImmutableArray<string> NoTransformSounds = [];
 
 		[NotificationReference("Speech")]
 		[Desc("Speech notification to play when transforming.")]

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MaxMoveDelay = 0;
 
 		[Desc("The terrain types that this actor should avoid wandering on to.")]
-		public readonly HashSet<string> AvoidTerrainTypes = [];
+		public readonly FrozenSet<string> AvoidTerrainTypes = FrozenSet<string>.Empty;
 
 		public override object Create(ActorInitializer init) { return new Wanders(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -30,17 +31,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Time (in ticks) between actor spawn. Supports 1 or 2 values.",
 			"If 2 values are provided they are used as a range from which a value is randomly selected.")]
-		public readonly int[] SpawnInterval = [6000];
+		public readonly ImmutableArray<int> SpawnInterval = [6000];
 
 		[FieldLoader.Require]
 		[ActorReference]
 		[Desc("Name of the actor that will be randomly picked to spawn.")]
-		public readonly string[] Actors = [];
+		public readonly ImmutableArray<string> Actors = [];
 
 		public readonly string Owner = "Creeps";
 
 		[Desc("Type of ActorSpawner with which it connects.")]
-		public readonly HashSet<string> Types = [];
+		public readonly FrozenSet<string> Types = FrozenSet<string>.Empty;
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		string Type { get; }
 		DamageState DamageState { get; }
-		CVec[] NeighbourOffsets { get; }
+		ImmutableArray<CVec> NeighbourOffsets { get; }
 		bool Valid { get; }
 		CPos Location { get; }
 	}

--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class BuildableTerrainOverlayInfo : TraitInfo
 	{
 		[FieldLoader.Require]
-		public readonly HashSet<string> AllowedTerrainTypes = null;
+		public readonly FrozenSet<string> AllowedTerrainTypes = null;
 
 		[PaletteReference]
 		[Desc("Palette to use for rendering the sprite.")]

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Support;
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Tilesets that are compatible with this map generator.")]
-		public readonly string[] Tilesets = null;
+		public readonly ImmutableArray<string> Tilesets = default;
 
 		[FluentReference]
 		[Desc("The title to use for generated maps.")]
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		// This is purely of interest to the linter.
 		[FieldLoader.LoadUsing(nameof(FluentReferencesLoader))]
 		[FluentReference]
-		public readonly List<string> FluentReferences = null;
+		public readonly ImmutableArray<string> FluentReferences = default;
 
 		[FieldLoader.LoadUsing(nameof(SettingsLoader))]
 		public readonly MiniYaml Settings;
@@ -58,10 +58,10 @@ namespace OpenRA.Mods.Common.Traits
 			return my.NodeWithKey("Settings").Value;
 		}
 
-		static List<string> FluentReferencesLoader(MiniYaml my)
+		static object FluentReferencesLoader(MiniYaml my)
 		{
 			return new MapGeneratorSettings(null, my.NodeWithKey("Settings").Value)
-				.Options.SelectMany(o => o.GetFluentReferences()).ToList();
+				.Options.SelectMany(o => o.GetFluentReferences()).ToImmutableArray();
 		}
 
 		public IMapGeneratorSettings GetSettings()
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new ClearMapGenerator(this);
 		}
 
-		string[] IEditorMapGeneratorInfo.Tilesets => Tilesets;
+		ImmutableArray<string> IEditorMapGeneratorInfo.Tilesets => Tilesets;
 	}
 
 	public class ClearMapGenerator : IEditorTool

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
@@ -34,16 +36,16 @@ namespace OpenRA.Mods.Common.Traits
 		const string InvalidPlayerColor = "notification-invalid-player-color";
 
 		[Desc("Minimum and maximum saturation levels that are valid for use.")]
-		public readonly float[] HsvSaturationRange = [0.3f, 0.95f];
+		public readonly ImmutableArray<float> HsvSaturationRange = [0.3f, 0.95f];
 
 		[Desc("Minimum and maximum value levels that are valid for use.")]
-		public readonly float[] HsvValueRange = [0.3f, 0.95f];
+		public readonly ImmutableArray<float> HsvValueRange = [0.3f, 0.95f];
 
 		[Desc("Perceptual color threshold for determining whether two colors are too similar.")]
 		public readonly int SimilarityThreshold = 0x50;
 
 		[Desc("List of colors to be displayed in the palette tab.")]
-		public readonly Color[] PresetColors = [];
+		public readonly ImmutableArray<Color> PresetColors = [];
 
 		[ActorReference]
 		[Desc("Actor type to show in the color picker. This can be overridden for specific factions with FactionPreviewActors.")]
@@ -52,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(dictionaryReference: LintDictionaryReference.Values)]
 		[Desc("Actor type to show in the color picker for specific factions. Overrides PreviewActor.",
 			"A dictionary of [faction name]: [actor name].")]
-		public readonly Dictionary<string, string> FactionPreviewActors = [];
+		public readonly FrozenDictionary<string, string> FactionPreviewActors = FrozenDictionary<string, string>.Empty;
 
 		public bool IsInvalidColor(Color color, IEnumerable<Color> candidateBlockers)
 		{
@@ -131,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits
 		(float SMin, float SMax) IColorPickerManagerInfo.SaturationRange => (HsvSaturationRange[0], HsvSaturationRange[1]);
 		(float VMin, float VMax) IColorPickerManagerInfo.ValueRange => (HsvValueRange[0], HsvValueRange[1]);
 
-		Color[] IColorPickerManagerInfo.PresetColors => PresetColors;
+		ImmutableArray<Color> IColorPickerManagerInfo.PresetColors => PresetColors;
 
 		Color IColorPickerManagerInfo.RandomPresetColor(
 			MersenneTwister random,

--- a/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
+++ b/OpenRA.Mods.Common/Traits/World/ControlGroups.cs
@@ -18,18 +18,18 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class ControlGroupsInfo : TraitInfo, IControlGroupsInfo
 	{
-		public readonly string[] Groups = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"];
+		public readonly ImmutableArray<string> Groups = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"];
 
 		public override object Create(ActorInitializer init) { return new ControlGroups(init.World, this); }
 
-		string[] IControlGroupsInfo.Groups => Groups;
+		ImmutableArray<string> IControlGroupsInfo.Groups => Groups;
 	}
 
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	public class ControlGroups : IControlGroups, ITick, IGameSaveTraitData
 	{
 		readonly World world;
-		public string[] Groups { get; }
+		public ImmutableArray<string> Groups { get; }
 
 		readonly List<Actor>[] controlGroups;
 

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
@@ -53,20 +55,20 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int InitialSpawnDelay = 0;
 
 		[Desc("Which terrain types can we drop on?")]
-		public readonly HashSet<string> ValidGround = ["Clear", "Rough", "Road", "Ore", "Beach"];
+		public readonly FrozenSet<string> ValidGround = new HashSet<string> { "Clear", "Rough", "Road", "Ore", "Beach" }.ToFrozenSet();
 
 		[Desc("Which terrain types count as water?")]
-		public readonly HashSet<string> ValidWater = ["Water"];
+		public readonly FrozenSet<string> ValidWater = new HashSet<string> { "Water" }.ToFrozenSet();
 
 		[Desc("Chance of generating a water crate instead of a land crate.")]
 		public readonly int WaterChance = 20;
 
 		[ActorReference]
 		[Desc("Crate actors to drop.")]
-		public readonly string[] CrateActors = ["crate"];
+		public readonly ImmutableArray<string> CrateActors = ["crate"];
 
 		[Desc("Chance of each crate actor spawning.")]
-		public readonly int[] CrateActorShares = [10];
+		public readonly ImmutableArray<int> CrateActorShares = [10];
 
 		[ActorReference]
 		[Desc("If a DeliveryAircraft: is specified, then this actor will deliver crates.")]

--- a/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMapPlayers.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Network;
 using OpenRA.Support;
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Traits
 				NonCombatant = true,
 				Spectating = true,
 				Faction = "Random",
-				Allies = worldPlayers.Where(p => !p.NonCombatant && p.Playable).Select(p => p.InternalName).ToArray()
+				Allies = worldPlayers.Where(p => !p.NonCombatant && p.Playable).Select(p => p.InternalName).ToImmutableArray()
 			}, playerRandom));
 
 			w.SetPlayers(worldPlayers, localPlayer);

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -342,7 +343,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var creeps = Players.Players.Keys.FirstOrDefault(p => p == "Creeps");
 			if (!string.IsNullOrEmpty(creeps))
-				Players.Players[creeps].Enemies = Players.Players.Keys.Where(p => !Players.Players[p].NonCombatant).ToArray();
+				Players.Players[creeps].Enemies = Players.Players.Keys.Where(p => !Players.Players[p].NonCombatant).ToImmutableArray();
 		}
 
 		void UpdateNeighbours(ReadOnlySpan<EditorActorPreview> previews)

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class EditorResourceLayerInfo : TraitInfo, IResourceLayerInfo
 	{
 		[FieldLoader.LoadUsing(nameof(LoadResourceTypes))]
-		public readonly Dictionary<string, ResourceLayerInfo.ResourceTypeInfo> ResourceTypes = null;
+		public readonly FrozenDictionary<string, ResourceLayerInfo.ResourceTypeInfo> ResourceTypes = null;
 
 		// Copied from ResourceLayerInfo
 		protected static object LoadResourceTypes(MiniYaml yaml)
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var r in resources.Value.Nodes)
 					ret[r.Key] = new ResourceLayerInfo.ResourceTypeInfo(r.Value);
 
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 
 		[Desc("Override the density saved in maps with values calculated based on the number of neighbouring resource cells.")]
@@ -72,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected readonly Map Map;
 		protected readonly Dictionary<byte, string> ResourceTypesByIndex;
 		protected readonly CellLayer<ResourceLayerContents> Tiles;
-		protected Dictionary<string, int> resourceValues;
+		protected FrozenDictionary<string, int> resourceValues;
 
 		public int NetWorth { get; protected set; }
 
@@ -109,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			var playerResourcesInfo = w.Map.Rules.Actors[SystemActors.Player].TraitInfoOrDefault<PlayerResourcesInfo>();
-			resourceValues = playerResourcesInfo?.ResourceValues ?? [];
+			resourceValues = playerResourcesInfo?.ResourceValues ?? FrozenDictionary<string, int>.Empty;
 
 			foreach (var cell in Map.AllCells)
 				UpdateCell(cell);

--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.Require]
 		[Desc("Tilesets that are compatible with this map generator.")]
-		public readonly string[] Tilesets = null;
+		public readonly ImmutableArray<string> Tilesets = default;
 
 		[FluentReference]
 		[Desc("The title to use for generated maps.")]
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		// This is purely of interest to the linter.
 		[FieldLoader.LoadUsing(nameof(FluentReferencesLoader))]
 		[FluentReference]
-		public readonly List<string> FluentReferences = null;
+		public readonly ImmutableArray<string> FluentReferences = default;
 
 		[FieldLoader.LoadUsing(nameof(SettingsLoader))]
 		public readonly MiniYaml Settings;
@@ -53,17 +54,17 @@ namespace OpenRA.Mods.Common.Traits
 		string IMapGeneratorInfo.Type => Type;
 		string IMapGeneratorInfo.Name => Name;
 		string IMapGeneratorInfo.MapTitle => MapTitle;
-		string[] IEditorMapGeneratorInfo.Tilesets => Tilesets;
+		ImmutableArray<string> IEditorMapGeneratorInfo.Tilesets => Tilesets;
 
 		static MiniYaml SettingsLoader(MiniYaml my)
 		{
 			return my.NodeWithKey("Settings").Value;
 		}
 
-		static List<string> FluentReferencesLoader(MiniYaml my)
+		static object FluentReferencesLoader(MiniYaml my)
 		{
 			return new MapGeneratorSettings(null, my.NodeWithKey("Settings").Value)
-				.Options.SelectMany(o => o.GetFluentReferences()).ToList();
+				.Options.SelectMany(o => o.GetFluentReferences()).ToImmutableArray();
 		}
 
 		const int FractionMax = Terraformer.FractionMax;
@@ -280,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
 						.Select(terrainInfo.GetTerrainIndex)
-						.ToImmutableHashSet();
+						.ToFrozenSet();
 				}
 
 				IReadOnlyList<string> ParseSegmentTypes(string key)

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class LegacyBridgeLayerInfo : TraitInfo
 	{
 		[ActorReference]
-		public readonly string[] Bridges = ["bridge1", "bridge2"];
+		public readonly ImmutableArray<string> Bridges = ["bridge1", "bridge2"];
 
 		public override object Create(ActorInitializer init) { return new LegacyBridgeLayer(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -80,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.LoadUsing(nameof(LoadSpeeds), true)]
 		[Desc("Lower the value on rough terrain. Leave out entries for impassable terrain.")]
-		public readonly Dictionary<string, TerrainInfo> TerrainSpeeds;
+		public readonly FrozenDictionary<string, TerrainInfo> TerrainSpeeds;
 
 		protected static object LoadSpeeds(MiniYaml y)
 		{
@@ -99,8 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			ret.TrimExcess();
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 
 		public class TerrainInfo

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Widgets.Logic;
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		sealed class AssignSpawnLocationsState
 		{
-			public CPos[] SpawnLocations;
+			public ImmutableArray<CPos> SpawnLocations;
 			public List<int> AvailableSpawnPoints;
 			public readonly Dictionary<int, Session.Client> OccupiedSpawnPoints = [];
 		}

--- a/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingUnits.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -26,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string ClassName = "Unlabeled";
 
 		[Desc("Only available when selecting one of these factions.", "Leave empty for no restrictions.")]
-		public readonly HashSet<string> Factions = [];
+		public readonly FrozenSet<string> Factions = FrozenSet<string>.Empty;
 
 		[Desc("The actor at the center, usually the mobile construction vehicle.")]
 		[ActorReference]
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("A group of units ready to defend or scout.")]
 		[ActorReference]
-		public readonly string[] SupportActors = [];
+		public readonly ImmutableArray<string> SupportActors = [];
 
 		[Desc("Inner radius for spawning support actors")]
 		public readonly int InnerSupportRadius = 2;

--- a/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -33,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FluentReference(LintDictionaryReference.Keys)]
 		[Desc("A list of colors to be used for drawing.")]
-		public readonly Dictionary<string, Color> Colors = new()
+		public readonly FrozenDictionary<string, Color> Colors = new Dictionary<string, Color>
 		{
 			{ "notification-added-marker-tiles-markers.red", Color.FromArgb(255, 0, 0) },
 			{ "notification-added-marker-tiles-markers.orange", Color.FromArgb(255, 127, 0) },
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			{ "notification-added-marker-tiles-markers.blue", Color.FromArgb(0, 42, 255) },
 			{ "notification-added-marker-tiles-markers.purple", Color.FromArgb(165, 0, 255) },
 			{ "notification-added-marker-tiles-markers.magenta", Color.FromArgb(255, 0, 220) }
-		};
+		}.ToFrozenDictionary();
 
 		[Desc("Default alpha blend.")]
 		public readonly int Alpha = 85;
@@ -174,7 +175,7 @@ namespace OpenRA.Mods.Common.Traits
 				NumSides = file.NumSides;
 				AxisAngle = file.AxisAngle;
 
-				SetAll(file.Tiles.ToImmutableDictionary(d => d.Key, d => d.Value.ToImmutableArray()));
+				SetAll(file.Tiles.ToFrozenDictionary(d => d.Key, d => d.Value.ToImmutableArray()));
 			}
 			catch (Exception e)
 			{
@@ -204,7 +205,7 @@ namespace OpenRA.Mods.Common.Traits
 			Tiles.Clear();
 		}
 
-		public void SetAll(IImmutableDictionary<int, ImmutableArray<CPos>> newTiles)
+		public void SetAll(FrozenDictionary<int, ImmutableArray<CPos>> newTiles)
 		{
 			ClearAll();
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
@@ -40,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			[FieldLoader.Require]
 			[Desc("Terrain types that this resource can spawn on.")]
-			public readonly HashSet<string> AllowedTerrainTypes = null;
+			public readonly FrozenSet<string> AllowedTerrainTypes = null;
 
 			[Desc("Maximum number of resource units allowed in a single cell.")]
 			public readonly byte MaxDensity = 10;
@@ -52,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		[FieldLoader.LoadUsing(nameof(LoadResourceTypes))]
-		public readonly Dictionary<string, ResourceTypeInfo> ResourceTypes = null;
+		public readonly FrozenDictionary<string, ResourceTypeInfo> ResourceTypes = null;
 
 		[Desc("Override the density saved in maps with values calculated based on the number of neighbouring resource cells.")]
 		public readonly bool RecalculateResourceDensity = false;
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var r in resources.Value.Nodes)
 					ret[r.Key] = new ResourceTypeInfo(r.Value);
 
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 
 		bool IResourceLayerInfo.TryGetTerrainType(string resourceType, out string terrainType)

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -31,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Require]
 			[SequenceReference(nameof(Image))]
 			[Desc("Randomly chosen image sequences.")]
-			public readonly string[] Sequences = [];
+			public readonly ImmutableArray<string> Sequences = [];
 
 			[PaletteReference]
 			[Desc("Palette used for rendering the resource sprites.")]
@@ -50,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[IncludeFluentReferences(LintDictionaryReference.Values)]
 		[FieldLoader.LoadUsing(nameof(LoadResourceTypes))]
-		public readonly Dictionary<string, ResourceTypeInfo> ResourceTypes = null;
+		public readonly FrozenDictionary<string, ResourceTypeInfo> ResourceTypes = null;
 
 		// Copied from ResourceLayerInfo
 		protected static object LoadResourceTypes(MiniYaml yaml)
@@ -61,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var r in resources.Value.Nodes)
 					ret[r.Key] = new ResourceTypeInfo(r.Value);
 
-			return ret;
+			return ret.ToFrozenDictionary();
 		}
 
 		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -24,10 +25,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly string Sequence = "shroud";
 		[SequenceReference(nameof(Sequence))]
-		public readonly string[] ShroudVariants = ["shroud"];
+		public readonly ImmutableArray<string> ShroudVariants = ["shroud"];
 
 		[SequenceReference(nameof(Sequence))]
-		public readonly string[] FogVariants = ["fog"];
+		public readonly ImmutableArray<string> FogVariants = ["fog"];
 
 		[PaletteReference]
 		public readonly string ShroudPalette = "shroud";
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Bitfield of shroud directions for each frame. Lower four bits are",
 			"corners clockwise from TL; upper four are edges clockwise from top")]
-		public readonly int[] Index = [12, 9, 8, 3, 1, 6, 4, 2, 13, 11, 7, 14];
+		public readonly ImmutableArray<int> Index = [12, 9, 8, 3, 1, 6, 4, 2, 13, 11, 7, 14];
 
 		[Desc("Use the upper four bits when calculating frame")]
 		public readonly bool UseExtendedIndex = false;

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -46,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[SequenceReference(nameof(SmokeImage), allowNullImage: true)]
 		[Desc("Smoke sprite sequences randomly chosen from")]
-		public readonly string[] SmokeSequences = [];
+		public readonly ImmutableArray<string> SmokeSequences = [];
 
 		[PaletteReference]
 		public readonly string SmokePalette = "effect";
@@ -55,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
 		[FieldLoader.LoadUsing(nameof(LoadInitialSmudges))]
-		public readonly Dictionary<CPos, MapSmudge> InitialSmudges;
+		public readonly FrozenDictionary<CPos, MapSmudge> InitialSmudges;
 
 		public static object LoadInitialSmudges(MiniYaml yaml)
 		{
@@ -77,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			return smudges;
+			return smudges.ToFrozenDictionary();
 		}
 
 		public override object Create(ActorInitializer init) { return new SmudgeLayer(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly short SubterraneanTransitionCost = 0;
 
 		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
-		public readonly HashSet<string> SubterraneanTransitionTerrainTypes = [];
+		public readonly FrozenSet<string> SubterraneanTransitionTerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("Can this actor transition on slopes?")]
 		public readonly bool SubterraneanTransitionOnRamps = false;

--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -27,11 +27,11 @@ namespace OpenRA.Mods.Common.Traits
 	public sealed class TilingPathToolInfo : TraitInfo
 	{
 		[Desc("The preferred defaults for the start type.")]
-		public readonly string[] DefaultStart = [];
+		public readonly ImmutableArray<string> DefaultStart = [];
 		[Desc("The preferred defaults for the inner type.")]
-		public readonly string[] DefaultInner = [];
+		public readonly ImmutableArray<string> DefaultInner = [];
 		[Desc("The preferred defaults for the end type.")]
-		public readonly string[] DefaultEnd = [];
+		public readonly ImmutableArray<string> DefaultEnd = [];
 
 		public override object Create(ActorInitializer init)
 		{

--- a/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/TimeLimitManager.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
@@ -32,10 +34,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string TimeLimitDescription = "dropdown-time-limit.description";
 
 		[Desc("Time Limit options that will be shown in the lobby dropdown. Values are in minutes.")]
-		public readonly int[] TimeLimitOptions = [0, 10, 20, 30, 40, 60, 90];
+		public readonly ImmutableArray<int> TimeLimitOptions = [0, 10, 20, 30, 40, 60, 90];
 
 		[Desc("List of remaining minutes of game time when a text and optional speech notification should be made to players.")]
-		public readonly Dictionary<int, string> TimeLimitWarnings = new()
+		public readonly FrozenDictionary<int, string> TimeLimitWarnings = new Dictionary<int, string>
 		{
 			{ 1, null },
 			{ 2, null },
@@ -43,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			{ 4, null },
 			{ 5, null },
 			{ 10, null },
-		};
+		}.ToFrozenDictionary();
 
 		[Desc("Default selection for the time limit option in the lobby. Needs to use one of the TimeLimitOptions.")]
 		public readonly int TimeLimitDefault = 0;

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
@@ -28,10 +29,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class WarheadDebugOverlay : IRenderAnnotations
 	{
-		sealed class WHImpact(WPos pos, WDist[] range, int time, Color color)
+		sealed class WHImpact(WPos pos, ImmutableArray<WDist> range, int time, Color color)
 		{
 			public readonly WPos CenterPosition = pos;
-			public readonly WDist[] Range = range;
+			public readonly ImmutableArray<WDist> Range = range;
 			public readonly Color Color = color;
 			public int Time = time;
 
@@ -46,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void AddImpact(WPos pos, WDist[] range, Color color)
+		public void AddImpact(WPos pos, ImmutableArray<WDist> range, Color color)
 		{
 			impacts.Add(new WHImpact(pos, range, info.DisplayDuration, color));
 		}

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -28,10 +29,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool ChangingWindLevel = true;
 
 		[Desc("The levels of wind intensity (particles x-axis movement in px/tick).")]
-		public readonly int[] WindLevels = [-12, -7, -5, 0, 5, 7, 12];
+		public readonly ImmutableArray<int> WindLevels = [-12, -7, -5, 0, 5, 7, 12];
 
 		[Desc("Works only if ChangingWindLevel is enabled. Min. and max. ticks needed to change the WindLevel.")]
-		public readonly int[] WindTick = [150, 550];
+		public readonly ImmutableArray<int> WindTick = [150, 550];
 
 		[Desc("Hard or soft fading between the WindLevels.")]
 		public readonly bool InstantWindChanges = false;
@@ -40,25 +41,25 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool UseSquares = true;
 
 		[Desc("Size / width of the particle in px.")]
-		public readonly int[] ParticleSize = [1, 3];
+		public readonly ImmutableArray<int> ParticleSize = [1, 3];
 
 		[Desc("Scatters falling direction on the x-axis. Scatter min. and max. value in px/tick.")]
-		public readonly int[] ScatterDirection = [-1, 1];
+		public readonly ImmutableArray<int> ScatterDirection = [-1, 1];
 
 		[Desc("Min. and max. speed at which particles fall in px/tick.")]
-		public readonly float[] Gravity = [2.5f, 5f];
+		public readonly ImmutableArray<float> Gravity = [2.5f, 5f];
 
 		[Desc("The current offset value for the swing movement. SwingOffset min. and max. value in px/tick.")]
-		public readonly float[] SwingOffset = [2.5f, 3.5f];
+		public readonly ImmutableArray<float> SwingOffset = [2.5f, 3.5f];
 
 		[Desc("The value that particles swing to the side each update. SwingSpeed min. and max. value in px/tick.")]
-		public readonly float[] SwingSpeed = [0.0025f, 0.06f];
+		public readonly ImmutableArray<float> SwingSpeed = [0.0025f, 0.06f];
 
 		[Desc("The value range that can be swung to the left or right. SwingAmplitude min. and max. value in px/tick.")]
-		public readonly float[] SwingAmplitude = [1.0f, 1.5f];
+		public readonly ImmutableArray<float> SwingAmplitude = [1.0f, 1.5f];
 
 		[Desc("The randomly selected rgb(a) hex colors for the particles. Use this order: rrggbb[aa], rrggbb[aa], ...")]
-		public readonly Color[] ParticleColors =
+		public readonly ImmutableArray<Color> ParticleColors =
 		[
 			Color.FromArgb(236, 236, 236),
 			Color.FromArgb(228, 228, 228),

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Activities;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
@@ -373,7 +375,7 @@ namespace OpenRA.Mods.Common.Traits
 		(float SMin, float SMax) SaturationRange { get; }
 		(float VMin, float VMax) ValueRange { get; }
 		event Action<Color> OnColorPickerColorUpdate;
-		Color[] PresetColors { get; }
+		ImmutableArray<Color> PresetColors { get; }
 		Color RandomPresetColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
 		Color RandomValidColor(MersenneTwister random, IReadOnlyCollection<Color> terrainColors, IReadOnlyCollection<Color> playerColors);
 		Color MakeValid(
@@ -553,7 +555,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IOverrideAircraftLanding
 	{
-		HashSet<string> LandableTerrainTypes { get; }
+		FrozenSet<string> LandableTerrainTypes { get; }
 	}
 
 	public interface IRadarSignature
@@ -703,16 +705,16 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class EditorActorDropdown : EditorActorOption
 	{
-		public readonly Func<EditorActorPreview, Dictionary<string, string>> GetLabels;
-		public readonly Func<EditorActorPreview, Dictionary<string, string>, string> GetValue;
+		public readonly Func<EditorActorPreview, IReadOnlyDictionary<string, string>> GetLabels;
+		public readonly Func<EditorActorPreview, IReadOnlyDictionary<string, string>, string> GetValue;
 		public readonly Action<EditorActorPreview, string> OnChange;
 
 		/// <summary>
 		/// Creates dropdown for editing actor's metadata with dynamically created items.
 		/// </summary>
 		public EditorActorDropdown(string name, int displayOrder,
-			Func<EditorActorPreview, Dictionary<string, string>> getLabels,
-			Func<EditorActorPreview, Dictionary<string, string>, string> getValue,
+			Func<EditorActorPreview, IReadOnlyDictionary<string, string>> getLabels,
+			Func<EditorActorPreview, IReadOnlyDictionary<string, string>, string> getValue,
 			Action<EditorActorPreview, string> onChange)
 			: base(name, displayOrder)
 		{
@@ -1007,7 +1009,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IMapGeneratorSettings
 	{
-		List<MapGeneratorOption> Options { get; }
+		ImmutableArray<MapGeneratorOption> Options { get; }
 
 		int PlayerCount { get; }
 
@@ -1020,7 +1022,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IEditorMapGeneratorInfo : IMapGeneratorInfo
 	{
-		string[] Tilesets { get; }
+		ImmutableArray<string> Tilesets { get; }
 		IMapGeneratorSettings GetSettings();
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using OpenRA.FileSystem;
@@ -52,7 +53,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 		/// </summary>
 		public static YamlFileSet LoadExternalMapYaml(ModData modData, MiniYamlBuilder yaml, HashSet<string> externalFilenames)
 		{
-			return FieldLoader.GetValue<string[]>("value", yaml.Value)
+			return FieldLoader.GetValue<ImmutableArray<string>>("value", yaml.Value)
 				.Where(f => f.Contains('|'))
 				.SelectMany(f => LoadModYaml(modData, FilterExternalFiles(modData, [f], externalFilenames)))
 				.ToList();
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				(null, "map.yaml", yaml.Nodes)
 			};
 
-			var files = FieldLoader.GetValue<string[]>("value", yaml.Value);
+			var files = FieldLoader.GetValue<ImmutableArray<string>>("value", yaml.Value);
 			foreach (var filename in files)
 			{
 				// Ignore any files that aren't in the map bundle
@@ -178,7 +179,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			if (mapNode != null && mapNode.Value != null)
 			{
-				var mapFiles = FieldLoader.GetValue<string[]>("value", mapNode.Value);
+				var mapFiles = FieldLoader.GetValue<ImmutableArray<string>>("value", mapNode.Value);
 				yaml.AddRange(mapFiles.Select(filename =>
 				{
 					// Explicit package paths never refer to a map

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
@@ -223,7 +224,7 @@ namespace OpenRA.Mods.Common
 			}
 		}
 
-		public static int RandomInRange(MersenneTwister random, int[] range)
+		public static int RandomInRange(MersenneTwister random, ImmutableArray<int> range)
 		{
 			if (range.Length == 0)
 				return 0;
@@ -241,7 +242,7 @@ namespace OpenRA.Mods.Common
 				: t.Name;
 		}
 
-		public static WDist RandomDistance(MersenneTwister random, WDist[] distance)
+		public static WDist RandomDistance(MersenneTwister random, ImmutableArray<WDist> distance)
 		{
 			if (distance.Length == 0)
 				return WDist.Zero;
@@ -252,7 +253,7 @@ namespace OpenRA.Mods.Common
 			return new WDist(random.Next(distance[0].Length, distance[1].Length));
 		}
 
-		public static WVec RandomVector(MersenneTwister random, WVec[] vector)
+		public static WVec RandomVector(MersenneTwister random, ImmutableArray<WVec> vector)
 		{
 			if (vector.Length == 0)
 				return WVec.Zero;

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -270,10 +271,20 @@ namespace OpenRA.Mods.Common
 			if (t.IsEnum)
 				return $"{t.Name} (enum)";
 
-			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))
+			if (t.IsGenericType &&
+				(t.GetGenericTypeDefinition() == typeof(HashSet<>) ||
+				t.GetGenericTypeDefinition()
+					.BaseTypes()
+					.Select(bt => bt.IsGenericType ? bt.GetGenericTypeDefinition() : null)
+					.Any(bt => bt == typeof(FrozenSet<>))))
 				return $"Set of {t.GetGenericArguments().Select(FriendlyTypeName).First()}";
 
-			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+			if (t.IsGenericType &&
+				(t.GetGenericTypeDefinition() == typeof(Dictionary<,>) ||
+				t.GetGenericTypeDefinition()
+					.BaseTypes()
+					.Select(bt => bt.IsGenericType ? bt.GetGenericTypeDefinition() : null)
+					.Any(bt => bt == typeof(FrozenDictionary<,>))))
 			{
 				var args = t.GetGenericArguments().Select(FriendlyTypeName).ToArray();
 				return $"Dictionary with Key: {args[0]}, Value: {args[1]}";

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
@@ -44,7 +45,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				shadowIndex[^3] = 4;
 			}
 
-			var palette = new ImmutablePalette(args[2], [0], shadowIndex);
+			var palette = new ImmutablePalette(args[2], [0], shadowIndex.ToImmutableArray());
 			var palColors = new Color[Palette.Size];
 			for (var i = 0; i < Palette.Size; i++)
 				palColors[i] = palette.GetColor(i);

--- a/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 
@@ -67,7 +68,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
-				foreach (var kv in c.Value.Regions)
+				foreach (var kv in c.Value.Regions.OrderBy(kvp => kvp.Key))
 				{
 					var r = kv.Value;
 					regions.Add($"[\"{c.Key}.{kv.Key}\",{r.X},{r.Y},{r.Width},{r.Height}]");

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -29,7 +30,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// The order of the included files matter, so we can defer to system files
 				// only as long as they are included first.
 				var include = false;
-				var files = FieldLoader.GetValue<string[]>("value", value.Value);
+				var files = FieldLoader.GetValue<ImmutableArray<string>>("value", value.Value);
 				foreach (var f in files)
 				{
 					include |= map.Package.Contains(f);
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// The order of the included files matter, so we can defer to system files
 				// only as long as they are included first.
 				var include = false;
-				var files = FieldLoader.GetValue<string[]>("value", value.Value);
+				var files = FieldLoader.GetValue<ImmutableArray<string>>("value", value.Value);
 				foreach (var f in files)
 				{
 					include |= map.Package.Contains(f);

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			public readonly int Shard;
 			public readonly int ShardCount;
 			public readonly ImmutableArray<string> Variables;
-			public readonly ImmutableDictionary<string, ImmutableArray<string>> Choices;
+			public readonly FrozenDictionary<string, ImmutableArray<string>> Choices;
 
 			Configuration(
 				string mapGeneratorName,
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				int shard,
 				int shardCount,
 				ImmutableArray<string> variables,
-				ImmutableDictionary<string, ImmutableArray<string>> choices)
+				FrozenDictionary<string, ImmutableArray<string>> choices)
 			{
 				MapGeneratorType = mapGeneratorName;
 				NoDefaults = noDefaults;
@@ -176,7 +177,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					shard,
 					shardCount,
 					variables.ToImmutableArray(),
-					choices.ToImmutableDictionary());
+					choices.ToFrozenDictionary());
 			}
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 	public static class Utilities
 	{
 		public static MiniYamlNode GetTopLevelNodeByKey(ModData modData, string key,
-			Func<Manifest, string[]> manifestPropertySelector,
+			Func<Manifest, ImmutableArray<string>> manifestPropertySelector,
 			Func<Map, MiniYaml> mapPropertySelector = null,
 			string mapPath = null)
 		{

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Warheads
 	{
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("List of explosion sequences that can be used.")]
-		public readonly string[] Explosions = [];
+		public readonly ImmutableArray<string> Explosions = [];
 
 		[Desc("Image containing explosion effect sequence.")]
 		public readonly string Image = "explosion";
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly bool ForceDisplayAtGroundLevel = false;
 
 		[Desc("List of sounds that can be played on impact.")]
-		public readonly string[] ImpactSounds = [];
+		public readonly ImmutableArray<string> ImpactSounds = [];
 
 		[Desc("Chance of impact sound to play.")]
 		public readonly int ImpactSoundChance = 100;

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -19,7 +20,7 @@ namespace OpenRA.Mods.Common.Warheads
 	public class CreateResourceWarhead : Warhead
 	{
 		[Desc("Size of the area. The resources are seeded within this area.", "Provide 2 values for a ring effect (outer/inner).")]
-		public readonly int[] Size = [0, 0];
+		public readonly ImmutableArray<int> Size = [0, 0];
 
 		[Desc("Will this splatter resources and which?")]
 		[FieldLoader.Require]

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Damage percentage versus each armor type.")]
-		public readonly Dictionary<string, int> Versus = [];
+		public readonly FrozenDictionary<string, int> Versus = FrozenDictionary<string, int>.Empty;
 
 		public override bool IsValidAgainst(Actor victim, Actor firedBy)
 		{

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -9,7 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -20,13 +21,13 @@ namespace OpenRA.Mods.Common.Warheads
 	public class DestroyResourceWarhead : Warhead
 	{
 		[Desc("Size of the area. The resources are removed within this area.", "Provide 2 values for a ring effect (outer/inner).")]
-		public readonly int[] Size = [0, 0];
+		public readonly ImmutableArray<int> Size = [0, 0];
 
 		[Desc("Amount of resources to be removed. If zero, all resources within the area will be removed.")]
 		public readonly byte ResourceAmount = 0;
 
 		[Desc("Resource types to remove with this warhead.", "If empty, all resource types will be removed.")]
-		public readonly HashSet<string> ResourceTypes = [];
+		public readonly FrozenSet<string> ResourceTypes = FrozenSet<string>.Empty;
 
 		public override void DoImpact(in Target target, WarheadArgs args)
 		{

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -10,7 +10,8 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
@@ -22,10 +23,10 @@ namespace OpenRA.Mods.Common.Warheads
 	public class LeaveSmudgeWarhead : Warhead
 	{
 		[Desc("Size of the area. A smudge will be created in each tile.", "Provide 2 values for a ring effect (outer/inner).")]
-		public readonly int[] Size = [0, 0];
+		public readonly ImmutableArray<int> Size = [0, 0];
 
 		[Desc("Type of smudge to apply to terrain.")]
-		public readonly HashSet<string> SmudgeType = [];
+		public readonly FrozenSet<string> SmudgeType = FrozenSet<string>.Empty;
 
 		[Desc("Percentage chance the smudge is created.")]
 		public readonly int Chance = 100;

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
@@ -25,15 +26,15 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly WDist Spread = new(43);
 
 		[Desc("Damage percentage at each range step")]
-		public readonly int[] Falloff = [100, 37, 14, 5, 0];
+		public readonly ImmutableArray<int> Falloff = [100, 37, 14, 5, 0];
 
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
-		public readonly WDist[] Range = null;
+		public readonly ImmutableArray<WDist> Range = default;
 
 		[Desc("Controls the way damage is calculated. Possible values are 'HitShape', 'ClosestTargetablePosition' and 'CenterPosition'.")]
 		public readonly DamageCalculationType DamageCalculationType = DamageCalculationType.HitShape;
 
-		WDist[] effectiveRange;
+		ImmutableArray<WDist> effectiveRange;
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
@@ -49,7 +50,7 @@ namespace OpenRA.Mods.Common.Warheads
 				effectiveRange = Range;
 			}
 			else
-				effectiveRange = Exts.MakeArray(Falloff.Length, i => i * Spread);
+				effectiveRange = Exts.MakeArray(Falloff.Length, i => i * Spread).ToImmutableArray();
 		}
 
 		protected override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -168,7 +169,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						.Where(c => c != mixer.Color)
 						.Append(mixer.Color)
 						.Reverse().Take(paletteCustomRows * paletteCols).Reverse()
-						.ToArray();
+						.ToImmutableArray();
 					Game.Settings.Save();
 
 					// Flash the palette tab to show players that something has happened

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference("actorType")]
 		const string ActorTypeTooltip = "label-actor-type";
 
-		sealed record ActorSelectorActor(ActorInfo Actor, string[] Categories, string[] SearchTerms, string Tooltip);
+		sealed record ActorSelectorActor(ActorInfo Actor, ImmutableArray<string> Categories, string[] SearchTerms, string Tooltip);
 
 		readonly DropDownButtonWidget ownersDropDown;
 		readonly Ruleset mapRules;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var validChoices = mo.ValidChoices(world.Map.Rules.TerrainInfo, playerCount);
 						if (!validChoices.Contains(mo.Value))
-							mo.Value = mo.Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
+							mo.Value = mo.Default != null ? mo.Default.FirstOrDefault(validChoices.Contains) : validChoices.FirstOrDefault();
 
 						if (mo.Value != null && mo.Label != null && validChoices.Count > 0)
 						{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		sealed class TileSelectorTemplate
 		{
 			public readonly TerrainTemplateInfo Template;
-			public readonly string[] Categories;
+			public readonly ImmutableArray<string> Categories;
 			public readonly string[] SearchTerms;
 			public readonly string Tooltip;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Scripting;
@@ -200,7 +201,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (logicArgs.TryGetValue("Buttons", out var buttonsNode))
 			{
-				var buttonIds = FieldLoader.GetValue<string[]>("Buttons", buttonsNode.Value);
+				var buttonIds = FieldLoader.GetValue<ImmutableArray<string>>("Buttons", buttonsNode.Value);
 				foreach (var button in buttonIds)
 					if (buttonHandlers.TryGetValue(button, out var createHandler))
 						createHandler();

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromSourceLogic.cs
@@ -178,7 +178,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						Log.Write("install", $"Using installer `{kv.Key}: {kv.Value.Title}` of type `{kv.Value.Type.Value}`:");
 
-						availablePackages = content.Packages.Values
+						availablePackages = content.Packages
+							.Select(kvp => kvp.Value)
 							.Where(p => p.Sources.Contains(kv.Key) && !p.IsInstalled())
 							.ToArray();
 
@@ -198,7 +199,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 				}
 
-				var missingSources = content.Packages.Values
+				var missingSources = content.Packages
+					.Select(kvp => kvp.Value)
 					.Where(p => !p.IsInstalled())
 					.SelectMany(p => p.Sources)
 					.Select(d => sources[d]);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				scrollPanel.AddChild(container);
 			}
 
-			sourceAvailable = content.Packages.Values.Any(p => p.Sources.Length > 0 && !p.IsInstalled());
+			sourceAvailable = content.Packages.Select(kvp => kvp.Value).Any(p => p.Sources.Length > 0 && !p.IsInstalled());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -67,7 +68,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		internal MapPreviewLogic(Widget widget, ModData modData, Func<(MapPreview Map, Session.MapStatus Status)> getMap,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
-			bool mapUpdatesEnabled, Action<string> onMapUpdate, Func<HashSet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints)
+			bool mapUpdatesEnabled, Action<string> onMapUpdate, Func<IReadOnlySet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints)
 		{
 			this.getMap = getMap;
 
@@ -112,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Widget SetupAuthorAndMapType(Widget parent)
 			{
 				var typeLabel = parent.Get<LabelWidget>("MAP_TYPE");
-				var typeCache = new CachedTransform<string[], string>(c => c.FirstOrDefault() ?? "");
+				var typeCache = new CachedTransform<ImmutableArray<string>, string>(c => c.FirstOrDefault() ?? "");
 
 				typeLabel.GetText = () => typeCache.Update(getMap().Map.Categories);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileSystem;
@@ -112,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget widget;
 		readonly DropDownButtonWidget gameModeDropdown;
 		readonly ModData modData;
-		readonly HashSet<string> remoteMapPool;
+		readonly FrozenSet<string> remoteMapPool;
 		readonly ScrollItemWidget itemTemplate;
 		readonly MapVisibility filter;
 
@@ -138,7 +139,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Func<MapPreview, long> orderByFunc;
 
 		[ObjectCreator.UseCtor]
-		internal MapChooserLogic(Widget widget, ModData modData, string initialMap, MapGenerationArgs initialGeneratedMap, HashSet<string> remoteMapPool,
+		internal MapChooserLogic(Widget widget, ModData modData, string initialMap, MapGenerationArgs initialGeneratedMap, FrozenSet<string> remoteMapPool,
 			MapClassification initialTab, Action onExit, Action<string> onSelect, Action<MapGenerationArgs> onSelectGenerated, MapVisibility filter)
 		{
 			this.widget = widget;

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -336,7 +336,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var validChoices = mo.ValidChoices(selectedTerrain, playerCount);
 						if (!validChoices.Contains(mo.Value))
-							mo.Value = mo.Default?.FirstOrDefault(validChoices.Contains) ?? validChoices.FirstOrDefault();
+							mo.Value = mo.Default != null ? mo.Default.FirstOrDefault(validChoices.Contains) : validChoices.FirstOrDefault();
 
 						if (mo.Label != null && validChoices.Count > 0)
 						{

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -167,8 +168,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return occupants;
 			});
 
-			var noSpawns = new HashSet<int>();
-			var disabledSpawnPoints = new CachedTransform<ReplayMetadata, HashSet<int>>(r => r.GameInfo.DisabledSpawnPoints ?? noSpawns);
+			var disabledSpawnPoints = new CachedTransform<ReplayMetadata, FrozenSet<int>>(r => r.GameInfo.DisabledSpawnPoints ?? FrozenSet<int>.Empty);
 
 			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
 			{
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "getMap", (Func<(MapPreview, Session.MapStatus)>)(() => (map, Session.MapStatus.Playable)) },
 				{ "onMouseDown", null },
 				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedReplay)) },
-				{ "getDisabledSpawnPoints", (Func<HashSet<int>>)(() => disabledSpawnPoints.Update(selectedReplay)) },
+				{ "getDisabledSpawnPoints", (Func<FrozenSet<int>>)(() => disabledSpawnPoints.Update(selectedReplay)) },
 				{ "showUnoccupiedSpawnpoints", false },
 				{ "mapUpdatesEnabled", false },
 				{ "onMapUpdate", (Action<string>)(_ => { }) },

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -51,7 +52,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		string currentContext = AnyContext;
 		readonly HashSet<string> contexts = [AnyContext];
-		readonly Dictionary<string, HashSet<string>> hotkeyGroups = [];
+		readonly Dictionary<string, FrozenSet<string>> hotkeyGroups = [];
 		TextFieldWidget filterInput;
 
 		Widget headerTemplate;
@@ -155,7 +156,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var typesNode = hg.Value.NodeWithKeyOrDefault("Types");
 					if (typesNode != null)
-						hotkeyGroups.Add(hg.Key, FieldLoader.GetValue<HashSet<string>>("Types", typesNode.Value.Value));
+						hotkeyGroups.Add(hg.Key, FieldLoader.GetValue<FrozenSet<string>>("Types", typesNode.Value.Value));
 				}
 
 				InitHotkeyRemapDialog(panel);

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -10,8 +10,8 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -57,8 +57,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 	public class MapPreviewWidget : Widget
 	{
-		static readonly int[] NoDisabledSpawnPoints = [];
-
 		public readonly bool IgnoreMouseInput = false;
 		public readonly bool ShowSpawnPoints = true;
 
@@ -73,7 +71,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public Func<MapPreview> Preview = () => null;
 		public Func<Dictionary<int, SpawnOccupant>> SpawnOccupants = () => [];
-		public Func<IEnumerable<int>> DisabledSpawnPoints = () => NoDisabledSpawnPoints;
+		public Func<IReadOnlySet<int>> DisabledSpawnPoints = () => FrozenSet<int>.Empty;
 		public Action<MouseInput> OnMouseDown = _ => { };
 		public int TooltipSpawnIndex = -1;
 		public bool ShowUnoccupiedSpawnpoints = true;

--- a/OpenRA.Mods.D2k/Projectiles/SonicBlast.cs
+++ b/OpenRA.Mods.D2k/Projectiles/SonicBlast.cs
@@ -10,6 +10,7 @@
 #endregion
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.D2k.Projectiles
 	public class SonicBlastInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate a randomly picked velocity per blast.")]
-		public readonly WDist[] Speed = [new(128)];
+		public readonly ImmutableArray<WDist> Speed = [new(128)];
 
 		[Desc("The number of ticks between the blast causing warhead impacts in its area of effect.")]
 		public readonly int DamageInterval = 1;
@@ -37,10 +38,10 @@ namespace OpenRA.Mods.D2k.Projectiles
 		public readonly WDist Width = new(650);
 
 		[Desc("Damage modifier applied at each range step.")]
-		public readonly int[] Falloff = [100, 100];
+		public readonly ImmutableArray<int> Falloff = [100, 100];
 
 		[Desc("Ranges at which each Falloff step is defined.")]
-		public readonly WDist[] Range = [WDist.Zero, new(int.MaxValue)];
+		public readonly ImmutableArray<WDist> Range = [WDist.Zero, new(int.MaxValue)];
 
 		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -70,7 +71,7 @@ namespace OpenRA.Mods.D2k.SpriteLoaders
 
 						if (remap != default)
 						{
-							var r = new PlayerColorRemap(Enumerable.Range(240, 16).ToArray(), remap);
+							var r = new PlayerColorRemap(Enumerable.Range(240, 16).ToImmutableArray(), remap);
 							for (var i = 240; i < 256; i++)
 								palette[i] = r.GetRemappedColor(Color.FromArgb(palette[i]), i).ToArgb();
 						}

--- a/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
+++ b/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
@@ -20,13 +21,13 @@ namespace OpenRA.Mods.D2k.Traits
 		public readonly int Intensity = 0;
 
 		[Desc("Noise percentage at Range step away from the actor.")]
-		public readonly int[] Falloff = [100, 100, 25, 11, 6, 4, 3, 2, 1, 0];
+		public readonly ImmutableArray<int> Falloff = [100, 100, 25, 11, 6, 4, 3, 2, 1, 0];
 
 		[Desc("Range between falloff steps.")]
 		public readonly WDist Spread = new(3072);
 
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
-		public readonly WDist[] Range = null;
+		public readonly ImmutableArray<WDist> Range = default;
 
 		public override object Create(ActorInitializer init) { return new AttractsWorms(init, this); }
 	}
@@ -34,14 +35,14 @@ namespace OpenRA.Mods.D2k.Traits
 	public class AttractsWorms : ConditionalTrait<AttractsWormsInfo>
 	{
 		readonly Actor self;
-		readonly WDist[] effectiveRange;
+		readonly ImmutableArray<WDist> effectiveRange;
 
 		public AttractsWorms(ActorInitializer init, AttractsWormsInfo info)
 			: base(info)
 		{
 			self = init.Self;
 
-			effectiveRange = info.Range ?? Exts.MakeArray(info.Falloff.Length, i => i * info.Spread);
+			effectiveRange = info.Range != null ? info.Range : Exts.MakeArray(info.Falloff.Length, i => i * info.Spread).ToImmutableArray();
 		}
 
 		int GetNoisePercentageAtDistance(int distance)

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Orders;
@@ -23,10 +25,10 @@ namespace OpenRA.Mods.D2k.Traits
 	public class D2kActorPreviewPlaceBuildingPreviewInfo : ActorPreviewPlaceBuildingPreviewInfo
 	{
 		[Desc("Terrain types that should show the 'unsafe' footprint tile.")]
-		public readonly HashSet<string> UnsafeTerrainTypes = ["Rock"];
+		public readonly FrozenSet<string> UnsafeTerrainTypes = new HashSet<string> { "Rock" }.ToFrozenSet();
 
 		[Desc("Only check for 'unsafe' footprint tiles when you have these prerequisites.")]
-		public readonly string[] RequiresPrerequisites = [];
+		public readonly ImmutableArray<string> RequiresPrerequisites = [];
 
 		[Desc("Sprite image to use for the overlay.")]
 		public readonly string Image = "overlay";

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kBuilding.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Mods.Common.Terrain;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 		public readonly BitSet<DamageType> DamageTypes = default;
 
 		[Desc("Terrain types where the actor will take damage.")]
-		public readonly string[] DamageTerrainTypes = ["Rock"];
+		public readonly ImmutableArray<string> DamageTerrainTypes = ["Rock"];
 
 		[Desc("Percentage health below which the actor will not receive further damage.")]
 		public readonly int DamageThreshold = 50;
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.D2k.Traits.Buildings
 		public readonly ushort ConcreteTemplate = 88;
 
 		[Desc("List of required prerequisites to place a terrain template.")]
-		public readonly string[] ConcretePrerequisites = [];
+		public readonly ImmutableArray<string> ConcretePrerequisites = [];
 
 		public override object Create(ActorInitializer init) { return new D2kBuilding(init, this); }
 	}

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
@@ -25,28 +27,28 @@ namespace OpenRA.Mods.D2k.Traits
 	public class SpiceBloomInfo : TraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
-		public readonly string[] GrowthSequences = ["grow1", "grow2", "grow3"];
+		public readonly ImmutableArray<string> GrowthSequences = ["grow1", "grow2", "grow3"];
 
 		[SequenceReference]
 		public readonly string SpurtSequence = "spurt";
 
 		[Desc("The range of time (in ticks) that the spicebloom will take to grow until it blows up.")]
-		public readonly int[] Lifetime = [2000, 3000];
+		public readonly ImmutableArray<int> Lifetime = [2000, 3000];
 
 		public readonly string ResourceType = "Spice";
 
 		[Desc("Spice blooms only grow on these terrain types.")]
-		public readonly HashSet<string> GrowthTerrainTypes = [];
+		public readonly FrozenSet<string> GrowthTerrainTypes = FrozenSet<string>.Empty;
 
 		[Desc("The weapon to use for spice creation.")]
 		[WeaponReference]
 		public readonly string Weapon = null;
 
 		[Desc("The number of times to fire Weapon at the minimum and maximum actor age.")]
-		public readonly int[] Bursts = [4, 12];
+		public readonly ImmutableArray<int> Bursts = [4, 12];
 
 		[Desc("The minimum and maximum distance in cells that spice may be expelled.")]
-		public readonly int[] Range = [3, 5];
+		public readonly ImmutableArray<int> Range = [3, 5];
 
 		[Desc("Delay between each burst. (in Ticks)")]
 		public readonly int BurstInterval = 1;

--- a/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -34,7 +35,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		[FieldLoader.Require]
 		[Desc("Tilesets that are compatible with this map generator.")]
-		public readonly string[] Tilesets = null;
+		public readonly ImmutableArray<string> Tilesets = default;
 
 		[FluentReference]
 		[Desc("The title to use for generated maps.")]
@@ -46,7 +47,7 @@ namespace OpenRA.Mods.D2k.Traits
 		// This is purely of interest to the linter.
 		[FieldLoader.LoadUsing(nameof(FluentReferencesLoader))]
 		[FluentReference]
-		public readonly List<string> FluentReferences = null;
+		public readonly ImmutableArray<string> FluentReferences = default;
 
 		[FieldLoader.LoadUsing(nameof(SettingsLoader))]
 		public readonly MiniYaml Settings;
@@ -54,17 +55,17 @@ namespace OpenRA.Mods.D2k.Traits
 		string IMapGeneratorInfo.Type => Type;
 		string IMapGeneratorInfo.Name => Name;
 		string IMapGeneratorInfo.MapTitle => MapTitle;
-		string[] IEditorMapGeneratorInfo.Tilesets => Tilesets;
+		ImmutableArray<string> IEditorMapGeneratorInfo.Tilesets => Tilesets;
 
 		static MiniYaml SettingsLoader(MiniYaml my)
 		{
 			return my.NodeWithKey("Settings").Value;
 		}
 
-		static List<string> FluentReferencesLoader(MiniYaml my)
+		static object FluentReferencesLoader(MiniYaml my)
 		{
 			return new MapGeneratorSettings(null, my.NodeWithKey("Settings").Value)
-				.Options.SelectMany(o => o.GetFluentReferences()).ToList();
+				.Options.SelectMany(o => o.GetFluentReferences()).ToImmutableArray();
 		}
 
 		const int FractionMax = Terraformer.FractionMax;
@@ -217,7 +218,7 @@ namespace OpenRA.Mods.D2k.Traits
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
 						.Select(terrainInfo.GetTerrainIndex)
-						.ToImmutableHashSet();
+						.ToFrozenSet();
 				}
 
 				var resourceTypes = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<ResourceLayerInfo>().ResourceTypes;

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -217,13 +217,13 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
-		public void SetVec(string name, float[] vec, int length)
+		public void SetVec(string name, ReadOnlyMemory<float> vec, int length)
 		{
 			VerifyThreadAffinity();
 			var param = uniformCache[name];
 			unsafe
 			{
-				fixed (float* pVec = vec)
+				fixed (float* pVec = vec.Span)
 				{
 					var ptr = new IntPtr(pVec);
 					switch (length)

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -815,7 +815,7 @@ namespace OpenRA.Platforms.Default
 			device.Post(setVec1, (name, x));
 		}
 
-		public void SetVec(string name, float[] vec, int length)
+		public void SetVec(string name, ReadOnlyMemory<float> vec, int length)
 		{
 			device.Post(setVec2, (name, vec, length));
 		}

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -82,7 +83,7 @@ namespace OpenRA.Server
 
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
 			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
-				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
+				FieldLoader.GetValue<ImmutableArray<string>>("MOD_SEARCH_PATHS", envModSearchPaths) :
 				[Path.Combine(Platform.EngineDir, "mods")];
 
 			var mods = new InstalledMods(modSearchPaths, explicitModPaths);

--- a/OpenRA.Test/OpenRA.Game/FieldSaverTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FieldSaverTest.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
@@ -113,6 +115,38 @@ namespace OpenRA.Test
 			Assert.That(actual, Is.EqualTo("1,2, 3,4, 5,6"));
 		}
 
+		[Test]
+		public void FormatValue_WVecImmutableArray()
+		{
+			var actual = FieldSaver.FormatValue(new WVec[] { new(1, 2, 3), new(4, 5, 6) }.ToImmutableArray());
+
+			Assert.That(actual, Is.EqualTo("1,2,3, 4,5,6"));
+		}
+
+		[Test]
+		public void FormatValue_CPosImmutableArray()
+		{
+			var actual = FieldSaver.FormatValue(new CPos[] { new(1, 2), new(3, 4), new(5, 6) }.ToImmutableArray());
+
+			Assert.That(actual, Is.EqualTo("1,2, 3,4, 5,6"));
+		}
+
+		[Test]
+		public void FormatValue_CVecImmutableArray()
+		{
+			var actual = FieldSaver.FormatValue(new CVec[] { new(1, 2), new(3, 4), new(5, 6) }.ToImmutableArray());
+
+			Assert.That(actual, Is.EqualTo("1,2, 3,4, 5,6"));
+		}
+
+		[Test]
+		public void FormatValue_int2ImmutableArray()
+		{
+			var actual = FieldSaver.FormatValue(new int2[] { new(1, 2), new(3, 4), new(5, 6) }.ToImmutableArray());
+
+			Assert.That(actual, Is.EqualTo("1,2, 3,4, 5,6"));
+		}
+
 		[TestCase(null, "")]
 		[TestCase(123, "123")]
 		public void FormatValue_Nullable(int? input, string expected)
@@ -177,6 +211,50 @@ namespace OpenRA.Test
 		public void FormatValue_Dictionary()
 		{
 			var input = new Dictionary<int, int> { { 12, 34 }, { 56, 78 } };
+
+			var actual = FieldSaver.FormatValue(input);
+
+			Assert.That(actual, Is.EqualTo($"12: 34{Environment.NewLine}56: 78{Environment.NewLine}"));
+		}
+
+		[TestCase(null, "")]
+		[TestCase(new int[] { }, "")]
+		[TestCase(new int[] { 1 }, "1")]
+		[TestCase(new int[] { 1, 2, 3 }, "1, 2, 3")]
+		[TestCase(new int[] { 1, 1, 2, 2, 3 }, "1, 1, 2, 2, 3")]
+		[TestCase(new int[] { 1, 1, 1, 1 }, "1, 1, 1, 1")]
+		public void FormatValue_ImmutableArray(int[] input, string expected)
+		{
+			var actual = FieldSaver.FormatValue(input?.ToImmutableArray());
+
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		[Test]
+		public void FormatValue_ImmutableArray_Default()
+		{
+			var actual = FieldSaver.FormatValue(default(ImmutableArray<int>));
+
+			Assert.That(actual, Is.Empty);
+		}
+
+		[TestCase(null, "")]
+		[TestCase(new int[] { }, "")]
+		[TestCase(new int[] { 1 }, "1")]
+		[TestCase(new int[] { 1, 2, 3 }, "1, 2, 3")]
+		[TestCase(new int[] { 1, 1, 2, 2, 3 }, "1, 2, 3")]
+		[TestCase(new int[] { 1, 1, 1, 1 }, "1")]
+		public void FormatValue_FrozenSet(int[] input, string expected)
+		{
+			var actual = FieldSaver.FormatValue(input?.ToFrozenSet());
+
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		[Test]
+		public void FormatValue_FrozenDictionary()
+		{
+			var input = new Dictionary<int, int> { { 12, 34 }, { 56, 78 } }.ToFrozenDictionary();
 
 			var actual = FieldSaver.FormatValue(input);
 

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 
@@ -62,7 +63,7 @@ namespace OpenRA
 
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
 			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
-				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
+				FieldLoader.GetValue<ImmutableArray<string>>("MOD_SEARCH_PATHS", envModSearchPaths) :
 				[Path.Combine(Platform.EngineDir, "mods")];
 
 			if (args.Length == 0)


### PR DESCRIPTION
As config is often meant to be loaded and then never modified, it is helpful to support collections that are read-only after creation. This allows various classes that load config from YAML and elsewhere to deserialize straight into read-only collections and enforce invariants around data mutation.

Change classes that use FieldLoader to use read-only collections.

Fixes #22033