### PR TITLE
Fix Path Tiler UI positioning for RectangularIsometric

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
@@ -220,7 +220,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var mainColor = tool.EditorBlitSource != null ? Color.Cyan : Color.Red;
 
-			var gridType = worldRenderer.World.Map.Grid.Type;
+			var map = worldRenderer.World.Map;
+			var gridType = map.Grid.Type;
 			WPos CornerOfCell(CPos cpos) => CellLayerUtils.CornerToWPos(cpos, gridType);
 
 			var points = plan.Points();
@@ -250,7 +251,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (plan.AutoEnd != Direction.None)
 				yield return new CircleAnnotationRenderable(
-					CornerOfCell(plan.LastPoint) + plan.AutoEnd.ToWVec() * 768,
+					CornerOfCell(plan.LastPoint) + map.Offset(plan.AutoEnd.ToCVec(), 0) * 768 / 1024,
 					new WDist(256),
 					2,
 					plan.End != Direction.None ? Color.Magenta : Color.Gray,
@@ -258,7 +259,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (plan.AutoStart != Direction.None)
 				yield return new CircleAnnotationRenderable(
-					CornerOfCell(plan.FirstPoint) - plan.AutoStart.ToWVec() * 768,
+					CornerOfCell(plan.FirstPoint) - map.Offset(plan.AutoStart.ToCVec(), 0) * 768 / 1024,
 					new WDist(256),
 					2,
 					plan.Start != Direction.None ? Color.Magenta : Color.Gray,

--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -100,19 +100,19 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>Get the closest -X-Y corner of a CPos cell to a WPos.</summary>
-		public static CPos WPosToCorner(WPos cpos, MapGridType gridType)
+		public static CPos WPosToCorner(WPos wpos, MapGridType gridType)
 		{
 			switch (gridType)
 			{
 				case MapGridType.Rectangular:
 					return new CPos(
-						FloorDiv(cpos.X + 512, 1024),
-						FloorDiv(cpos.Y + 512, 1024),
+						FloorDiv(wpos.X + 512, 1024),
+						FloorDiv(wpos.Y + 512, 1024),
 						0);
 				case MapGridType.RectangularIsometric:
 					return new CPos(
-						FloorDiv(cpos.Y + cpos.X, 1448),
-						FloorDiv(cpos.Y - cpos.X, 1448),
+						FloorDiv(wpos.Y + wpos.X, 1448),
+						FloorDiv(wpos.Y - wpos.X + 1448, 1448),
 						0);
 				default:
 					throw new NotImplementedException();

--- a/OpenRA.Mods.Common/MapGenerator/Direction.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Direction.cs
@@ -17,7 +17,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 {
 	/// <summary>
 	/// Utilities for simple directions and adjacency. Note that coordinate systems might not agree
-	/// as to which directions are conceptually left/right or up/down.
+	/// as to which directions are conceptually left/right or up/down. Direction is typically used
+	/// with the CPos coordinate system.
 	/// </summary>
 	public enum Direction
 	{
@@ -142,18 +143,6 @@ namespace OpenRA.Mods.Common.MapGenerator
 		{
 			if (direction >= Direction.R && direction <= Direction.RU)
 				return Spread8CVec[(int)direction];
-			else
-				throw new ArgumentException("bad direction");
-		}
-
-		/// <summary>
-		/// Convert a non-none direction to a WVec offset. Assumes that
-		/// WVec(1, 0, 0) corresponds to Direction.R.
-		/// </summary>
-		public static WVec ToWVec(this Direction direction)
-		{
-			if (direction >= Direction.R && direction <= Direction.RU)
-				return new WVec(Spread8[(int)direction].X, Spread8[(int)direction].Y, 0);
 			else
 				throw new ArgumentException("bad direction");
 		}


### PR DESCRIPTION
The on-map path editor for the Path Tiler had incorrect offsets and direction markers when used with a RectangularIsometric grid. This fixes the grid alignment.

Note that map height information is currently ignored by the tool.
