### PR TITLE
Create coordinate system conversion wrapper around Mirror

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/NoiseUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/NoiseUtils.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			MersenneTwister random,
 			CellLayer<int> cellLayer,
 			int rotations,
-			Symmetry.Mirror mirror,
+			Symmetry.WMirror wmirror,
 			int featureSize,
 			Func<int, int> ampFunc)
 		{
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				size,
 				rotations,
-				mirror,
+				wmirror.ForCPos(),
 				featureSize,
 				ampFunc);
 			CellLayerUtils.FromMatrix(cellLayer, noise);

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public readonly Map Map;
 		public readonly ModData ModData;
 		public readonly List<ActorPlan> ActorPlans;
-		public readonly Symmetry.Mirror Mirror;
+		public readonly Symmetry.WMirror WMirror;
 		public readonly int Rotations;
 
 		readonly ITerrainInfo terrainInfo;
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Map = map;
 			ModData = modData;
 			ActorPlans = actorPlans;
-			Mirror = mirror;
+			WMirror = new Symmetry.WMirror(mirror, map.Grid.Type);
 			Rotations = rotations;
 
 			terrainInfo = modData.DefaultTerrainInfo[map.Tileset];
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Symmetry.RotateAndMirrorOverCPos(
 				layer,
 				Rotations,
-				Mirror,
+				WMirror,
 				(sources, destination)
 					=> newLayer[destination] = sources
 						.Select(source => layer.TryGetValue(source, out var value) ? value : outsideValue)
@@ -354,7 +354,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			if (mask != null)
 				zoneable = CellLayerUtils.Intersect([zoneable, mask]);
 
-			if (Rotations > 1 || Mirror != Symmetry.Mirror.None)
+			if (Rotations > 1 || WMirror.HasMirror)
 			{
 				// Reserve the center of the map - otherwise it will mess with symmetries
 				CellLayerUtils.OverCircle(
@@ -394,7 +394,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Symmetry.RotateAndMirrorOverCPos(
 				projectionSpacing,
 				Rotations,
-				Mirror,
+				WMirror,
 				(projections, cpos) =>
 					projectionSpacing[cpos] = Symmetry.ProjectionProximity(projections) / 2);
 			return projectionSpacing;
@@ -426,7 +426,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Symmetry.RotateAndMirrorOverCPos(
 				incompatibilities,
 				Rotations,
-				Mirror,
+				WMirror,
 				(sources, destination) =>
 				{
 					if (!dominant[destination])
@@ -528,7 +528,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				Symmetry.RotateAndMirrorOverCPos(
 					regionMask,
 					Rotations,
-					Mirror,
+					WMirror,
 					TestSymmetry);
 
 				for (var id = 0; id < symmetryScore.Length; id++)
@@ -709,7 +709,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		{
 			CheckHasMapShapeOrNull(zoneable);
 			var projections = Symmetry.RotateAndMirrorActorPlan(
-				actorPlan, Rotations, Mirror);
+				actorPlan, Rotations, WMirror);
 			ActorPlans.AddRange(projections);
 			if (zoneable != null)
 				foreach (var projection in projections)
@@ -981,7 +981,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				noise,
 				Rotations,
-				Mirror,
+				WMirror,
 				noiseFeatureSize,
 				wavelength => NoiseUtils.ClumpinessAmplitude(wavelength, clumpiness));
 
@@ -1004,7 +1004,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				CellLayerUtils.CellBounds(Map).Size.ToInt2(),
 				Rotations,
-				Mirror,
+				WMirror.ForCPos(),
 				noiseFeatureSize,
 				NoiseUtils.PinkAmplitude);
 			MatrixUtils.NormalizeRangeInPlace(elevation, 1024);
@@ -1033,7 +1033,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				pattern,
 				Rotations,
-				Mirror,
+				WMirror,
 				noiseFeatureSize,
 				wavelength => NoiseUtils.ClumpinessAmplitude(wavelength, clumpiness));
 			{
@@ -1747,7 +1747,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 						chosenMPos.ToCPos(Map),
 						space,
 						Rotations,
-						Mirror);
+						WMirror);
 					foreach (var projection in projections)
 					{
 						if (space.Contains(projection))
@@ -1794,7 +1794,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			// For awkward symmetries, we try harder to make sure roads are fairer.
 			// This can degrade the quantity of roads, though.
 			var imperfectSymmetry =
-				Mirror != Symmetry.Mirror.None ||
+				WMirror.HasMirror ||
 				Rotations == 3 ||
 				Rotations >= 5;
 			var gridType = Map.Grid.Type;
@@ -1873,7 +1873,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 						{
 							var cposPath = CellLayerUtils.FromMatrixPoints([path], space)[0];
 							var projectedPoints = cposPath
-								.SelectMany(p => Symmetry.RotateAndMirrorCPos(p, space, Rotations, Mirror))
+								.SelectMany(p => Symmetry.RotateAndMirrorCPos(p, space, Rotations, WMirror))
 								.ToArray();
 							var matrixPoints = CellLayerUtils.ToMatrixPoints([projectedPoints], space)[0];
 							if (!matrixPoints.All(p => !nearPath.ContainsXY(p) || nearPath[p]))
@@ -2123,7 +2123,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 				var chosenMPos = PriorityMPos(n);
 				var chosenCPos = chosenMPos.ToCPos(gridType);
-				foreach (var cpos in Symmetry.RotateAndMirrorCPos(chosenCPos, plan, Rotations, Mirror))
+				foreach (var cpos in Symmetry.RotateAndMirrorCPos(chosenCPos, plan, Rotations, WMirror))
 					if (Map.Resources.Contains(cpos))
 						remaining -= AddResource(cpos);
 			}
@@ -2169,7 +2169,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				decorationNoise,
 				Rotations,
-				Mirror,
+				WMirror,
 				featureSize,
 				NoiseUtils.WhiteAmplitude);
 
@@ -2178,7 +2178,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				random,
 				densityNoise,
 				Rotations,
-				Mirror,
+				WMirror,
 				1024,
 				NoiseUtils.PinkAmplitude);
 			var densityMask = CellLayerUtils.CalibratedBooleanThreshold(


### PR DESCRIPTION
The Symmetry.Mirror enum was previously documented as defined in terms of the WPos system, which happens to align with CPos for Rectangular grid types. However, the existing code gets confused when attempting to support RectangularIsometric, due to a lack of appropriate conversion logic.

This change makes Mirror agnostic to specific coordinate systems and introduces a WMirror wrapper that provides getters for the correct Mirror configuration given the coordinate system being used.
