### PR TITLE
Fix various map generator bounds and size related issues

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -747,7 +747,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var replace = PlayableToReplaceable();
 					foreach (var mpos in map.AllCells.MapCoords)
-						if (playable[mpos] || !map.Contains(mpos))
+						if (playable[mpos] || !map.Bounds.Contains(mpos.U, mpos.V))
 							replace[mpos] = MultiBrush.Replaceability.None;
 
 					terraformer.PaintArea(debrisTilingRandom, replace, param.UnplayableObstacles);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -261,8 +261,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var map = world.Map;
 			var terrainInfo = modData.DefaultTerrainInfo[map.Tileset];
-			var size = new Size(map.Bounds.Width + 2, map.Bounds.Height + 2);
-			var args = settings.Compile(terrainInfo, size);
+			var args = settings.Compile(terrainInfo, map.MapSize);
 
 			// Run main generator logic. May throw.
 			var generateStopwatch = Stopwatch.StartNew();
@@ -301,12 +300,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				previews.Add(kv.Key, preview);
 			}
 
-			var offset = map.CellContaining(map.ProjectedTopLeft) - generatedMap.CellContaining(generatedMap.ProjectedTopLeft);
-			var blitSource = new EditorBlitSource(generatedMap.AllCells, previews, tiles);
+			var cellBounds = CellLayerUtils.CellBounds(map);
+			var topLeft = new CPos(cellBounds.TopLeft.X, cellBounds.TopLeft.Y);
+			var bottomRight = new CPos(cellBounds.BottomRight.X, cellBounds.BottomRight.Y);
+			var cellRegion = new CellRegion(map.Grid.Type, topLeft, bottomRight);
+			var blitSource = new EditorBlitSource(cellRegion, previews, tiles);
 			var editorBlit = new EditorBlit(
 				MapBlitFilters.All,
 				resourceLayer,
-				new CPos(offset.X, offset.Y),
+				topLeft,
 				map,
 				blitSource,
 				editorActorLayer,

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -234,9 +234,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void RandomizeSize()
 		{
+			var mapGrid = modData.Manifest.Get<MapGrid>();
 			var sizeRange = MapSizes[selectedSize];
 			var width = Game.CosmeticRandom.Next(sizeRange.X, sizeRange.Y);
-			size = new Size(width + 2, width + 2);
+			var height =
+				mapGrid.Type == MapGridType.RectangularIsometric
+					? width * 2
+					: width;
+
+			size = new Size(width + 2, height + mapGrid.MaximumTerrainHeight * 2 + 2);
 		}
 
 		void RefreshSettings()


### PR DESCRIPTION
Fixes various issues mostly of importance to the upcoming TS map generator.

- If generating a RectangularIsometric map via lobby, make the height twice the width so that the map is approximately world-square.
- Use equal top and bottom cordons for RectangularIsometric maps.
- Change some map bounds checking.
- Check that actors are at least partially inside map.Contains before placing. (To avoid frozen actor crashes.)
- Fix editor generated map blitting for RectangularIsometric.
