### PR TITLE
Enable AI to use chronoshift and ironcurtain

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				var targetCell = target.Location + targetDelta;
 
-				if (self.Owner.Shroud.IsExplored(targetCell) && cs.CanChronoshiftTo(target, targetCell))
+				if ((self.Owner.Shroud.IsExplored(targetCell) || self.Owner.IsBot) && cs.CanChronoshiftTo(target, targetCell))
 					cs.Teleport(target, targetCell, info.Duration, info.KillCargo, self);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -9,13 +9,19 @@
  */
 #endregion
 
+using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public enum BotSupportPowerTriggerMode { Periodically, OnAttacked }
+
+	public enum BotSupportPowerTargetLocationMode { CheckCenter, ActorLocation, ActorCenter, CellCanBeEnteredByTargetedActor }
+
 	[Desc("Adds metadata for the AI bots.")]
 	public class SupportPowerDecision
 	{
@@ -24,11 +30,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("What support power does this decision apply to?")]
 		public readonly string OrderName = "AirstrikePowerInfoOrder";
-
 		[Desc(
 			"What is the coarse scan radius of this power?",
-			"For finding the general target area, before doing a detail scan",
-			"Should be 10 or more to avoid lag")]
+			$"For finding the general target area, before doing a detail scan when {nameof(DecisionMode)} is Periodically",
+			$"For picking the area around attacked actor, before doing a detail scan when {nameof(DecisionMode)} is OnAttacked",
+			$"Should be 10 or more to avoid lag, when {nameof(DecisionMode)} is Periodically")]
 		public readonly int CoarseScanRadius = 20;
 
 		[Desc(
@@ -39,13 +45,32 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.LoadUsing(nameof(LoadConsiderations))]
 		[Desc("The decisions associated with this power")]
-		public readonly ImmutableArray<Consideration> Considerations = [];
+		public readonly FrozenDictionary<string, SupportPowerStrategy> Considerations = FrozenDictionary<string, SupportPowerStrategy>.Empty;
 
 		[Desc("Minimum ticks to wait until next Decision scan attempt.")]
 		public readonly int MinimumScanTimeInterval = 250;
 
 		[Desc("Maximum ticks to wait until next Decision scan attempt.")]
 		public readonly int MaximumScanTimeInterval = 262;
+
+		[Desc("Extra data that put into support power order.")]
+		public readonly uint ExtraData = uint.MaxValue;
+
+		[Desc("The way of triggering the order.")]
+		public readonly BotSupportPowerTriggerMode DecisionMode = BotSupportPowerTriggerMode.Periodically;
+
+		[Desc("What kind of the location should the bot find as target?")]
+		public readonly BotSupportPowerTargetLocationMode TargetLocationMode = BotSupportPowerTargetLocationMode.CheckCenter;
+
+		[Desc("What kind of the location should the bot find as extra location?", "Extra location is used for support power act like Chronoshift.")]
+		public readonly BotSupportPowerTargetLocationMode ExtraLocationMode = BotSupportPowerTargetLocationMode.CheckCenter;
+
+		[Desc("When set to true, the bot will find target location earlier than extra location, and vice versa",
+			"when earlier check is ActorLocation or ActorCenter and later check is CellCanBeEnteredByTargetedActor, the targetted actor will be passed from early check to later check.")]
+		public readonly bool CheckTargetLocationFirst = true;
+
+		[Desc("Visibility check")]
+		public readonly bool VisibilityCheck = true;
 
 		public SupportPowerDecision(MiniYaml yaml)
 		{
@@ -54,86 +79,198 @@ namespace OpenRA.Mods.Common.Traits
 
 		static object LoadConsiderations(MiniYaml yaml)
 		{
-			var ret = new List<Consideration>();
+			var ret = new Dictionary<string, SupportPowerStrategy>();
 			foreach (var d in yaml.Nodes)
+			{
 				if (d.Key.Split('@')[0] == "Consideration")
-					ret.Add(new Consideration(d.Value));
+				{
+					var consideration = new Consideration(d.Value);
+					if (!ret.ContainsKey(consideration.StrategyName))
+						ret.Add(consideration.StrategyName, new SupportPowerStrategy());
 
-			return ret.ToImmutableArray();
+					var strategy = ret[consideration.StrategyName];
+					if (consideration.AsExtraLocation)
+						strategy.ExtraPositionConsiderations.Add(consideration);
+					else
+						strategy.TargetPositionConsiderations.Add(consideration);
+				}
+			}
+
+			return ret.ToFrozenDictionary();
+		}
+
+		/// <summary>Get a random strategy consists of a set considerations.</summary>
+		public string GetRandomStrategy(int randomNumber)
+		{
+			randomNumber = Math.Abs(randomNumber);
+			var names = Considerations.Keys.ToList();
+			if (names.Count == 0)
+				return null;
+			return names[randomNumber % names.Count];
+		}
+
+		public bool NeedsConsiderTargetPosition(string strategyName)
+		{
+			return strategyName != null && Considerations.TryGetValue(strategyName, out var strategy) && strategy.TargetPositionConsiderations.Count > 0;
+		}
+
+		public bool NeedsConsiderExtraLocation(string strategyName)
+		{
+			return strategyName != null && Considerations.TryGetValue(strategyName, out var strategy) && strategy.ExtraPositionConsiderations.Count > 0;
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>
-		public int GetAttractiveness(WPos pos, Player firedBy)
+		public (int Attractiveness, Actor TargetActor, FrozenActor FrozenActor) GetAttractiveness(
+			WPos pos,
+			Player firedBy,
+			string considerationName,
+			bool asExtraPos = false)
 		{
 			var answer = 0;
 			var world = firedBy.World;
 			var targetTile = world.Map.CellContaining(pos);
 
-			if (!world.Map.Contains(targetTile))
-				return 0;
+			if (!Considerations.TryGetValue(considerationName, out var strategy) && !world.Map.Contains(targetTile))
+				return (0, null, null);
 
-			foreach (var consideration in Considerations)
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+			var goodActors = new List<Actor>();
+			var goodFrozenActors = new List<FrozenActor>();
+			foreach (var consideration in considerations)
 			{
 				var radiusToUse = new WDist(consideration.CheckRadius.Length);
 
 				var checkActors = world.FindActorsInCircle(pos, radiusToUse);
 				foreach (var scrutinized in checkActors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner), firedBy);
+				{
+					var attractiveness = consideration.GetAttractiveness(scrutinized, firedBy, VisibilityCheck);
+
+					if (attractiveness > 0)
+						goodActors.Add(scrutinized);
+
+					answer += attractiveness;
+				}
+
+				if (!VisibilityCheck)
+					continue;
 
 				var delta = new WVec(radiusToUse, radiusToUse, WDist.Zero);
 				var tl = world.Map.CellContaining(pos - delta);
 				var br = world.Map.CellContaining(pos + delta);
-				var checkFrozen = firedBy.FrozenActorLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
 
-				// IsValid check filters out Frozen Actors that have not initialized their Owner
+				var checkFrozen = firedBy.FrozenActorLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
 				foreach (var scrutinized in checkFrozen)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner));
+				{
+					// IsValid check filters out Frozen Actors that have not initialized their Owner
+					var attractiveness = consideration.GetAttractiveness(scrutinized, firedBy);
+
+					if (attractiveness > 0)
+						goodFrozenActors.Add(scrutinized);
+
+					answer += attractiveness;
+				}
 			}
+
+			return (answer, goodActors.RandomOrDefault(world.LocalRandom), goodFrozenActors.RandomOrDefault(world.LocalRandom));
+		}
+
+		/// <summary>Evaluates the attractiveness of an actor according to all considerations.</summary>
+		public int GetAttractiveness(Actor actor, Player firedBy, string strategyName, bool asExtraPos = false)
+		{
+			var answer = 0;
+
+			if (!Considerations.TryGetValue(strategyName, out var strategy))
+				return 0;
+
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+
+			foreach (var consideration in considerations)
+				answer += consideration.GetAttractiveness(actor, firedBy, VisibilityCheck);
 
 			return answer;
 		}
 
 		/// <summary>Evaluates the attractiveness of a group of actors according to all considerations.</summary>
-		public int GetAttractiveness(IEnumerable<Actor> actors, Player firedBy)
+		public int GetAttractiveness(IEnumerable<Actor> actors, Player firedBy, string considerationName, bool asExtraPos = false)
 		{
 			var answer = 0;
 
-			foreach (var consideration in Considerations)
+			if (!Considerations.TryGetValue(considerationName, out var strategy))
+				return 0;
+
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+
+			foreach (var consideration in considerations)
 				foreach (var scrutinized in actors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner), firedBy);
+					answer += consideration.GetAttractiveness(scrutinized, firedBy, VisibilityCheck);
 
 			return answer;
 		}
 
-		public int GetAttractiveness(IEnumerable<FrozenActor> frozenActors, Player firedBy)
+		public int GetAttractiveness(IEnumerable<FrozenActor> frozenActors, Player firedBy, string considerationName, bool asExtraPos = false)
 		{
+			if (!VisibilityCheck)
+				return 0;
+
+			if (!Considerations.TryGetValue(considerationName, out var strategy))
+				return 0;
+
 			var answer = 0;
 
-			foreach (var consideration in Considerations)
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+			foreach (var consideration in considerations)
 				foreach (var scrutinized in frozenActors)
 					if (scrutinized.IsValid && scrutinized.Visible)
-						answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner));
+						answer += consideration.GetAttractiveness(scrutinized, firedBy);
 
 			return answer;
 		}
 
-		public int GetNextScanTime(World world) { return world.LocalRandom.Next(MinimumScanTimeInterval, MaximumScanTimeInterval); }
+		public int GetNextScanTime(World world, int minScanTime)
+		{
+			return Math.Max(world.LocalRandom.Next(MinimumScanTimeInterval, MaximumScanTimeInterval), minScanTime);
+		}
+
+		public class SupportPowerStrategy
+		{
+			public string Name;
+			public List<Consideration> TargetPositionConsiderations = [];
+			public List<Consideration> ExtraPositionConsiderations = [];
+		}
 
 		/// <summary>Makes up part of a decision, describing how to evaluate a target.</summary>
 		public class Consideration
 		{
-			public enum DecisionMetric { Health, Value, None }
+			public enum DecisionMetric { Health, HealthLoss, Value, None }
 
-			[Desc("Against whom should this power be used?", "Allowed keywords: Ally, Neutral, Enemy")]
+			[Desc("The strategy name of the consideration", "Considerations of the same strategy will be considered together in one check run.")]
+			public readonly string StrategyName = "primary";
+
+			[Desc("This consideration is used as extra location in order", "Used for support power needs extra location.")]
+			public readonly bool AsExtraLocation = false;
+
+			[Desc("Against whom should this power be used?", "Allowed keywords: Ally, Neutral, Enemy.")]
 			public readonly PlayerRelationship Against = PlayerRelationship.Enemy;
 
-			[Desc("What types should the desired targets of this power be?")]
-			public readonly BitSet<TargetableType> Types = new("Air", "Ground", "Water");
+			[Desc("Only target actors belongs to this bot.")]
+			public readonly bool AgainstOwnActors = false;
+
+			[Desc("What target types should the desired targets of this power be?")]
+			public readonly BitSet<TargetableType> ValidTargetTypes = [];
+
+			[Desc("What target types should the undesired targets of this power be?")]
+			public readonly BitSet<TargetableType> InvalidTargetTypes = [];
+
+			[Desc("What types of actor should the desired targets of this power be?")]
+			public readonly FrozenSet<string> ValidActorTypes = FrozenSet<string>.Empty;
+
+			[Desc("What types of actor should the undesired targets of this power be?")]
+			public readonly FrozenSet<string> InvalidActorTypes = FrozenSet<string>.Empty;
 
 			[Desc("How attractive are these types of targets?")]
 			public readonly int Attractiveness = 100;
 
-			[Desc("Weight the target attractiveness by this property", "Allowed keywords: Health, Value, None")]
+			[Desc("Weight the target attractiveness by this property", "Allowed keywords: Health, HealthLoss, Value, None")]
 			public readonly DecisionMetric TargetMetric = DecisionMetric.None;
 
 			[Desc("What is the check radius of this decision?")]
@@ -145,18 +282,25 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			/// <summary>Evaluates a single actor according to the rules defined in this consideration.</summary>
-			public int GetAttractiveness(Actor a, PlayerRelationship stance, Player firedBy)
+			public int GetAttractiveness(Actor a, Player firedBy, bool visibilityCheck = true)
 			{
-				if (stance != Against)
+				if (a == null || a.IsDead)
 					return 0;
 
-				if (a == null)
+				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(a.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(a.Info.Name)))
 					return 0;
 
-				if (!a.IsTargetableBy(firedBy.PlayerActor) || !a.CanBeViewedByPlayer(firedBy))
+				if ((AgainstOwnActors && a.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(a.Owner))))
 					return 0;
 
-				if (Types.Overlaps(a.GetEnabledTargetTypes()))
+				if (visibilityCheck && !a.CanBeViewedByPlayer(firedBy))
+					return 0;
+
+				if ((!a.IsTargetableBy(firedBy.PlayerActor)) && ((!ValidTargetTypes.IsEmpty) || !InvalidTargetTypes.IsEmpty))
+					return 0;
+
+				if ((ValidTargetTypes.IsEmpty || ValidTargetTypes.Overlaps(a.GetEnabledTargetTypes())) &&
+					(InvalidTargetTypes.IsEmpty || !InvalidTargetTypes.Overlaps(a.GetEnabledTargetTypes())))
 				{
 					switch (TargetMetric)
 					{
@@ -165,13 +309,17 @@ namespace OpenRA.Mods.Common.Traits
 							return (valueInfo != null) ? valueInfo.Cost * Attractiveness : 0;
 
 						case DecisionMetric.Health:
+						case DecisionMetric.HealthLoss:
+
 							var health = a.TraitOrDefault<IHealth>();
 
 							if (health == null)
 								return 0;
 
+							var healthneed = TargetMetric == DecisionMetric.Health ? health.HP : (health.MaxHP - health.HP);
+
 							// Cast to long to avoid overflow when multiplying by the health
-							return (int)((long)health.HP * Attractiveness / health.MaxHP);
+							return (int)((long)healthneed * Attractiveness / health.MaxHP);
 
 						default:
 							return Attractiveness;
@@ -181,15 +329,18 @@ namespace OpenRA.Mods.Common.Traits
 				return 0;
 			}
 
-			public int GetAttractiveness(FrozenActor fa, PlayerRelationship stance)
+			public int GetAttractiveness(FrozenActor fa, Player firedBy)
 			{
-				if (stance != Against)
+				if ((AgainstOwnActors && fa.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(fa.Owner))))
 					return 0;
 
 				if (fa == null || !fa.IsValid || !fa.Visible)
 					return 0;
 
-				if (Types.Overlaps(fa.TargetTypes))
+				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(fa.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(fa.Info.Name)))
+					return 0;
+
+				if ((ValidTargetTypes.IsEmpty || ValidTargetTypes.Overlaps(fa.TargetTypes)) && (InvalidTargetTypes.IsEmpty || !InvalidTargetTypes.Overlaps(fa.TargetTypes)))
 				{
 					switch (TargetMetric)
 					{

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Makes up part of a decision, describing how to evaluate a target.</summary>
 		public class Consideration
 		{
-			public enum DecisionMetric { Health, HealthLoss, Value, None }
+			public enum DecisionMetric { Health, HealthLoss, Value, Undetected, None }
 
 			[Desc("The strategy name of the consideration", "Considerations of the same strategy will be considered together in one check run.")]
 			public readonly string StrategyName = "primary";
@@ -284,7 +284,7 @@ namespace OpenRA.Mods.Common.Traits
 			/// <summary>Evaluates a single actor according to the rules defined in this consideration.</summary>
 			public int GetAttractiveness(Actor a, Player firedBy, bool visibilityCheck = true)
 			{
-				if (a == null || a.IsDead)
+				if (a == null || a.IsDead || !a.IsInWorld)
 					return 0;
 
 				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(a.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(a.Info.Name)))
@@ -293,7 +293,8 @@ namespace OpenRA.Mods.Common.Traits
 				if ((AgainstOwnActors && a.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(a.Owner))))
 					return 0;
 
-				if (visibilityCheck && !a.CanBeViewedByPlayer(firedBy))
+				var canbeview = a.CanBeViewedByPlayer(firedBy);
+				if (TargetMetric != DecisionMetric.Undetected && visibilityCheck && !canbeview)
 					return 0;
 
 				if ((!a.IsTargetableBy(firedBy.PlayerActor)) && ((!ValidTargetTypes.IsEmpty) || !InvalidTargetTypes.IsEmpty))
@@ -321,6 +322,17 @@ namespace OpenRA.Mods.Common.Traits
 							// Cast to long to avoid overflow when multiplying by the health
 							return (int)((long)healthneed * Attractiveness / health.MaxHP);
 
+						case DecisionMetric.Undetected:
+							if (canbeview)
+								return 0;
+
+							// we consider visible frozen actor can be regard as detected actor for this bot module.
+							var frozen = a.TraitOrDefault<FrozenUnderFog>();
+							if (frozen != null && frozen.IsVisible(a, firedBy))
+								return 0;
+
+							return Attractiveness;
+
 						default:
 							return Attractiveness;
 					}
@@ -334,7 +346,7 @@ namespace OpenRA.Mods.Common.Traits
 				if ((AgainstOwnActors && fa.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(fa.Owner))))
 					return 0;
 
-				if (fa == null || !fa.IsValid || !fa.Visible)
+				if (fa == null || !fa.IsValid || !fa.Visible || TargetMetric == DecisionMetric.Undetected)
 					return 0;
 
 				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(fa.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(fa.Info.Name)))

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.LoadUsing(nameof(LoadDecisions))]
 		public readonly ImmutableArray<SupportPowerDecision> Decisions = [];
 
+		[Desc("The interval of checking support powers when attacked.")]
+		public int RespondToAttackCoolDown = 31;
+
 		static object LoadDecisions(MiniYaml yaml)
 		{
 			var ret = new List<SupportPowerDecision>();
@@ -38,14 +41,16 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new SupportPowerBotModule(init.Self, this); }
 	}
 
-	public class SupportPowerBotModule : ConditionalTrait<SupportPowerBotModuleInfo>, IBotTick, IGameSaveTraitData
+	public class SupportPowerBotModule : ConditionalTrait<SupportPowerBotModuleInfo>, IBotTick, IBotRespondToAttack, IGameSaveTraitData
 	{
 		readonly World world;
 		readonly Player player;
 		readonly Dictionary<SupportPowerInstance, int> waitingPowers = [];
 		readonly Dictionary<string, SupportPowerDecision> powerDecisions = [];
+		readonly Dictionary<string, SupportPowerDecision> powerDecisionsWhenAttacked = [];
 		readonly List<SupportPowerInstance> stalePowers = [];
 		SupportPowerManager supportPowerManager;
+		int attackedcooldown;
 
 		public SupportPowerBotModule(Actor self, SupportPowerBotModuleInfo info)
 			: base(info)
@@ -62,11 +67,30 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			foreach (var decision in Info.Decisions)
-				powerDecisions.Add(decision.OrderName, decision);
+			{
+				switch (decision.DecisionMode)
+				{
+					case BotSupportPowerTriggerMode.OnAttacked:
+						powerDecisionsWhenAttacked.Add(decision.OrderName, decision);
+						break;
+
+					case BotSupportPowerTriggerMode.Periodically:
+						powerDecisions.Add(decision.OrderName, decision);
+						break;
+
+					default:
+						break;
+				}
+			}
 		}
 
 		void IBotTick.BotTick(IBot bot)
 		{
+			attackedcooldown--;
+
+			// We only check one support power per tick, as the support power check here is expensive,
+			// which will go through all map cells in coarse and fine scans.
+			var supportPowerNotChecked = true;
 			foreach (var sp in supportPowerManager.Powers.Values)
 			{
 				if (sp.Disabled)
@@ -74,47 +98,138 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Add power to dictionary if not in delay dictionary yet
 				waitingPowers.TryAdd(sp, 0);
-
 				if (waitingPowers[sp] > 0)
 					waitingPowers[sp]--;
 
 				// If we have recently tried and failed to find a use location for a power, then do not try again until later
-				var isDelayed = waitingPowers[sp] > 0;
-				if (sp.Ready && !isDelayed && powerDecisions.TryGetValue(sp.Info.OrderName, out var powerDecision))
+				if (supportPowerNotChecked && sp.Ready && waitingPowers[sp] <= 0 && powerDecisions.TryGetValue(sp.Info.OrderName, out var powerDecision))
 				{
-					if (powerDecision == null)
+					var strategyName = powerDecision.GetRandomStrategy(world.LocalRandom.Next());
+
+					WPos? targetPosition = null;
+					WPos? extraPosition = null;
+					Actor actorNeedsPosition = null;
+					supportPowerNotChecked = false;
+					waitingPowers[sp] += powerDecision.GetNextScanTime(world, Info.Decisions.Length);
+
+					if (powerDecision.CheckTargetLocationFirst)
 					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {sp.Info.OrderName}");
-						continue;
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							var targetLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, false);
+							if (targetLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(targetPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, targetLocation.Value, strategyName, false);
+							if (targetPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
+
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							if (actorNeedsPosition == null && powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+							{
+								AIUtils.BotDebug(
+									$"{player.ResolvedPlayerName} can't find suitable target location actor for extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							var extraLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, true);
+							if (extraLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(extraPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, extraLocation.Value, strategyName, true, actorNeedsPosition);
+							if (extraPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 					}
-
-					var attackLocation = FindCoarseAttackLocationToSupportPower(sp);
-					if (attackLocation == null)
+					else
 					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse attack location for support power {sp.Info.OrderName}. Delaying rescan.");
-						waitingPowers[sp] += powerDecision.GetNextScanTime(world);
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							var extraLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, true);
+							if (extraLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
 
-						continue;
-					}
+							// Found a target location, check for precise target
+							(extraPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, extraLocation.Value, strategyName, true);
+							if (extraPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 
-					// Found a target location, check for precise target
-					attackLocation = FindFineAttackLocationToSupportPower(sp, (CPos)attackLocation);
-					if (attackLocation == null)
-					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final attack location for support power {sp.Info.OrderName}. Delaying rescan.");
-						waitingPowers[sp] += powerDecision.GetNextScanTime(world);
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							if (actorNeedsPosition == null && powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+							{
+								AIUtils.BotDebug(
+									$"{player.ResolvedPlayerName} can't find suitable extra location actor for target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
 
-						continue;
+							var targetLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, false);
+							if (targetLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(targetPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, targetLocation.Value, strategyName, false, actorNeedsPosition);
+							if (targetPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 					}
 
 					// Valid target found, delay by a few ticks to avoid rescanning before power fires via order
-					AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target location {attackLocation} for support power {sp.Info.OrderName}.");
-					waitingPowers[sp] += 10;
+					AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target position {(targetPosition != null ? targetPosition.Value.ToString() : "null")}" +
+						$"and extra location {(extraPosition != null ? extraPosition.Value.ToString() : "null")} for support power {sp.Info.OrderName}.");
+
+					var order = new Order(sp.Key, supportPowerManager.Self, false);
+
+					if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+					{
+						if (targetPosition != null)
+							order = new Order(sp.Key, supportPowerManager.Self, Target.FromPos(targetPosition.Value), false);
+						else
+							continue;
+					}
+
+					order.SuppressVisualFeedback = true;
+					order.ExtraData = powerDecision.ExtraData;
+
+					if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+					{
+						if (extraPosition != null)
+							order.ExtraLocation = world.Map.CellContaining(extraPosition.Value);
+						else
+							continue;
+					}
 
 					// Note: SelectDirectionalTarget uses uint.MaxValue in ExtraData to indicate that the player did not pick a direction.
-					bot.QueueOrder(
-						new Order(sp.Key, supportPowerManager.Self, Target.FromCell(world, attackLocation.Value), false)
-						{ SuppressVisualFeedback = true, ExtraData = uint.MaxValue });
+					bot.QueueOrder(order);
 				}
 			}
 
@@ -126,15 +241,130 @@ namespace OpenRA.Mods.Common.Traits
 			stalePowers.Clear();
 		}
 
-		/// <summary>Scans the map in chunks, evaluating all actors in each.</summary>
-		CPos? FindCoarseAttackLocationToSupportPower(SupportPowerInstance readyPower)
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
-			var powerDecision = powerDecisions[readyPower.Info.OrderName];
-			if (powerDecision == null)
+			// Only consider enmey attack
+			if (attackedcooldown < 0 && self != null && !self.IsDead && self.IsInWorld && e.Attacker.AppearsHostileTo(self))
 			{
-				AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {readyPower.Info.OrderName}");
-				return null;
+				attackedcooldown = Info.RespondToAttackCoolDown;
+				foreach (var sp in supportPowerManager.Powers.Values)
+				{
+					// Note: We only check one support power per tick, as the support power check here may be expensive
+					if (!sp.Disabled && sp.Ready && waitingPowers[sp] <= 0 && powerDecisionsWhenAttacked.TryGetValue(sp.Info.OrderName, out var powerDecision))
+					{
+						// Add power to dictionary if not in delay dictionary yet
+						waitingPowers.TryAdd(sp, 0);
+
+						var strategyName = powerDecision.GetRandomStrategy(world.LocalRandom.Next());
+
+						if (strategyName != null && powerDecision.GetAttractiveness(self, player, strategyName) <= 0)
+							continue;
+
+						waitingPowers[sp] += powerDecision.GetNextScanTime(world, Info.Decisions.Length);
+
+						WPos? targetPosition = null;
+						WPos? extraPosition = null;
+						Actor actorNeedsPosition = null;
+
+						// Found a target location, check for precise target
+						if (powerDecision.CheckTargetLocationFirst)
+						{
+							if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+							{
+								(targetPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, false);
+								if (targetPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+
+							if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+							{
+								if (actorNeedsPosition == null && powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+								{
+									AIUtils.BotDebug(
+										$"{player.ResolvedPlayerName} can't find suitable target location actor for extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+
+								(extraPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, true, actorNeedsPosition);
+								if (extraPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+						}
+						else
+						{
+							if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+							{
+								(extraPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, true);
+								if (extraPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+
+							if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+							{
+								if (actorNeedsPosition == null && powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+								{
+									AIUtils.BotDebug(
+										$"{player.ResolvedPlayerName} can't find suitable extra location actor for target location for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+
+								(targetPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, false, actorNeedsPosition);
+								if (targetPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+						}
+
+						// Valid target found, delay by a few ticks to avoid rescanning before power fires via order
+						AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target position {(targetPosition != null ? targetPosition.Value.ToString() : "null")}" +
+							$"and extra location {(extraPosition != null ? extraPosition.Value.ToString() : "null")} for support power {sp.Info.OrderName}.");
+
+						var order = new Order(sp.Key, supportPowerManager.Self, false);
+
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							if (targetPosition != null)
+								order = new Order(sp.Key, supportPowerManager.Self, Target.FromPos(targetPosition.Value), false);
+							else
+								continue;
+						}
+
+						order.SuppressVisualFeedback = true;
+						order.ExtraData = powerDecision.ExtraData;
+
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							if (extraPosition != null)
+								order.ExtraLocation = world.Map.CellContaining(extraPosition.Value);
+							else
+								continue;
+						}
+
+						// Note: SelectDirectionalTarget uses uint.MaxValue in ExtraData to indicate that the player did not pick a direction.
+						bot.QueueOrder(order);
+						break;
+					}
+				}
 			}
+		}
+
+		/// <summary>Scans the map in chunks, evaluating all actors in each.</summary>
+		CPos? FindCoarseAttackLocationToSupportPower(SupportPowerDecision powerDecision, string strategyName, bool asExtraPos)
+		{
+			if ((asExtraPos && powerDecision.Considerations[strategyName].ExtraPositionConsiderations.Count == 0)
+				|| (!asExtraPos && powerDecision.Considerations[strategyName].TargetPositionConsiderations.Count == 0))
+				return null;
 
 			var map = world.Map;
 			var checkRadius = powerDecision.CoarseScanRadius;
@@ -155,7 +385,8 @@ namespace OpenRA.Mods.Common.Traits
 					var targets = world.ActorMap.ActorsInBox(wtl, wbr);
 
 					var frozenTargets = player.FrozenActorLayer != null ? player.FrozenActorLayer.FrozenActorsInRegion(region) : [];
-					var consideredAttractiveness = powerDecision.GetAttractiveness(targets, player) + powerDecision.GetAttractiveness(frozenTargets, player);
+					var consideredAttractiveness = powerDecision.GetAttractiveness(targets, player, strategyName, asExtraPos)
+						+ powerDecision.GetAttractiveness(frozenTargets, player, strategyName, asExtraPos);
 					if (consideredAttractiveness < powerDecision.MinimumAttractiveness)
 						continue;
 
@@ -175,17 +406,22 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		/// <summary>Detail scans an area, evaluating positions.</summary>
-		CPos? FindFineAttackLocationToSupportPower(SupportPowerInstance readyPower, CPos checkPos, int extendedRange = 1)
+		(WPos? BestPos, Actor BestActor) FindFineAttackPositionToSupportPower(
+			SupportPowerDecision powerDecision,
+			CPos checkPos,
+			string strategyName,
+			bool asExtraPos,
+			Actor actorNeedsPlace = null,
+			int extendedRange = 1)
 		{
-			CPos? bestLocation = null;
-			var bestAttractiveness = 0;
-			var powerDecision = powerDecisions[readyPower.Info.OrderName];
-			if (powerDecision == null)
-			{
-				AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {readyPower.Info.OrderName}");
-				return null;
-			}
+			if ((asExtraPos && powerDecision.Considerations[strategyName].ExtraPositionConsiderations.Count == 0)
+				|| (!asExtraPos && powerDecision.Considerations[strategyName].TargetPositionConsiderations.Count == 0))
+				return (null, null);
 
+			WPos? bestPos = null;
+			Actor bestActor = null;
+
+			var bestAttractiveness = powerDecision.MinimumAttractiveness;
 			var checkRadius = powerDecision.CoarseScanRadius;
 			var fineCheck = powerDecision.FineScanRadius;
 			for (var i = 0 - extendedRange; i <= checkRadius + extendedRange; i += fineCheck)
@@ -197,17 +433,65 @@ namespace OpenRA.Mods.Common.Traits
 					var y = checkPos.Y + j;
 					var pos = world.Map.CenterOfCell(new CPos(x, y));
 					var consideredAttractiveness = 0;
-					consideredAttractiveness += powerDecision.GetAttractiveness(pos, player);
 
-					if (consideredAttractiveness <= bestAttractiveness || consideredAttractiveness < powerDecision.MinimumAttractiveness)
+					var (attractiveness, targetActor, frozenTarget) = powerDecision.GetAttractiveness(pos, player, strategyName, asExtraPos);
+
+					consideredAttractiveness += attractiveness;
+
+					if (consideredAttractiveness < bestAttractiveness)
 						continue;
 
 					bestAttractiveness = consideredAttractiveness;
-					bestLocation = new CPos(x, y);
+
+					if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.ActorLocation && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorLocation && !asExtraPos))
+					{
+						if (targetActor == null)
+						{
+							if (frozenTarget == null)
+								continue;
+
+							bestPos = frozenTarget.CenterPosition;
+						}
+						else
+						{
+							bestPos = world.Map.CenterOfCell(targetActor.Location);
+							bestActor = targetActor;
+						}
+					}
+					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && !asExtraPos))
+					{
+						if (targetActor == null)
+						{
+							if (frozenTarget == null)
+								continue;
+
+							bestPos = frozenTarget.CenterPosition;
+						}
+						else
+						{
+							bestPos = targetActor.CenterPosition;
+							bestActor = targetActor;
+						}
+					}
+					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && !asExtraPos))
+					{
+						var cell = world.Map.FindTilesInAnnulus(new CPos(x, y), 0, fineCheck).Shuffle(world.LocalRandom)
+							.FirstOrDefault(c => actorNeedsPlace?.TraitOrDefault<IPositionable>()?.CanEnterCell(c) ?? false);
+
+						if (cell == CPos.Zero)
+							continue;
+
+						bestPos = world.Map.CenterOfCell(cell);
+					}
+					else
+						bestPos = world.Map.CenterOfCell(new CPos(x, y));
 				}
 			}
 
-			return bestLocation;
+			return (bestPos, bestActor);
 		}
 
 		List<MiniYamlNode> IGameSaveTraitData.IssueTraitData(Actor self)

--- a/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Support;
@@ -33,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Excess orders remain queued for subsequent ticks.")]
 		public readonly int MinOrderQuotientPerTick = 5;
 
+		[Desc("Those orders will be issued immediately.", "Used for orders that is very sensitive to delays.")]
+		public readonly FrozenSet<string> HighPriorityOrders = FrozenSet<string>.Empty;
+
 		string IBotInfo.Type => Type;
 
 		string IBotInfo.Name => Name;
@@ -47,6 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly ModularBotInfo info;
 		readonly World world;
 		readonly Queue<Order> orders = [];
+		readonly List<Order> highPriorityOrders = [];
 
 		Player player;
 
@@ -80,7 +85,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBot.QueueOrder(Order order)
 		{
-			orders.Enqueue(order);
+			if (info.HighPriorityOrders.Contains(order.OrderString))
+				highPriorityOrders.Add(order);
+			else
+				orders.Enqueue(order);
 		}
 
 		void ITick.Tick(Actor self)
@@ -97,6 +105,10 @@ namespace OpenRA.Mods.Common.Traits
 							t.BotTick(this);
 				});
 			}
+
+			foreach (var order in highPriorityOrders)
+				world.IssueOrder(order);
+			highPriorityOrders.Clear();
 
 			var ordersToIssueThisTick = Math.Min((orders.Count + info.MinOrderQuotientPerTick - 1) / info.MinOrderQuotientPerTick, orders.Count);
 			for (var i = 0; i < ordersToIssueThisTick; i++)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RenameTypesUnderConsiderations.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RenameTypesUnderConsiderations.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	sealed class RenameTypesUnderConsiderations : UpdateRule
+	{
+		public override string Name => "Rename Types to ValidTargetTypes under Considerations.";
+
+		public override string Description => "Types -> ValidTargetTypes";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var spbm in actorNode.ChildrenMatching("SupportPowerBotModule"))
+			{
+				foreach (var decision in spbm.ChildrenMatching("Decisions"))
+				{
+					foreach (var sp in decision.Value.Nodes)
+					{
+						foreach (var consideration in sp.ChildrenMatching("Consideration"))
+						{
+							consideration.RenameChildrenMatching("Types", "ValidTargetTypes");
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new EditorMarkerTileLabels(),
 				new RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule(),
 				new RemoveAlwaysVisible(),
+				new RenameTypesUnderConsiderations(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new WithDamageOverlayPropertyRename(),

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -2,12 +2,15 @@ Player:
 	ModularBot@Cabal:
 		Name: bot-cabal.name
 		Type: cabal
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Watson:
 		Name: bot-watson.name
 		Type: watson
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@HAL9001:
 		Name: bot-hal9001.name
 		Type: hal9001
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@cabal:
 		Condition: enable-cabal-ai
 		Bots: cabal

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -23,21 +23,22 @@ Player:
 			Airstrike:
 				OrderName: AirstrikePowerInfoOrder
 				MinimumAttractiveness: 2000
+				TargetLocationMode: ActorCenter
 				Consideration@1:
 					Against: Enemy
-					Types: Vehicle, Infantry
+					ValidTargetTypes: Vehicle, Infantry
 					Attractiveness: 3
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@2:
 					Against: Ally
-					Types: Ground, Water
+					ValidTargetTypes: Ground, Water
 					Attractiveness: -20
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@3:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 2c0
@@ -47,19 +48,19 @@ Player:
 				FineScanRadius: 2
 				Consideration@1:
 					Against: Enemy
-					Types: Air, Tank, Vehicle, Infantry, Water
+					ValidTargetTypes: Air, Tank, Vehicle, Infantry, Water
 					Attractiveness: 2
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@2:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@3:
 					Against: Ally
-					Types: Ground, Water
+					ValidTargetTypes: Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 3c0
@@ -68,13 +69,13 @@ Player:
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground, Water
+					ValidTargetTypes: Air, Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -28,25 +28,25 @@ Player:
 				MinimumAttractiveness: 2500
 				Consideration@1:
 					Against: Enemy
-					Types: Vehicle, Tank, Infantry
+					ValidTargetTypes: Vehicle, Tank, Infantry
 					Attractiveness: 2
 					TargetMetric: Value
 					CheckRadius: 3c0
 				Consideration@2:
 					Against: Enemy
-					Types: Structure, Defense
+					ValidTargetTypes: Structure, Defense
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@3:
 					Against: Ally
-					Types: Ground
+					ValidTargetTypes: Ground
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 4c0
 				Consideration@4:
 					Against: Enemy
-					Types: Defense
+					ValidTargetTypes: Defense
 					Attractiveness: 6
 					TargetMetric: Value
 					CheckRadius: 4c0
@@ -55,26 +55,26 @@ Player:
 				MinimumAttractiveness: 3500
 				Consideration@1:
 					Against: Enemy
-					Types: Structure, Defense
+					ValidTargetTypes: Structure, Defense
 					Attractiveness: 10
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@3:
 					Against: Enemy
-					Types: Infantry, Vehicle, Tank, Defense
+					ValidTargetTypes: Infantry, Vehicle, Tank, Defense
 					Attractiveness: 5
 					TargetMetric: Value
 					CheckRadius: 4c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground
+					ValidTargetTypes: Air, Ground
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
 			Fremen:
 				OrderName: ProduceActorPower.Fremen
-				Consideration@1:
-					Against: Ally
+				MinimumAttractiveness: -1
+
 	HarvesterBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 		HarvesterTypes: harvester

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -2,12 +2,15 @@ Player:
 	ModularBot@Omnius:
 		Name: bot-omnius.name
 		Type: omnius
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Vidius:
 		Name: bot-vidius.name
 		Type: vidious
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Gladius:
 		Name: bot-gladius.name
 		Type: gladius
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@omnius:
 		Condition: enable-omnius-ai
 		Bots: omnius

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -307,14 +307,15 @@ Player:
 				VisibilityCheck: false
 				Consideration@1:
 					Against: Enemy
-					Attractiveness: 1
-					TargetMetric: None
+					Attractiveness: 1100
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					TargetMetric: Undetected
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Enemy
+					Attractiveness: 1
 					ValidTargetTypes: Structure
-					Attractiveness: 100
-					TargetMetric: None
+					TargetMetric: Value
 					CheckRadius: 5c0
 			paratroopers:
 				OrderName: SovietParatroopers

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -2,15 +2,19 @@ Player:
 	ModularBot@RushAI:
 		Name: bot-rush-ai.name
 		Type: rush
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@NormalAI:
 		Name: bot-normal-ai.name
 		Type: normal
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@TurtleAI:
 		Name: bot-turtle-ai.name
 		Type: turtle
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@NavalAI:
 		Name: bot-naval-ai.name
 		Type: naval
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	GrantConditionOnBotOwner@rush:
 		Condition: enable-rush-ai
 		Bots: rush

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -33,51 +33,350 @@ Player:
 	SupportPowerBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		Decisions:
+			ioncurtain:
+				OrderName: ironcurtain
+				DecisionMode: OnAttacked
+				TargetLocationMode: ActorCenter
+				VisibilityCheck: false
+				CoarseScanRadius: 8 ##triggered by OnAttacked
+				MinimumAttractiveness: 100
+				Consideration@1:
+					AgainstOwnActors: true
+					ValidTargetTypes: Structure, Vehicle
+					InvalidActorTypes: dtrk
+					Attractiveness: 150
+					TargetMetric: HealthLoss
+					CheckRadius: 1c512
+				Consideration@2:
+					Against: Ally
+					ValidTargetTypes: Infantry
+					Attractiveness: -20
+					TargetMetric: None
+					CheckRadius: 1c512
+				Consideration@4:
+					Against: Enemy
+					ValidTargetTypes: Structure, Vehicle
+					Attractiveness: -40
+					CheckRadius: 1c512
+			chronoshift:
+				OrderName: Chronoshift
+				CheckTargetLocationFirst: false
+				TargetLocationMode: CellCanBeEnteredByTargetedActor
+				ExtraLocationMode: ActorLocation
+				MinimumAttractiveness: 10000
+				VisibilityCheck: false
+				FineScanRadius: 4
+				## steal enemy harvester\mcv
+				Consideration@enemy-harvester-extraloc1:
+					StrategyName: harvester-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@enemy-harvester-target1:
+					StrategyName: harvester-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## steal enemy vehicles
+				Consideration@enemy-vehicles-extraloc1:
+					StrategyName: vehicles-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidTargetTypes: Vehicle
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@enemy-vehicles-target1:
+					StrategyName: vehicles-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 50
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## teleport vehicles to attack weak spot (harv)
+				Consideration@ally-harv-assualt-extraloc1:
+					StrategyName: harv-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@ally-harv-assualt-target1:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-harv-assualt-target2:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport vehicles to attack weak spot (structure)
+				Consideration@ally-structure-assualt-extraloc1:
+					StrategyName: structure-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk, v2rl, arty, msub,ca
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@ally-structure-assualt-target1:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-structure-assualt-target2:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport mcv for expansion
+				Consideration@ally-mcv-expansion-extraloc1:
+					StrategyName: ally-expansion-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: mcv
+					Attractiveness: 14000 ## Teleport will kill conyard HP below 50%
+					TargetMetric: Health
+					CheckRadius: 1c512
+				Consideration@ally-mcv-expansion-target1:
+					StrategyName: ally-expansion-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					InvalidActorTypes: harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target2:
+					StrategyName: ally-expansion-magic
+					Against: Ally
+					ValidActorTypes: mcv, proc, fact
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target3:
+					StrategyName: ally-expansion-magic
+					Against: Ally, Neutral, Enemy
+					ValidActorTypes: mine, gmine
+					Attractiveness: 10001
+					TargetMetric: None
+					CheckRadius: 8c0
+			advancedchronoshift:
+				OrderName: AdvancedChronoshift
+				CheckTargetLocationFirst: false
+				TargetLocationMode: CellCanBeEnteredByTargetedActor
+				ExtraLocationMode: ActorLocation
+				VisibilityCheck: false
+				MinimumAttractiveness: 10000
+				FineScanRadius: 4
+				## steal enemy harvester\mcv
+				Consideration@enemy-harvester-extraloc1:
+					StrategyName: harvester-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@enemy-harvester-target1:
+					StrategyName: harvester-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## steal enemy vehicles
+				Consideration@enemy-vehicles-extraloc1:
+					StrategyName: vehicles-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidTargetTypes: Vehicle
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@enemy-vehicles-target1:
+					StrategyName: vehicles-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 50
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## teleport vehicles to attack weak spot (harv)
+				Consideration@ally-harv-assualt-extraloc1:
+					StrategyName: harv-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@ally-harv-assualt-target1:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-harv-assualt-target2:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport vehicles to attack weak spot (structure)
+				Consideration@ally-structure-assualt-extraloc1:
+					StrategyName: structure-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk, v2rl, arty, msub,ca
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@ally-structure-assualt-target1:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-structure-assualt-target2:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport mcv for expansion
+				Consideration@ally-mcv-expansion-extraloc1:
+					StrategyName: ally-expansion-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: mcv
+					Attractiveness: 14000 ## Teleport will kill conyard HP below 50%
+					TargetMetric: Health
+					CheckRadius: 2c512
+				Consideration@ally-mcv-expansion-target1:
+					StrategyName: ally-expansion-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					InvalidActorTypes: harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target2:
+					StrategyName: ally-expansion-magic
+					Against: Ally
+					ValidActorTypes: mcv, proc, fact
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target3:
+					StrategyName: ally-expansion-magic
+					Against: Ally, Neutral, Enemy
+					ValidActorTypes: mine, gmine
+					Attractiveness: 100001
+					TargetMetric: None
+					CheckRadius: 8c0
 			spyplane:
 				OrderName: SovietSpyPlane
 				MinimumAttractiveness: 1
+				TargetLocationMode: ActorCenter
+				VisibilityCheck: false
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
 					Attractiveness: 1
+					TargetMetric: None
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 100
 					TargetMetric: None
 					CheckRadius: 5c0
 			paratroopers:
 				OrderName: SovietParatroopers
-				MinimumAttractiveness: 5
-				Consideration@1:
+				MinimumAttractiveness: 3
+				VisibilityCheck: false
+				FineScanRadius: 4
+				## paratroopers attack weak spot (structure)
+				Consideration@assualt1:
+					StrategyName: structure-assualt
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
+					InvalidActorTypes: ftur, pbox, hbox, tsla
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 8c0
-				Consideration@2:
+				Consideration@assualt2:
+					StrategyName: structure-assualt
 					Against: Enemy
-					Types: Water
+					ValidTargetTypes: Water, Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
 					Attractiveness: -5
+					TargetMetric: None
+					CheckRadius: 8c0
+				## paratroopers reinforce the expansion
+				Consideration@reinforce1:
+					StrategyName: reinforce-expansion
+					Against: Ally
+					ValidActorTypes: proc, fact
+					Attractiveness: 2
+					TargetMetric: None
+					CheckRadius: 8c0
+				Consideration@reinforce2:
+					StrategyName: reinforce-expansion
+					Against: Ally
+					ValidTargetTypes: Vehicle, Infantry
+					InvalidActorTypes: mcv, harv
+					Attractiveness: -3
 					TargetMetric: None
 					CheckRadius: 8c0
 			parabombs:
 				OrderName: UkraineParabombs
-				MinimumAttractiveness: 1
+				TargetLocationMode: ActorCenter
+				MinimumAttractiveness: 4000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
 					Attractiveness: 1
-					TargetMetric: None
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 2
+					TargetMetric: Value
 					CheckRadius: 5c0
 			nukepower:
 				OrderName: NukePowerInfoOrder
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground, Water
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
@@ -115,6 +414,9 @@ Player:
 			kenn: 1
 			dome: 1
 			weap: 4
+			hpad: 1
+			afld: 1
+			afld.ukraine: 1
 			atek: 1
 			stek: 1
 			fix: 1
@@ -125,6 +427,9 @@ Player:
 			kenn: 1
 			tent: 3
 			weap: 4
+			hpad: 1
+			afld: 1
+			afld.ukraine: 1
 			pbox: 3
 			gun: 3
 			tsla: 3
@@ -137,6 +442,8 @@ Player:
 			fix: 1
 			dome: 10
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 7000
 			fix: 3000
@@ -202,6 +509,8 @@ Player:
 			atek: 1
 			stek: 1
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 6000
 			fix: 3000
@@ -267,6 +576,8 @@ Player:
 			atek: 1
 			stek: 1
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 5000
 			atek: 7000
@@ -322,6 +633,8 @@ Player:
 			agun: 5
 			sam: 5
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 3000
 			fix: 20000
@@ -329,7 +642,7 @@ Player:
 			kenn: 4000
 	PowerDownBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
-		PowerDownTypes: dome,tsla,mslo,agun,sam
+		PowerDownTypes: dome,tsla,mslo,agun,sam, gap, iron, pdox
 	BuildingRepairBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 	SquadManagerBotModule@rush:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -431,6 +431,7 @@ IRON:
 		HasMinibib: true
 	GrantExternalConditionPower@IRONCURTAIN:
 		PauseOnCondition: disabled
+		OrderName: ironcurtain
 		Icon: invuln
 		ChargeInterval: 3000
 		Name: actor-iron.grantexternalconditionpower-ironcurtain-name

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -2,6 +2,7 @@ Player:
 	ModularBot@bot-test-ai:
 		Name: bot-test-ai.name
 		Type: test
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@test:
 		Condition: enable-test-ai
 		Bots: test


### PR DESCRIPTION
Solves  #18265 and #18267

1. Add a setting to allow support power triggered by enemy attack (ironcurtain)
2. Add settings to allow support power applying ExtraLocation parameter (chronoshift)
3. Add `strategy` as grouped considerations, which can support flexible support power like chronoshift (current strategies are teleporting enemy harvester or tanks to anti-armor army, teleporting army to weak spot, and teleport MCV for expansion on a unoccupied resource creator.)

~~Need to notify that the chronoshift and ironcurtain are not very ideal: when teleport moving actor the teleport can sometimes fail.~~ mostly fixed by [78b9092](https://github.com/OpenRA/OpenRA/pull/22177/commits/78b90921db8ed9a59574e77498044e1faed35c05)

