### PR TITLE
Style fixes (.NET 10 SDK)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -330,6 +330,10 @@ dotnet_diagnostic.IDE0304.severity = warning
 # From above, uses dotnet_style_prefer_collection_expression
 dotnet_diagnostic.IDE0305.severity = silent
 
+# IDE0350 Use implicitly typed lambda
+#csharp_style_prefer_implicitly_typed_lambda_expression = true
+dotnet_diagnostic.IDE0350.severity = warning
+
 ## Field preferences
 
 # IDE0044 Add readonly modifier

--- a/.editorconfig
+++ b/.editorconfig
@@ -229,6 +229,10 @@ dotnet_diagnostic.IDE0100.severity = warning
 # No options
 dotnet_diagnostic.IDE0120.severity = warning
 
+# IDE0121 Simplify LINQ type check and cast
+# No options
+dotnet_diagnostic.IDE0121.severity = warning
+
 # IDE0130 Namespace does not match folder structure
 #dotnet_style_namespace_match_folder = true
 # This rule doesn't appear to work (never reports violations)
@@ -330,9 +334,21 @@ dotnet_diagnostic.IDE0304.severity = warning
 # From above, uses dotnet_style_prefer_collection_expression
 dotnet_diagnostic.IDE0305.severity = silent
 
+# IDE0306 Use collection expression for new
+# From above, uses dotnet_style_prefer_collection_expression
+dotnet_diagnostic.IDE0306.severity = warning
+
+# IDE0340 Use unbound generic type
+#csharp_style_prefer_unbound_generic_type_in_nameof = true
+dotnet_diagnostic.IDE0340.severity = silent # Requires C# 14
+
 # IDE0350 Use implicitly typed lambda
 #csharp_style_prefer_implicitly_typed_lambda_expression = true
 dotnet_diagnostic.IDE0350.severity = warning
+
+# IDE0360 Simplify property accessor
+#csharp_style_prefer_simple_property_accessors = true
+dotnet_diagnostic.IDE0360.severity = silent # Requires C# 13
 
 ## Field preferences
 
@@ -376,6 +392,10 @@ dotnet_diagnostic.IDE0251.severity = warning
 # IDE0320 Make anonymous function static
 #csharp_prefer_static_anonymous_function = true
 dotnet_diagnostic.IDE0320.severity = warning
+
+# IDE0380 Remove unnecessary 'unsafe' modifier
+# No options
+dotnet_diagnostic.IDE0380.severity = warning
 
 ## Null-checking preferences
 
@@ -437,6 +457,10 @@ dotnet_diagnostic.IDE0170.severity = warning
 # IDE0079 Remove unnecessary suppression
 #dotnet_remove_unnecessary_suppression_exclusions = none
 dotnet_diagnostic.IDE0079.severity = warning
+
+# IDE0370 Remove unnecessary suppression (null-forgiving operator)
+# No options
+dotnet_diagnostic.IDE0370.severity = warning
 
 ## 'this' and 'Me' preferences
 
@@ -784,6 +808,9 @@ dotnet_diagnostic.CA1514.severity = warning
 # Consider making public types internal.
 dotnet_diagnostic.CA1515.severity = warning
 
+# Use cross-platform intrinsics.
+dotnet_diagnostic.CA1516.severity = warning
+
 ### Naming Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/naming-warnings
 
@@ -949,6 +976,18 @@ dotnet_diagnostic.CA1871.severity = warning
 # Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'.
 dotnet_diagnostic.CA1872.severity = warning
 
+# Avoid potentially expensive logging.
+dotnet_diagnostic.CA1873.severity = warning
+
+# Use 'Regex.IsMatch'.
+dotnet_diagnostic.CA1874.severity = warning
+
+# Use Use 'Regex.Count'.
+dotnet_diagnostic.CA1875.severity = warning
+
+# Use 'Path.Combine' or 'Path.Join' overloads.
+dotnet_diagnostic.CA1877.severity = warning
+
 ### Reliability Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/reliability-warnings
 
@@ -979,8 +1018,17 @@ dotnet_diagnostic.CA2021.severity = warning
 # Avoid inexact read with Stream.Read.
 dotnet_diagnostic.CA2022.severity = warning
 
+# Invalid braces in message template.
+dotnet_diagnostic.CA2023.severity = warning
+
 # Do not use StreamReader.EndOfStream in async methods.
 dotnet_diagnostic.CA2024.severity = warning
+
+# Do not pass 'IDisposable' instances into unawaited tasks.
+dotnet_diagnostic.CA2025.severity = warning
+
+# Prefer JsonElement.Parse over JsonDocument.Parse().RootElement.
+dotnet_diagnostic.CA2026.severity = warning
 
 ### Security Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/security-warnings

--- a/.editorconfig
+++ b/.editorconfig
@@ -781,6 +781,9 @@ dotnet_diagnostic.CA1513.severity = warning
 # Avoid redundant length argument.
 dotnet_diagnostic.CA1514.severity = warning
 
+# Consider making public types internal.
+dotnet_diagnostic.CA1515.severity = warning
+
 ### Naming Rules
 ### https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/naming-warnings
 

--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -283,11 +283,8 @@ namespace OpenRA.Graphics
 			{
 				for (var i = 0; i < c.Cursors.Length; i++)
 				{
-					if (c.Cursors[i] != null)
-					{
-						c.Cursors[i].Dispose();
-						c.Cursors[i] = null;
-					}
+					c.Cursors[i]?.Dispose();
+					c.Cursors[i] = null;
 				}
 			}
 		}

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -663,11 +663,8 @@ namespace OpenRA
 
 		public void Dispose()
 		{
-			if (package != null)
-			{
-				package.Dispose();
-				package = null;
-			}
+			package?.Dispose();
+			package = null;
 		}
 
 		public void Delete()

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -149,7 +149,7 @@ namespace OpenRA
 
 		public static string ReadASCII(this Stream s, int length)
 		{
-			Span<byte> buffer = length < 128 ? stackalloc byte[length] : new byte[length];
+			var buffer = length < 128 ? stackalloc byte[length] : new byte[length];
 			s.ReadBytes(buffer);
 			return Encoding.ASCII.GetString(buffer);
 		}
@@ -263,7 +263,7 @@ namespace OpenRA
 			if (length > maxLength)
 				throw new InvalidOperationException($"The length of the string ({length}) is longer than the maximum allowed ({maxLength}).");
 
-			Span<byte> buffer = length < 128 ? stackalloc byte[length] : new byte[length];
+			var buffer = length < 128 ? stackalloc byte[length] : new byte[length];
 			s.ReadBytes(buffer);
 			return encoding.GetString(buffer);
 		}

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -427,7 +427,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				incompatibilities,
 				Rotations,
 				Mirror,
-				(CPos[] sources, CPos destination) =>
+				(sources, destination) =>
 				{
 					if (!dominant[destination])
 						incompatibilities[destination] = sources

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 		static float RelativeSpeed(IReadOnlyCollection<Actor> own, IReadOnlyCollection<Actor> enemy)
 		{
-			return RelativeValue(own, enemy, 100, Average<MobileInfo>, (Actor a) => a.Info.TraitInfo<MobileInfo>().Speed);
+			return RelativeValue(own, enemy, 100, Average<MobileInfo>, a => a.Info.TraitInfo<MobileInfo>().Speed);
 		}
 
 		static float RelativeValue(IReadOnlyCollection<Actor> own, IReadOnlyCollection<Actor> enemy, float normalizeByValue,

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Test
 	sealed class MockLInfo : MockTraitInfo, NotBefore<MockJInfo> { }
 
 	[TestFixture]
-	public class ActorInfoTest
+	sealed class ActorInfoTest
 	{
 		[TestCase(TestName = "Trait ordering sorts in dependency order correctly")]
 		public void TraitOrderingSortsCorrectly()

--- a/OpenRA.Test/OpenRA.Game/CPosTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CPosTest.cs
@@ -14,7 +14,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class CPosTest
+	sealed class CPosTest
 	{
 		[TestCase(TestName = "Packing x,y and layer into int")]
 		public void PackUnpackBits()

--- a/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
@@ -16,7 +16,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class CoordinateTest
+	sealed class CoordinateTest
 	{
 		[TestCase(TestName = "Test CPos to MPos conversion and back again.")]
 		public void CPosConversionRoundtrip()

--- a/OpenRA.Test/OpenRA.Game/FluentTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FluentTest.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class FluentTest
+	sealed class FluentTest
 	{
 		readonly string pluralForms = @"
 label-players = {$player ->

--- a/OpenRA.Test/OpenRA.Game/MediatorTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MediatorTest.cs
@@ -15,7 +15,7 @@ using OpenRA.Widgets;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class MediatorTest
+	sealed class MediatorTest
 	{
 		[TestCase(TestName = "Mediator test")]
 		public void Test()
@@ -30,7 +30,7 @@ namespace OpenRA.Test
 		}
 	}
 
-	public class TestHandler : INotificationHandler<TestNotificaton>
+	sealed class TestHandler : INotificationHandler<TestNotificaton>
 	{
 		public bool WasNotified { get; set; }
 
@@ -40,5 +40,5 @@ namespace OpenRA.Test
 		}
 	}
 
-	public class TestNotificaton { }
+	sealed class TestNotificaton { }
 }

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -21,7 +21,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class MiniYamlTest
+	sealed class MiniYamlTest
 	{
 		[TestCase(TestName = "Parse tree roundtrips")]
 		public void TestParseRoundtrip()

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class OrderTest
+	sealed class OrderTest
 	{
 		static byte[] RoundTripOrder(byte[] bytes)
 		{

--- a/OpenRA.Test/OpenRA.Game/PlatformTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PlatformTest.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class PlatformTest
+	sealed class PlatformTest
 	{
 		string supportDir;
 		string engineDir;

--- a/OpenRA.Test/OpenRA.Game/PngTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PngTest.cs
@@ -19,7 +19,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class PngTests
+	sealed class PngTests
 	{
 		[Test]
 		public void Save_ShouldProduceValidPngFile()
@@ -128,6 +128,8 @@ namespace OpenRA.Test
 			}
 		}
 
+		[Test]
+		[Ignore("Failing test should be fixed")]
 		public void PngConstructor_CompressionMethodNotSupported_ThrowsInvalidDataException()
 		{
 			// Arrange

--- a/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
@@ -17,7 +17,7 @@ using OpenRA.Support;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class VariableExpressionTest
+	sealed class VariableExpressionTest
 	{
 		readonly IReadOnlyDictionary<string, int> testValues = new Dictionary<string, int>
 		{

--- a/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
@@ -15,7 +15,7 @@ using OpenRA.Mods.Common.HitShapes;
 namespace OpenRA.Test
 {
 	[TestFixture]
-	public class ShapeTest
+	sealed class ShapeTest
 	{
 		IHitShape shape;
 

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -18,7 +18,7 @@ namespace OpenRA
 {
 	using UtilityActions = Dictionary<string, KeyValuePair<Action<Utility, string[]>, Func<string[], bool>>>;
 
-	public class NoSuchCommandException : Exception
+	sealed class NoSuchCommandException : Exception
 	{
 		public readonly string Command;
 		public NoSuchCommandException(string command)


### PR DESCRIPTION
If you're using the .NET 10 SDK that came out today (or e.g. updated Visual Studio which ships it) then some of the style rules have been updated and trigger additional warnings locally. We can also expect them to be flagged by CI if the runners move to .NET 10, even if we continue to specify .NET 8 as the build target.

Fix these issues to improve the local dev experience for anybody using this SDK:

```
> dotnet --version
10.0.100
```

See also #21643