### PR TITLE
Change default player color to blue

### DIFF
--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -21,7 +21,7 @@ Metrics:
 	PlayerStanceColorAllies: FFFF00
 	PlayerStanceColorEnemies: FF0000
 	PlayerStanceColorNeutrals: D2B48C
-	PlayerStanceColorSelf: 32CD32
+	PlayerStanceColorSelf: 3232CD
 	ProtectedGameColor: FF0000
 	SpawnColor: FFFFFF
 	SpawnContrastColor: 000000


### PR DESCRIPTION

Because players can pick any colors they want, I often run into combinations that are hard to distinguish with deuteranopia, so I prefer using the "Player Relationship Colors" setting. The issue is that this mode makes me green and enemies red, which are difficult for me to tell apart.

Setting the default player color to **blue** avoids this and keeps all three groups clearly distinguishable for colorblind players.