### PR TITLE
Fix AI only builds production line (ignore important tech building) when cash always above NewProductionCashThreshold

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -110,6 +110,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Try to build another production building if there is too much cash.")]
 		public readonly int NewProductionCashThreshold = 5000;
 
+		[Desc("Try to build another tech building if there is too much cash.")]
+		public readonly int NewTechCashThreshold = 5000;
+
+		[Desc("Try to build another tech building if there is enough production buildings.")]
+		public readonly int MinProductionRequiredForTechBuilding = 4;
+
 		[Desc("Radius in cells around a factory scanned for rally points by the AI.")]
 		public readonly int RallyPointScanRadius = 8;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -320,8 +320,17 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			// Make sure that we can spend as fast as we are earning
-			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold)
+			// Make sure that we can spend as fast as we are earning, by building production or tech buildings
+			var shouldBuildProduction =
+				baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold;
+
+			var shouldBuildTech = baseBuilder.Info.NewTechCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewTechCashThreshold
+				&& AIUtils.CountActorByCommonName(baseBuilder.ProductionBuildings) >= baseBuilder.Info.MinProductionRequiredForTechBuilding;
+
+			// When both are needed, randomly pick one to avoid always building the same type first
+			shouldBuildProduction = shouldBuildTech && shouldBuildProduction ? world.LocalRandom.Next(2) == 0 : shouldBuildProduction;
+
+			if (shouldBuildProduction)
 			{
 				var production = GetProducibleBuilding(baseBuilder.Info.ProductionTypes, buildableThings);
 				if (production != null && HasSufficientPowerForActor(production))
@@ -331,6 +340,22 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				if (power != null && production != null && !HasSufficientPowerForActor(production))
+				{
+					AIUtils.BotDebug("{0} decided to build {1}: Priority override (would be low power)", queue.Actor.Owner, power.Name);
+					return power;
+				}
+			}
+
+			if (shouldBuildTech)
+			{
+				var tech = GetProducibleBuilding(baseBuilder.Info.TechTypes, buildableThings);
+				if (tech != null && HasSufficientPowerForActor(tech))
+				{
+					AIUtils.BotDebug("{0} decided to build {1}: Priority override (tech)", queue.Actor.Owner, tech.Name);
+					return tech;
+				}
+
+				if (power != null && tech != null && !HasSufficientPowerForActor(tech))
 				{
 					AIUtils.BotDebug("{0} decided to build {1}: Priority override (would be low power)", queue.Actor.Owner, power.Name);
 					return power;

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -107,6 +107,7 @@ Player:
 		TechTypes: hq, tmpl, fix, eye, hpad
 		ProductionTypes: pyle, hand, weap, afld
 		NewProductionCashThreshold: 8000
+		NewTechCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:
@@ -162,6 +163,7 @@ Player:
 		ExpansionTolerate: 0
 		ForceExpansionTolerate: 0
 		NewProductionCashThreshold: 6000
+		NewTechCashThreshold: 6000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:
@@ -218,6 +220,7 @@ Player:
 		ExpansionTolerate: 0
 		ForceExpansionTolerate: 0
 		NewProductionCashThreshold: 7000
+		NewTechCashThreshold: 7000
 		SiloTypes: silo
 		DefenseTypes: gtwr,gun,atwr,obli,sam
 		BuildingLimits:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -107,6 +107,7 @@ Player:
 		AdditionalMinimumRefineryCount: 2
 		ProductionTypes: barr,tent,weap
 		NewProductionCashThreshold: 7000
+		NewTechCashThreshold: 7000
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:
@@ -162,6 +163,7 @@ Player:
 		TechTypes: dome, atek, stek, fix, afld, hpad
 		ProductionTypes: barr,tent,weap
 		NewProductionCashThreshold: 8000
+		NewTechCashThreshold: 8000
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
@@ -227,6 +229,8 @@ Player:
 		TechTypes: dome, atek, stek, fix, afld, hpad
 		ProductionTypes: barr,tent,weap
 		NavalProductionTypes: spen, syrd
+		NewProductionCashThreshold: 8000
+		NewTechCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:
@@ -286,6 +290,8 @@ Player:
 		TechTypes: mslo, dome, atek, stek, fix
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen, syrd
+		NewProductionCashThreshold: 8000
+		NewTechCashThreshold: 8000
 		SiloTypes: silo
 		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
 		BuildingLimits:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -117,6 +117,7 @@ Player:
 		InsufficientFundsTextNotification: notification-insufficient-funds
 		CashTickUpNotification: CashTickUp
 		CashTickDownNotification: CashTickDown
+		SelectableCash: 2500, 5000, 10000, 2000000
 	DeveloperMode:
 		CheckboxDisplayOrder: 10
 	GpsWatcher:


### PR DESCRIPTION
Test: give bot almost infinite cash, now AI will build tech building if possible.