### PR TITLE
Map: specify use of CryptoUtil.SHA1Hash(byte[])

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,7 +282,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash([]);
+					return CryptoUtil.SHA1Hash(Array.Empty<byte>());
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)


### PR DESCRIPTION
	/home/buildozer/git/aports/testing/openra/src/OpenRA-56e6a9e6dc4f649b9c5939847e5673c04b3670c1/OpenRA.Game/Map/Map.cs(285,24): error CS0121:
	The call is ambiguous between the following methods or properties:
	'CryptoUtil.SHA1Hash(byte[])' and 'CryptoUtil.SHA1Hash(string)'
	[/home/buildozer/git/aports/testing/openra/src/OpenRA-56e6a9e6dc4f649b9c5939847e5673c04b3670c1/OpenRA.Game/OpenRA.Game.csproj]

Fixes: 79454d8fd29b ("Fix IDE0028, IDE0300, IDE0301, IDE0302, IDE0303, IDE0304.")

Thank you for your contribution to OpenRA!

Please be aware that we do not have enough project maintainers to match the rate of contributions, so it may take several days before somebody is able to respond to your Pull Request.

You can help speed up the review process by following a few steps:

* Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard).
* Write quality commit messages (see https://chris.beams.io/posts/git-commit/).
* Only commit changes that directly relate to your Pull Request.  Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
* Review the code diff view below to double check that your changes satisfy the above three points.
* Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.
* If you are changing shared mod or engine code, make sure that you have tested your changes in all four default mods.
* Respond to review comments as soon as you reasonably can.  Reviewers will usually prioritize Pull Requests that are still fresh in their minds.  Make sure to leave a comment when you push new changes, otherwise GitHub does not automatically notify reviewers!
* Leave a polite comment asking for reviews if a week or more has passed without feedback.

If you need any help you can ask on Discord (https://discord.openra.net) or in the #openra IRC channel on Libera (not as active as Discord).