### PR TITLE
Remove Exts.Enum<T>

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -676,27 +676,4 @@ namespace OpenRA
 
 		public ReadOnlySpan<char> Current { get; private set; }
 	}
-
-	public static class Enum<T>
-	{
-		public static T Parse(string s) { return (T)Enum.Parse(typeof(T), s); }
-		public static T[] GetValues() { return (T[])Enum.GetValues(typeof(T)); }
-
-		public static bool TryParse(string s, bool ignoreCase, out T value)
-		{
-			// The string may be a comma delimited list of values
-			var names = ignoreCase ? Enum.GetNames(typeof(T)).Select(x => x.ToLowerInvariant()) : Enum.GetNames(typeof(T));
-			var values = ignoreCase ? s.Split(',').Select(x => x.Trim().ToLowerInvariant()) : s.Split(',').Select(x => x.Trim());
-
-			if (values.Any(x => !names.Contains(x)))
-			{
-				value = default;
-				return false;
-			}
-
-			value = (T)Enum.Parse(typeof(T), s, ignoreCase);
-
-			return true;
-		}
-	}
 }

--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -27,25 +27,21 @@ namespace OpenRA
 		public static bool TryParse(string s, out Hotkey result)
 		{
 			result = Invalid;
-			if (string.IsNullOrWhiteSpace(s))
+			if (s == null)
 				return false;
 
-			var parts = s.Split(' ');
+			Span<Range> ranges = stackalloc Range[2];
+			var span = s.AsSpan();
+			var count = span.Split(ranges, ' ');
+			if (count == 0)
+				return false;
 
-			if (!Enum<Keycode>.TryParse(parts[0], true, out var key))
-			{
-				if (!int.TryParse(parts[0], out var c))
-					return false;
-				key = (Keycode)c;
-			}
+			if (!Enum.TryParse(span[ranges[0]], true, out Keycode key))
+				return false;
 
 			var mods = Modifiers.None;
-			if (parts.Length >= 2)
-			{
-				var modString = s[s.IndexOf(' ')..];
-				if (!Enum<Modifiers>.TryParse(modString, true, out mods))
-					return false;
-			}
+			if (count == 2 && !Enum.TryParse(span[ranges[1]], true, out mods))
+				return false;
 
 			result = new Hotkey(key, mods);
 			return true;

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -93,7 +93,7 @@ namespace OpenRA
 			{
 				var name = kv.Key;
 				var classification = string.IsNullOrEmpty(kv.Value)
-					? MapClassification.Unknown : Enum<MapClassification>.Parse(kv.Value);
+					? MapClassification.Unknown : Enum.Parse<MapClassification>(kv.Value);
 
 				IReadOnlyPackage package;
 				var optional = name.StartsWith('~');

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -212,9 +212,9 @@ namespace OpenRA.Support
 
 		static IEnumerable<TokenTypeInfo> CreateTokenTypeInfoEnumeration()
 		{
-			for (var i = 0; i <= (int)TokenType.Invalid; i++)
+			for (var tt = TokenType.False; tt <= TokenType.Invalid; tt++)
 			{
-				switch ((TokenType)i)
+				switch (tt)
 				{
 					case TokenType.Invalid:
 						yield return new TokenTypeInfo("(<INVALID>)", Precedence.Invalid);
@@ -287,7 +287,7 @@ namespace OpenRA.Support
 						continue;
 				}
 
-				throw new InvalidProgramException($"CreateTokenTypeInfoEnumeration is missing a TokenTypeInfo entry for TokenType.{Enum<TokenType>.GetValues()[i]}");
+				throw new InvalidProgramException($"CreateTokenTypeInfoEnumeration is missing a TokenTypeInfo entry for TokenType.{tt}");
 			}
 		}
 
@@ -741,8 +741,8 @@ namespace OpenRA.Support
 
 				throw new InvalidProgramException(
 					"Unable to convert " +
-					$"ExpressionType.{Enum<ExpressionType>.GetValues()[(int)fromType]} to " +
-					$"ExpressionType.{Enum<ExpressionType>.GetValues()[(int)toType]}");
+					$"ExpressionType.{fromType} to " +
+					$"ExpressionType.{toType}");
 			}
 
 			public Expression Pop(ExpressionType type)
@@ -941,7 +941,7 @@ namespace OpenRA.Support
 						default:
 							throw new InvalidProgramException(
 								"ConditionExpression.Compiler.Compile() is missing an expression builder for " +
-								$"TokenType.{Enum<TokenType>.GetValues()[(int)t.Type]}");
+								$"TokenType.{t.Type}");
 					}
 				}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Activities;
@@ -153,7 +154,7 @@ namespace OpenRA.Mods.Common.Scripting
 				if (autotarget == null)
 					return;
 
-				if (!Enum<UnitStance>.TryParse(value, true, out var stance))
+				if (!Enum.TryParse<UnitStance>(value, true, out var stance))
 					throw new LuaException($"Unknown stance type '{value}'");
 
 				autotarget.SetStance(Self, stance);

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Server
 		{
 			lock (server.LobbyInfo)
 			{
-				if (!Enum<Session.ClientState>.TryParse(s, false, out var state))
+				if (!Enum.TryParse<Session.ClientState>(s, out var state))
 				{
 					server.SendFluentMessageTo(conn, MalformedCommand, ["command", "state"]);
 


### PR DESCRIPTION
This functionality is now built in. We can rely on the built in functions rather than a custom class.