### PR TITLE
Revert "In RemoveCellsFromPlayerShroud, don't call RemoveSource unless required."

### DIFF
--- a/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
+++ b/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
@@ -49,13 +49,7 @@ namespace OpenRA.Mods.Common.Effects
 			p.Shroud.AddSource(this, sourceType, uv);
 		}
 
-		void RemoveCellsFromPlayerShroud(Player p)
-		{
-			if (!validStances.HasRelationship(player.RelationshipWith(p)))
-				return;
-
-			p.Shroud.RemoveSource(this);
-		}
+		void RemoveCellsFromPlayerShroud(Player p) { p.Shroud.RemoveSource(this); }
 
 		PPos[] ProjectedCells(World world)
 		{

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -49,13 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, Shroud.SourceType.Shroud, uv);
 		}
 
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p)
-		{
-			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
-				return;
-
-			p.Shroud.RemoveSource(this);
-		}
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveSource(this); }
 
 		public override WDist Range
 		{

--- a/OpenRA.Mods.Common/Traits/RevealsMap.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsMap.cs
@@ -44,13 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, type, uv);
 		}
 
-		protected void RemoveCellsFromPlayerShroud(Actor self, Player p)
-		{
-			if (!Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
-				return;
-
-			p.Shroud.RemoveSource(this);
-		}
+		protected void RemoveCellsFromPlayerShroud(Player p) { p.Shroud.RemoveSource(this); }
 
 		protected PPos[] ProjectedCells(Actor self)
 		{
@@ -64,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				var cells = ProjectedCells(self);
 				foreach (var player in self.World.Players)
 				{
-					RemoveCellsFromPlayerShroud(self, player);
+					RemoveCellsFromPlayerShroud(player);
 					AddCellsToPlayerShroud(self, player, cells);
 				}
 			}
@@ -73,13 +67,13 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyActorDisposing.Disposing(Actor self)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(self, player);
+				RemoveCellsFromPlayerShroud(player);
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(self, player);
+				RemoveCellsFromPlayerShroud(player);
 		}
 
 		protected override void TraitEnabled(Actor self)
@@ -92,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitDisabled(Actor self)
 		{
 			foreach (var player in self.World.Players)
-				RemoveCellsFromPlayerShroud(self, player);
+				RemoveCellsFromPlayerShroud(player);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -55,13 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			p.Shroud.AddSource(this, type, uv);
 		}
 
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p)
-		{
-			if (!info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(p)))
-				return;
-
-			p.Shroud.RemoveSource(this);
-		}
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveSource(this); }
 
 		public override WDist Range
 		{


### PR DESCRIPTION
This reverts commit 86b92275771f89166bb9c69deb9fee484b785017.

This commit relied on the relationship not changing, but when a player is defeated their relationship can change due to becoming a spectator. This can cause a crash if the shroud is not removed. Revert the commit to resolve this crash.

Fixes #22137