### PR TITLE
Add Tiberian Sun Map Generator

### DIFF
--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using OpenRA.FileSystem;
@@ -41,6 +42,115 @@ namespace OpenRA
 		float MaxHeightColorBrightness { get; }
 	}
 
+	/// <summary>
+	/// Describes expected discontinuities in height with neighboring tiles. Each tile has eight
+	/// outgoing riser connections in a formation resembling a hash symbol (#). These specify the
+	/// height of each neighboring cell corner relative to the template height. For example, a
+	/// cliff tile might have a Height of 4 in the template, but connect to a lower tile at height
+	/// 0 for some of its corners.
+	/// </summary>
+	public readonly struct Riser
+	{
+		/// <summary>
+		/// Corner connection of a Riser definition.
+		/// UL means "the upper (-Y) neighboring cell, leftward adjoining (-X) corner", whereas
+		/// LU means "the leftward (-X) neighboring cell, upper adjoining (-Y) corner".
+		/// </summary>
+		public enum Connection
+		{
+			UL = 0,
+			UR = 1,
+			RU = 2,
+			RD = 3,
+			DR = 4,
+			DL = 5,
+			LD = 6,
+			LU = 7,
+		}
+
+		const byte Default = byte.MaxValue;
+
+		readonly ulong bits = ulong.MaxValue;
+
+		/// <summary>
+		/// Parses a riser definition from MiniYaml. Two formats are accepted: a long-hand and a
+		/// short-hand. An example long-hand looks like "Riser: 6,6,0,0,0,0,6,6", specifying each
+		/// connection height explicitly. A short-hand may instead look like "Riser: LU=6", which
+		/// means set all left corners and upper corners to 6 (setting 4 connections in total),
+		/// leaving the rest default/automatic.
+		/// </summary>
+		public Riser(MiniYaml my)
+		{
+			var definition = my?.Value;
+			if (definition == null)
+				return;
+
+			string[] parts;
+
+			parts = definition.Split(",");
+			if (parts.Length == 8)
+			{
+				bits = 0;
+				for (var i = 0; i < 8; i++)
+				{
+					if (!Exts.TryParseByteInvariant(parts[i], out var b))
+						throw new YamlException($"`{definition}` is not a valid Riser definition");
+
+					bits |= (ulong)b << (i * 8);
+				}
+
+				return;
+			}
+
+			parts = definition.Split("=");
+			if (parts.Length == 2)
+			{
+				if (!Exts.TryParseByteInvariant(parts[1], out var b))
+					throw new YamlException($"`{definition}` is not a valid Riser definition");
+
+				bits = b * 0x0101010101010101u;
+
+				// TODO: make stricter
+				if (!parts[0].Contains('U', StringComparison.InvariantCultureIgnoreCase))
+					bits |= 0x00_00_00_00_00_00_ff_ffu;
+
+				if (!parts[0].Contains('R', StringComparison.InvariantCultureIgnoreCase))
+					bits |= 0x00_00_00_00_ff_ff_00_00u;
+
+				if (!parts[0].Contains('D', StringComparison.InvariantCultureIgnoreCase))
+					bits |= 0x00_00_ff_ff_00_00_00_00u;
+
+				if (!parts[0].Contains('L', StringComparison.InvariantCultureIgnoreCase))
+					bits |= 0xff_ff_00_00_00_00_00_00u;
+
+				return;
+			}
+
+			throw new YamlException($"`{definition}` is not a valid Riser definition");
+		}
+
+		readonly byte? this[int i]
+		{
+			get
+			{
+				if (i < 0 || i >= 8)
+					throw new IndexOutOfRangeException();
+
+				var b = (byte)((bits >> (i * 8)) & 0xff);
+				return b != Default ? b : null;
+			}
+		}
+
+		/// <summary>
+		/// Fetch the expected height of the given connecting corner, or null if the tile's Height
+		/// value should be used instead.
+		/// </summary>
+		public readonly byte? this[Connection c]
+		{
+			get => this[(int)c];
+		}
+	}
+
 	public class TerrainTileInfo
 	{
 		[FieldLoader.Ignore]
@@ -49,6 +159,14 @@ namespace OpenRA
 		public readonly byte RampType;
 		public readonly Color MinColor;
 		public readonly Color MaxColor;
+		[FieldLoader.LoadUsing(nameof(LoadRiser))]
+		public readonly Riser Riser;
+
+		// Needs to be defined for subclasses
+		public static object LoadRiser(MiniYaml my)
+		{
+			return new Riser(my.NodeWithKeyOrDefault("Riser")?.Value);
+		}
 
 		public Color GetColor(MersenneTwister random)
 		{

--- a/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
@@ -10,27 +10,30 @@
 #endregion
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Support;
 using OpenRA.Traits;
 using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class ClassicMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
+	[Desc("A purpose-built Tiberian Sun map generator.")]
+	public sealed class TSMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
 	{
 		[FieldLoader.Require]
-		public readonly string Type = null;
-
-		[FieldLoader.Require]
+		[Desc("Human-readable name this generator uses.")]
 		[FluentReference]
 		public readonly string Name = null;
+
+		[FieldLoader.Require]
+		[Desc("Internal id for this map generator.")]
+		public readonly string Type = null;
 
 		[FieldLoader.Require]
 		[Desc("Tilesets that are compatible with this map generator.")]
@@ -83,6 +86,8 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Require]
 			public readonly int TerrainFeatureSize = default;
 			[FieldLoader.Require]
+			public readonly int RampFeatureSize = default;
+			[FieldLoader.Require]
 			public readonly int ForestFeatureSize = default;
 			[FieldLoader.Require]
 			public readonly int ResourceFeatureSize = default;
@@ -95,16 +100,18 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Require]
 			public readonly int Forests = default;
 			[FieldLoader.Require]
+			public readonly int ForestFloor = default;
+			[FieldLoader.Require]
 			public readonly int ForestCutout = default;
 			[FieldLoader.Require]
 			public readonly int MaximumCutoutSpacing = default;
 			[FieldLoader.Require]
-			public readonly int ExternalCircularBias = default;
-			[FieldLoader.Require]
 			public readonly int TerrainSmoothing = default;
 			[FieldLoader.Require]
 			public readonly int SmoothingThreshold = default;
-			public readonly int MinimumCoastStraight = -1;
+			public readonly int MinimumCoastStraight = 0;
+			[FieldLoader.Require]
+			public readonly int MinimumCliffStraight = default;
 			[FieldLoader.Require]
 			public readonly int MinimumLandSeaThickness = default;
 			[FieldLoader.Require]
@@ -115,25 +122,27 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly int RoughnessRadius = default;
 			[FieldLoader.Require]
 			public readonly int Roughness = default;
+			[FieldLoader.Require]
+			public readonly bool WaterCliffs = default;
 			public readonly int WaterRoughness = 0;
 			[FieldLoader.Require]
 			public readonly int MinimumTerrainContourSpacing = default;
-			public readonly int MinimumBeachLength = 0;
+			[FieldLoader.Require]
+			public readonly int MinimumBeachLength = default;
 			public readonly int MinimumWaterCliffLength = 0;
 			[FieldLoader.Require]
 			public readonly int MinimumCliffLength = default;
+			[FieldLoader.Require]
+			public readonly int MinimumClearLength = default;
+			public readonly int BeachSpreadWhenWaterCliffing = 0;
+			[FieldLoader.Require]
+			public readonly int RampSoften = default;
 			[FieldLoader.Require]
 			public readonly int ForestClumpiness = default;
 			[FieldLoader.Require]
 			public readonly bool DenyWalledAreas = default;
 			[FieldLoader.Require]
 			public readonly int EnforceSymmetry = default;
-			[FieldLoader.Require]
-			public readonly bool Roads = default;
-			[FieldLoader.Require]
-			public readonly int RoadSpacing = default;
-			[FieldLoader.Require]
-			public readonly int RoadShrink = default;
 			[FieldLoader.Require]
 			public readonly bool CreateEntities = default;
 			[FieldLoader.Require]
@@ -201,8 +210,20 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly IReadOnlyList<MultiBrush> UnplayableObstacles;
 			[FieldLoader.Ignore]
 			public readonly IReadOnlyList<MultiBrush> CivilianBuildingsObstacles;
+			[FieldLoader.Require]
+			public readonly ushort ForestFloorTile = default;
+			[FieldLoader.Ignore]
+			public readonly IReadOnlyList<(ushort, int)> OtherGround;
 			[FieldLoader.Ignore]
 			public readonly IReadOnlyDictionary<ushort, IReadOnlyList<MultiBrush>> RepaintTiles;
+			[FieldLoader.Ignore]
+			public readonly IReadOnlyList<ushort> RampTiles;
+			[FieldLoader.Ignore]
+			public readonly LatTiler LatTiler;
+			[FieldLoader.Ignore]
+			public readonly LatTiler IceLatTiler = null;
+			[FieldLoader.Require]
+			public readonly bool UseIceLatTiler = false;
 
 			[FieldLoader.Ignore]
 			public readonly ResourceTypeInfo DefaultResource;
@@ -220,15 +241,13 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Ignore]
 			public readonly IReadOnlySet<byte> ZoneableTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> ClearSegmentTypes;
+			public readonly string ClearSegmentType;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> BeachSegmentTypes;
+			public readonly string BeachSegmentType;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> WaterCliffSegmentTypes;
+			public readonly string WaterCliffSegmentType;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> CliffSegmentTypes;
-			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> RoadSegmentTypes;
+			public readonly string CliffSegmentType;
 
 			public Parameters(Map map, MiniYaml my)
 			{
@@ -239,6 +258,17 @@ namespace OpenRA.Mods.Common.Traits
 				ForestObstacles = MultiBrush.LoadCollection(map, my.NodeWithKey("ForestObstacles").Value.Value);
 				UnplayableObstacles = MultiBrush.LoadCollection(map, my.NodeWithKey("UnplayableObstacles").Value.Value);
 				CivilianBuildingsObstacles = MultiBrush.LoadCollection(map, my.NodeWithKey("CivilianBuildingsObstacles").Value.Value);
+				OtherGround = my.NodeWithKeyOrDefault("OtherGround")?.Value.Nodes.Select(
+					n =>
+					{
+						if (!Exts.TryParseUshortInvariant(n.Key, out var tile))
+							throw new YamlException($"OtherGround {n.Key} is not a ushort");
+
+						if (!Exts.TryParseInt32Invariant(n.Value.Value, out var fraction))
+							throw new YamlException($"OtherGround {n.Key} has invalid fraction (should be 0 to {FractionMax})");
+
+						return (tile, fraction);
+					}).ToList();
 				RepaintTiles = my.NodeWithKeyOrDefault("RepaintTiles")?.Value.ToDictionary(
 					k =>
 					{
@@ -249,6 +279,13 @@ namespace OpenRA.Mods.Common.Traits
 					},
 					v => MultiBrush.LoadCollection(map, v.Value) as IReadOnlyList<MultiBrush>);
 				RepaintTiles ??= ImmutableDictionary<ushort, IReadOnlyList<MultiBrush>>.Empty;
+
+				RampTiles = FieldLoader.GetValue<List<ushort>>(
+					nameof(RampTiles),
+					my.NodeWithKey(nameof(RampTiles)).Value.Value);
+				LatTiler = new LatTiler(my.NodeWithKey("LatTiler").Value, terrainInfo);
+				if (my.NodeWithKeyOrDefault("IceLatTiler") != null)
+					IceLatTiler = new LatTiler(my.NodeWithKeyOrDefault("IceLatTiler").Value, terrainInfo);
 
 				var resourceTypes = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<ResourceLayerInfo>().ResourceTypes;
 				if (!resourceTypes.TryGetValue(my.NodeWithKey("DefaultResource").Value.Value, out DefaultResource))
@@ -281,14 +318,7 @@ namespace OpenRA.Mods.Common.Traits
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
 						.Select(terrainInfo.GetTerrainIndex)
-						.ToFrozenSet();
-				}
-
-				IReadOnlyList<string> ParseSegmentTypes(string key)
-				{
-					return my.NodeWithKey(key).Value.Value
-						.Split(',', StringSplitOptions.RemoveEmptyEntries)
-						.ToImmutableArray();
+						.ToImmutableHashSet();
 				}
 
 				ClearTerrain = ParseTerrainIndexes("ClearTerrain");
@@ -296,15 +326,12 @@ namespace OpenRA.Mods.Common.Traits
 				DominantTerrain = ParseTerrainIndexes("DominantTerrain");
 				ZoneableTerrain = ParseTerrainIndexes("ZoneableTerrain");
 
-				ClearSegmentTypes = ParseSegmentTypes("ClearSegmentTypes");
-				BeachSegmentTypes = ParseSegmentTypes("BeachSegmentTypes");
-				if (WaterRoughness > 0)
-					WaterCliffSegmentTypes = ParseSegmentTypes("WaterCliffSegmentTypes");
+				ClearSegmentType = my.NodeWithKey("ClearSegmentTypes").Value.Value;
+				BeachSegmentType = my.NodeWithKey("BeachSegmentTypes").Value.Value;
+				if (WaterCliffs)
+					WaterCliffSegmentType = my.NodeWithKey("WaterCliffSegmentTypes").Value.Value;
 
-				CliffSegmentTypes = ParseSegmentTypes("CliffSegmentTypes");
-				RoadSegmentTypes = ParseSegmentTypes("RoadSegmentTypes");
-
-				Validate(terrainInfo);
+				CliffSegmentType = my.NodeWithKey("CliffSegmentTypes").Value.Value;
 			}
 
 			static object MirrorLoader(MiniYaml my)
@@ -336,137 +363,6 @@ namespace OpenRA.Mods.Common.Traits
 							throw new YamlException($"Invalid resource spawn weight `{subMy.Value}`");
 					});
 			}
-
-			public void Validate(ITemplatedTerrainInfo terrainInfo)
-			{
-				if (Rotations < 1)
-					throw new MapGenerationException("Rotations must be >= 1");
-				if (TerrainFeatureSize < 1)
-					throw new MapGenerationException("TerrainFeatureSize must be >= 1");
-				if (ForestFeatureSize < 1)
-					throw new MapGenerationException("ForestFeatureSize must be >= 1");
-				if (ResourceFeatureSize < 1)
-					throw new MapGenerationException("ResourceFeatureSize must be >= 1");
-				if (CivilianBuildingsFeatureSize < 1)
-					throw new MapGenerationException("CivilianBuildingsFeatureSize must be >= 1");
-				if (TerrainSmoothing < 0 || TerrainSmoothing > MatrixUtils.MaxBinomialKernelRadius)
-					throw new MapGenerationException($"TerrainSmoothing must be between 0 and {MatrixUtils.MaxBinomialKernelRadius} inclusive");
-				if (WaterRoughness > 0 && MinimumCoastStraight < 0)
-					throw new MapGenerationException("MinimumCoastStraight must be >= 0");
-				if (SmoothingThreshold < (FractionMax + 1) / 2 || SmoothingThreshold > FractionMax)
-					throw new MapGenerationException($"SmoothingThreshold must be between {(FractionMax + 1) / 2} and {FractionMax} inclusive");
-				if (MinimumLandSeaThickness < 1)
-					throw new MapGenerationException("MinimumLandSeaThickness must be >= 1");
-				if (MinimumMountainThickness < 1)
-					throw new MapGenerationException("MinimumMountainThickness must be >= 1");
-				if (Water < 0 || Water > FractionMax)
-					throw new MapGenerationException($"Water must be between 0 and {FractionMax} inclusive");
-				if (Forests < 0 || Forests > FractionMax)
-					throw new MapGenerationException($"Forest must be between 0 and {FractionMax} inclusive");
-				if (ForestCutout < 0)
-					throw new MapGenerationException("ForestCutout must be >= 0");
-				if (MaximumCutoutSpacing < 0)
-					throw new MapGenerationException("TopologyAugmentationThreshold must be >= 0");
-				if (ForestClumpiness < 0)
-					throw new MapGenerationException("ForestClumpiness must be >= 0");
-				if (Mountains < 0 || Mountains > FractionMax)
-					throw new MapGenerationException($"Mountains must be between 0 and {FractionMax} inclusive");
-				if (Roughness < 0 || Roughness > FractionMax)
-					throw new MapGenerationException("Roughness must be between 0 and {FractionMax}");
-				if (WaterRoughness < 0 || WaterRoughness > FractionMax)
-					throw new MapGenerationException("WaterRoughness must be between 0 and {FractionMax}");
-				if (RoughnessRadius < 1)
-					throw new MapGenerationException("RoughnessRadius must be >= 1");
-				if (MaximumAltitude < 0)
-					throw new MapGenerationException("MaximumAltitude must be >= 0");
-				if (MinimumTerrainContourSpacing < 0)
-					throw new MapGenerationException("MinimumTerrainContourSpacing must be >= 0");
-				if (WaterRoughness > 0 && MinimumBeachLength < 1)
-					throw new MapGenerationException("MinimumBeachLength must be >= 1");
-				if (WaterRoughness > 0 && MinimumCliffLength < 1)
-					throw new MapGenerationException("MinimumWaterCliffLength must be >= 1");
-				if (MinimumCliffLength < 1)
-					throw new MapGenerationException("MinimumCliffLength must be >= 1");
-				if (RoadSpacing < 0)
-					throw new MapGenerationException("RoadSpacing must be >= 0");
-				if (RoadShrink < 0)
-					throw new MapGenerationException("RoadShrink must be >= 0");
-				if (Players < 0)
-					throw new MapGenerationException("Players must be >= 0");
-				if (CentralSpawnReservationFraction < 0)
-					throw new MapGenerationException("CentralSpawnReservationFraction must be >= 0");
-				if (AreaEntityBonus < 0)
-					throw new MapGenerationException("PlayableAreaDensityBonus must be >= 0");
-				if (PlayerCountEntityBonus < 0)
-					throw new MapGenerationException("PlayerCountDensityBonus must be >= 0");
-				if (SpawnRegionSize < 1)
-					throw new MapGenerationException("SpawnRegionSize must be >= 1");
-				if (SpawnReservation < 1)
-					throw new MapGenerationException("SpawnReservation must be >= 1");
-				if (SpawnBuildSize < 1)
-					throw new MapGenerationException("SpawnBuildSize must be >= 1");
-				if (MinimumSpawnRadius < 1)
-					throw new MapGenerationException("MinimumSpawnRadius must be >= 1");
-				if (SpawnResourceSpawns < 0)
-					throw new MapGenerationException("SpawnResourceSpawns must be >= 0");
-				if (ResourceSpawnReservation < 1)
-					throw new MapGenerationException("ResourceSpawnReservation must be >= 1");
-				if (MaximumExpansionResourceSpawns < 0)
-					throw new MapGenerationException("MaximumExpansionResourceSpawns must be >= 0");
-				if (MinimumExpansionSize < 1)
-					throw new MapGenerationException("MinimumExpansionSize must be >= 1");
-				if (MaximumExpansionSize < 1)
-					throw new MapGenerationException("MaximumExpansionSize must be >= 1");
-				if (MinimumExpansionSize > MaximumExpansionSize)
-					throw new MapGenerationException("MinimumExpansionSize must be <= maximumExpansionSize");
-				if (ExpansionBorder < 1)
-					throw new MapGenerationException("ExpansionBorder must be >= 1");
-				if (ExpansionInner < 1)
-					throw new MapGenerationException("ExpansionInner must be >= 1");
-				if (MaximumResourceSpawnsPerExpansion < 1)
-					throw new MapGenerationException("MaximumResourceSpawnsPerExpansion must be >= 1");
-				if (MinimumBuildings < 0)
-					throw new MapGenerationException("MinimumBuildings must be >= 0");
-				if (MaximumBuildings < 0)
-					throw new MapGenerationException("MaximumBuildings must be >= 0");
-				if (MinimumBuildings > MaximumBuildings)
-					throw new MapGenerationException("MinimumBuildings must be <= maximumBuildings");
-				if (CivilianBuildings < 0 || CivilianBuildings > FractionMax)
-					throw new MapGenerationException($"CivilianBuildings must be between 0 and {FractionMax} inclusive");
-				if (CivilianBuildingDensity < 0 || CivilianBuildingDensity > FractionMax)
-					throw new MapGenerationException($"CivilianBuildingDensity must be between 0 and {FractionMax} inclusive");
-				if (MinimumCivilianBuildingDensity < 0 || MinimumCivilianBuildingDensity > FractionMax)
-					throw new MapGenerationException($"MinimumCivilianBuildingDensity must be between 0 and {FractionMax} inclusive");
-				if (CivilianBuildingDensityRadius < 0)
-					throw new MapGenerationException("CivilianBuildingDensityRadius must be >= 0");
-				if (ResourcesPerPlayer < 0)
-					throw new MapGenerationException("ResourcesPerPlayer must be >= 0");
-				if (OreUniformity < 0)
-					throw new MapGenerationException("OreUniformity must be >= 0");
-				if (OreClumpiness < 0)
-					throw new MapGenerationException("OreClumpiness must be >= 0");
-				foreach (var kv in BuildingWeights)
-					if (kv.Value < 0)
-						throw new MapGenerationException("BuildingWeights.* must be >= 0");
-				foreach (var kv in ResourceSpawnWeights)
-					if (kv.Value < 0)
-						throw new MapGenerationException("ResourceSpawnWeights.* must be >= 0");
-				foreach (var kv in ResourceSpawnWeights)
-					if (!ResourceSpawnSeeds.ContainsKey(kv.Key))
-						throw new MapGenerationException($"ResourceSpawnSeeds does not contain possible resource spawn `{kv.Key}`");
-
-				if (!(terrainInfo.Templates.TryGetValue(LandTile, out var landTemplate) && landTemplate.Contains(0)))
-					throw new MapGenerationException("LandTile is not valid");
-				if (!(terrainInfo.Templates.TryGetValue(LandTile, out var waterTemplate) && waterTemplate.Contains(0)))
-					throw new MapGenerationException("WaterTile is not valid");
-
-				if (Players > 32)
-					throw new MapGenerationException("Total number of players must not exceed 32");
-
-				var symmetryCount = Symmetry.RotateAndMirrorProjectionCount(Rotations, Mirror);
-				if (Players % symmetryCount != 0)
-					throw new MapGenerationException($"Total number of players must be a multiple of {symmetryCount}");
-			}
 		}
 
 		public IMapGeneratorSettings GetSettings()
@@ -485,12 +381,6 @@ namespace OpenRA.Mods.Common.Traits
 			var param = new Parameters(map, args.Settings);
 
 			var terraformer = new Terraformer(args, map, modData, actorPlans, param.Mirror, param.Rotations);
-
-			var waterIsPlayable = param.PlayableTerrain.Contains(terrainInfo.GetTerrainIndex(new TerrainTile(param.WaterTile, 0)));
-
-			var externalCircleRadius = CellLayerUtils.Radius(map) - new WDist((param.MinimumLandSeaThickness + param.MinimumMountainThickness) * 1024);
-			if (param.ExternalCircularBias != 0 && externalCircleRadius.Length <= 0)
-				throw new MapGenerationException("map is too small for circular shaping");
 
 			CellLayer<MultiBrush.Replaceability> PlayableToReplaceable()
 			{
@@ -513,25 +403,28 @@ namespace OpenRA.Mods.Common.Traits
 				return replace;
 			}
 
+			var cellBounds = CellLayerUtils.CellBounds(map);
+
 			// Use `random` to derive separate independent random number generators.
 			//
 			// This prevents changes in one part of the algorithm from affecting randomness in
-			// other parts and provides flexibility for future parallel processing.
+			// other parts.
 			//
-			// In order to maximize stability, additions should be appended only. Disused
+			// In order to maintain stability, additions should be appended only. Disused
 			// derivatives may be deleted but should be replaced with their unused call to
-			// random.Next(). All generators should be created unconditionally.
+			// random.Next(). All derived RNGs should be created unconditionally.
 			var random = new MersenneTwister(param.Seed);
 
+			var pickAnyRandom = new MersenneTwister(random.Next());
 			var elevationRandom = new MersenneTwister(random.Next());
 			var coastTilingRandom = new MersenneTwister(random.Next());
 			var cliffTilingRandom = new MersenneTwister(random.Next());
+			var rampTilingRandom = new MersenneTwister(random.Next());
 			var forestRandom = new MersenneTwister(random.Next());
 			var forestTilingRandom = new MersenneTwister(random.Next());
 			var symmetryTilingRandom = new MersenneTwister(random.Next());
 			var debrisTilingRandom = new MersenneTwister(random.Next());
 			var resourceRandom = new MersenneTwister(random.Next());
-			var roadTilingRandom = new MersenneTwister(random.Next());
 			var playerRandom = new MersenneTwister(random.Next());
 			var expansionRandom = new MersenneTwister(random.Next());
 			var buildingRandom = new MersenneTwister(random.Next());
@@ -539,9 +432,31 @@ namespace OpenRA.Mods.Common.Traits
 			var repaintRandom = new MersenneTwister(random.Next());
 			var decorationRandom = new MersenneTwister(random.Next());
 			var decorationTilingRandom = new MersenneTwister(random.Next());
-			var pickAnyRandom = new MersenneTwister(random.Next());
+			var heightMapNoiseRandom = new MersenneTwister(random.Next());
+			var groundTypeNoiseRandom = new MersenneTwister(random.Next());
 
 			terraformer.InitMap();
+
+			var rampTiler = new RampTiler(map, param.RampTiles);
+
+			var clearZone = new Terraformer.PathPartitionZone()
+			{
+				ShouldTile = false,
+				SegmentType = param.ClearSegmentType,
+				MinimumLength = param.MinimumClearLength,
+			};
+			var beachZone = new Terraformer.PathPartitionZone()
+			{
+				SegmentType = param.BeachSegmentType,
+				MinimumLength = param.MinimumBeachLength,
+				MaximumDeviation = param.MinimumLandSeaThickness - 1,
+			};
+			var cliffZone = new Terraformer.PathPartitionZone()
+			{
+				SegmentType = param.CliffSegmentType,
+				MinimumLength = param.MinimumCliffLength,
+				MaximumDeviation = param.MinimumMountainThickness - 1,
+			};
 
 			foreach (var mpos in map.AllCells.MapCoords)
 				map.Tiles[mpos] = terraformer.PickTile(pickAnyRandom, param.LandTile);
@@ -554,56 +469,35 @@ namespace OpenRA.Mods.Common.Traits
 				elevation,
 				param.RoughnessRadius);
 
-			Matrix<bool> mapShape;
-			if (param.ExternalCircularBias == 0)
-				mapShape = new Matrix<bool>(CellLayerUtils.CellBounds(map).Size.ToInt2()).Fill(true);
-			else
-				mapShape = CellLayerUtils.ToMatrix(terraformer.CenteredCircle(true, false, externalCircleRadius), false);
-
-			var landPlan = terraformer.SliceElevation(elevation, mapShape, FractionMax - param.Water);
-
-			if (param.ExternalCircularBias > 0)
-			{
-				for (var n = 0; n < landPlan.Data.Length; n++)
-					landPlan[n] |= !mapShape[n];
-				var ring = terraformer.CenteredCircle(false, true, externalCircleRadius + new WDist(param.MinimumMountainThickness * 1024));
-				var path = TilingPath.QuickCreate(
-					map,
-					param.SegmentedBrushes,
-					CellLayerUtils.BordersToPoints(ring)[0],
-					(param.MinimumMountainThickness - 1) / 2,
-					param.CliffSegmentTypes[0],
-					param.CliffSegmentTypes[0]);
-				var brush = path.Tile(cliffTilingRandom)
-					?? throw new MapGenerationException("Could not fit tiles for exterior circle cliffs");
-				terraformer.PaintTiling(pickAnyRandom, brush);
-			}
-
+			var landPlan = terraformer.SliceElevation(elevation, null, FractionMax - param.Water);
 			landPlan = MatrixUtils.BooleanBlotch(
 				landPlan,
 				param.TerrainSmoothing,
 				param.SmoothingThreshold, /*smoothingThresholdOutOf=*/FractionMax,
 				param.MinimumLandSeaThickness,
 				/*bias=*/param.Water <= FractionMax / 2);
+			var elevationPlan = landPlan;
+
+			var elevationCalibration =
+				Enumerable.Zip(
+					landPlan.Data,
+					elevation.Data,
+					(p, e) => p ? e : int.MaxValue)
+				.Min();
+			elevation = elevation.Map(v => v - elevationCalibration);
+
+			var heightMap = new RampTiler.HeightMap(map);
 
 			var coast = MatrixUtils.BordersToPoints(landPlan);
 			List<TilingPath> coastPaths;
-			if (param.WaterRoughness > 0)
+			if (param.WaterCliffs)
 			{
-				var beachZone = new Terraformer.PathPartitionZone()
-				{
-					RequiredSomewhere = true,
-					SegmentType = param.BeachSegmentTypes[0],
-					MinimumLength = param.MinimumBeachLength,
-					MaximumDeviation = param.MinimumLandSeaThickness - 1,
-				};
 				var waterCliffZone = new Terraformer.PathPartitionZone()
 				{
-					SegmentType = param.WaterCliffSegmentTypes[0],
-					MinimumLength = param.MinimumCliffLength,
+					SegmentType = param.WaterCliffSegmentType,
+					MinimumLength = param.MinimumWaterCliffLength,
 					MaximumDeviation = param.MinimumLandSeaThickness - 1,
 				};
-
 				var waterCliffMask = MatrixUtils.CalibratedBooleanThreshold(
 					roughnessMatrix,
 					param.WaterRoughness, FractionMax);
@@ -629,8 +523,8 @@ namespace OpenRA.Mods.Common.Traits
 								param.SegmentedBrushes,
 								beach,
 								param.MinimumLandSeaThickness - 1,
-								param.BeachSegmentTypes[0],
-								param.BeachSegmentTypes[0])
+								param.BeachSegmentType,
+								param.BeachSegmentType)
 									.ExtendEdge(4))
 					.ToList();
 			}
@@ -645,49 +539,145 @@ namespace OpenRA.Mods.Common.Traits
 				0)
 					?? throw new MapGenerationException("Could not fit tiles for coast");
 
+			var cliffHeight = MultiBrush.MaxHeightOfSegmentType(
+				param.CliffSegmentType,
+				param.SegmentedBrushes);
+
+			if (param.WaterCliffs)
+			{
+				var waterCliffHeight = MultiBrush.MaxHeightOfSegmentType(
+					param.WaterCliffSegmentType,
+					param.SegmentedBrushes);
+
+				elevationPlan = terraformer.SliceElevation(
+					elevation,
+					elevationPlan,
+					FractionMax,
+					param.MinimumTerrainContourSpacing);
+
+				heightMap.SetCellHeights(
+					waterCliffHeight,
+					CellLayerUtils.Map(landCoastWater, v => v == Terraformer.Side.In));
+				heightMap.MarkUntileable(
+					CellLayerUtils.Map(map.Height, v => v != 0));
+				heightMap.SeedHeights(
+					heightMap.Target.Enumerate()
+						.Where(v => v.Value == 0)
+						.Select(v => (v.Xy, param.BeachSpreadWhenWaterCliffing, (byte)0)));
+			}
+
+			heightMap.MarkUntileable(
+				CellLayerUtils.Map(landCoastWater, v => v != Terraformer.Side.In));
+
 			if (param.Mountains > 0)
 			{
 				var cliffMask = MatrixUtils.CalibratedBooleanThreshold(
 					roughnessMatrix,
 					param.Roughness, FractionMax);
-				var cliffPlan = Matrix<bool>.Zip(landPlan, mapShape, (a, b) => a && b);
 
 				for (var altitude = 0; altitude < param.MaximumAltitude; altitude++)
 				{
-					cliffPlan = terraformer.SliceElevation(
+					elevationPlan = terraformer.SliceElevation(
 						elevation,
-						cliffPlan,
+						elevationPlan,
 						param.Mountains,
 						param.MinimumTerrainContourSpacing);
-					cliffPlan = MatrixUtils.BooleanBlotch(
-						cliffPlan,
+					elevationPlan = MatrixUtils.BooleanBlotch(
+						elevationPlan,
 						param.TerrainSmoothing,
 						param.SmoothingThreshold, /*smoothingThresholdOutOf=*/FractionMax,
 						param.MinimumMountainThickness,
 						/*bias=*/false);
-					var unmaskedCliffs = MatrixUtils.BordersToPoints(cliffPlan);
-					var maskedCliffs = MatrixUtils.MaskPathPoints(unmaskedCliffs, cliffMask);
-					var cliffs = CellLayerUtils.FromMatrixPoints(maskedCliffs, map.Tiles)
-						.Where(cliff => cliff.Length >= param.MinimumCliffLength).ToArray();
-					if (cliffs.Length == 0)
-						break;
-					foreach (var cliff in cliffs)
+
+					var planCellLayer = new CellLayer<bool>(map);
+					CellLayerUtils.FromMatrix(planCellLayer, elevationPlan);
+
+					var contours = MatrixUtils.BordersToPoints(elevationPlan);
+					var partitionMask = cliffMask.Map(masked => masked ? cliffZone : clearZone);
+
+					var shortContours = new List<int2[]>();
+					var tallContours = new List<int2[]>();
+
+					foreach (var contour in contours)
 					{
-						var cliffPath = TilingPath.QuickCreate(
-							map,
+						var tilingPaths = terraformer.PartitionPath(
+							contour,
+							[cliffZone, clearZone],
+							partitionMask,
 							param.SegmentedBrushes,
-							cliff,
-							(param.MinimumMountainThickness - 1) / 2,
-							param.CliffSegmentTypes[0],
-							param.ClearSegmentTypes[0])
-								.ExtendEdge(4);
-						var brush = cliffPath.Tile(cliffTilingRandom)
-							?? throw new MapGenerationException("Could not fit tiles for cliffs");
-						terraformer.PaintTiling(pickAnyRandom, brush);
+							param.MinimumCliffStraight);
+
+						if (tilingPaths.Count > 0)
+							tallContours.Add(contour);
+						else
+							shortContours.Add(contour);
+
+						var baseHeight = contour.Max(xy => heightMap.Target[xy]);
+
+						foreach (var tilingPath in tilingPaths)
+						{
+							var brush = tilingPath
+								.OptimizeLoop()
+								.ExtendEdge(4)
+								.SetAutoEndDeviation()
+								.Tile(cliffTilingRandom)
+									?? throw new MapGenerationException("Could not fit tiles for sand-sand cliffs");
+
+							terraformer.PaintTiling(pickAnyRandom, brush, baseHeight);
+
+							heightMap.MarkUntileable(brush.Shape.Select(cvec => CPos.Zero + cvec));
+						}
 					}
+
+					var shortMask = new CellLayer<bool>(map);
+					var tallMask = new CellLayer<bool>(map);
+
+					var shortChirality = MatrixUtils.PointsChirality(cellBounds.Size.ToInt2(), shortContours);
+					if (shortChirality != null)
+					{
+						CellLayerUtils.FromMatrix(
+							shortMask,
+							shortChirality.Map(v => v > 0));
+					}
+
+					var tallChirality = MatrixUtils.PointsChirality(cellBounds.Size.ToInt2(), tallContours);
+					if (tallChirality != null)
+					{
+						CellLayerUtils.FromMatrix(
+							tallMask,
+							tallChirality.Map(v => v > 0));
+					}
+
+					heightMap.AdjustCellHeights(1, shortMask);
+					heightMap.AdjustCellHeights(cliffHeight, tallMask);
 				}
 			}
 
+			{
+				rampTiler.PullHeightMap(heightMap);
+
+				var noise = NoiseUtils.SymmetricFractalNoise(
+					heightMapNoiseRandom,
+					heightMap.Target.Size,
+					terraformer.Rotations,
+					terraformer.WMirror.ForCPos(),
+					param.RampFeatureSize,
+					NoiseUtils.PinkAmplitude);
+				noise = MatrixUtils.BinomialBlur(noise, 1);
+				noise = MatrixUtils.NormalizeRangeInPlace(noise, 3);
+				for (var i = 0; i < noise.Data.Length; i++)
+					heightMap.Target[i] = (byte)Math.Clamp(noise[i] + heightMap.Target[i], byte.MinValue, byte.MaxValue);
+
+				heightMap.Soften(param.RampSoften);
+				if (!heightMap.Constrain(RampTiler.AdjustmentMode.LowerMiddle))
+					throw new MapGenerationException("created unfixable heightmap");
+
+				var brush = rampTiler.TileHeightMap(heightMap, rampTilingRandom)
+					?? throw new MapGenerationException("created invalid heightmap");
+				terraformer.PaintTiling(rampTilingRandom, brush, 0);
+			}
+
+			CellLayer<bool> forestPlan = null;
 			if (param.Forests > 0)
 			{
 				var space = terraformer.CheckSpace(param.ClearTerrain);
@@ -696,14 +686,14 @@ namespace OpenRA.Mods.Common.Traits
 					terraformer.ImproveSymmetry(space, true, (a, b) => a && b),
 					param.ForestCutout,
 					param.MaximumCutoutSpacing);
-				var forestNoise = terraformer.BooleanNoise(
+				forestPlan = terraformer.BooleanNoise(
 					forestRandom,
 					param.ForestFeatureSize,
 					param.Forests,
 					param.ForestClumpiness);
 				var replace = PlayableToReplaceable();
 				foreach (var mpos in map.AllCells.MapCoords)
-					if (!forestNoise[mpos] || !space[mpos] || passages[mpos])
+					if (!forestPlan[mpos] || !space[mpos] || passages[mpos])
 						replace[mpos] = MultiBrush.Replaceability.None;
 				terraformer.PaintArea(forestTilingRandom, replace, param.ForestObstacles);
 			}
@@ -716,16 +706,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			CellLayer<bool> playable;
 			{
-				// For circle-in-mountains, the outside is unplayable and should never count as
-				// the largest/preferred region.
-				CellLayer<bool> poison = null;
-				if (param.ExternalCircularBias > 0)
-					poison = terraformer.CenteredCircle(
-						false, true, CellLayerUtils.Radius(map.Tiles) - new WDist(1024));
-
 				playable = terraformer.ChoosePlayableRegion(
 					terraformer.CheckSpace(param.PlayableTerrain, true, false, true),
-					poison)
+					null)
 						?? throw new MapGenerationException("could not find a playable region");
 
 				var minimumPlayableSpace = (int)(param.Players * Math.PI * param.SpawnBuildSize * param.SpawnBuildSize);
@@ -734,69 +717,19 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (param.DenyWalledAreas)
 				{
-					// Coast tiles are particularly problematic. If they're for unplayable bodies
-					// of water, they should be obliterated. If they're just surrounded by rocks,
-					// trees, etc, they should be filled in with actors.
-					if (waterIsPlayable)
-					{
-						var mask = CellLayerUtils.Clone(playable);
-						terraformer.ZoneFromOutOfBounds(mask, true);
-						terraformer.FillUnmaskedSideAndBorder(
-							mask,
-							landCoastWater,
-							Terraformer.Side.Out,
-							cpos => map.Tiles[cpos] = terraformer.PickTile(pickAnyRandom, param.LandTile));
-					}
-
 					var replace = PlayableToReplaceable();
 					foreach (var mpos in map.AllCells.MapCoords)
-						if (playable[mpos] || !map.Bounds.Contains(mpos.U, mpos.V))
+						if (playable[mpos] || !map.Contains(mpos))
 							replace[mpos] = MultiBrush.Replaceability.None;
 
 					terraformer.PaintArea(debrisTilingRandom, replace, param.UnplayableObstacles);
 				}
 			}
 
-			if (param.Roads)
-			{
-				// TODO: Move or collapse into configuration
-				const int RoadMinimumShrinkLength = 12;
-				const int RoadStraightenShrink = 4;
-				const int RoadStraightenGrow = 2;
-				const int RoadInertialRange = 8;
-
-				var roadPaths = terraformer.PlanRoads(
-					terraformer.CheckSpace(param.ClearTerrain, true, false),
-					param.RoadSpacing,
-					RoadMinimumShrinkLength + 2 * (RoadStraightenShrink + param.RoadShrink));
-				foreach (var roadPath in roadPaths)
-				{
-					var tilingPath = TilingPath.QuickCreate(
-						map,
-						param.SegmentedBrushes,
-						roadPath,
-						param.RoadSpacing - 1,
-						param.RoadSegmentTypes[0],
-						param.ClearSegmentTypes[0])
-							.StraightenEnds(
-								RoadStraightenShrink + param.RoadShrink,
-								RoadStraightenGrow,
-								RoadMinimumShrinkLength,
-								RoadInertialRange)
-							.RetainIfValid();
-					if (tilingPath.Points == null)
-						continue;
-
-					var brush = tilingPath.Tile(roadTilingRandom)
-						?? throw new MapGenerationException("Could not fit tiles for roads");
-					terraformer.PaintTiling(pickAnyRandom, brush);
-				}
-			}
+			var zoneable = terraformer.GetZoneable(param.ZoneableTerrain, playable);
 
 			if (param.CreateEntities)
 			{
-				var zoneable = terraformer.GetZoneable(param.ZoneableTerrain, playable);
-
 				var zoneableArea = zoneable.Count(v => v);
 				var symmetryCount = Symmetry.RotateAndMirrorProjectionCount(param.Rotations, param.Mirror);
 				var entityMultiplier =
@@ -904,6 +837,15 @@ namespace OpenRA.Mods.Common.Traits
 								}));
 					}
 
+					// Give veinholes even more bias. (Note: they don't consume resource quota.)
+					resourceBiases.AddRange(
+						terraformer.ActorsOfType("veinhole")
+							.Select(a => new Terraformer.ResourceBias(a)
+							{
+								BiasRadius = new WDist(16 * 1024),
+								Bias = (value, rSq) => value + (int)(512 * 1024 / (1024 + Exts.ISqrt(rSq))),
+							}));
+
 					// Bias towards player spawns, but also reserve an area for base building.
 					resourceBiases.AddRange(
 						terraformer.ActorsOfType("mpspawn")
@@ -914,16 +856,28 @@ namespace OpenRA.Mods.Common.Traits
 								Bias = (value, rSq) => value + (int)(value * param.SpawnResourceBias * wSpawnBuildSizeSq / Math.Max(rSq, 1024 * 1024) / FractionMax),
 							}));
 
+					var resourceMask = CellLayerUtils.Clone(playable);
+					terraformer.ZoneFromActors(resourceMask, false);
+					terraformer.ZoneFromNonCardinalRamps(resourceMask, false);
+
 					var (plan, typePlan) = terraformer.PlanResources(
 						resourcePattern,
-						CellLayerUtils.Intersect([playable, terraformer.CheckSpace(null, true)]),
+						resourceMask,
 						param.DefaultResource,
 						resourceBiases);
 					terraformer.GrowResources(
 						plan,
 						typePlan,
-						targetResourceValue);
+						targetResourceValue,
+						Terraformer.ResourceDensityMode.BakedAdjacency);
 					terraformer.ZoneFromResources(zoneable, false);
+
+					// Veins should be max density.
+					var veinType = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<ResourceLayerInfo>().ResourceTypes["Veins"];
+					var veinResourceTile = new ResourceTile(veinType.ResourceIndex, veinType.MaxDensity);
+					foreach (var mpos in map.Resources.CellRegion.MapCoords)
+						if (map.Resources[mpos].Type == veinType.ResourceIndex)
+							map.Resources[mpos] = veinResourceTile;
 				}
 
 				// CivilianBuildings
@@ -946,7 +900,30 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
+			void DecorateFloorTiles(ushort tile, int fraction, CellLayer<bool> addIn = null)
+			{
+				var tileable = terraformer.CheckSpace(param.LandTile);
+				var noise = terraformer.BooleanNoise(groundTypeNoiseRandom, 10240, fraction);
+				noise = CellLayerUtils.Intersect([noise, zoneable]);
+				if (addIn != null)
+					noise = CellLayerUtils.Union([noise, addIn]);
+
+				noise = CellLayerUtils.Intersect([noise, tileable]);
+				noise = terraformer.ImproveSymmetry(noise, true, (a, b) => a && b);
+				foreach (var cpos in map.Tiles.CellRegion)
+					if (noise[cpos])
+						map.Tiles[cpos] = new TerrainTile(tile, 0);
+			}
+
+			DecorateFloorTiles(param.ForestFloorTile, param.ForestFloor, forestPlan);
+			foreach (var (tile, fraction) in param.OtherGround)
+				DecorateFloorTiles(tile, fraction);
+
 			// Cosmetically repaint tiles
+			terraformer.PaintTiling(pickAnyRandom, param.LatTiler.OfferReplacements(map, pickAnyRandom), 0);
+			if (param.UseIceLatTiler)
+				terraformer.PaintTiling(pickAnyRandom, param.IceLatTiler.OfferReplacements(map, pickAnyRandom), 0);
+
 			terraformer.RepaintTiles(repaintRandom, param.RepaintTiles);
 
 			terraformer.ReorderPlayerSpawns();
@@ -977,23 +954,22 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init)
 		{
-			return new ClassicMapGenerator(init, this);
+			return new TSMapGenerator(this);
 		}
 	}
 
-	public class ClassicMapGenerator : IEditorTool
+	public class TSMapGenerator : IEditorTool
 	{
 		public string Label { get; }
 		public string PanelWidget { get; }
 		public TraitInfo TraitInfo { get; }
-		public bool IsEnabled { get; }
+		public bool IsEnabled => true;
 
-		public ClassicMapGenerator(ActorInitializer init, ClassicMapGeneratorInfo info)
+		public TSMapGenerator(TSMapGeneratorInfo info)
 		{
 			Label = info.Name;
 			PanelWidget = info.PanelWidget;
 			TraitInfo = info;
-			IsEnabled = info.Tilesets.Contains(init.Self.World.Map.Tileset);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -656,6 +656,12 @@ namespace OpenRA.Mods.Common.MapGenerator
 			return Aggregate(layers, (a, b) => a && b);
 		}
 
+		/// <summary>Return logical AND / conjunction / intersection of layers.</summary>
+		public static CellLayer<bool> Union(IEnumerable<CellLayer<bool>> layers)
+		{
+			return Aggregate(layers, (a, b) => a || b);
+		}
+
 		/// <summary>
 		/// Return the difference of layers. Each cell is true if and only if something appears
 		/// only in the first layer.

--- a/OpenRA.Mods.Common/MapGenerator/LatTiler.cs
+++ b/OpenRA.Mods.Common/MapGenerator/LatTiler.cs
@@ -1,0 +1,238 @@
+#region Copyright & License Information
+/*
+* Copyright (c) The OpenRA Developers and Contributors
+* This file is part of OpenRA, which is free software. It is made
+* available to you under the terms of the GNU General Public License
+* as published by the Free Software Foundation, either version 3 of
+* the License, or (at your option) any later version. For more
+* information, see COPYING.
+*/
+#endregion
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using OpenRA.Mods.Common.Terrain;
+using OpenRA.Support;
+
+namespace OpenRA.Mods.Common.MapGenerator
+{
+	/// <summary>
+	/// Replaces tiles to create smooth visual transistions based on "Lookup Adjacent Tile" rules.
+	/// </summary>
+	public sealed class LatTiler
+	{
+		/// <summary>
+		/// Defines how a tile should be replaced based on its neighboring tiles.
+		/// </summary>
+		public class LatRule
+		{
+			static readonly string[] LookupNames = [
+				"____",
+				"___x",
+				"__x_",
+				"__xx",
+				"_x__",
+				"_x_x",
+				"_xx_",
+				"_xxx",
+				"x___",
+				"x__x",
+				"x_x_",
+				"x_xx",
+				"xx__",
+				"xx_x",
+				"xxx_",
+				"xxxx",
+			];
+
+			static List<ushort> LoadUshortList(MiniYaml my, string field)
+			{
+				var node = my.NodeWithKeyOrDefault(field);
+				if (node == null)
+					return null;
+
+				var str = node.Value.Value;
+				if (str == null)
+					return [];
+
+				return FieldLoader.GetValue<List<ushort>>(field, str);
+			}
+
+			/// <summary>
+			/// The tile types that this rule considers to replace (or null to match any).
+			/// </summary>
+			[FieldLoader.Ignore]
+			public readonly ImmutableHashSet<ushort> Main = null;
+
+			/// <summary>
+			/// Required type of a neighboring tile to match as a low bit in the lookup, or null
+			/// to match any not in High. One of Low or High must be non-null.
+			/// </summary>
+			[FieldLoader.Ignore]
+			public readonly ImmutableHashSet<ushort> Low = null;
+
+			/// <summary>
+			/// Required type of a neighboring tile to match as a high bit in the lookup, or null
+			/// to match any not in Low. One of Low or High must be non-null.
+			/// </summary>
+			[FieldLoader.Ignore]
+			public readonly ImmutableHashSet<ushort> High = null;
+
+			/// <summary>Replacement lookup table. Array index is a bitmask of U=1, R=2, D=4, L=8.</summary>
+			[FieldLoader.Ignore]
+			public readonly ImmutableArray<ImmutableArray<MultiBrush>> Replacements;
+
+			public LatRule(MiniYaml my, ITemplatedTerrainInfo itti)
+			{
+				FieldLoader.Load(this, my);
+
+				var autoMain = my.NodeWithKeyOrDefault("AutoMain") != null;
+				List<ushort> main;
+				if (autoMain)
+					main = LoadUshortList(my, "AutoMain");
+				else
+					main = LoadUshortList(my, "Main");
+
+				Low = LoadUshortList(my, "Low")?.ToImmutableHashSet();
+				High = LoadUshortList(my, "High")?.ToImmutableHashSet();
+
+				if (Low == null && High == null)
+					throw new YamlException("both Low and High were null in LatRule");
+
+				if (Low != null && High != null && Low.Any(High.Contains))
+					throw new YamlException("Low and High have overlap in LatRule");
+
+				// For now, just support ushort lists. Arbitrary MultiBrushes could be supported by
+				// also treating the numeric nodes as MultiBrush collections.
+				var replacements = new ImmutableArray<MultiBrush>[16];
+				for (var i = 0; i < 16; i++)
+				{
+					var node = my.NodeWithKeyOrDefault(LookupNames[i]);
+					if (node == null)
+						continue;
+
+					var list = FieldLoader.GetValue<List<ushort>>(LookupNames[i], node.Value.Value);
+
+					if (autoMain)
+						main.AddRange(list);
+
+					replacements[i] =
+						list
+							.Select(t => new MultiBrush().WithTemplate(itti, t, CVec.Zero, 0))
+							.ToImmutableArray();
+					if (replacements[i].Length == 0)
+						throw new YamlException($"LatRule replacement {LookupNames[i]} has no values");
+				}
+
+				Main = main?.ToImmutableHashSet();
+				Replacements = replacements.ToImmutableArray();
+			}
+
+			/// <summary>
+			/// Given a tile type and its neighboring tile types, determine whether this rule
+			/// specifies a replacement MultiBrush and return it if so (else null).
+			/// </summary>
+			/// <param name="main">The central tile, for which replacement is being considered.</param>
+			/// <param name="adjacents">The surrounding -Y, +X, +Y, -X tiles (in that order).</param>
+			/// <param name="random">Random source for picking replacements if multiple match.</param>
+			public MultiBrush OfferReplacement(ushort main, ushort[] adjacents, MersenneTwister random)
+			{
+				if (Main != null && !Main.Contains(main))
+					return null;
+
+				if (Low != null &&
+					High != null &&
+					!adjacents.All(t => Low.Contains(t) || High.Contains(t)))
+				{
+					return null;
+				}
+
+				bool CheckBit(ushort type) =>
+					(Low != null)
+						? !Low.Contains(type)
+						: High.Contains(type);
+
+				var index =
+					(CheckBit(adjacents[0]) ? 1 : 0) |
+					(CheckBit(adjacents[1]) ? 2 : 0) |
+					(CheckBit(adjacents[2]) ? 4 : 0) |
+					(CheckBit(adjacents[3]) ? 8 : 0);
+
+				if (Replacements[index] == null)
+					return null;
+
+				return MultiBrush.PickAny(Replacements[index], random);
+			}
+		}
+
+		readonly ImmutableArray<LatRule> latRules;
+
+		public LatTiler(ImmutableArray<LatRule> latRules)
+		{
+			this.latRules = latRules;
+		}
+
+		public LatTiler(MiniYaml my, ITemplatedTerrainInfo itti)
+		{
+			var latRules = new List<LatRule>();
+			foreach (var node in my.Nodes)
+			{
+				var parts = node.Key.Split('@');
+				switch (parts[0])
+				{
+					case "Rule":
+						latRules.Add(new LatRule(node.Value, itti));
+						break;
+					default:
+						throw new YamlException($"Invalid LatTiler key `{node.Key}`");
+				}
+			}
+
+			this.latRules = latRules.ToImmutableArray();
+		}
+
+		/// <summary>
+		/// Provided a CellLayer of tiles, runs (first matching) rules against all tiles.
+		/// </summary>
+		/// <param name="map">Map to offer replacements for.</param>
+		/// <param name="random">Optional random source for picking replacements.</param>
+		/// <returns>A MultiBrush with the applicable map edits to apply.</returns>
+		public MultiBrush OfferReplacements(
+			Map map,
+			MersenneTwister random)
+		{
+			var result = new MultiBrush();
+			var gridType = map.Grid.Type;
+
+			foreach (var cpos in map.Tiles.CellRegion)
+			{
+				var main = map.Tiles[cpos].Type;
+				ushort[] adjacents = [main, main, main, main];
+				if (map.Tiles.Contains(cpos + new CVec(0, -1)))
+					adjacents[0] = map.Tiles[cpos + new CVec(0, -1)].Type;
+
+				if (map.Tiles.Contains(cpos + new CVec(1, 0)))
+					adjacents[1] = map.Tiles[cpos + new CVec(1, 0)].Type;
+
+				if (map.Tiles.Contains(cpos + new CVec(0, 1)))
+					adjacents[2] = map.Tiles[cpos + new CVec(0, 1)].Type;
+
+				if (map.Tiles.Contains(cpos + new CVec(-1, 0)))
+					adjacents[3] = map.Tiles[cpos + new CVec(-1, 0)].Type;
+
+				foreach (var latRule in latRules)
+				{
+					var replacement = latRule.OfferReplacement(main, adjacents, random);
+					if (replacement != null)
+					{
+						result.MergeFrom(replacement, cpos - CPos.Zero, gridType, map.Height[cpos]);
+						break;
+					}
+				}
+			}
+
+			return result;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/MapGenerator/Matrix.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Matrix.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.MapGenerator
 {
@@ -196,6 +197,25 @@ namespace OpenRA.Mods.Common.MapGenerator
 			for (var i = 0; i < a.Data.Length; i++)
 				matrix.Data[i] = func(a.Data[i], b.Data[i]);
 			return matrix;
+		}
+
+		/// <summary>
+		/// Copy the underlying data from one matrix to another similar matrix.
+		/// </summary>
+		public void CopyTo(Matrix<T> destination)
+		{
+			if (Size != destination.Size)
+				throw new ArgumentException("source and destination have different size");
+
+			Data.CopyTo(destination.Data, 0);
+		}
+
+		/// <summary>Return an IEnumerable over the coordinates and values.</summary>
+		public IEnumerable<(int2 Xy, T Value)> Enumerate()
+		{
+			for (var y = 0; y < Size.Y; y++)
+				for (var x = 0; x < Size.X; x++)
+					yield return (new int2(x, y), this[x, y]);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
@@ -637,18 +637,44 @@ namespace OpenRA.Mods.Common.MapGenerator
 				for (var cx = 0; cx < input.Size.X; cx++)
 				{
 					long total = 0;
-					var samples = 0;
 					for (var ky = 0; ky < kernel.Size.Y; ky++)
 						for (var kx = 0; kx < kernel.Size.X; kx++)
 						{
 							var x = cx + kx - kernelCenter.X;
 							var y = cy + ky - kernelCenter.Y;
 							total += input[input.ClampXY(new int2(x, y))] * kernel[kx, ky];
-							samples++;
 						}
 
 					output[cx, cy] = total;
 				}
+
+			return output;
+		}
+
+		/// <summary>
+		/// Apply an aggregator over submatrices of input with a given size and store it to an
+		/// output, returning the output. Sampling a coordinate outside of the input matrix uses
+		/// the closest coordinate inside the matrix.
+		/// </summary>
+		public static Matrix<R> KernelAggregate<T, R>(
+			Matrix<T> input,
+			Matrix<R> output,
+			int2 kernelSize,
+			int2 kernelCenter,
+			Func<Matrix<T>, R> aggregator)
+		{
+			var submatrix = new Matrix<T>(kernelSize);
+			for (var y = 0; y < output.Size.Y; y++)
+			{
+				for (var x = 0; x < output.Size.X; x++)
+				{
+					for (var oy = 0; oy < kernelSize.Y; oy++)
+						for (var ox = 0; ox < kernelSize.X; ox++)
+							submatrix[ox, oy] = input[input.ClampXY(new int2(x + ox, y + oy) - kernelCenter)];
+
+					output[x, y] = aggregator(submatrix);
+				}
+			}
 
 			return output;
 		}

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -890,5 +890,41 @@ namespace OpenRA.Mods.Common.MapGenerator
 					possible.Add(new(tileRange.Type, (byte)i));
 			return possible;
 		}
+
+		/// <summary>Pick a random brush from a list, respecting brush weights.</summary>
+		public static MultiBrush PickAny(IReadOnlyList<MultiBrush> brushes, MersenneTwister random)
+		{
+			if (brushes.Count == 0)
+				throw new ArgumentException("brushes was empty");
+
+			if (brushes.Count == 1)
+				return brushes[0];
+
+			var weights = new int[brushes.Count];
+			for (var i = 0; i < weights.Length; i++)
+				weights[i] = brushes[i].Weight;
+
+			return brushes[random.PickWeighted(weights)];
+		}
+
+		/// <summary>
+		/// Get the highest cell height in a MultiBrush collection. Does not consider ramps.
+		/// </summary>
+		public static byte MaxHeightOfBrushes(IEnumerable<MultiBrush> brushes)
+		{
+			return brushes
+				.SelectMany(b => b.GetHeightsAndRamps())
+				.Max(v => (byte)v.Height);
+		}
+
+		/// <summary>
+		/// Get the highest cell height in a MultiBrush collection filtered by segment inner type.
+		/// Does not consider ramps.
+		/// </summary>
+		public static byte MaxHeightOfSegmentType(string type, IEnumerable<MultiBrush> brushes)
+		{
+			return MaxHeightOfBrushes(
+				brushes.Where(b => b.Segment?.HasInnerType(type) ?? false));
+		}
 	}
 }

--- a/OpenRA.Mods.Common/MapGenerator/RampTiler.cs
+++ b/OpenRA.Mods.Common/MapGenerator/RampTiler.cs
@@ -1,0 +1,774 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Data;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Support;
+
+namespace OpenRA.Mods.Common.MapGenerator
+{
+	/// <summary>Combines ramp tiles to fit a target height map.</summary>
+	public sealed class RampTiler
+	{
+		static readonly ImmutableArray<CVec> CellsAroundCorner = [
+			new(0, 0), new(-1, 0), new(0, -1), new(-1, -1)
+		];
+		static readonly ImmutableArray<int2> CornersAroundCell = [
+			new(0, 0), new(1, 0), new(0, 1), new(1, 1)
+		];
+
+		public enum AdjustmentMode
+		{
+			/// <summary>Heights will only increase if absolutely necessary.</summary>
+			Minimal,
+
+			/// <summary>Heights will be a rounded down median of minimal and maximal.</summary>
+			LowerMiddle,
+
+			/// <summary>Heights will be a rounded up median of minimal and maximal.</summary>
+			UpperMiddle,
+
+			/// <summary>Heights will only decrease if absolutely necessary.</summary>
+			Maximal,
+		}
+
+		/// <summary>Height targets and constraints for tiling a map with ramps.</summary>
+		public sealed class HeightMap
+		{
+			/// <summary>Mapping from Matrix to CellLayer space.</summary>
+			public readonly Rectangle CellBounds;
+
+			/// <summary>Ideal cell corner heights.</summary>
+			public readonly Matrix<byte> Target;
+
+			/// <summary>Minimum permitted cell corner heights.</summary>
+			public readonly Matrix<byte> LowerBound;
+
+			/// <summary>Maximum permitted cell corner heights.</summary>
+			public readonly Matrix<byte> UpperBound;
+
+			/// <summary>Whether cell corner heights can deviate from Target when constraining or setting heights.</summary>
+			public readonly Matrix<bool> Adjustable;
+
+			/// <summary>Mask for cells to tile.</summary>
+			public readonly CellLayer<bool> Tileable;
+
+			public HeightMap(Map map)
+			{
+				CellBounds = CellLayerUtils.CellBounds(map);
+				var size = CellBounds.Size.ToInt2() + new int2(1, 1);
+				Target = new Matrix<byte>(size);
+				LowerBound = new Matrix<byte>(size).Fill(byte.MinValue);
+				UpperBound = new Matrix<byte>(size).Fill(byte.MaxValue);
+				Adjustable = new Matrix<bool>(size).Fill(true);
+				Tileable = new CellLayer<bool>(map);
+				Tileable.Clear(true);
+
+				for (var y = 0; y < size.Y; y++)
+				{
+					for (var x = 0; x < size.X; x++)
+					{
+						if (!ContainsCorner(new int2(x, y)))
+						{
+							LowerBound[x, y] = byte.MaxValue;
+							UpperBound[x, y] = byte.MinValue;
+							Adjustable[x, y] = false;
+						}
+					}
+				}
+			}
+
+			/// <summary>Helper to convert from CellLayer to Matrix space.</summary>
+			public int2 CPosToXy(CPos cpos)
+			{
+				return new int2(cpos.X, cpos.Y) - CellBounds.TopLeft;
+			}
+
+			/// <summary>Helper to convert from Matrix to CellLayer space.</summary>
+			public CPos XyToCPos(int2 xy)
+			{
+				xy += CellBounds.TopLeft;
+				return new CPos(xy.X, xy.Y);
+			}
+
+			/// <summary>Return true iff a map cell has a full 4 adjacent cells.</summary>
+			public bool IsInternalCell(CPos cpos)
+			{
+				return DirectionExts.Spread4CVec
+					.Select(cvec => cpos + cvec)
+					.All(Tileable.Contains);
+			}
+
+			/// <summary>Return true iff a cell corner has a full 4 adjacent corners.</summary>
+			public bool IsInternalCorner(int2 xy)
+			{
+				var cpos = XyToCPos(xy);
+				return CellsAroundCorner
+					.Select(cvec => cpos + cvec)
+					.Count(Tileable.Contains) >= 3;
+			}
+
+			/// <summary>Return true if a corner touches any cell within the map.</summary>
+			public bool ContainsCorner(int2 xy)
+			{
+				var cpos = XyToCPos(xy);
+				return CellsAroundCorner
+					.Select(cvec => cpos + cvec)
+					.Any(Tileable.Contains);
+			}
+
+			public void MarkUntileable(CellLayer<bool> mask)
+			{
+				foreach (var cpos in mask.CellRegion)
+					if (mask[cpos])
+						MarkUntileable(cpos);
+			}
+
+			public void MarkUntileable(IEnumerable<CPos> cells)
+			{
+				foreach (var cpos in cells)
+					MarkUntileable(cpos);
+			}
+
+			/// <summary>
+			/// Updates the corner heights of a given cell (each cell has 4 corners) according to what
+			/// is currently in the map, and do not include the cell in the ramp tiling result.
+			/// </summary>
+			public void MarkUntileable(CPos cpos)
+			{
+				if (!Tileable.Contains(cpos))
+					return;
+
+				Tileable[cpos] = false;
+				var xy = CPosToXy(cpos);
+
+				foreach (var offset in CornersAroundCell)
+				{
+					var corner = xy + offset;
+					Target[corner] = 0;
+					LowerBound[corner] = byte.MaxValue;
+					UpperBound[corner] = byte.MinValue;
+					Adjustable[corner] = false;
+				}
+			}
+
+			IEnumerable<(int2 XY, (byte Height, bool First) Prop)> FillSeeds(Matrix<byte> heights)
+			{
+				for (var y = 0; y < Adjustable.Size.Y; y++)
+					for (var x = 0; x < Adjustable.Size.X; x++)
+						if (Adjustable[x, y])
+							yield return (new int2(x, y), (heights[x, y], true));
+			}
+
+			// Given an input matrix of cell corner heights, finds the output height
+			// matrix where:
+			// - Each output[xy] <= input[xy]
+			// - Each output[xy] is no more than 1 height step away from its
+			//   (at most) 4 adjacent neighbors.
+			// - Each output[xy] is as high as it can possibly be otherwise.
+			//
+			// A 1D representation of this looks like:
+			//   4  ..x.....    ........
+			//   3  ....x...    ........
+			//   2  .x....xx -> .xx....x
+			//   1  x..x....    x..xx.x.
+			//   0  .....x..    .....x..
+			Matrix<byte> GetLowerHull(Matrix<byte> matrix)
+			{
+				(byte Lower, bool First)? Fill(int2 xy, (byte Lower, bool First) prop)
+				{
+					if (!prop.First && (!Adjustable[xy] || prop.Lower >= matrix[xy]))
+						return null;
+
+					matrix[xy] = prop.Lower;
+					if (prop.Lower == byte.MaxValue)
+						return null;
+
+					return ((byte)(prop.Lower + 1), false);
+				}
+
+				MatrixUtils.FloodFill(
+					matrix.Size,
+					FillSeeds(matrix).OrderBy(s => s.Prop.Height),
+					Fill,
+					DirectionExts.Spread4);
+				return matrix;
+			}
+
+			// Like GetLowerHull, but the other way around. :)
+			Matrix<byte> GetUpperHull(Matrix<byte> matrix)
+			{
+				(byte Upper, bool First)? Fill(int2 xy, (byte Upper, bool First) prop)
+				{
+					if (!prop.First && (!Adjustable[xy] || prop.Upper <= matrix[xy]))
+						return null;
+
+					matrix[xy] = prop.Upper;
+					if (prop.Upper == byte.MinValue)
+						return null;
+
+					return ((byte)(prop.Upper - 1), false);
+				}
+
+				MatrixUtils.FloodFill(
+					matrix.Size,
+					FillSeeds(matrix).OrderByDescending(s => s.Prop.Height),
+					Fill,
+					DirectionExts.Spread4);
+				return matrix;
+			}
+
+			/// <summary>
+			/// Attempt to constrain the Target heights such that all adjustable corners are
+			/// no more than 1 height step away from any adjacent corner,
+			/// and are within LowerBound and UpperBound.
+			/// </summary>
+			/// <param name="mode">How to set the height of targets than need to be adjusted.</param>
+			/// <returns>
+			/// Whether the constraints could be satisfied (and the target heights were updated).
+			/// </returns>
+			public bool Constrain(AdjustmentMode mode)
+			{
+				var forcedMaximum = GetLowerHull(UpperBound.Clone());
+				var forcedMinimum = GetUpperHull(LowerBound.Clone());
+				var constrained = Target.Clone();
+
+				for (var y = 0; y < Target.Size.Y; y++)
+				{
+					for (var x = 0; x < Target.Size.X; x++)
+					{
+						if (!Adjustable[x, y])
+							continue;
+
+						if (forcedMinimum[x, y] > forcedMaximum[x, y])
+							return false;
+						else if (constrained[x, y] < forcedMinimum[x, y])
+							constrained[x, y] = forcedMinimum[x, y];
+						else if (constrained[x, y] > forcedMaximum[x, y])
+							constrained[x, y] = forcedMaximum[x, y];
+					}
+				}
+
+				switch (mode)
+				{
+					case AdjustmentMode.Minimal:
+						constrained = GetLowerHull(constrained);
+						break;
+					case AdjustmentMode.LowerMiddle:
+						constrained = Matrix<byte>.Zip(
+							GetLowerHull(constrained.Clone()),
+							GetUpperHull(constrained),
+							(a, b) => (byte)((a + b) / 2));
+						break;
+					case AdjustmentMode.UpperMiddle:
+						constrained = Matrix<byte>.Zip(
+							GetLowerHull(constrained.Clone()),
+							GetUpperHull(constrained),
+							(a, b) => (byte)((a + b + 1) / 2));
+						break;
+					case AdjustmentMode.Maximal:
+						constrained = GetUpperHull(constrained);
+						break;
+					default:
+						throw new ArgumentException("invalid fitting mode");
+				}
+
+				constrained.CopyTo(Target);
+
+				return true;
+			}
+
+			/// <summary>
+			/// Uniformally adjust the corner heights of masked cells.
+			/// </summary>
+			/// <param name="adjustment">Height adjustment.</param>
+			/// <param name="mask">Cells to apply height change to.</param>
+			public void AdjustCellHeights(int adjustment, CellLayer<bool> mask)
+			{
+				var matrixMask = MatrixUtils.KernelAggregate(
+					CellLayerUtils.ToMatrix(mask, false),
+					new Matrix<bool>(Target.Size),
+					new int2(2, 2),
+					new int2(1, 1),
+					submatrix => submatrix.Data.Any(v => v));
+				for (var y = 0; y < Target.Size.Y; y++)
+					for (var x = 0; x < Target.Size.X; x++)
+						if (matrixMask[x, y])
+							Target[x, y] = (byte)Math.Clamp(Target[x, y] + adjustment, byte.MinValue, byte.MaxValue);
+			}
+
+			/// <summary>Set the target height of all masked cells' corners to a target value.</summary>
+			public void SetCellHeights(byte height, CellLayer<bool> mask)
+			{
+				foreach (var cpos in mask.CellRegion)
+					if (mask[cpos])
+						SetCellHeight(height, cpos);
+			}
+
+			/// <summary>Set the target height of a cell's corners to a target value.</summary>
+			public void SetCellHeight(byte height, CPos cpos)
+			{
+				var xy = CPosToXy(cpos);
+				foreach (var offset in CornersAroundCell)
+					Target[xy + offset] = height;
+			}
+
+			/// <summary>
+			/// Sets specified corners to a given height and expands outward for radius, without
+			/// expanding through unadjustable points.
+			/// </summary>
+			public void SeedHeights(IEnumerable<(int2 Xy, int Radius, byte Height)> corners)
+			{
+				var expandable = Adjustable.Clone();
+				(int Radius, byte Height)? Filler(int2 xy, (int Radius, byte Height) prop)
+				{
+					if (!expandable[xy] || prop.Radius == 0)
+						return null;
+
+					expandable[xy] = false;
+					Target[xy] = prop.Height;
+					return (prop.Radius - 1, prop.Height);
+				}
+
+				MatrixUtils.FloodFill(
+					Target.Size,
+					corners.Select(corner => (corner.Xy, (corner.Radius, corner.Height))),
+					Filler,
+					DirectionExts.Spread4);
+			}
+
+			/// <summary>Blur Target heights, but only through adjustable space.</summary>
+			public void Soften(int distance)
+			{
+				// Split the softening into multiple steps if needed to avoid numeric limitations.
+				// Make sure the last step isn't too small to improve precision.
+				while (distance > 12)
+				{
+					Soften(8);
+					distance -= 8;
+				}
+
+				var newNumerator = Target.Map(v => (int)v);
+				var newDenominator = new Matrix<int>(Target.Size).Fill(1);
+
+				for (var iteration = 0; iteration < distance; iteration++)
+				{
+					var oldNumerator = newNumerator;
+					var oldDenominator = newDenominator;
+					newNumerator = new Matrix<int>(Target.Size);
+					newDenominator = new Matrix<int>(Target.Size);
+
+					(int Numerator, int Denominator, bool First)? Filler(int2 xy, (int Numerator, int Denominator, bool First) prop)
+					{
+						if (Adjustable[xy])
+						{
+							newNumerator[xy] += prop.Numerator;
+							newDenominator[xy] += prop.Denominator;
+						}
+
+						if (prop.First)
+							return (prop.Numerator, prop.Denominator, false);
+						else
+							return null;
+					}
+
+					MatrixUtils.FloodFill(
+						Target.Size,
+						Adjustable.Enumerate()
+							.Where(v => v.Value)
+							.Select(v => (v.Xy, (oldNumerator[v.Xy], oldDenominator[v.Xy], true))),
+						Filler,
+						DirectionExts.Spread4);
+				}
+
+				for (var i = 0; i < Target.Data.Length; i++)
+					if (Adjustable[i])
+						Target[i] = (byte)((newNumerator[i] + newDenominator[i] / 2) / newDenominator[i]);
+			}
+		}
+
+		record struct RampProperties
+		{
+			public MultiBrush[] Brushes;
+			public byte Tl;
+			public byte Tr;
+			public byte Br;
+			public byte Bl;
+
+			public readonly byte GetCorner(Riser.Connection connection)
+			{
+				switch (connection)
+				{
+					case Riser.Connection.LU:
+					case Riser.Connection.UL:
+						return Tl;
+					case Riser.Connection.UR:
+					case Riser.Connection.RU:
+						return Tr;
+					case Riser.Connection.RD:
+					case Riser.Connection.DR:
+						return Br;
+					case Riser.Connection.DL:
+					case Riser.Connection.LD:
+						return Bl;
+				}
+
+				throw new ArgumentException("invalid connection");
+			}
+		}
+
+		static CVec ConnectionToAdjacentCorner(Riser.Connection connection)
+		{
+			switch (connection)
+			{
+				case Riser.Connection.LU:
+					return new CVec(-1, 0);
+				case Riser.Connection.UL:
+					return new CVec(0, -1);
+				case Riser.Connection.UR:
+					return new CVec(1, -1);
+				case Riser.Connection.RU:
+					return new CVec(2, 0);
+				case Riser.Connection.RD:
+					return new CVec(2, 1);
+				case Riser.Connection.DR:
+					return new CVec(1, 2);
+				case Riser.Connection.DL:
+					return new CVec(0, 2);
+				case Riser.Connection.LD:
+					return new CVec(-1, 1);
+			}
+
+			throw new ArgumentException("invalid connection");
+		}
+
+		readonly Map map;
+
+		// Contains single-tile brushes with zero height offset.
+		readonly RampProperties[] rampProperties;
+
+		// Lookup from a binary-concatenation of corner heights (0, 1, or 2) to ramp types.
+		// Only contains mappings for which there are brushes.
+		readonly Dictionary<int, List<byte>> rampLookup;
+
+		public RampTiler(Map map, IEnumerable<ushort> rampTemplates)
+			: this(
+				map,
+				rampTemplates
+					.Select(t => new MultiBrush().WithTemplate(map, t, CVec.Zero))
+					.ToList())
+		{ }
+
+		public RampTiler(Map map, IReadOnlyList<MultiBrush> rampBrushes)
+		{
+			this.map = map;
+			var heightStep = map.Grid.TileScale / 2;
+
+			var rampsToBrushes = new Dictionary<byte, List<MultiBrush>>();
+			foreach (var brush in rampBrushes)
+			{
+				var heightsAndRamps = brush.GetHeightsAndRamps().ToList();
+				if (heightsAndRamps.Count != 1 || heightsAndRamps[0].Height != 0)
+					throw new ArgumentException("brushes that are not single-tile are not supported");
+
+				var ramp = heightsAndRamps[0].Ramp;
+				if (!rampsToBrushes.ContainsKey(ramp))
+					rampsToBrushes.Add(ramp, []);
+
+				rampsToBrushes[ramp].Add(brush);
+			}
+
+			rampLookup = [];
+			rampProperties = new RampProperties[map.Grid.Ramps.Length];
+
+			for (byte ramp = 0; ramp < rampProperties.Length; ramp++)
+			{
+				var cellRamp = map.Grid.Ramps[ramp];
+				var tl = cellRamp.Corners[0].Z / heightStep;
+				var tr = cellRamp.Corners[1].Z / heightStep;
+				var br = cellRamp.Corners[2].Z / heightStep;
+				var bl = cellRamp.Corners[3].Z / heightStep;
+
+				rampProperties[ramp] = new RampProperties()
+				{
+					Brushes = rampsToBrushes.GetValueOrDefault(ramp, []).ToArray(),
+					Tl = (byte)tl,
+					Tr = (byte)tr,
+					Br = (byte)br,
+					Bl = (byte)bl,
+				};
+
+				if (rampProperties[ramp].Brushes.Length > 0)
+				{
+					var lookup = tl | (tr << 2) | (br << 4) | (bl << 6);
+					if (!rampLookup.ContainsKey(lookup))
+						rampLookup.Add(lookup, []);
+
+					rampLookup[lookup].Add(ramp);
+				}
+			}
+		}
+
+		byte GetConnectionHeight(byte height, TerrainTileInfo info, Riser.Connection connection)
+		{
+			var riser = info.Riser;
+			var properties = rampProperties[info.RampType];
+			var unclamped =
+				riser[connection].HasValue
+					? height + riser[connection].Value - info.Height
+					: height + properties.GetCorner(connection);
+			return (byte)Math.Clamp(unclamped, byte.MinValue, byte.MaxValue);
+		}
+
+		/// <summary>
+		/// Pull the heights of untileable cells from the map into a heightMap,
+		/// providing anchor points for later constraints and tiling.
+		/// </summary>
+		public void PullHeightMap(HeightMap heightMap)
+		{
+			foreach (var cpos in heightMap.Tileable.CellRegion)
+				PullHeightMap(heightMap, cpos);
+		}
+
+		/// <summary>
+		/// Pull the heights of an untileable cell from the map into a heightMap,
+		/// providing anchor points for later constraints and tiling.
+		/// </summary>
+		public void PullHeightMap(HeightMap heightMap, CPos cpos)
+		{
+			if (!heightMap.Tileable.Contains(cpos) || heightMap.Tileable[cpos])
+				return;
+
+			var height = map.Height[cpos];
+			var info = map.Rules.TerrainInfo.GetTerrainInfo(map.Tiles[cpos]);
+			for (var i = 0; i < 8; i++)
+			{
+				var connection = (Riser.Connection)i;
+				var toCVec = ConnectionToAdjacentCorner(connection);
+				var toCPos = cpos + toCVec;
+				var toXy = heightMap.CPosToXy(toCPos);
+				if (!(heightMap.Adjustable.ContainsXY(toXy) && heightMap.Adjustable[toXy]))
+					continue;
+
+				if (!heightMap.IsInternalCorner(toXy))
+					continue;
+
+				var connectionHeight = GetConnectionHeight(height, info, connection);
+
+				var lower = Math.Clamp(connectionHeight - 1, byte.MinValue, byte.MaxValue);
+				var upper = Math.Clamp(connectionHeight + 1, byte.MinValue, byte.MaxValue);
+				heightMap.LowerBound[toXy] = (byte)Math.Max(heightMap.LowerBound[toXy], lower);
+				heightMap.UpperBound[toXy] = (byte)Math.Min(heightMap.UpperBound[toXy], upper);
+			}
+		}
+
+		/// <summary>
+		/// Generate height and ramp CellLayers (as might be used in a Map) from a heightMap.
+		/// </summary>
+		/// <param name="heightMap">HeightMap to derive heights and ramps from.</param>
+		/// <param name="random">Random source for picking ramps with identical corner heights.</param>
+		/// <returns>The height and ramp CellLayers, or (null, null) if no solution is available.</returns>
+		public (CellLayer<byte> Heights, CellLayer<byte> Ramps) GenerateRampsAndHeights(
+			HeightMap heightMap,
+			MersenneTwister random)
+		{
+			var tlCorners = new CellLayer<byte>(map);
+			var trCorners = new CellLayer<byte>(map);
+			var brCorners = new CellLayer<byte>(map);
+			var blCorners = new CellLayer<byte>(map);
+
+			var heights = CellLayerUtils.Clone(map.Height);
+
+			// Map may not have ramps initialized. Don't clone.
+			var ramps = new CellLayer<byte>(map);
+
+			foreach (var cpos in heightMap.Tileable.CellRegion)
+			{
+				var height = map.Height[cpos];
+				var info = map.Rules.TerrainInfo.GetTerrainInfo(map.Tiles[cpos]);
+				ramps[cpos] = info.RampType;
+
+				if (heightMap.Tileable[cpos])
+				{
+					var xy = heightMap.CPosToXy(cpos);
+					var tl = xy;
+					var tr = xy + new int2(1, 0);
+					var br = xy + new int2(1, 1);
+					var bl = xy + new int2(0, 1);
+					if (heightMap.Adjustable[tl])
+						tlCorners[cpos] = heightMap.Target[tl];
+
+					if (heightMap.Adjustable[tr])
+						trCorners[cpos] = heightMap.Target[tr];
+
+					if (heightMap.Adjustable[br])
+						brCorners[cpos] = heightMap.Target[br];
+
+					if (heightMap.Adjustable[bl])
+						blCorners[cpos] = heightMap.Target[bl];
+				}
+				else
+				{
+					var r = new CVec(1, 0);
+					var d = new CVec(0, 1);
+					var l = new CVec(-1, 0);
+					var u = new CVec(0, -1);
+
+					if (heightMap.Tileable.Contains(cpos + r) && heightMap.Tileable[cpos + r])
+					{
+						tlCorners[cpos + r] = GetConnectionHeight(height, info, Riser.Connection.RU);
+						blCorners[cpos + r] = GetConnectionHeight(height, info, Riser.Connection.RD);
+
+						if (heightMap.Tileable.Contains(cpos + r + u) && heightMap.Tileable[cpos + r + u])
+						{
+							blCorners[cpos + r + u] = GetConnectionHeight(height, info, Riser.Connection.RU);
+						}
+
+						if (heightMap.Tileable.Contains(cpos + r + d) && heightMap.Tileable[cpos + r + d])
+						{
+							tlCorners[cpos + r + d] = GetConnectionHeight(height, info, Riser.Connection.RD);
+						}
+					}
+
+					if (heightMap.Tileable.Contains(cpos + d) && heightMap.Tileable[cpos + d])
+					{
+						trCorners[cpos + d] = GetConnectionHeight(height, info, Riser.Connection.DR);
+						tlCorners[cpos + d] = GetConnectionHeight(height, info, Riser.Connection.DL);
+
+						if (heightMap.Tileable.Contains(cpos + d + r) && heightMap.Tileable[cpos + d + r])
+						{
+							tlCorners[cpos + d + r] = GetConnectionHeight(height, info, Riser.Connection.DR);
+						}
+
+						if (heightMap.Tileable.Contains(cpos + d + l) && heightMap.Tileable[cpos + d + l])
+						{
+							trCorners[cpos + d + l] = GetConnectionHeight(height, info, Riser.Connection.DL);
+						}
+					}
+
+					if (heightMap.Tileable.Contains(cpos + l) && heightMap.Tileable[cpos + l])
+					{
+						brCorners[cpos + l] = GetConnectionHeight(height, info, Riser.Connection.LD);
+						trCorners[cpos + l] = GetConnectionHeight(height, info, Riser.Connection.LU);
+
+						if (heightMap.Tileable.Contains(cpos + l + d) && heightMap.Tileable[cpos + l + d])
+						{
+							trCorners[cpos + l + d] = GetConnectionHeight(height, info, Riser.Connection.LD);
+						}
+
+						if (heightMap.Tileable.Contains(cpos + l + u) && heightMap.Tileable[cpos + l + u])
+						{
+							brCorners[cpos + l + u] = GetConnectionHeight(height, info, Riser.Connection.LU);
+						}
+					}
+
+					if (heightMap.Tileable.Contains(cpos + u) && heightMap.Tileable[cpos + u])
+					{
+						blCorners[cpos + u] = GetConnectionHeight(height, info, Riser.Connection.UL);
+						brCorners[cpos + u] = GetConnectionHeight(height, info, Riser.Connection.UR);
+
+						if (heightMap.Tileable.Contains(cpos + u + l) && heightMap.Tileable[cpos + u + l])
+						{
+							brCorners[cpos + u + l] = GetConnectionHeight(height, info, Riser.Connection.UL);
+						}
+
+						if (heightMap.Tileable.Contains(cpos + u + r) && heightMap.Tileable[cpos + u + r])
+						{
+							blCorners[cpos + u + r] = GetConnectionHeight(height, info, Riser.Connection.UR);
+						}
+					}
+				}
+			}
+
+			foreach (var cpos in heightMap.Tileable.CellRegion)
+			{
+				if (!heightMap.Tileable[cpos])
+					continue;
+
+				if (!heightMap.IsInternalCell(cpos))
+					continue;
+
+				var tl = tlCorners[cpos];
+				var tr = trCorners[cpos];
+				var br = brCorners[cpos];
+				var bl = blCorners[cpos];
+
+				var baseHeight = Math.Min(Math.Min(tl, tr), Math.Min(bl, br));
+				tl -= baseHeight;
+				tr -= baseHeight;
+				br -= baseHeight;
+				bl -= baseHeight;
+				if (Math.Abs(tl - tr) > 1 ||
+					Math.Abs(tr - br) > 1 ||
+					Math.Abs(br - bl) > 1 ||
+					Math.Abs(bl - tl) > 1)
+				{
+					return (null, null);
+				}
+
+				var lookup = tl | (tr << 2) | (br << 4) | (bl << 6);
+				if (!rampLookup.TryGetValue(lookup, out var validRamps))
+					return (null, null);
+
+				heights[cpos] = baseHeight;
+				ramps[cpos] =
+					validRamps.Count == 1
+						? validRamps[0]
+						: validRamps[random.Next() % validRamps.Count];
+			}
+
+			return (heights, ramps);
+		}
+
+		/// <summary>Wrapper around CornersToRampsAndHeights and Tile.</summary>
+		public MultiBrush TileHeightMap(HeightMap heightMap, MersenneTwister random)
+		{
+			var (heights, ramps) = GenerateRampsAndHeights(heightMap, random);
+			if (heights == null)
+				return null;
+
+			return Tile(heights, ramps, heightMap.Tileable, random);
+		}
+
+		/// <summary>
+		/// Tile a heightmap with pre-computed ramps.
+		/// </summary>
+		/// <param name="heights">Heights for tiles.</param>
+		/// <param name="ramps">Ramps for tiles.</param>
+		/// <param name="mask">Cells to include in the output. Can be null to include everything.</param>
+		/// <param name="random">Random source for picking brushes.</param>
+		/// <returns>A MultiBrush containing the tiled result, or null if tiling is not possible.</returns>
+		public MultiBrush Tile(CellLayer<byte> heights, CellLayer<byte> ramps, CellLayer<bool> mask, MersenneTwister random)
+		{
+			var result = new MultiBrush();
+			var mapGridType = map.Grid.Type;
+			var masked =
+				mask != null
+					? mask.CellRegion.Where(cpos => mask[cpos])
+					: map.Tiles.CellRegion;
+			foreach (var cpos in masked)
+			{
+				var brushes = rampProperties[ramps[cpos]].Brushes;
+				if (brushes.Length == 0)
+					return null;
+
+				var brush = MultiBrush.PickAny(brushes, random);
+				result.MergeFrom(brush, cpos - CPos.Zero, mapGridType, heights[cpos]);
+			}
+
+			return result;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -90,6 +90,20 @@ namespace OpenRA.Mods.Common.MapGenerator
 			In = 1,
 		}
 
+		public enum ResourceDensityMode
+		{
+			/// <summary>
+			/// For mods where density values are not saved to map data, but calculated based on the
+			/// number of adjacent matching resources.
+			/// </summary>
+			Adjacency,
+
+			/// <summary>
+			/// Emulates the effect of the Adjacency mode, but saves density values to map data.
+			/// </summary>
+			BakedAdjacency,
+		}
+
 		public static (T[] Types, U[] Weights) SplitDictionary<T, U>(IReadOnlyDictionary<T, U> typeWeights)
 		{
 			var types = typeWeights
@@ -116,6 +130,15 @@ namespace OpenRA.Mods.Common.MapGenerator
 		readonly ITemplatedTerrainInfo templatedTerrainInfo;
 		readonly Lazy<CellLayer<int>> lazyProjectionSpacing;
 
+		/// <summary>
+		/// Create a new terraformer providing map generation utilities for a map.
+		/// </summary>
+		/// <param name="mapGenerationArgs">Map generation args.</param>
+		/// <param name="map">Mutable map for utilities to apply to.</param>
+		/// <param name="modData">ModData.</param>
+		/// <param name="actorPlans">Mutable ActorPlan list to track eventual actors to bake into map.</param>
+		/// <param name="mirror">Mirror symmetry defined in terms of WPos coordinate system.</param>
+		/// <param name="rotations">Rotational symmetries.</param>
 		public Terraformer(
 			MapGenerationArgs mapGenerationArgs,
 			Map map,
@@ -286,6 +309,32 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>
+		/// Zone all cells that have ramps. This is a no-op if the map grid does not support
+		/// variable terrain heights.
+		/// </summary>
+		public void ZoneFromRamps<T>(CellLayer<T> zoneable, T value)
+		{
+			if (Map.Grid.MaximumTerrainHeight == 0)
+				return;
+
+			var terrainInfo = Map.Rules.TerrainInfo;
+			foreach (var mpos in Map.AllCells.MapCoords)
+				if (terrainInfo.GetTerrainInfo(Map.Tiles[mpos]).RampType != 0)
+					zoneable[mpos] = value;
+		}
+
+		/// <summary>
+		/// Zones all cells that have ramps, except for cardinal ramps.
+		/// </summary>
+		public void ZoneFromNonCardinalRamps<T>(CellLayer<T> zoneable, T value)
+		{
+			var terrainInfo = Map.Rules.TerrainInfo;
+			foreach (var mpos in Map.AllCells.MapCoords)
+				if (terrainInfo.GetTerrainInfo(Map.Tiles[mpos]).RampType > 4)
+					zoneable[mpos] = value;
+		}
+
+		/// <summary>
 		/// Returns a CellLayer describing whether the space in a map satisfies given terrain types
 		/// (if allowedTerrain is non-null), is free of actors, and/or is free of resources.
 		/// </summary>
@@ -293,7 +342,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 			IReadOnlySet<byte> allowedTerrain,
 			bool checkActors = false,
 			bool checkResources = false,
-			bool checkBounds = false)
+			bool checkBounds = false,
+			bool checkRamps = false)
 		{
 			var space = new CellLayer<bool>(Map);
 			if (allowedTerrain != null)
@@ -315,6 +365,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 			if (checkBounds)
 				ZoneFromOutOfBounds(space, false);
 
+			if (checkRamps)
+				ZoneFromRamps(space, false);
+
 			return space;
 		}
 
@@ -326,7 +379,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 			ushort requiredTile,
 			bool checkActors = false,
 			bool checkResources = false,
-			bool checkBounds = false)
+			bool checkBounds = false,
+			bool checkRamps = false)
 		{
 			var space = new CellLayer<bool>(Map);
 			foreach (var mpos in Map.AllCells.MapCoords)
@@ -340,6 +394,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 			if (checkBounds)
 				ZoneFromOutOfBounds(space, false);
+
+			if (checkRamps)
+				ZoneFromRamps(space, false);
 
 			return space;
 		}
@@ -367,7 +424,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		{
 			CheckHasMapShapeOrNull(mask);
 
-			var zoneable = CheckSpace(zoneableTerrain, true, true, true);
+			var zoneable = CheckSpace(zoneableTerrain, true, true, true, true);
 			if (mask != null)
 				zoneable = CellLayerUtils.Intersect([zoneable, mask]);
 
@@ -2044,7 +2101,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public void GrowResources(
 			CellLayer<int> plan,
 			CellLayer<ResourceTypeInfo> typePlan,
-			long targetValue)
+			long targetValue,
+			ResourceDensityMode densityMode = ResourceDensityMode.Adjacency)
 		{
 			CheckHasMapShape(plan);
 			CheckHasMapShape(typePlan);
@@ -2075,9 +2133,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 			Map.Resources.Clear();
 
-			// Return resource value of a given square.
-			// Matches the logic in ResourceLayer trait.
-			int CheckValue(CPos cpos)
+			int CheckDensity(CPos cpos)
 			{
 				if (!Map.Resources.Contains(cpos))
 					return 0;
@@ -2099,9 +2155,18 @@ namespace OpenRA.Mods.Common.MapGenerator
 				// We need to have at least one resource in the cell.
 				// HACK: we should not be lerping to 9, as maximum adjacent resources is 8.
 				// HACK: it's too disruptive to fix.
-				var density = Math.Max(int2.Lerp(0, resourceType.MaxDensity, adjacent, 9), 1);
+				return Math.Max(int2.Lerp(0, resourceType.MaxDensity, adjacent, 9), 1);
+			}
 
-				return resourceValues[resourceType] * density;
+			// Return resource value of a given square.
+			// Matches the logic in ResourceLayer trait.
+			int CheckValue(CPos cpos)
+			{
+				if (!typePlan.Contains(cpos))
+					return 0;
+
+				var resourceType = typePlan[cpos];
+				return resourceValues[resourceType] * CheckDensity(cpos);
 			}
 
 			int CheckValue3By3(CPos cpos)
@@ -2146,6 +2211,16 @@ namespace OpenRA.Mods.Common.MapGenerator
 				foreach (var cpos in Symmetry.RotateAndMirrorCPos(chosenCPos, plan, Rotations, WMirror))
 					if (Map.Resources.Contains(cpos))
 						remaining -= AddResource(cpos);
+			}
+
+			if (densityMode == ResourceDensityMode.BakedAdjacency)
+			{
+				foreach (var cpos in Map.Resources.CellRegion)
+				{
+					Map.Resources[cpos] = new ResourceTile(
+						Map.Resources[cpos].Type,
+						(byte)CheckDensity(cpos));
+				}
 			}
 		}
 

--- a/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
@@ -351,7 +351,9 @@ namespace OpenRA.Mods.D2k.Traits
 					tilingPaths,
 					plan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
 					null,
-					[new MultiBrush().WithTemplate(map, param.RockTile, CVec.Zero)])
+					[new MultiBrush().WithTemplate(map, param.RockTile, CVec.Zero)],
+					null,
+					0)
 						?? throw new MapGenerationException("Could not fit tiles for rock platforms");
 			}
 
@@ -460,7 +462,9 @@ namespace OpenRA.Mods.D2k.Traits
 					tilingPaths,
 					plan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
 					null,
-					param.DuneBrushes)
+					param.DuneBrushes,
+					null,
+					0)
 						?? throw new MapGenerationException("Could not fit tiles for rock platforms");
 			}
 

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -26,6 +26,36 @@ ScrollPanel@LABEL_DROPDOWN_TEMPLATE:
 					Width: PARENT_WIDTH - 20
 					Height: 25
 
+ScrollPanel@LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@HEADER:
+			Background: scrollheader
+			Width: PARENT_WIDTH - 27
+			Height: 13
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					Font: TinyBold
+					Width: PARENT_WIDTH
+					Height: 13
+					Align: Center
+		ScrollItem@TEMPLATE:
+			Width: PARENT_WIDTH - 27
+			Height: 25
+			X: 2
+			Y: 0
+			TooltipContainer: TOOLTIP_CONTAINER
+			TooltipTemplate: BUTTON_TOOLTIP
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 10
+					Width: PARENT_WIDTH - 20
+					Height: 25
+
 ScrollPanel@TEAM_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:

--- a/mods/ts/fluent/rules.ftl
+++ b/mods/ts/fluent/rules.ftl
@@ -53,6 +53,9 @@ faction-nod =
      and the alien substance Tiberium. They employ stealth technology
      and guerrilla tactics to defeat those who oppose them.
 
+map-generator-ts = Map Generator
+map-generator-clear = Clear Terrain
+
 ## Structures
 notification-construction-complete = Construction complete.
 notification-unit-ready = Unit ready.
@@ -827,3 +830,169 @@ actor-cahosp =
 ## ai.yaml
 bot-test-ai =
     .name = Test AI
+
+## map-generators.yaml
+label-random-map = Random Map
+label-clear-map-generator-option-tile = Tile
+label-clear-map-generator-choice-tile-clear =
+   .label = Clear
+label-clear-map-generator-choice-tile-snow =
+   .label = Snow
+label-clear-map-generator-choice-tile-blank =
+   .label = Blank
+label-clear-map-generator-choice-tile-rough =
+   .label = Rough
+label-clear-map-generator-choice-tile-water =
+   .label = Water
+label-clear-map-generator-choice-tile-ground01 =
+   .label = Ground 01
+label-clear-map-generator-choice-tile-sand =
+   .label = Sand
+label-clear-map-generator-choice-tile-green =
+   .label = Green
+label-clear-map-generator-choice-tile-pavement =
+   .label = Pavement
+label-clear-map-generator-choice-tile-crystal =
+   .label = Crystal
+label-clear-map-generator-choice-tile-swamp =
+   .label = Swamp
+label-clear-map-generator-choice-tile-rock =
+   .label = Rock
+label-clear-map-generator-choice-tile-bluemold =
+   .label = Blue Mold
+label-clear-map-generator-choice-tile-grey =
+   .label = Grey
+
+label-ts-map-generator-option-seed = Seed
+
+label-ts-map-generator-option-terrain-type = Terrain Type
+label-ts-map-generator-choice-terrain-type-lakes =
+   .label = Lakes
+   .description = Open spaces with moderately sized lakes
+label-ts-map-generator-choice-terrain-type-puddles =
+   .label = Puddles
+   .description = Open spaces with small ponds
+label-ts-map-generator-choice-terrain-type-gardens =
+   .label = Gardens
+   .description = Featureful terrain with ponds, cliffs, and forests
+label-ts-map-generator-choice-terrain-type-plots =
+   .label = Plots
+   .description = Loosely-packed terrain with ponds, cliffs, and forests
+label-ts-map-generator-choice-terrain-type-plains =
+   .label = Plains
+   .description = Open spaces with sparse trees and cliffs
+label-ts-map-generator-choice-terrain-type-parks =
+   .label = Parks
+   .description = Open spaces with light forestry and occasional cliffs
+label-ts-map-generator-choice-terrain-type-woodlands =
+   .label = Woodlands
+   .description = Moderate forestry with occasional cliffs
+label-ts-map-generator-choice-terrain-type-overgrown =
+   .label = Overgrown
+   .description = Narrow passages, dense forestry and moderate cliffs
+label-ts-map-generator-choice-terrain-type-rocky =
+   .label = Rocky
+   .description = Moderate cliffs with light forestry
+label-ts-map-generator-choice-terrain-type-mountains =
+   .label = Mountains
+   .description = Many long cliffs
+label-ts-map-generator-choice-terrain-type-mountain-lakes =
+   .label = Mountain Lakes
+   .description = Lakes and many long cliffs
+
+label-ts-map-generator-option-symmetry = Symmetry
+label-ts-map-generator-choice-mirror-none =
+   .label = None
+label-ts-map-generator-choice-symmetry-mirror-horizontal =
+   .label = Mirror Horizontal
+label-ts-map-generator-choice-symmetry-mirror-vertical =
+   .label = Mirror Vertical
+label-ts-map-generator-choice-symmetry-mirror-diagonal-tl =
+   .label = Mirror Diagonal (Top-Left)
+label-ts-map-generator-choice-symmetry-mirror-diagonal-tr =
+   .label = Mirror Diagonal (Top-Right)
+label-ts-map-generator-choice-symmetry-mirror-2-rotations =
+   .label = 2 Rotations
+label-ts-map-generator-choice-symmetry-mirror-3-rotations =
+   .label = 3 Rotations
+label-ts-map-generator-choice-symmetry-mirror-4-rotations =
+   .label = 4 Rotations
+label-ts-map-generator-choice-symmetry-mirror-5-rotations =
+   .label = 5 Rotations
+label-ts-map-generator-choice-symmetry-mirror-6-rotations =
+   .label = 6 Rotations
+label-ts-map-generator-choice-symmetry-mirror-7-rotations =
+   .label = 7 Rotations
+label-ts-map-generator-choice-symmetry-mirror-8-rotations =
+   .label = 8 Rotations
+
+label-ts-map-generator-option-players = Players
+
+label-ts-map-generator-option-resources = Resources
+label-ts-map-generator-choice-resources-none =
+   .label = None
+label-ts-map-generator-choice-resources-low =
+   .label = Low
+label-ts-map-generator-choice-resources-medium =
+   .label = Medium
+label-ts-map-generator-choice-resources-high =
+   .label = High
+label-ts-map-generator-choice-resources-very-high =
+   .label = Very High
+label-ts-map-generator-choice-resources-full =
+   .label = Oreful
+
+label-ts-map-generator-option-buildings = Veinholes
+label-ts-map-generator-choice-buildings-none =
+   .label = None
+   .description = No veinholes
+label-ts-map-generator-choice-buildings-veinholes =
+   .label = Veinholes
+   .description = Standard number of veinholes
+label-ts-map-generator-choice-buildings-more-veinholes =
+   .label = More Veinholes
+   .description = Doubled number of veinholes
+
+label-ts-map-generator-option-density = Expansion Opportunities
+label-ts-map-generator-choice-density-players =
+   .label = Scale with players
+label-ts-map-generator-choice-density-area-and-players =
+   .label = Scale with size and players
+label-ts-map-generator-choice-density-area-very-low =
+   .label = Very Low
+label-ts-map-generator-choice-density-area-low =
+   .label = Low
+label-ts-map-generator-choice-density-area-medium =
+   .label = Medium
+label-ts-map-generator-choice-density-area-high =
+   .label = High
+label-ts-map-generator-choice-density-area-very-high =
+   .label = Very High
+
+label-ts-map-generator-option-civilian-density = Civilian Density
+label-ts-map-generator-choice-civilian-density-default =
+   .label = Default
+label-ts-map-generator-choice-civilian-density-none =
+   .label = None
+label-ts-map-generator-choice-civilian-density-low =
+   .label = Low
+label-ts-map-generator-choice-civilian-density-medium =
+   .label = Medium
+label-ts-map-generator-choice-civilian-density-high =
+   .label = High
+label-ts-map-generator-choice-civilian-density-very-high =
+   .label = Very High
+label-ts-map-generator-choice-civilian-density-max =
+   .label = Maximum
+
+label-ts-map-generator-option-coastlines = Coastlines
+label-ts-map-generator-choice-coastlines-beaches =
+   .label = Beaches
+label-ts-map-generator-choice-coastlines-sunken-beaches =
+   .label = Sunken Beaches
+label-ts-map-generator-choice-coastlines-cliffs =
+   .label = Cliffs
+label-ts-map-generator-choice-coastlines-mixed =
+   .label = Mixed
+
+label-ts-map-generator-option-deny-walled-areas = Obstruct walled areas

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -73,6 +73,7 @@ Rules:
 	ts|rules/shared-vehicles.yaml
 	ts|rules/trees.yaml
 	ts|rules/bridges.yaml
+	ts|rules/map-generators.yaml
 
 Weapons:
 	ts|weapons/ballisticweapons.yaml

--- a/mods/ts/rules/map-generators.yaml
+++ b/mods/ts/rules/map-generators.yaml
@@ -1,0 +1,677 @@
+^MapGenerators:
+	TSMapGenerator@ts:
+		Type: ts
+		Name: map-generator-ts
+		Tilesets: TEMPERATE
+		Settings:
+			MultiChoiceOption@hidden_defaults:
+				Choice@hidden_defaults:
+					Settings:
+						Rotations: 1
+						Mirror: None
+						TerrainFeatureSize: 20480
+						RampFeatureSize: 16384
+						ForestFeatureSize: 20480
+						ResourceFeatureSize: 20480
+						CivilianBuildingsFeatureSize: 10240
+						Water: 200
+						Mountains: 300
+						Forests: 25
+						ForestCutout: 2
+						MaximumCutoutSpacing: 12
+						TerrainSmoothing: 4
+						SmoothingThreshold: 833
+						MinimumCoastStraight: 2
+						MinimumCliffStraight: 2
+						MinimumLandSeaThickness: 4
+						MinimumMountainThickness: 4
+						MaximumAltitude: 8
+						RoughnessRadius: 5
+						Roughness: 250
+						WaterCliffs: False
+						WaterRoughness: 300
+						MinimumTerrainContourSpacing: 7
+						MinimumBeachLength: 10
+						MinimumWaterCliffLength: 10
+						MinimumCliffLength: 10
+						MinimumClearLength: 4
+						BeachSpreadWhenWaterCliffing: 8
+						RampSoften: 16
+						ForestClumpiness: 1
+						DenyWalledAreas: True
+						EnforceSymmetry: 0
+						CreateEntities: True
+						CentralSpawnReservationFraction: 250
+						ResourceSpawnReservation: 8
+						SpawnRegionSize: 12
+						SpawnBuildSize: 8
+						MinimumSpawnRadius: 5
+						SpawnResourceSpawns: 3
+						SpawnReservation: 16
+						SpawnResourceBias: 500
+						OreUniformity: 250
+						OreClumpiness: 2
+						MinimumExpansionSize: 2
+						MaximumExpansionSize: 12
+						ExpansionInner: 2
+						ExpansionBorder: 1
+						CivilianBuildings: 125
+						CivilianBuildingDensity: 500
+						MinimumCivilianBuildingDensity: 90
+						CivilianBuildingDensityRadius: 3
+						DefaultResource: Tiberium
+						ResourceSpawnSeeds:
+							tibtre01: Tiberium
+							tibtre02: Tiberium
+							tibtre03: Tiberium
+							bigblue: BlueTiberium
+							bigblue3: BlueTiberium
+							veinhole: Veins
+						ClearTerrain: Clear
+						PlayableTerrain: BlueTiberium,Bridge,Clear,DirtRoad,Rail,Road,Rough,Tiberium,Veins
+						DominantTerrain: Cliff,Impassable,Rock,Tree,Water
+						ZoneableTerrain: Clear,Road
+						ClearSegmentTypes: Clear
+						BeachSegmentTypes: Shore
+						CliffSegmentTypes: Cliff
+						WaterCliffSegmentTypes: WaterCliff
+						ForestObstacles: Trees
+						UnplayableObstacles: Obstructions
+						CivilianBuildingsObstacles: CivilianBuildings
+						LandTile: 0
+						WaterTile: 341
+						ForestFloor: 125
+						RepaintTiles:
+							341: Water
+						RampTiles: 0, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57
+						UseIceLatTiler: False
+			MultiChoiceOption@hidden_tileset_overrides:
+				Choice@temperat:
+					Tileset: TEMPERATE
+					Settings:
+						ForestFloorTile: 626
+						OtherGround:
+							535: 150
+							150: 250
+						LatTiler:
+							Rule@Rough:
+								AutoMain:
+								Low: 150
+								____: 150
+								___x: 152
+								__x_: 153
+								__xx: 154
+								_x__: 155
+								_x_x: 156
+								_xx_: 157
+								_xxx: 158
+								x___: 159
+								x__x: 160
+								x_x_: 161
+								x_xx: 162
+								xx__: 163
+								xx_x: 164
+								xxx_: 165
+								xxxx: 166
+							Rule@Sand:
+								AutoMain:
+								Low: 535
+								____: 535
+								___x: 537
+								__x_: 538
+								__xx: 539
+								_x__: 540
+								_x_x: 541
+								_xx_: 542
+								_xxx: 543
+								x___: 544
+								x__x: 545
+								x_x_: 546
+								x_xx: 547
+								xx__: 548
+								xx_x: 549
+								xxx_: 550
+								xxxx: 551
+							Rule@Green:
+								AutoMain:
+								Low: 626
+								____: 626
+								___x: 628
+								__x_: 629
+								__xx: 630
+								_x__: 631
+								_x_x: 632
+								_xx_: 633
+								_xxx: 634
+								x___: 635
+								x__x: 636
+								x_x_: 637
+								x_xx: 638
+								xx__: 639
+								xx_x: 640
+								xxx_: 641
+								xxxx: 642
+				Choice@snow:
+					Tileset: SNOW
+					Settings:
+						ForestFloorTile: 150
+						OtherGround:
+							150: 250
+							989: 150
+							1006: 150
+						LatTiler:
+							Rule@Rough:
+								AutoMain:
+								Low: 150
+								____: 150
+								___x: 152
+								__x_: 153
+								__xx: 154
+								_x__: 155
+								_x_x: 156
+								_xx_: 157
+								_xxx: 158
+								x___: 159
+								x__x: 160
+								x_x_: 161
+								x_xx: 162
+								xx__: 163
+								xx_x: 164
+								xxx_: 165
+								xxxx: 166
+							Rule@Rock:
+								AutoMain:
+								Low: 989
+								____: 989
+								___x: 991
+								__x_: 992
+								__xx: 993
+								_x__: 994
+								_x_x: 995
+								_xx_: 996
+								_xxx: 997
+								x___: 998
+								x__x: 999
+								x_x_: 1000
+								x_xx: 1001
+								xx__: 1002
+								xx_x: 1003
+								xxx_: 1004
+								xxxx: 1005
+							Rule@Grey:
+								AutoMain:
+								Low: 1006
+								____: 1006
+								___x: 1008
+								__x_: 1009
+								__xx: 1010
+								_x__: 1011
+								_x_x: 1012
+								_xx_: 1013
+								_xxx: 1014
+								x___: 1015
+								x__x: 1016
+								x_x_: 1017
+								x_xx: 1018
+								xx__: 1019
+								xx_x: 1020
+								xxx_: 1021
+								xxxx: 1007
+						IceLatTiler:
+							Rule@Ice:
+								AutoMain:
+								Low: 341
+								____: 341
+								___x: 456, 520, 584
+								__x_: 457, 521, 585
+								__xx: 458, 522, 586
+								_x__: 459, 523, 587
+								_x_x: 460, 524, 588
+								_xx_: 461, 525, 589
+								_xxx: 462, 526, 590
+								x___: 463, 527, 591
+								x__x: 464, 528, 592
+								x_x_: 465, 529, 593
+								x_xx: 466, 530, 594
+								xx__: 467, 531, 595
+								xx_x: 468, 532, 596
+								xxx_: 469, 533, 597
+								xxxx: 470, 534, 598
+			IntegerOption@Seed:
+				Label: label-ts-map-generator-option-seed
+				Parameter: Seed
+				Default: 0
+			MultiChoiceOption@TerrainType:
+				Label: label-ts-map-generator-option-terrain-type
+				Priority: 2
+				Default: Plots
+				Choice@Lakes:
+					Label: label-ts-map-generator-choice-terrain-type-lakes
+					Settings:
+				Choice@Puddles:
+					Label: label-ts-map-generator-choice-terrain-type-puddles
+					Settings:
+						Water: 100
+				Choice@Gardens:
+					Label: label-ts-map-generator-choice-terrain-type-gardens
+					Settings:
+						Water: 50
+						Forests: 300
+						ForestCutout: 3
+						EnforceSymmetry: 2
+				Choice@Plots:
+					Label: label-ts-map-generator-choice-terrain-type-plots
+					Settings:
+						TerrainFeatureSize: 10240
+						ForestFeatureSize: 10240
+						ResourceFeatureSize: 10240
+						Water: 100
+						Forests: 300
+						ForestCutout: 5
+						EnforceSymmetry: 2
+						Mountains: 300
+						MinimumTerrainContourSpacing: 12
+						MinimumCliffLength: 8
+						Roughness: 150
+						CivilianBuildings: 100
+				Choice@Plains:
+					Label: label-ts-map-generator-choice-terrain-type-plains
+					Settings:
+						Water: 0
+						Mountains: 100
+						CivilianBuildings: 100
+				Choice@Parks:
+					Label: label-ts-map-generator-choice-terrain-type-parks
+					Settings:
+						Water: 0
+						Forests: 100
+						Mountains: 100
+						CivilianBuildings: 100
+				Choice@Woodlands:
+					Label: label-ts-map-generator-choice-terrain-type-woodlands
+					Settings:
+						Water: 0
+						Forests: 400
+						ForestCutout: 3
+						EnforceSymmetry: 2
+				Choice@Overgrown:
+					Label: label-ts-map-generator-choice-terrain-type-overgrown
+					Settings:
+						Water: 0
+						Forests: 500
+						EnforceSymmetry: 2
+						Mountains: 500
+						Roughness: 250
+				Choice@Rocky:
+					Label: label-ts-map-generator-choice-terrain-type-rocky
+					Settings:
+						Water: 0
+						Forests: 300
+						ForestCutout: 3
+						EnforceSymmetry: 2
+						Mountains: 500
+						Roughness: 250
+				Choice@Mountains:
+					Label: label-ts-map-generator-choice-terrain-type-mountains
+					Settings:
+						Water: 0
+						Mountains: 900
+						Roughness: 600
+				Choice@MountainLakes:
+					Label: label-ts-map-generator-choice-terrain-type-mountain-lakes
+					Settings:
+						Water: 200
+						Mountains: 900
+						Roughness: 850
+			MultiIntegerChoiceOption@Players:
+				Label: label-ts-map-generator-option-players
+				Parameter: Players
+				Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+				Default: 2
+				Priority: 1
+			MultiChoiceOption@Symmetry:
+				Label: label-ts-map-generator-option-symmetry
+				Default: 2Rotations
+				Priority: 1
+				Choice@None:
+					Label: label-ts-map-generator-choice-mirror-none
+					Settings:
+						Mirror: None
+				Choice@LeftMatchesRight:
+					Label: label-ts-map-generator-choice-symmetry-mirror-horizontal
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Mirror: LeftMatchesRight
+				Choice@TopLeftMatchesBottomRight:
+					Label: label-ts-map-generator-choice-symmetry-mirror-diagonal-tl
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Mirror: TopLeftMatchesBottomRight
+				Choice@TopMatchesBottom:
+					Label: label-ts-map-generator-choice-symmetry-mirror-vertical
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Mirror: TopMatchesBottom
+				Choice@TopRightMatchesBottomLeft:
+					Label: label-ts-map-generator-choice-symmetry-mirror-diagonal-tr
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Mirror: TopRightMatchesBottomLeft
+				Choice@2Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-2-rotations
+					Players: 2, 4, 6, 8, 10, 12, 14, 16
+					Settings:
+						Rotations: 2
+				Choice@3Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-3-rotations
+					Players: 3, 6, 9, 12, 15
+					Settings:
+						Rotations: 3
+				Choice@4Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-4-rotations
+					Players: 4, 8, 12, 16
+					Settings:
+						Rotations: 4
+				Choice@5Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-5-rotations
+					Players: 5, 10, 15
+					Settings:
+						Rotations: 5
+				Choice@6Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-6-rotations
+					Players: 6, 12
+					Settings:
+						Rotations: 6
+				Choice@7Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-7-rotations
+					Players: 7, 14
+					Settings:
+						Rotations: 7
+				Choice@8Rotations:
+					Label: label-ts-map-generator-choice-symmetry-mirror-8-rotations
+					Players: 8, 16
+					Settings:
+						Rotations: 8
+			MultiChoiceOption@Resources:
+				Label: label-ts-map-generator-option-resources
+				Default: Medium
+				Choice@None:
+					Label: label-ts-map-generator-choice-resources-none
+					Settings:
+						SpawnResourceSpawns: 0
+						ResourcesPerPlayer: 0
+						ResourceSpawnWeights:
+						MaximumExpansionResourceSpawns: 0
+						MaximumResourceSpawnsPerExpansion: 1
+				Choice@Low:
+					Label: label-ts-map-generator-choice-resources-low
+					Settings:
+						SpawnResourceSpawns: 2
+						ResourcesPerPlayer: 50000
+						ResourceSpawnWeights:
+							tibtre01: 1
+							tibtre02: 1
+							tibtre03: 1
+						MaximumExpansionResourceSpawns: 3
+						MaximumResourceSpawnsPerExpansion: 1
+				Choice@Medium:
+					Label: label-ts-map-generator-choice-resources-medium
+					Settings:
+						SpawnResourceSpawns: 3
+						ResourcesPerPlayer: 75000
+						ResourceSpawnWeights:
+							tibtre01: 2
+							tibtre02: 2
+							tibtre03: 2
+							bigblue: 1
+							bigblue3: 1
+						MaximumExpansionResourceSpawns: 5
+						MaximumResourceSpawnsPerExpansion: 2
+				Choice@High:
+					Label: label-ts-map-generator-choice-resources-high
+					Settings:
+						SpawnResourceSpawns: 3
+						ResourcesPerPlayer: 100000
+						ResourceSpawnWeights:
+							tibtre01: 2
+							tibtre02: 2
+							tibtre03: 2
+							bigblue: 2
+							bigblue3: 2
+						MaximumExpansionResourceSpawns: 8
+						MaximumResourceSpawnsPerExpansion: 3
+				Choice@VeryHigh:
+					Label: label-ts-map-generator-choice-resources-very-high
+					Settings:
+						SpawnResourceSpawns: 4
+						ResourcesPerPlayer: 200000
+						ResourceSpawnWeights:
+							tibtre01: 2
+							tibtre02: 2
+							tibtre03: 2
+							bigblue: 3
+							bigblue3: 3
+						MaximumExpansionResourceSpawns: 10
+						MaximumResourceSpawnsPerExpansion: 3
+				Choice@Full:
+					Label: label-ts-map-generator-choice-resources-full
+					Settings:
+						SpawnResourceSpawns: 0
+						ResourcesPerPlayer: 1000000000
+						ResourceSpawnWeights:
+						MaximumExpansionResourceSpawns: 0
+						MaximumResourceSpawnsPerExpansion: 1
+			MultiChoiceOption@Buildings:
+				Label: label-ts-map-generator-option-buildings
+				Default: Standard
+				Choice@None:
+					Label: label-ts-map-generator-choice-buildings-none
+					Settings:
+						MinimumBuildings: 0
+						MaximumBuildings: 0
+						BuildingWeights:
+				Choice@Veinholes:
+					Label: label-ts-map-generator-choice-buildings-veinholes
+					Settings:
+						MinimumBuildings: 1
+						MaximumBuildings: 1
+						BuildingWeights:
+							veinhole: 1
+				Choice@MoreVeinholes:
+					Label: label-ts-map-generator-choice-buildings-more-veinholes
+					Settings:
+						MinimumBuildings: 2
+						MaximumBuildings: 2
+						BuildingWeights:
+							veinhole: 1
+			MultiChoiceOption@Density:
+				Label: label-ts-map-generator-option-density
+				Default: Players
+				Priority: 1
+				Choice@Players:
+					Label: label-ts-map-generator-choice-density-players
+					Settings:
+						AreaEntityBonus: 0
+						PlayerCountEntityBonus: 1000000
+				Choice@AreaAndPlayers:
+					Label: label-ts-map-generator-choice-density-area-and-players
+					Settings:
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 500000
+				Choice@AreaVeryLow:
+					Label: label-ts-map-generator-choice-density-area-very-low
+					Settings:
+						AreaEntityBonus: 100
+						PlayerCountEntityBonus: 0
+				Choice@AreaLow:
+					Label: label-ts-map-generator-choice-density-area-low
+					Settings:
+						AreaEntityBonus: 200
+						PlayerCountEntityBonus: 0
+				Choice@AreaMedium:
+					Label: label-ts-map-generator-choice-density-area-medium
+					Settings:
+						AreaEntityBonus: 400
+						PlayerCountEntityBonus: 0
+				Choice@AreaHigh:
+					Label: label-ts-map-generator-choice-density-area-high
+					Settings:
+						AreaEntityBonus: 600
+						PlayerCountEntityBonus: 0
+				Choice@AreaVeryHigh:
+					Label: label-ts-map-generator-choice-density-area-very-high
+					Settings:
+						AreaEntityBonus: 800
+						PlayerCountEntityBonus: 0
+			MultiChoiceOption@CivilianDensity:
+				Label: label-ts-map-generator-option-civilian-density
+				Default: Default
+				Priority: 3
+				Choice@Default:
+					Label: label-ts-map-generator-choice-civilian-density-default
+					Settings:
+				Choice@None:
+					Label: label-ts-map-generator-choice-civilian-density-none
+					Settings:
+						CivilianBuildings: 0
+				Choice@Low:
+					Label: label-ts-map-generator-choice-civilian-density-low
+					Settings:
+						CivilianBuildings: 75
+				Choice@Medium:
+					Label: label-ts-map-generator-choice-civilian-density-medium
+					Settings:
+						CivilianBuildings: 125
+				Choice@High:
+					Label: label-ts-map-generator-choice-civilian-density-high
+					Settings:
+						CivilianBuildings: 250
+				Choice@VeryHigh:
+					Label: label-ts-map-generator-choice-civilian-density-very-high
+					Settings:
+						CivilianBuildings: 500
+				Choice@Max:
+					Label: label-ts-map-generator-choice-civilian-density-max
+					Settings:
+						CivilianBuildings: 1000
+			MultiChoiceOption@Coastlines:
+				Label: label-ts-map-generator-option-coastlines
+				Default: Beaches
+				Priority: 3
+				Choice@Beaches:
+					Label: label-ts-map-generator-choice-coastlines-beaches
+					Settings:
+						WaterCliffs: False
+				Choice@SunkenBeaches:
+					Label: label-ts-map-generator-choice-coastlines-sunken-beaches
+					Settings:
+						WaterCliffs: True
+						WaterRoughness: 0
+				Choice@TemperateCliffs:
+					Label: label-ts-map-generator-choice-coastlines-cliffs
+					Tileset: TEMPERATE
+					Settings:
+						WaterCliffs: True
+						WaterRoughness: 1000
+				Choice@SnowCliffs:
+					Label: label-ts-map-generator-choice-coastlines-cliffs
+					Tileset: SNOW
+					Settings:
+						WaterCliffs: True
+						WaterRoughness: 1000
+						UseIceLatTiler: True
+				Choice@TemperateMixed:
+					Label: label-ts-map-generator-choice-coastlines-mixed
+					Tileset: TEMPERATE
+					Settings:
+						WaterCliffs: True
+				Choice@SnowMixed:
+					Label: label-ts-map-generator-choice-coastlines-mixed
+					Tileset: SNOW
+					Settings:
+						WaterCliffs: True
+						BeachSegmentTypes: IceShore
+						UseIceLatTiler: True
+			BooleanOption@DenyWalledArea:
+				Label: label-ts-map-generator-option-deny-walled-areas
+				Parameter: DenyWalledAreas
+				Default: True
+				Priority: 1
+
+	ClearMapGenerator@clear:
+		Type: clear
+		Name: map-generator-clear
+		Tilesets: TEMPERATE, SNOW
+		Settings:
+			MultiChoiceOption@Tile:
+				Label: label-clear-map-generator-option-tile
+				Choice@Clear:
+					Label: label-clear-map-generator-choice-tile-clear
+					Settings:
+						Tile: 0
+				Choice@Snow:
+					Label: label-clear-map-generator-choice-tile-snow
+					Settings:
+						Tile: 4
+				Choice@Blank:
+					Label: label-clear-map-generator-choice-tile-blank
+					Settings:
+						Tile: 12
+				Choice@Rough:
+					Label: label-clear-map-generator-choice-tile-rough
+					Settings:
+						Tile: 150
+				Choice@Water:
+					Label: label-clear-map-generator-choice-tile-water
+					Settings:
+						Tile: 341
+				Choice@Ground01:
+					Label: label-clear-map-generator-choice-tile-ground01
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 447
+				Choice@Sand:
+					Label: label-clear-map-generator-choice-tile-sand
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 535
+				Choice@Green:
+					Label: label-clear-map-generator-choice-tile-green
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 626
+				Choice@TemperatePavement:
+					Label: label-clear-map-generator-choice-tile-pavement
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 671
+				Choice@Crystal:
+					Label: label-clear-map-generator-choice-tile-crystal
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 960
+				Choice@Swamp:
+					Label: label-clear-map-generator-choice-tile-swamp
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 977
+				Choice@Rock:
+					Label: label-clear-map-generator-choice-tile-rock
+					Tileset: SNOW
+					Settings:
+						Tile: 989
+				Choice@BlueMold:
+					Label: label-clear-map-generator-choice-tile-bluemold
+					Tileset: TEMPERATE
+					Settings:
+						Tile: 1002
+				Choice@Grey:
+					Label: label-clear-map-generator-choice-tile-grey
+					Tileset: SNOW
+					Settings:
+						Tile: 1006
+				Choice@SnowPavement:
+					Label: label-clear-map-generator-choice-tile-pavement
+					Tileset: SNOW
+					Settings:
+						Tile: 1031

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -435,3 +435,4 @@ EditorWorld:
 		DefaultStart: Clear
 		DefaultInner: Beach
 		DefaultEnd: Clear
+	Inherits@MapGenerators: ^MapGenerators

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -80,7 +80,8 @@ Terrain:
 		Type: Jumpjet
 		Color: C7C9FA
 
-# Automatically generated. DO NOT EDIT!
+# Formerly generated using LegacyTilesetImporter.cs.
+# Contains manual modifications.
 Templates:
 	Template@0:
 		Categories: Clear
@@ -720,22 +721,26 @@ Templates:
 				Height: 4
 				MinColor: 6E808E
 				MaxColor: 8393A0
+				Riser: LD=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 9CB7CD
 				MaxColor: 96ACBF
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 5A6C7A
 				MaxColor: 7B8D9B
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: B6CFE4
 				MaxColor: 9DB4C8
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@61:
@@ -748,11 +753,13 @@ Templates:
 				Height: 4
 				MinColor: 8090A0
 				MaxColor: 8B9FB2
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 9EB6D1
 				MaxColor: 93ABC2
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@62:
@@ -765,22 +772,26 @@ Templates:
 				Height: 4
 				MinColor: 78899A
 				MaxColor: 879AA9
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: B3C8DF
 				MaxColor: 94A9C0
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 798795
 				MaxColor: 7D8D9B
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: C0DBF2
 				MaxColor: 98AEC4
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@63:
@@ -793,22 +804,26 @@ Templates:
 				Height: 4
 				MinColor: 8798A6
 				MaxColor: 8EA1B0
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: BBD3E6
 				MaxColor: A9BECE
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 8B99A7
 				MaxColor: 8698A8
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: C0DBF2
 				MaxColor: B3CBDF
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@64:
@@ -821,22 +836,26 @@ Templates:
 				Height: 4
 				MinColor: 7D8D9D
 				MaxColor: 8296A8
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 7D8C9E
 				MaxColor: 879CB1
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: BAD5F0
 				MaxColor: AAC0D5
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: B6D0E9
 				MaxColor: A9BED2
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@65:
@@ -849,22 +868,26 @@ Templates:
 				Height: 4
 				MinColor: 617487
 				MaxColor: 8494A5
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 647586
 				MaxColor: 7E91A3
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: BAD4ED
 				MaxColor: 9EB4C7
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: B4CDE6
 				MaxColor: 97AEC4
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@66:
@@ -877,22 +900,26 @@ Templates:
 				Height: 4
 				MinColor: 8295A7
 				MaxColor: 8D9EAF
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 889AAA
 				MaxColor: 8B9FB0
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: B9D4EF
 				MaxColor: 91A8BB
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: B3CDE4
 				MaxColor: A6BACB
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@67:
@@ -905,11 +932,13 @@ Templates:
 				Height: 4
 				MinColor: 728497
 				MaxColor: 8095A7
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: ACC4DB
 				MaxColor: 8BA4BA
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@68:
@@ -922,16 +951,19 @@ Templates:
 				Height: 4
 				MinColor: 90A4B6
 				MaxColor: 92A6B6
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 9AAEBE
 				MaxColor: 99ADC0
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: A4B8CC
 				MaxColor: A4B9CE
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@69:
@@ -944,16 +976,19 @@ Templates:
 				Height: 4
 				MinColor: 889BAF
 				MaxColor: 889BAC
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: A1BCD5
 				MaxColor: 9CB3CA
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 83A0BC
 				MaxColor: 93ADCC
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@70:
@@ -966,16 +1001,19 @@ Templates:
 				Height: 4
 				MinColor: 8CA1B4
 				MaxColor: 8DA2B5
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 98B0C3
 				MaxColor: 8FA9C4
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 8FA8C0
 				MaxColor: A8C0D4
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@71:
@@ -987,6 +1025,7 @@ Templates:
 			0: Cliff
 				MinColor: B2C6DB
 				MaxColor: A3B9CE
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@72:
@@ -998,6 +1037,7 @@ Templates:
 			0: Cliff
 				MinColor: 94ACC4
 				MaxColor: A6BDD2
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@73:
@@ -1009,6 +1049,7 @@ Templates:
 			0: Cliff
 				MinColor: A8BED1
 				MaxColor: 83A0B5
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@74:
@@ -1021,22 +1062,26 @@ Templates:
 				Height: 4
 				MinColor: 879BAE
 				MaxColor: 7B8D9D
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 86A3C1
 				MaxColor: 7997AE
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 899EB0
 				MaxColor: 7F909F
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: B0CAE5
 				MaxColor: 819EB5
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@75:
@@ -1049,22 +1094,26 @@ Templates:
 				Height: 4
 				MinColor: 778998
 				MaxColor: 758692
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 98B2C7
 				MaxColor: 7795AA
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 8296A9
 				MaxColor: 768898
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: AAC2DC
 				MaxColor: 83A1BA
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@76:
@@ -1077,22 +1126,26 @@ Templates:
 				Height: 4
 				MinColor: 7E92A4
 				MaxColor: 7D8FA0
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 93AAC0
 				MaxColor: 829CB4
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 8BA0B4
 				MaxColor: 708395
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 9AB1C5
 				MaxColor: 7991A6
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@77:
@@ -1105,11 +1158,13 @@ Templates:
 				Height: 4
 				MinColor: 8395A7
 				MaxColor: 7B8D9E
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 97B2CB
 				MaxColor: 859EB1
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@78:
@@ -1122,22 +1177,26 @@ Templates:
 				Height: 4
 				MinColor: 8A9EAF
 				MaxColor: 8395A6
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 657E90
 				MaxColor: 7F9AAE
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 889BAD
 				MaxColor: 596C78
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: ADC6DE
 				MaxColor: 8EA9C3
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@79:
@@ -1150,22 +1209,26 @@ Templates:
 				Height: 4
 				MinColor: 8CA0B4
 				MaxColor: 8699AB
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 768E9F
 				MaxColor: 849EB0
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 8A9FB2
 				MaxColor: 5B6F7D
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: B4CEE5
 				MaxColor: 9CB7D0
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@80:
@@ -1178,22 +1241,26 @@ Templates:
 				Height: 4
 				MinColor: 8090A0
 				MaxColor: 7F8C98
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 8399AD
 				MaxColor: 94AABD
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 8DA0B2
 				MaxColor: 778594
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: AABFD2
 				MaxColor: A4BBD1
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@81:
@@ -1206,11 +1273,13 @@ Templates:
 				Height: 4
 				MinColor: 879BAC
 				MaxColor: 788794
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 90A8BC
 				MaxColor: 88A0B4
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@82:
@@ -1223,12 +1292,14 @@ Templates:
 				Height: 4
 				MinColor: 879BAE
 				MaxColor: 7C8E9F
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 8598A8
 				MaxColor: 738394
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@83:
@@ -1241,12 +1312,14 @@ Templates:
 				Height: 4
 				MinColor: 8999A8
 				MaxColor: 707F8F
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 8A9BAC
 				MaxColor: 8393A3
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@84:
@@ -1259,12 +1332,14 @@ Templates:
 				Height: 4
 				MinColor: 8A9EAF
 				MaxColor: 758896
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 647581
 				MaxColor: 5A7080
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@85:
@@ -1277,6 +1352,7 @@ Templates:
 				Height: 4
 				MinColor: 8393A6
 				MaxColor: 738295
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@86:
@@ -1289,18 +1365,21 @@ Templates:
 				Height: 4
 				MinColor: 7B8B9D
 				MaxColor: 78879B
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 879CB0
 				MaxColor: 8295A9
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 78879D
 				MaxColor: 90A3B4
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@87:
@@ -1313,12 +1392,14 @@ Templates:
 				Height: 4
 				MinColor: 768A9C
 				MaxColor: 708495
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 7E92A4
 				MaxColor: 798B9B
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -1337,6 +1418,7 @@ Templates:
 				Height: 4
 				MinColor: 7D8C9E
 				MaxColor: 8597A9
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@89:
@@ -1349,6 +1431,7 @@ Templates:
 				Height: 4
 				MinColor: 8495A4
 				MaxColor: 738293
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@90:
@@ -1361,6 +1444,7 @@ Templates:
 				Height: 4
 				MinColor: 778696
 				MaxColor: 758596
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
@@ -1385,12 +1469,14 @@ Templates:
 				Height: 4
 				MinColor: 879BB0
 				MaxColor: 788C9C
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 8EA2B3
 				MaxColor: 728492
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -1433,12 +1519,14 @@ Templates:
 				Height: 4
 				MinColor: 899AAA
 				MaxColor: 8596A6
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 788899
 				MaxColor: 8798A9
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@95:
@@ -1451,12 +1539,14 @@ Templates:
 				Height: 4
 				MinColor: 8293A3
 				MaxColor: 879AAE
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 798799
 				MaxColor: 8697A4
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@96:
@@ -1469,12 +1559,14 @@ Templates:
 				Height: 4
 				MinColor: 7F91A4
 				MaxColor: 8A9BAF
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 7F93A8
 				MaxColor: 8498A9
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@97:
@@ -1487,6 +1579,7 @@ Templates:
 				Height: 4
 				MinColor: 778799
 				MaxColor: 7C8C9E
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@98:
@@ -3235,22 +3328,26 @@ Templates:
 				Height: 4
 				MinColor: 798996
 				MaxColor: 8B9AA7
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: A9BDD1
 				MaxColor: A2B6C6
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 6A7B87
 				MaxColor: 768894
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 879CBF
 				MaxColor: 93A8BE
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@168:
@@ -3263,11 +3360,13 @@ Templates:
 				Height: 4
 				MinColor: 8091A1
 				MaxColor: 8B9FB2
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 90A9C2
 				MaxColor: 8BA3BB
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@169:
@@ -3280,22 +3379,26 @@ Templates:
 				Height: 4
 				MinColor: 8393A1
 				MaxColor: 8C9FAE
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 8DA4C8
 				MaxColor: 96AAC0
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 788695
 				MaxColor: 8394A3
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 8095B6
 				MaxColor: 8DA1BF
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@170:
@@ -3308,22 +3411,26 @@ Templates:
 				Height: 4
 				MinColor: 8998A7
 				MaxColor: 8FA1B1
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: AAC1E2
 				MaxColor: A7BBCB
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 8997A4
 				MaxColor: 8798A8
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 889FC4
 				MaxColor: A1B7CC
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@171:
@@ -3336,22 +3443,26 @@ Templates:
 				Height: 4
 				MinColor: 7D8D9D
 				MaxColor: 8296A8
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 7D8C9F
 				MaxColor: 879CB1
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 8297BF
 				MaxColor: 8CA6B9
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 8A9FBB
 				MaxColor: 93A8BE
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@172:
@@ -3364,22 +3475,26 @@ Templates:
 				Height: 4
 				MinColor: 798C9E
 				MaxColor: 8596A7
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 627384
 				MaxColor: 7E91A3
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 7E95B7
 				MaxColor: A3B7C8
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 96ACC7
 				MaxColor: A1B6CB
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@173:
@@ -3392,22 +3507,26 @@ Templates:
 				Height: 4
 				MinColor: 8295A7
 				MaxColor: 8D9EAF
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 8E9FAC
 				MaxColor: 8B9FB0
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 879DC0
 				MaxColor: 95A8B7
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: B5C4D8
 				MaxColor: 96ABBE
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@174:
@@ -3420,11 +3539,13 @@ Templates:
 				Height: 4
 				MinColor: 728497
 				MaxColor: 8095A7
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 97ADC3
 				MaxColor: 859CB3
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@175:
@@ -3437,16 +3558,19 @@ Templates:
 				Height: 4
 				MinColor: 92A0AD
 				MaxColor: 8693A0
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 8196B0
 				MaxColor: 92A8BC
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: A3B7CE
 				MaxColor: 9AAFC5
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@176:
@@ -3459,16 +3583,19 @@ Templates:
 				Height: 4
 				MinColor: 8C9EB1
 				MaxColor: 889BAC
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 7287A0
 				MaxColor: 9EB7D0
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 8CA6C1
 				MaxColor: 84A0BC
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -3486,16 +3613,19 @@ Templates:
 				Height: 4
 				MinColor: 92A1AD
 				MaxColor: 8A9AAA
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 9FB4CD
 				MaxColor: 94AEC7
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 94ABC3
 				MaxColor: AEC4D9
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@178:
@@ -3507,6 +3637,7 @@ Templates:
 			0: Cliff
 				MinColor: ACC0D6
 				MaxColor: 9DB2C7
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@179:
@@ -3518,6 +3649,7 @@ Templates:
 			0: Cliff
 				MinColor: 9CB3CA
 				MaxColor: A4B9CF
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@180:
@@ -3529,6 +3661,7 @@ Templates:
 			0: Cliff
 				MinColor: ADC1D4
 				MaxColor: 8AA3B6
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@181:
@@ -3541,22 +3674,26 @@ Templates:
 				Height: 4
 				MinColor: 879BAE
 				MaxColor: 7B8D9D
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 6A7F95
 				MaxColor: 7591AB
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 899EB0
 				MaxColor: 7F909F
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 72869B
 				MaxColor: 708BA0
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@182:
@@ -3569,22 +3706,26 @@ Templates:
 				Height: 4
 				MinColor: 778998
 				MaxColor: 758692
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 94A9BF
 				MaxColor: 738FA5
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 8296A9
 				MaxColor: 7C8D9C
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 8498BC
 				MaxColor: 859EB7
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@183:
@@ -3597,22 +3738,26 @@ Templates:
 				Height: 4
 				MinColor: 7E91A4
 				MaxColor: 8596A6
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 93A6BB
 				MaxColor: 7892AB
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 8BA0B4
 				MaxColor: 6C7F8F
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 768A9E
 				MaxColor: 657E90
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@184:
@@ -3625,11 +3770,13 @@ Templates:
 				Height: 4
 				MinColor: 8395A7
 				MaxColor: 7B8D9E
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 7B90A9
 				MaxColor: 7F98AC
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@185:
@@ -3642,22 +3789,26 @@ Templates:
 				Height: 4
 				MinColor: 8EA0B1
 				MaxColor: 8898A9
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 647B8B
 				MaxColor: 7991A6
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 899CAF
 				MaxColor: 63747E
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 889DBD
 				MaxColor: 889FBD
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@186:
@@ -3670,22 +3821,26 @@ Templates:
 				Height: 4
 				MinColor: 8CA1B4
 				MaxColor: 8D9FAF
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 8C9EAA
 				MaxColor: 7C95AB
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 8BA0B3
 				MaxColor: 677987
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 788CAF
 				MaxColor: 7C94B4
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@187:
@@ -3698,22 +3853,26 @@ Templates:
 				Height: 4
 				MinColor: 7C8C9A
 				MaxColor: 7A8793
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 899FB4
 				MaxColor: 859BAE
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 8DA0B2
 				MaxColor: 6F7D8A
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: A0B4CF
 				MaxColor: 8EA4C4
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@188:
@@ -3726,11 +3885,13 @@ Templates:
 				Height: 4
 				MinColor: 8A9EB0
 				MaxColor: 8091A2
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 8197AF
 				MaxColor: 8BA2B6
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@189:
@@ -19927,3 +20088,16 @@ MultiBrushCollections:
 				Start: IceShore.U
 				End: IceShore.L
 				Points: 0,1
+
+	Trees:
+		FromActors: tree01,tree02,tree03,tree04,tree05,tree06,tree07,tree08,tree09,tree10,tree11,tree12,tree13,tree14,tree15,tree16,tree17,tree18,tree19,tree20,tree21,tree22,tree23,tree24,tree25
+	Water:
+		FromTemplates: 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345
+		MultiBrush@346:
+			Template: 346
+			Weight: 100
+	CivilianBuildings:
+		FromActors: ca0001,ca0002,ca0003,ca0004,ca0005,ca0006,ca0007,ca0008,ca0009,ca0010,ca0011,ca0012,ca0013,ca0014,ca0015,ca0016,ca0017,ca0018,ca0019,ca0020,ca0021
+	Obstructions:
+		FromActors: tree01,tree02,tree03,tree04,tree05,tree06,tree07,tree08,tree09,tree10,tree11,tree12,tree13,tree14,tree15,tree16,tree17,tree18,tree19,tree20,tree21,tree22,tree23,tree24,tree25
+		FromActors: srock01,srock02,srock03,srock04,srock05,trock01,trock02,trock03,trock04,trock05

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -80,7 +80,8 @@ Terrain:
 		Type: Jumpjet
 		Color: 745537
 
-# Automatically generated. DO NOT EDIT!
+# Formerly generated using LegacyTilesetImporter.cs.
+# Contains manual modifications.
 Templates:
 	Template@0:
 		Categories: Clear
@@ -720,22 +721,26 @@ Templates:
 				Height: 4
 				MinColor: 3F3B34
 				MaxColor: 504537
+				Riser: LD=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 514638
 				MaxColor: 413D36
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 2D2B27
 				MaxColor: 413C35
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 67533B
 				MaxColor: 483E30
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@61:
@@ -748,11 +753,13 @@ Templates:
 				Height: 4
 				MinColor: 3C3831
 				MaxColor: 494134
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 615B51
 				MaxColor: 47423B
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@62:
@@ -765,22 +772,26 @@ Templates:
 				Height: 4
 				MinColor: 433D34
 				MaxColor: 483E32
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 5F513E
 				MaxColor: 3F3B34
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 2D2C28
 				MaxColor: 37322B
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 685945
 				MaxColor: 4A4134
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@63:
@@ -793,22 +804,26 @@ Templates:
 				Height: 4
 				MinColor: 524637
 				MaxColor: 594B38
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 5B503F
 				MaxColor: 4F4A41
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 49463F
 				MaxColor: 494338
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 695A45
 				MaxColor: 574D3F
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@64:
@@ -821,22 +836,26 @@ Templates:
 				Height: 4
 				MinColor: 4D463A
 				MaxColor: 4C4234
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 4A4235
 				MaxColor: 4F4436
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 695B49
 				MaxColor: 484339
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 5B4F3E
 				MaxColor: 534C40
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@65:
@@ -849,22 +868,26 @@ Templates:
 				Height: 4
 				MinColor: 2B2824
 				MaxColor: 4E4437
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 353028
 				MaxColor: 473F34
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 6D5B43
 				MaxColor: 51483C
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 544737
 				MaxColor: 4A4034
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@66:
@@ -877,22 +900,26 @@ Templates:
 				Height: 4
 				MinColor: 4A4338
 				MaxColor: 4F4436
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 484136
 				MaxColor: 4D4233
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 615443
 				MaxColor: 47443D
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 5A4D3C
 				MaxColor: 4E473D
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@67:
@@ -905,11 +932,13 @@ Templates:
 				Height: 4
 				MinColor: 39352E
 				MaxColor: 453B2D
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 5A5346
 				MaxColor: 47433C
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@68:
@@ -922,16 +951,19 @@ Templates:
 				Height: 4
 				MinColor: 494034
 				MaxColor: 4E4436
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 5A4F3F
 				MaxColor: 524C42
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 544C3F
 				MaxColor: 4E473C
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@69:
@@ -944,16 +976,19 @@ Templates:
 				Height: 4
 				MinColor: 4E4437
 				MaxColor: 514434
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 4F4639
 				MaxColor: 51493D
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 464035
 				MaxColor: 554E42
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@70:
@@ -966,16 +1001,19 @@ Templates:
 				Height: 4
 				MinColor: 4F4334
 				MaxColor: 494135
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 564D3F
 				MaxColor: 48443B
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 555046
 				MaxColor: 5E564A
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@71:
@@ -987,6 +1025,7 @@ Templates:
 			0: Cliff
 				MinColor: 524D43
 				MaxColor: 534D42
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@72:
@@ -998,6 +1037,7 @@ Templates:
 			0: Cliff
 				MinColor: 443F37
 				MaxColor: 524B3F
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@73:
@@ -1009,6 +1049,7 @@ Templates:
 			0: Cliff
 				MinColor: 544E43
 				MaxColor: 3D3830
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@74:
@@ -1021,22 +1062,26 @@ Templates:
 				Height: 4
 				MinColor: 453C30
 				MaxColor: 42392D
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 4B4135
 				MaxColor: 3E3931
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 4D4334
 				MaxColor: 403A31
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 5C4F3F
 				MaxColor: 3D3931
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@75:
@@ -1049,22 +1094,26 @@ Templates:
 				Height: 4
 				MinColor: 4B4032
 				MaxColor: 413A31
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 453C31
 				MaxColor: 39342D
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 453B2F
 				MaxColor: 443D34
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 584C3C
 				MaxColor: 454038
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@76:
@@ -1077,22 +1126,26 @@ Templates:
 				Height: 4
 				MinColor: 443C30
 				MaxColor: 453C30
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 36322C
 				MaxColor: 3A3731
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 4F4231
 				MaxColor: 443D34
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 4B4338
 				MaxColor: 3F3C37
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@77:
@@ -1105,11 +1158,13 @@ Templates:
 				Height: 4
 				MinColor: 4A3F2F
 				MaxColor: 4A4338
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 484137
 				MaxColor: 3E3A34
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@78:
@@ -1122,22 +1177,26 @@ Templates:
 				Height: 4
 				MinColor: 4B4031
 				MaxColor: 403C33
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 323230
 				MaxColor: 46413A
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 4A4236
 				MaxColor: 2B2A27
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 5E5446
 				MaxColor: 4E4538
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@79:
@@ -1150,22 +1209,26 @@ Templates:
 				Height: 4
 				MinColor: 514637
 				MaxColor: 4A4134
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2D2C29
 				MaxColor: 423E36
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 4D4132
 				MaxColor: 302E2B
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 5A4F41
 				MaxColor: 483F33
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@80:
@@ -1178,22 +1241,26 @@ Templates:
 				Height: 4
 				MinColor: 42392C
 				MaxColor: 3B362E
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2A2826
 				MaxColor: 37342E
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 484034
 				MaxColor: 2A2926
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 574E41
 				MaxColor: 4A4237
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@81:
@@ -1206,11 +1273,13 @@ Templates:
 				Height: 4
 				MinColor: 3F382E
 				MaxColor: 433C33
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 42392C
 				MaxColor: 383530
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@82:
@@ -1223,12 +1292,14 @@ Templates:
 				Height: 4
 				MinColor: 504332
 				MaxColor: 494033
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 4A3F31
 				MaxColor: 3D3830
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@83:
@@ -1241,12 +1312,14 @@ Templates:
 				Height: 4
 				MinColor: 4F4334
 				MaxColor: 413B31
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 504434
 				MaxColor: 423A2F
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@84:
@@ -1259,12 +1332,14 @@ Templates:
 				Height: 4
 				MinColor: 4D4234
 				MaxColor: 423D35
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 433C32
 				MaxColor: 4A443B
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@85:
@@ -1277,6 +1352,7 @@ Templates:
 				Height: 4
 				MinColor: 4E4233
 				MaxColor: 3A3329
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@86:
@@ -1289,18 +1365,21 @@ Templates:
 				Height: 4
 				MinColor: 4F473B
 				MaxColor: 443F36
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 4E4232
 				MaxColor: 463F35
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 403B33
 				MaxColor: 50473A
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@87:
@@ -1313,12 +1392,14 @@ Templates:
 				Height: 4
 				MinColor: 3D372E
 				MaxColor: 3B362D
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 433D33
 				MaxColor: 3C372F
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -1337,6 +1418,7 @@ Templates:
 				Height: 4
 				MinColor: 413B32
 				MaxColor: 474136
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@89:
@@ -1349,6 +1431,7 @@ Templates:
 				Height: 4
 				MinColor: 474036
 				MaxColor: 3C3730
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@90:
@@ -1361,6 +1444,7 @@ Templates:
 				Height: 4
 				MinColor: 31302B
 				MaxColor: 39352F
+				Riser: UL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
@@ -1385,12 +1469,14 @@ Templates:
 				Height: 4
 				MinColor: 454038
 				MaxColor: 3F3931
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 4E4334
 				MaxColor: 3C3730
+				Riser: U=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -1433,12 +1519,14 @@ Templates:
 				Height: 4
 				MinColor: 4B453A
 				MaxColor: 473F34
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 444039
 				MaxColor: 52483B
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@95:
@@ -1451,12 +1539,14 @@ Templates:
 				Height: 4
 				MinColor: 49443B
 				MaxColor: 4B4032
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 46413A
 				MaxColor: 504638
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@96:
@@ -1469,12 +1559,14 @@ Templates:
 				Height: 4
 				MinColor: 474138
 				MaxColor: 474036
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 484239
 				MaxColor: 595042
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@97:
@@ -1487,6 +1579,7 @@ Templates:
 				Height: 4
 				MinColor: 35322C
 				MaxColor: 39332B
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@98:
@@ -3235,22 +3328,26 @@ Templates:
 				Height: 4
 				MinColor: 3D3325
 				MaxColor: 52432F
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 423B33
 				MaxColor: 493F30
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 31281B
 				MaxColor: 463827
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 2B333B
 				MaxColor: 3C372D
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@168:
@@ -3263,11 +3360,13 @@ Templates:
 				Height: 4
 				MinColor: 463F33
 				MaxColor: 524738
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 464138
 				MaxColor: 3E382E
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@169:
@@ -3280,22 +3379,26 @@ Templates:
 				Height: 4
 				MinColor: 3E372C
 				MaxColor: 4C402F
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 313842
 				MaxColor: 3F3930
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 353027
 				MaxColor: 3A342A
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 242D3A
 				MaxColor: 302E2A
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@170:
@@ -3308,22 +3411,26 @@ Templates:
 				Height: 4
 				MinColor: 504637
 				MaxColor: 514433
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 26313F
 				MaxColor: 4D4436
+				Riser: RU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				Height: 4
 				MinColor: 403A2D
 				MaxColor: 4C4234
+				Riser: DL=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 2D353F
 				MaxColor: 453F33
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@171:
@@ -3336,22 +3443,26 @@ Templates:
 				Height: 4
 				MinColor: 3E362A
 				MaxColor: 463C2E
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 3F3A32
 				MaxColor: 504434
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 2A3137
 				MaxColor: 423C32
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 2E3640
 				MaxColor: 4D463B
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@172:
@@ -3364,22 +3475,26 @@ Templates:
 				Height: 4
 				MinColor: 41392D
 				MaxColor: 4D4334
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 3A3429
 				MaxColor: 4A3E2E
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 363737
 				MaxColor: 4D4538
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 323436
 				MaxColor: 4D4436
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@173:
@@ -3392,22 +3507,26 @@ Templates:
 				Height: 4
 				MinColor: 483E30
 				MaxColor: 504332
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				Height: 4
 				MinColor: 483F33
 				MaxColor: 4E4130
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 2B323B
 				MaxColor: 3E3931
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 353B42
 				MaxColor: 484238
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@174:
@@ -3420,11 +3539,13 @@ Templates:
 				Height: 4
 				MinColor: 3E362C
 				MaxColor: 4D4233
+				Riser: D=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 484744
 				MaxColor: 444038
+				Riser: U=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@175:
@@ -3437,16 +3558,19 @@ Templates:
 				Height: 4
 				MinColor: 473E32
 				MaxColor: 524535
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 34373A
 				MaxColor: 4E473C
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 4A453B
 				MaxColor: 454139
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@176:
@@ -3459,16 +3583,19 @@ Templates:
 				Height: 4
 				MinColor: 494032
 				MaxColor: 4C4032
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 212932
 				MaxColor: 494339
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 3E3B35
 				MaxColor: 484237
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
@@ -3486,16 +3613,19 @@ Templates:
 				Height: 4
 				MinColor: 483D2F
 				MaxColor: 3F3629
+				Riser: RD=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2C333A
 				MaxColor: 3C382F
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				MinColor: 46433D
 				MaxColor: 48443E
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@178:
@@ -3507,6 +3637,7 @@ Templates:
 			0: Cliff
 				MinColor: 47433C
 				MaxColor: 3E3C37
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@179:
@@ -3518,6 +3649,7 @@ Templates:
 			0: Cliff
 				MinColor: 423F39
 				MaxColor: 4E473D
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@180:
@@ -3529,6 +3661,7 @@ Templates:
 			0: Cliff
 				MinColor: 4A453C
 				MaxColor: 3B372F
+				Riser: LU=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@181:
@@ -3541,22 +3674,26 @@ Templates:
 				Height: 4
 				MinColor: 4E4233
 				MaxColor: 42382C
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2E2E2D
 				MaxColor: 32302C
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 483D30
 				MaxColor: 3D3830
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 30353C
 				MaxColor: 2F3030
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@182:
@@ -3569,22 +3706,26 @@ Templates:
 				Height: 4
 				MinColor: 443E34
 				MaxColor: 423B30
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 363531
 				MaxColor: 27292A
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 473F33
 				MaxColor: 302E29
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 383837
 				MaxColor: 373632
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@183:
@@ -3597,22 +3738,26 @@ Templates:
 				Height: 4
 				MinColor: 453B2D
 				MaxColor: 463E32
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 302B22
 				MaxColor: 2F2E2B
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 			2: Cliff
 				Height: 4
 				MinColor: 504434
 				MaxColor: 463F34
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			3: Cliff
 				MinColor: 282C30
 				MaxColor: 3A3732
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@184:
@@ -3625,11 +3770,13 @@ Templates:
 				Height: 4
 				MinColor: 4F412F
 				MaxColor: 4A4033
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2C2E2D
 				MaxColor: 363531
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@185:
@@ -3642,22 +3789,26 @@ Templates:
 				Height: 4
 				MinColor: 514434
 				MaxColor: 3D372F
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2C2A25
 				MaxColor: 2B2E31
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 443B2D
 				MaxColor: 242320
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 303942
 				MaxColor: 2F3336
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@186:
@@ -3670,22 +3821,26 @@ Templates:
 				Height: 4
 				MinColor: 4E4232
 				MaxColor: 453E32
+				Riser: R=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2D2C2A
 				MaxColor: 23272D
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 514231
 				MaxColor: 2B2925
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 29313A
 				MaxColor: 252C34
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@187:
@@ -3698,22 +3853,26 @@ Templates:
 				Height: 4
 				MinColor: 463D30
 				MaxColor: 302F2B
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2B2C2B
 				MaxColor: 343431
+				Riser: DL=4
 				ZOffset: -12
 				ZRamp: 0
 			4: Cliff
 				Height: 4
 				MinColor: 504434
 				MaxColor: 24221F
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			5: Cliff
 				MinColor: 3C3E40
 				MaxColor: 2E343B
+				Riser: L=0
 				ZOffset: -12
 				ZRamp: 0
 	Template@188:
@@ -3726,11 +3885,13 @@ Templates:
 				Height: 4
 				MinColor: 4A3E2F
 				MaxColor: 444038
+				Riser: RU=0
 				ZOffset: -12
 				ZRamp: 0
 			1: Cliff
 				MinColor: 2B2D2F
 				MaxColor: 30302E
+				Riser: L=4
 				ZOffset: -12
 				ZRamp: 0
 	Template@189:
@@ -21428,3 +21589,16 @@ MultiBrushCollections:
 				Start: WaterCliff.L
 				End: Shore.L
 				Points: 3,4, 2,4, 1,4
+
+	Trees:
+		FromActors: tree01,tree02,tree03,tree04,tree05,tree06,tree07,tree08,tree09,tree10,tree11,tree12,tree13,tree14,tree15,tree16,tree17,tree18,tree19,tree20,tree21,tree22,tree23,tree24,tree25
+	Water:
+		FromTemplates: 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345
+		MultiBrush@346:
+			Template: 346
+			Weight: 100
+	CivilianBuildings:
+		FromActors: ca0001,ca0002,ca0003,ca0004,ca0005,ca0006,ca0007,ca0008,ca0009,ca0010,ca0011,ca0012,ca0013,ca0014,ca0015,ca0016,ca0017,ca0018,ca0019,ca0020,ca0021
+	Obstructions:
+		FromActors: tree01,tree02,tree03,tree04,tree05,tree06,tree07,tree08,tree09,tree10,tree11,tree12,tree13,tree14,tree15,tree16,tree17,tree18,tree19,tree20,tree21,tree22,tree23,tree24,tree25
+		FromActors: srock01,srock02,srock03,srock04,srock05,trock01,trock02,trock03,trock04,trock05


### PR DESCRIPTION
Implements a purpose-built map generator for Tiberian Sun.

This makes use of many of the same underlying utilities as the existing map generators, but also adds a few more utilities:

- RampTiler: for placing ramp tiles to best-fit a target heightmap.
- LatTiler: for smoothing out terrain transistions using LAT tiles.
- Support for mods where resource densities are baked into a map.
- Support for zoning based on ramps.

In order to support ramp tiling, additional "Riser" information is added to the TS tileset YAML to specify height discontinuities between tiles.

Key Features:

- Support for both Temperate and Snow tilesets.
- Largely similar options to the generator used by CnC.
- Variable terrain height with smooth transistions between cliffs.
- Configurable flat, cliffy, or mixed coastlines.
- Mixed patches of ground tiles.
- Optional veinholes.

The map generator primarily aims to provide a reasonable example of a RectangularIsometric map generator. It does not implement the full set of features available to TS maps. For example, it does not make use of all environments (urban areas, tiberium corruption); does not support roads, bridges, or tunnels; and does not add customized lighting.

The map generator can be used via either the lobby or the map editor. When used from the map generator, it is recommended to use a starting map with symmetric bounds/cordons.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b850c014-5089-437a-a7bb-e95297cbf5dd" />

Depends: #22200