### PR TITLE
Fix AI only builds production line with enough cash (simpler)

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -110,6 +110,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Try to build another production building if there is too much cash.")]
 		public readonly int NewProductionCashThreshold = 5000;
 
+		[Desc("Chance to build another production building if there is too much cash.")]
+		public readonly int NewProductionChance = 50;
+
 		[Desc("Radius in cells around a factory scanned for rally points by the AI.")]
 		public readonly int RallyPointScanRadius = 8;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -321,7 +321,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Make sure that we can spend as fast as we are earning
-			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold)
+			if (baseBuilder.Info.NewProductionCashThreshold > 0 && playerResources.GetCashAndResources() > baseBuilder.Info.NewProductionCashThreshold
+				&& world.LocalRandom.Next(100) < baseBuilder.Info.NewProductionChance)
 			{
 				var production = GetProducibleBuilding(baseBuilder.Info.ProductionTypes, buildableThings);
 				if (production != null && HasSufficientPowerForActor(production))


### PR DESCRIPTION
May supersudes #22184, simplier than #22184

About why this needs fixing for bot, consider following usecase:

When we have tons of cash:

1. in RA/CNC, when we have 2 barracks and 2 wf, building radar for artillery is always better than build 2 more barracks.
2. in RA, we need the RD to unlock important tanks and MCV. we cannot just goes 4 wf then RD when we have many cash.
3. in RA, when T3 is destroyed and we have 2 barracks and 2 wf, it is better that we restore T3 for support power buildings, instead of building 7 barracks and 4 warfactories to reach the max production buff.
4. in other mod where tech building unlock advance production line, we cannot make bot build the max baisc production line, then build the tech buildings.