### PR TITLE
Allow painting empty MultiBrushes with Replaceability.Any

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -633,9 +633,6 @@ namespace OpenRA.Mods.Common.MapGenerator
 				case Replaceability.None:
 					throw new ArgumentException("Cannot paint: Replaceability.None");
 				case Replaceability.Any:
-					if (this.actorPlans.Count == 0 && tiles.Count == 0)
-						throw new ArgumentException("Cannot paint: no tiles or actors");
-
 					PaintTiles(map, paintAt, finalHeightOffset, random);
 					PaintActors(map, actorPlans, paintAt);
 


### PR DESCRIPTION
Painting a MultiBrush previously required it to be non-empty. When using Replaceability.Any, this is unlikely to be the desired behavior, as some utilities (such as the upcoming LatTiler and RampTiler) may reasonably generate an empty MultiBrush as output.

This changes painting empty MultiBrushes using Replaceability.Any to be effectively no-ops. The .Tile and .Actor cases still use checks, as these still plausibly represent mistakes.
