### PR TITLE
Improve audio parsing performance.

### DIFF
--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -13,7 +13,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -178,13 +177,9 @@ namespace OpenRA
 				if (s.CanSeek)
 					return s.ReadBytes((int)(s.Length - s.Position));
 
-				var bytes = new List<byte>();
-				var buffer = new byte[1024];
-				int count;
-				while ((count = s.Read(buffer, 0, buffer.Length)) > 0)
-					bytes.AddRange(buffer.Take(count));
-
-				return bytes.ToArray();
+				using var ms = new MemoryStream();
+				s.CopyTo(ms);
+				return ms.Capacity == ms.Length ? ms.GetBuffer() : ms.ToArray();
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaVideo.cs
@@ -225,23 +225,25 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				}
 			}
 
+			static byte[] GetAudioData(bool compressed, MemoryStream audio, ref int adpcmIndex)
+			{
+				var audioArray = audio.ToArray();
+				if (!compressed)
+					return audioArray;
+
+				var result = new byte[audio.Length * 4];
+				ImaAdpcmReader.LoadImaAdpcmSound(audioArray, ref adpcmIndex, result);
+				return result;
+			}
+
 			if (AudioChannels == 1)
-				AudioData = compressed ? ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex) : audio1.ToArray();
+				AudioData = GetAudioData(compressed, audio1, ref adpcmIndex);
 			else
 			{
-				byte[] leftData, rightData;
-				if (!compressed)
-				{
-					leftData = audio1.ToArray();
-					rightData = audio2.ToArray();
-				}
-				else
-				{
-					adpcmIndex = 0;
-					leftData = ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex);
-					adpcmIndex = 0;
-					rightData = ImaAdpcmReader.LoadImaAdpcmSound(audio2.ToArray(), ref adpcmIndex);
-				}
+				adpcmIndex = 0;
+				var leftData = GetAudioData(compressed, audio1, ref adpcmIndex);
+				adpcmIndex = 0;
+				var rightData = GetAudioData(compressed, audio2, ref adpcmIndex);
 
 				AudioData = new byte[rightData.Length + leftData.Length];
 				var rightIndex = 0;

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -56,18 +56,18 @@ namespace OpenRA.Mods.Common.FileFormats
 			return (short)current;
 		}
 
-		public static byte[] LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index)
+		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, Span<byte> output)
 		{
 			var currentSample = 0;
-			return LoadImaAdpcmSound(raw, ref index, ref currentSample);
+			LoadImaAdpcmSound(raw, ref index, ref currentSample, output);
 		}
 
-		public static byte[] LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, ref int currentSample)
+		public static void LoadImaAdpcmSound(ReadOnlySpan<byte> raw, ref int index, ref int currentSample, Span<byte> output)
 		{
 			var dataSize = raw.Length;
-			var outputSize = raw.Length * 4;
+			if (output.Length != raw.Length * 4)
+				throw new ArgumentException($"{nameof(output)} must be 4 times the length of {nameof(raw)}.", nameof(output));
 
-			var output = new byte[outputSize];
 			var offset = 0;
 
 			while (dataSize-- > 0)
@@ -82,8 +82,6 @@ namespace OpenRA.Mods.Common.FileFormats
 				output[offset++] = (byte)t;
 				output[offset++] = (byte)(t >> 8);
 			}
-
-			return output;
 		}
 	}
 }


### PR DESCRIPTION
- Improve the AudReader and WavReader by performing fewer, larger stream reads to consume bytes more efficiently.
- Improve ImaAdpcmReader.LoadImaAdpcmSound by accepting an output buffer rather than allocating a new array.
- Improve StreamExts.ReadAllBytes by using MemoryStream.CopyTo. This internally rents a much larger buffer from the array pool, allowing for fewer, larger stream reads.

----

The following can be inserted at the bottom of `AssetBrowserLogic.PopulateAssetList` to approximate a benchmark by loading all audio files when opening the asset browser.

<details>
<summary>"Benchmark" code</summary>

```c#
	var sw = Stopwatch.StartNew();
	foreach (var file in files)
	{
		foreach (var package in file.Value)
		{
			var fileExtension = Path.GetExtension(file.Key.ToLowerInvariant());
			if (string.IsNullOrWhiteSpace(fileExtension) || (package.Name == Platform.EngineDir && !allowedExtensions.Contains(fileExtension)))
				continue;

			var filepath = file.Key;

			if (!allowedAudioExtensions.Any(ext => filepath.EndsWith(ext, true, CultureInfo.InvariantCulture)))
				continue;

			var prefix = "";

			if (modData.DefaultFileSystem is OpenRA.FileSystem.FileSystem fs)
			{
				prefix = fs.GetPrefix(package);
				if (prefix != null)
					prefix += "|";
			}

			if (allowedAudioExtensions.Contains(fileExtension))
			{
				var currentAudioStream = Game.ModData.DefaultFileSystem.Open(prefix + filepath);
				foreach (var modDataSoundLoader in Game.ModData.SoundLoaders)
				{
					if (modDataSoundLoader.TryParseSound(currentAudioStream, out var currentSoundFormat))
					{
						currentSoundFormat.GetPCMInputStream().ReadAllBytes();
					}
				}
			}
		}
	}

	Console.WriteLine($"Loaded all in {sw.Elapsed.TotalMilliseconds:0}ms");
```
</details>

The gives me the following timings (milliseconds):

| mod | cnc | ra | d2k | ts |
| --- | --- | --- | --- | --- |
| bleed | 6474 | 4771 | 753 | 3938 |
| pr | 4235 | 3153 | 309 | 2568 |