### PR TITLE
Fix the wrong parameter passing on bot's GetNearbyIndicesThreat

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -225,7 +225,7 @@ namespace OpenRA.Mods.Common.Traits
 					attraction -= indiceSideLengthSquare << 4;
 				else
 				{
-					var (indiceCount, nearbyEnemyBase, nearbyEnemy) = resourceMapModule.GetNearbyIndicesThreat(i);
+					var (indiceCount, nearbyEnemy, nearbyEnemyBase) = resourceMapModule.GetNearbyIndicesThreat(i);
 					if (nearbyEnemyBase + nearbyEnemy > 0)
 						attraction -= indiceSideLengthSquare >> 5;
 				}

--- a/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvExpansionManagerBotModule.cs
@@ -290,7 +290,7 @@ namespace OpenRA.Mods.Common.Traits
 			 *
 			 * 2). the weight of friendly construction yard within range: -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
 			 *
-			 * 3). the weight of enemy within range: -indiceSideLengthSquare*16 for base building, otherwise -indiceSideLengthSquare/64
+			 * 3). the weight of enemy within range: -indiceSideLengthSquare*8 for base building, otherwise -indiceSideLengthSquare/64
 			 *
 			 * 4). the weight of friendly refinery within range (not for CheckBase mode): -indiceSideLengthSquare. If it belongs to an ally, -indiceSideLengthSquare/2.
 			 *
@@ -503,17 +503,17 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var baseIndice = resourceMapModule.GetIndice(index);
 
-			var (indiceCount, nearbyEnemyBaseThreat, nearbyEnemyThreat) = resourceMapModule.GetNearbyIndicesThreat(index);
+			var (indiceCount, nearbyEnemyThreat, nearbyEnemyBaseThreat) = resourceMapModule.GetNearbyIndicesThreat(index);
 
 			var indiceEnemyBaseThreat = Math.Max(baseIndice.EnemyBaseCount - baseIndice.FriendlyBaseCount, 0);
 
 			var indiceEnemyUnitThreat = Math.Max(baseIndice.EnemyUnitCount - baseIndice.FriendlyUnitCount, 0);
 
 			if (indiceCount == 0)
-				return (indiceEnemyUnitThreat * indiceSideLengthSquare >> 6) + (indiceEnemyBaseThreat * indiceSideLengthSquare << 4);
+				return (indiceEnemyUnitThreat * indiceSideLengthSquare >> 6) + (indiceEnemyBaseThreat * indiceSideLengthSquare << 3);
 
-			return ((indiceEnemyUnitThreat + nearbyEnemyThreat / indiceCount) * indiceSideLengthSquare >> 6) +
-							((indiceEnemyBaseThreat + nearbyEnemyBaseThreat / indiceCount) * indiceSideLengthSquare << 4);
+			return ((indiceEnemyUnitThreat * indiceSideLengthSquare + nearbyEnemyThreat * indiceSideLengthSquare / indiceCount) >> 6) +
+							((indiceEnemyBaseThreat * indiceSideLengthSquare + nearbyEnemyBaseThreat * indiceSideLengthSquare / indiceCount) << 3);
 		}
 
 		void IBotTick.BotTick(IBot bot)


### PR DESCRIPTION
Correctly fix the issue in #22174,  fix a regression in #22116: I simply got the `nearbyEnemyThreat` and `nearbyEnemyBaseThreat` wrong when using `GetNearbyIndicesThreat(...)` :(

so in this PR, #22174 is reverted, as the correct place is fixed.

Tests:
Other tests like `Imminient Destruction` of full rush AI FFA is still normal.
AI behaviors in map "Ore Gradens" becomes better.
AI won't ignore enemy base in nearby indice, so they no longer (or at very low rate) expand to enemy base nearby.