### PR TITLE
Allow bot repairs all buildings.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -17,16 +18,46 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Manages AI repairing base buildings.")]
 	public class BuildingRepairBotModuleInfo : ConditionalTraitInfo
 	{
+		[Desc($"A delay (in ticks) of repair all actors with {nameof(RepairableBuilding)} periodically. Set it to -1 to disable it.")]
+		public readonly int RepairAllBuildingsCoolDown = 107;
+
 		public override object Create(ActorInitializer init) { return new BuildingRepairBotModule(this); }
 	}
 
 	public class BuildingRepairBotModule : ConditionalTrait<BuildingRepairBotModuleInfo>, IBotRespondToAttack
 	{
+		int prevTicks = 0;
+
 		public BuildingRepairBotModule(BuildingRepairBotModuleInfo info)
 			: base(info) { }
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
+			// Check all buildings for repair periodically.
+			// We add a RepairAllCoolDown >= 0 for d2k bots to disable it.
+			if (Info.RepairAllBuildingsCoolDown >= 0 && prevTicks + Info.RepairAllBuildingsCoolDown < bot.Player.World.WorldTick)
+			{
+				prevTicks = bot.Player.World.WorldTick;
+				var reaprableBuildings = bot.Player.World.ActorsWithTrait<RepairableBuilding>()
+					.Where(tp =>
+					{
+						if (tp.Actor.Owner != bot.Player)
+							return false;
+
+						var health = tp.Actor.TraitOrDefault<Health>();
+						if (health == null || health.DamageState <= DamageState.Undamaged || health.DamageState == DamageState.Dead)
+							return false;
+
+						return !tp.Trait.RepairActive;
+					});
+
+				foreach (var tp in reaprableBuildings)
+					bot.QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, Target.FromActor(tp.Actor), false));
+
+				return;
+			}
+
+			// Check if the attacked building needs repair.
 			// HACK: We don't want D2k bots to repair all their buildings on placement
 			// where half their HP is removed via neutral terrain damage.
 			// TODO: Implement concrete placement for D2k bots and remove this hack on players relationship check.

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -261,6 +261,7 @@ Player:
 			medium_gun_turret: 5000
 	BuildingRepairBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+		RepairAllBuildingsCoolDown: -1
 	SquadManagerBotModule@omnius:
 		RequiresCondition: enable-omnius-ai
 		SquadSize: 8


### PR DESCRIPTION
Closes #22195

Eases problems in #13288 and #22195 meanwhile not mess up d2k bot repair buildings, and friendly to high order latency situation for bot.
