### PR TITLE
Move palette reference definions to sequences

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -24,9 +24,9 @@ namespace OpenRA.Activities
 	{
 		public readonly Target Target;
 		public readonly Color Color;
-		public readonly Sprite Tile;
+		public readonly ISpriteSequence Tile;
 
-		public TargetLineNode(in Target target, Color color, Sprite tile = null)
+		public TargetLineNode(in Target target, Color color, ISpriteSequence tile = null)
 		{
 			// Note: Not all activities are drawable. In that case, pass Target.Invalid as target,
 			// if "yield break" in TargetLineNode(Actor self) is not feasible.

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -666,7 +666,7 @@ namespace OpenRA
 			return GetValue(fieldName, fieldType, value, null);
 		}
 
-		static object GetValue(string fieldName, Type fieldType, MiniYaml yaml)
+		public static object GetValue(string fieldName, Type fieldType, MiniYaml yaml)
 		{
 			return GetValue(fieldName, fieldType, yaml.Value, yaml);
 		}

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -55,7 +55,22 @@ namespace OpenRA.Graphics
 
 		public Sprite Image => CurrentSequence.GetSprite(CurrentFrame, facingFunc());
 
-		public IRenderable[] Render(WPos pos, in WVec offset, int zOffset, PaletteReference palette)
+		public string Palette(Player owner = null)
+		{
+			return CurrentSequence.GetPalette(owner?.InternalName);
+		}
+
+		public IRenderable[] Render(WorldRenderer wr, WPos pos, in WVec offset, int zOffset, OwnerInit owner)
+		{
+			return Render(pos, offset, zOffset, wr.Palette(CurrentSequence.GetPalette(owner?.InternalName)));
+		}
+
+		public IRenderable[] Render(WorldRenderer wr, WPos pos, in WVec offset, int zOffset, Player owner)
+		{
+			return Render(pos, offset, zOffset, wr.Palette(CurrentSequence.GetPalette(owner?.InternalName)));
+		}
+
+		IRenderable[] Render(WPos pos, in WVec offset, int zOffset, PaletteReference palette)
 		{
 			var tintModifiers = CurrentSequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
 			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
@@ -79,19 +94,30 @@ namespace OpenRA.Graphics
 			return [imageRenderable];
 		}
 
-		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, in WVec offset, int zOffset, PaletteReference palette, float scale = 1f, float rotation = 0f)
+		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, in WVec offset, int zOffset, string ownerName = null, float scale = 1f, float rotation = 0f)
 		{
 			scale *= CurrentSequence.Scale;
 			var screenOffset = (scale * wr.ScreenVectorComponents(offset)).XY.ToInt2();
 			var imagePos = pos + screenOffset - new int2((int)(scale * Image.Size.X / 2), (int)(scale * Image.Size.Y / 2));
 			var alpha = CurrentSequence.GetAlpha(CurrentFrame);
+			var palette = wr.Palette(CurrentSequence.GetPalette(ownerName));
 			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale, alpha, rotation);
 
 			var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 			if (shadow != null)
 			{
 				var shadowPos = pos - new int2((int)(scale * shadow.Size.X / 2), (int)(scale * shadow.Size.Y / 2));
-				var shadowRenderable = new UISpriteRenderable(shadow, WPos.Zero + offset, shadowPos, CurrentSequence.ShadowZOffset + zOffset, palette, scale, 1f, rotation);
+				var shadowPalette = wr.Palette(CurrentSequence.ShadowPalette);
+				var shadowRenderable = new UISpriteRenderable(
+					shadow,
+					WPos.Zero + offset,
+					shadowPos,
+					CurrentSequence.ShadowZOffset + zOffset,
+					shadowPalette,
+					scale,
+					1f,
+					rotation);
+
 				return [shadowRenderable, imageRenderable];
 			}
 
@@ -110,9 +136,9 @@ namespace OpenRA.Graphics
 				xy.Y + (int)(cb.Bottom * scale));
 		}
 
-		public IRenderable[] Render(WPos pos, PaletteReference palette)
+		public IRenderable[] Render(WorldRenderer wr, WPos pos, Player owner = null)
 		{
-			return Render(pos, WVec.Zero, 0, palette);
+			return Render(pos, WVec.Zero, 0, wr.Palette(CurrentSequence.GetPalette(owner?.InternalName)));
 		}
 
 		public void Play(string sequenceName)

--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -35,13 +35,13 @@ namespace OpenRA.Graphics
 			ZOffset = zOffset;
 		}
 
-		public IRenderable[] Render(Actor self, PaletteReference pal)
+		public IRenderable[] Render(WorldRenderer wr, Actor self, Player owner)
 		{
 			var center = self.CenterPosition;
 			var offset = OffsetFunc?.Invoke() ?? WVec.Zero;
 
 			var z = ZOffset?.Invoke(center + offset) ?? 0;
-			return Animation.Render(center, offset, z, pal);
+			return Animation.Render(wr, center, offset, z, owner);
 		}
 
 		public Rectangle ScreenBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Game/Graphics/SequenceSet.cs
+++ b/OpenRA.Game/Graphics/SequenceSet.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Graphics
 		void ResolveSprites(SpriteCache cache);
 		Sprite GetSprite(int frame);
 		Sprite GetSprite(int frame, WAngle facing);
+		string GetPalette(string owner = null);
+		bool IsPlayerPalette { get; }
+		string ShadowPalette { get; }
 		(Sprite Sprite, WAngle Rotation) GetSpriteWithRotation(int frame, WAngle facing);
 		Sprite GetShadow(int frame, WAngle facing);
 		float GetAlpha(int frame);
@@ -85,6 +88,13 @@ namespace OpenRA.Graphics
 				throw new InvalidOperationException($"Image `{image}` does not have any sequences defined.");
 
 			return sequences.Keys;
+		}
+
+		public IEnumerable<(string Image, string SequenceName, ISpriteSequence Sequence)> AllSequences()
+		{
+			foreach (var image in images)
+				foreach (var sequence in image.Value)
+					yield return (image.Key, sequence.Key, sequence.Value);
 		}
 
 		IReadOnlyDictionary<string, IReadOnlyDictionary<string, ISpriteSequence>> Load(IReadOnlyFileSystem fileSystem, MiniYaml additionalSequences)

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -89,9 +89,9 @@ namespace OpenRA.Graphics
 			Update(cell, null, null, 1f, 1f, true);
 		}
 
-		public void Update(CPos cell, ISpriteSequence sequence, PaletteReference palette, int frame)
+		public void Update(CPos cell, ISpriteSequence sequence, int frame)
 		{
-			Update(cell, sequence.GetSprite(frame), palette, sequence.Scale, sequence.GetAlpha(frame), sequence.IgnoreWorldTint);
+			Update(cell, sequence.GetSprite(frame), worldRenderer.Palette(sequence.GetPalette()), sequence.Scale, sequence.GetAlpha(frame), sequence.IgnoreWorldTint);
 		}
 
 		public void Update(CPos cell, Sprite sprite, PaletteReference palette, float scale = 1f, float alpha = 1f, bool ignoreTint = false)

--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -68,11 +68,4 @@ namespace OpenRA
 
 		public TerrainTypeInfo(MiniYaml my) { FieldLoader.Load(this, my); }
 	}
-
-	// HACK: Temporary placeholder to avoid having to change all the traits that reference this constant.
-	// This can be removed after the palette references have been moved from traits to sequences.
-	public static class TileSet
-	{
-		public const string TerrainPaletteInternalName = "terrain";
-	}
 }

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -22,7 +22,6 @@ namespace OpenRA.Mods.Cnc.Effects
 	sealed class GpsDotEffect : IEffect, IEffectAnnotation
 	{
 		readonly Actor actor;
-		readonly GpsDotInfo info;
 		readonly Animation anim;
 
 		readonly PlayerDictionary<DotState> dotStates;
@@ -47,7 +46,6 @@ namespace OpenRA.Mods.Cnc.Effects
 		public GpsDotEffect(Actor actor, GpsDotInfo info)
 		{
 			this.actor = actor;
-			this.info = info;
 			anim = new Animation(actor.World, info.Image);
 			anim.PlayRepeating(info.String);
 
@@ -111,9 +109,8 @@ namespace OpenRA.Mods.Cnc.Effects
 			var effectiveOwner = actor.EffectiveOwner != null && actor.EffectiveOwner.Owner != null ?
 				actor.EffectiveOwner.Owner : actor.Owner;
 
-			var palette = wr.Palette(info.IndicatorPalettePrefix + effectiveOwner.InternalName);
 			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(actor.CenterPosition));
-			return anim.RenderUI(wr, screenPos, WVec.Zero, 0, palette);
+			return anim.RenderUI(wr, screenPos, WVec.Zero, 0, effectiveOwner.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
@@ -20,14 +20,14 @@ namespace OpenRA.Mods.Cnc.Effects
 	{
 		readonly Player launcher;
 		readonly Animation anim;
-		readonly string palette;
+		readonly Player owner;
 		readonly int revealDelay;
 		WPos pos;
 		int tick;
 
-		public GpsSatellite(World world, WPos pos, string image, string sequence, string palette, int revealDelay, Player launcher)
+		public GpsSatellite(World world, WPos pos, string image, string sequence, Player owner, int revealDelay, Player launcher)
 		{
-			this.palette = palette;
+			this.owner = owner;
 			this.pos = pos;
 			this.launcher = launcher;
 			this.revealDelay = revealDelay;
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return anim.Render(pos, wr.Palette(palette));
+			return anim.Render(wr, pos, owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
@@ -44,15 +44,14 @@ namespace OpenRA.Mods.Cnc.Effects
 
 			if (++frame == 19)
 			{
-				var palette = info.SatellitePaletteIsPlayerPalette ? info.SatellitePalette + launcher.Owner.InternalName : info.SatellitePalette;
-				world.AddFrameEndTask(w => w.Add(new GpsSatellite(world, pos, info.SatelliteImage, info.SatelliteSequence, palette, info.RevealDelay, launcher.Owner)));
+				world.AddFrameEndTask(
+					w => w.Add(new GpsSatellite(world, pos, info.SatelliteImage, info.SatelliteSequence, launcher.Owner, info.RevealDelay, launcher.Owner)));
 			}
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			var palette = info.DoorPaletteIsPlayerPalette ? info.DoorPalette + launcher.Owner.InternalName : info.DoorPalette;
-			return doors.Render(pos, wr.Palette(palette));
+			return doors.Render(wr, pos, launcher.Owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -32,7 +32,6 @@ namespace OpenRA.Mods.Cnc.Graphics
 		];
 		readonly WVec length;
 		readonly string image;
-		readonly string palette;
 		readonly string dimSequence;
 		readonly string brightSequence;
 		readonly int brightZaps, dimZaps;
@@ -44,14 +43,12 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public TeslaZapRenderable(
 			WPos pos, int zOffset, in WVec length, string image,
 			string brightSequence, int brightZaps,
-			string dimSequence, int dimZaps,
-			string palette)
+			string dimSequence, int dimZaps)
 		{
 			Pos = pos;
 			ZOffset = zOffset;
 			this.length = length;
 			this.image = image;
-			this.palette = palette;
 			this.brightZaps = brightZaps;
 			this.dimZaps = dimZaps;
 			this.dimSequence = dimSequence;
@@ -69,13 +66,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		public IPalettedRenderable WithPalette(PaletteReference newPalette)
 		{
-			return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
+			return new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps);
 		}
 
 		public IRenderable WithZOffset(int newOffset) =>
-			new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
+			new TeslaZapRenderable(Pos, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps);
 		public IRenderable OffsetBy(in WVec vec) =>
-			new TeslaZapRenderable(Pos + vec, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps, palette);
+			new TeslaZapRenderable(Pos + vec, ZOffset, length, image, brightSequence, brightZaps, dimSequence, dimZaps);
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
@@ -97,20 +94,22 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public IEnumerable<IFinalizedRenderable> GenerateRenderables(WorldRenderer wr)
 		{
 			var bright = wr.World.Map.Sequences.GetSequence(image, brightSequence);
+			var brightPalette = wr.Palette(bright.GetPalette());
 			var dim = wr.World.Map.Sequences.GetSequence(image, dimSequence);
+			var dimPalette = wr.Palette(dim.GetPalette());
 
 			var source = wr.ScreenPosition(Pos);
 			var target = wr.ScreenPosition(Pos + length);
 
 			for (var n = 0; n < dimZaps; n++)
-				foreach (var z in DrawZapWandering(wr, source, target, dim, palette))
+				foreach (var z in DrawZapWandering(wr, source, target, dim, dimPalette))
 					yield return z;
 			for (var n = 0; n < brightZaps; n++)
-				foreach (var z in DrawZapWandering(wr, source, target, bright, palette))
+				foreach (var z in DrawZapWandering(wr, source, target, bright, brightPalette))
 					yield return z;
 		}
 
-		static IEnumerable<IFinalizedRenderable> DrawZapWandering(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, string pal)
+		static IEnumerable<IFinalizedRenderable> DrawZapWandering(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, PaletteReference pal)
 		{
 			var dist = to - from;
 			var norm = 1f / dist.Length * new float2(-dist.Y, dist.X);
@@ -136,14 +135,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 			return renderables;
 		}
 
-		static IEnumerable<IFinalizedRenderable> DrawZap(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, out float2 p, string palette)
+		static IEnumerable<IFinalizedRenderable> DrawZap(WorldRenderer wr, float2 from, float2 to, ISpriteSequence s, out float2 p, PaletteReference palette)
 		{
 			var dist = to - from;
 			var q = new float2(-dist.Y, dist.X);
 			var c = -float2.Dot(from, q);
 			var rs = new List<IFinalizedRenderable>();
 			var z = from;
-			var pal = wr.Palette(palette);
 
 			while ((to - z).X > 5 || (to - z).X < -5 || (to - z).Y > 5 || (to - z).Y < -5)
 			{
@@ -152,7 +150,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 				var pos = wr.ProjectedPosition((z + new float2(step[2], step[3])).ToInt2());
 				var tintModifiers = s.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
-				rs.Add(new SpriteRenderable(s.GetSprite(step[4]), pos, WVec.Zero, 0, pal, 1f, s.GetAlpha(step[4]), float3.Ones, tintModifiers, true).PrepareRender(wr));
+				rs.Add(new SpriteRenderable(s.GetSprite(step[4]), pos, WVec.Zero, 0, palette, 1f, s.GetAlpha(step[4]), float3.Ones, tintModifiers, true).PrepareRender(wr));
 
 				z += new float2(step[0], step[1]);
 				if (rs.Count >= 1000)

--- a/OpenRA.Mods.Cnc/Projectiles/DropPodImpact.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/DropPodImpact.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Mods.Cnc.Effects
 		readonly Target target;
 		readonly Animation entryAnimation;
 		readonly Player firedBy;
-		readonly string entryPalette;
 		readonly WeaponInfo weapon;
 		readonly WPos launchPos;
 
@@ -29,12 +28,11 @@ namespace OpenRA.Mods.Cnc.Effects
 		bool impacted = false;
 
 		public DropPodImpact(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, in Target target,
-			int delay, string entryEffect, string entrySequence, string entryPalette)
+			int delay, string entryEffect, string entrySequence)
 		{
 			this.target = target;
 			this.firedBy = firedBy;
 			this.weapon = weapon;
-			this.entryPalette = entryPalette;
 			weaponDelay = delay;
 			this.launchPos = launchPos;
 
@@ -66,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return entryAnimation.Render(launchPos, wr.Palette(entryPalette));
+			return entryAnimation.Render(wr, launchPos, firedBy);
 		}
 
 		void Finish(World world)

--- a/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
@@ -21,18 +21,16 @@ namespace OpenRA.Mods.Cnc.Effects
 		readonly Target target;
 		readonly Animation anim;
 		readonly Player firedBy;
-		readonly string palette;
 		readonly WeaponInfo weapon;
 
 		int weaponDelay;
 		bool impacted = false;
 
-		public IonCannon(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, in Target target, string effect, string sequence, string palette, int delay)
+		public IonCannon(Player firedBy, WeaponInfo weapon, World world, WPos launchPos, in Target target, string effect, string sequence, int delay)
 		{
 			this.target = target;
 			this.firedBy = firedBy;
 			this.weapon = weapon;
-			this.palette = palette;
 			weaponDelay = delay;
 			anim = new Animation(world, effect);
 			anim.PlayThen(sequence, () => Finish(world));
@@ -62,7 +60,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			return anim.Render(target.CenterPosition, wr.Palette(palette));
+			return anim.Render(wr, target.CenterPosition, firedBy);
 		}
 
 		void Finish(World world)

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -30,10 +30,6 @@ namespace OpenRA.Mods.Cnc.Projectiles
 		[Desc("Sprite sequence to play at the borders.")]
 		public readonly string DimSequence = "dim";
 
-		[PaletteReference]
-		[Desc("The palette used to draw this electric zap.")]
-		public readonly string Palette = "effect";
-
 		[Desc("How many sprite sequences to play at the center.")]
 		public readonly int BrightZaps = 1;
 
@@ -91,7 +87,7 @@ namespace OpenRA.Mods.Cnc.Projectiles
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
 			zap = new TeslaZapRenderable(args.Source, info.ZOffset, target - args.Source,
-				info.Image, info.BrightSequence, info.BrightZaps, info.DimSequence, info.DimZaps, info.Palette);
+				info.Image, info.BrightSequence, info.BrightZaps, info.DimSequence, info.DimZaps);
 
 			yield return zap;
 		}

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -24,9 +24,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sprite used for this actor.")]
 		public readonly string String = "Infantry";
 
-		[PaletteReference(true)]
-		public readonly string IndicatorPalettePrefix = "player";
-
 		public override object Create(ActorInitializer init) { return new GpsDot(this); }
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -23,20 +23,14 @@ namespace OpenRA.Mods.Cnc.Traits
 		[SequenceReference]
 		public readonly string Sequence = "bib";
 
-		[PaletteReference]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		public readonly bool HasMinibib = false;
 
 		public override object Create(ActorInitializer init) { return new WithBuildingBib(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (init.Contains<HideBibPreviewInit>(this))
 				yield break;
-
-			if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
 
 			var bi = init.Actor.TraitInfo<BuildingInfo>();
 
@@ -69,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				// Z-order is one set to the top of the footprint
 				var offset = map.CenterOfCell(cell) - map.CenterOfCell(location) - centerOffset;
-				yield return new SpriteActorPreview(anim, () => offset, () => -(offset.Y + centerOffset.Y + 512), p);
+				yield return new SpriteActorPreview(anim, () => offset, () => -(offset.Y + centerOffset.Y + 512), owner);
 			}
 		}
 
@@ -120,7 +114,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var offset = self.World.Map.CenterOfCell(cell) - self.World.Map.CenterOfCell(location) - centerOffset;
 				var awo = new AnimationWithOffset(anim, () => offset, null, -(offset.Y + centerOffset.Y + 512));
 				anims.Add(awo);
-				rs.Add(awo, info.Palette);
+				rs.Add(awo);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -68,8 +68,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				var sequence = DefaultAnimation.GetRandomExistingSequence(GetDisplayInfo().StandSequences, Game.CosmeticRandom);
 				if (sequence != null)
 					DefaultAnimation.ChangeImage(disguiseImage ?? rs.GetImage(self), sequence);
-
-				rs.UpdatePalette();
 			}
 
 			base.Tick(self);

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithEmbeddedTurretSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var anim = new Animation(init.World, image, t.WorldFacingFromInit(init));
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithSplitAttackPaletteInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithSplitAttackPaletteInfantryBody.cs
@@ -12,16 +12,11 @@
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	sealed class WithSplitAttackPaletteInfantryBodyInfo : WithInfantryBodyInfo
 	{
-		[PaletteReference]
-		[Desc("Palette to use for the split attack rendering.")]
-		public readonly string SplitAttackPalette = null;
-
 		[Desc("Sequence suffix to use.")]
 		public readonly string SplitAttackSuffix = "muzzle";
 
@@ -40,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			this.info = info;
 			var rs = init.Self.Trait<RenderSprites>();
 			splitAnimation = new Animation(init.World, rs.GetImage(init.Self), RenderSprites.MakeFacingFunc(init.Self));
-			rs.Add(new AnimationWithOffset(splitAnimation, null, () => IsTraitDisabled || !visible), info.SplitAttackPalette);
+			rs.Add(new AnimationWithOffset(splitAnimation, null, () => IsTraitDisabled || !visible));
 		}
 
 		protected override void Attacking(Actor self, Armament a, Barrel barrel)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -23,13 +23,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "active";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithTeslaChargeOverlay(init, this); }
 	}
 
@@ -48,8 +41,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 			overlay = new Animation(init.World, renderSprites.GetImage(init.Self));
 
-			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !charging),
-				info.Palette, info.IsPlayerPalette);
+			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !charging));
 		}
 
 		void INotifyTeslaCharging.Charging(Actor self, in Target target)

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -32,9 +32,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Ticks until returning after teleportation.")]
 		public readonly int Duration = 750;
 
-		[PaletteReference]
-		public readonly string TargetOverlayPalette = TileSet.TerrainPaletteInternalName;
-
 		public readonly string FootprintImage = "overlay";
 
 		[SequenceReference(nameof(FootprintImage), prefix: true)]
@@ -145,8 +142,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly ChronoshiftPower power;
 			readonly char[] footprint;
 			readonly CVec dimensions;
-			readonly Sprite tile;
-			readonly float alpha;
+			readonly ISpriteSequence tile;
 			readonly SupportPowerManager manager;
 			readonly string order;
 
@@ -164,8 +160,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var s = world.Map.Sequences.GetSequence(info.FootprintImage, info.SourceFootprintSequence);
 				footprint = info.Footprint.Where(c => !char.IsWhiteSpace(c)).ToArray();
 				dimensions = info.Dimensions;
-				tile = s.GetSprite(0);
-				alpha = s.GetAlpha(0);
+				tile = s;
 			}
 
 			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -207,10 +202,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var tiles = power.CellsMatching(xy, footprint, dimensions);
-				var palette = wr.Palette(((ChronoshiftPowerInfo)power.Info).TargetOverlayPalette);
+				var palette = wr.Palette(tile.GetPalette());
 				foreach (var t in tiles)
 					yield return new SpriteRenderable(
-						tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+						tile.GetSprite(0), wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, tile.GetAlpha(0), float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -225,7 +220,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly CPos sourceLocation;
 			readonly char[] footprint;
 			readonly CVec dimensions;
-			readonly Sprite validTile, invalidTile, sourceTile;
+			readonly ISpriteSequence validTile, invalidTile, sourceTile;
 			readonly float validAlpha, invalidAlpha, sourceAlpha;
 			readonly SupportPowerManager manager;
 			readonly string order;
@@ -246,22 +241,22 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (sequences.HasSequence(info.FootprintImage, tilesetValid))
 				{
 					var validSequence = sequences.GetSequence(info.FootprintImage, tilesetValid);
-					validTile = validSequence.GetSprite(0);
+					validTile = validSequence;
 					validAlpha = validSequence.GetAlpha(0);
 				}
 				else
 				{
 					var validSequence = sequences.GetSequence(info.FootprintImage, info.ValidFootprintSequence);
-					validTile = validSequence.GetSprite(0);
+					validTile = validSequence;
 					validAlpha = validSequence.GetAlpha(0);
 				}
 
 				var invalidSequence = sequences.GetSequence(info.FootprintImage, info.InvalidFootprintSequence);
-				invalidTile = invalidSequence.GetSprite(0);
+				invalidTile = invalidSequence;
 				invalidAlpha = invalidSequence.GetAlpha(0);
 
 				var sourceSequence = sequences.GetSequence(info.FootprintImage, info.SourceFootprintSequence);
-				sourceTile = sourceSequence.GetSprite(0);
+				sourceTile = sourceSequence;
 				sourceAlpha = sourceSequence.GetAlpha(0);
 			}
 
@@ -302,7 +297,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-				var palette = wr.Palette(power.Info.IconPalette);
 
 				// Destination tiles
 				var delta = xy - sourceLocation;
@@ -312,7 +306,8 @@ namespace OpenRA.Mods.Cnc.Traits
 					var tile = isValid ? validTile : invalidTile;
 					var alpha = isValid ? validAlpha : invalidAlpha;
 					yield return new SpriteRenderable(
-						tile, wr.World.Map.CenterOfCell(t + delta), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+						tile.GetSprite(0), wr.World.Map.CenterOfCell(t + delta), WVec.Zero, -511,
+						wr.Palette(tile.GetPalette()), 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 				}
 
 				// Unit previews
@@ -326,7 +321,8 @@ namespace OpenRA.Mods.Cnc.Traits
 						var tile = canEnter ? validTile : invalidTile;
 						var alpha = canEnter ? validAlpha : invalidAlpha;
 						yield return new SpriteRenderable(
-							tile, wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511, palette, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+							tile.GetSprite(0), wr.World.Map.CenterOfCell(targetCell), WVec.Zero, -511,
+							wr.Palette(tile.GetPalette()), 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 					}
 
 					var offset = world.Map.CenterOfCell(xy) - world.Map.CenterOfCell(sourceLocation);
@@ -352,12 +348,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
-				var palette = wr.Palette(power.Info.IconPalette);
-
 				// Source tiles
 				foreach (var t in power.CellsMatching(sourceLocation, footprint, dimensions))
 					yield return new SpriteRenderable(
-						sourceTile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, sourceAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+						sourceTile.GetSprite(0), wr.World.Map.CenterOfCell(t), WVec.Zero, -511,
+						wr.Palette(sourceTile.GetPalette()), 1f, sourceAlpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			bool IsValidTarget(CPos xy)

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -44,9 +44,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[SequenceReference(nameof(EntryEffect))]
 		public readonly string EntryEffectSequence = "idle";
 
-		[PaletteReference]
-		public readonly string EntryEffectPalette = "effect";
-
 		[ActorReference]
 		[Desc("Actor to spawn when the attack starts")]
 		public readonly string CameraActor = null;
@@ -178,7 +175,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					else
 					{
 						world.Add(new DropPodImpact(self.Owner, info.WeaponInfo, world, launchLocation, Target.FromCell(world, dropLocation),
-							info.WeaponDelay, info.EntryEffect, info.EntryEffectSequence, info.EntryEffectPalette));
+							info.WeaponDelay, info.EntryEffect, info.EntryEffectSequence));
 
 						world.Add(pod);
 					}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -28,24 +28,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		[SequenceReference(nameof(DoorImage))]
 		public readonly string DoorSequence = "active";
 
-		[PaletteReference(nameof(DoorPaletteIsPlayerPalette))]
-		[Desc("Palette to use for rendering the launch animation")]
-		public readonly string DoorPalette = "player";
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool DoorPaletteIsPlayerPalette = true;
-
 		public readonly string SatelliteImage = "sputnik";
 
 		[SequenceReference(nameof(SatelliteImage))]
 		public readonly string SatelliteSequence = "idle";
-
-		[PaletteReference(nameof(SatellitePaletteIsPlayerPalette))]
-		[Desc("Palette to use for rendering the satellite projectile")]
-		public readonly string SatellitePalette = "player";
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool SatellitePaletteIsPlayerPalette = true;
 
 		[Desc("Requires an actor with an online `ProvidesRadar` to show GPS dots.")]
 		public readonly bool RequiresActiveRadar = true;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -33,9 +33,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Effect sequence to display")]
 		public readonly string EffectSequence = "idle";
 
-		[PaletteReference]
-		public readonly string EffectPalette = "effect";
-
 		[WeaponReference]
 		[Desc("Which weapon to fire")]
 		public readonly string Weapon = "IonCannon";
@@ -85,7 +82,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				PlayLaunchSounds();
 				Game.Sound.Play(SoundType.World, info.OnFireSound, target.CenterPosition);
 				w.Add(new IonCannon(self.Owner, info.WeaponInfo, w, self.CenterPosition, target,
-					info.Effect, info.EffectSequence, info.EffectPalette, info.WeaponDelay));
+					info.Effect, info.EffectSequence, info.WeaponDelay));
 
 				if (info.CameraActor == null)
 					return;

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -34,10 +34,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Vein sequence name.")]
 		public readonly string Sequence = "veins";
 
-		[PaletteReference]
-		[Desc("Palette used for rendering the resource sprites.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		[FieldLoader.Require]
 		[FluentReference]
 		[Desc("Resource name used by tooltips.")]
@@ -196,7 +192,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var a in w.Actors)
 				ActorAddedToWorld(a);
 
-			veinPalette = wr.Palette(info.Palette);
+			veinPalette = wr.Palette(veinSequence.GetPalette());
+
 			var first = veinSequence.GetSprite(0);
 			var emptySprite = new Sprite(first.Sheet, Rectangle.Empty, TextureChannel.Alpha);
 			spriteLayer = new TerrainSpriteLayer(w, wr, emptySprite, first.BlendMode, wr.World.Type != WorldType.Editor);
@@ -321,7 +318,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		void UpdateSpriteLayers(CPos cell, int[] indices)
 		{
 			if (indices != null)
-				spriteLayer.Update(cell, veinSequence, veinPalette, indices.Random(world.LocalRandom));
+				spriteLayer.Update(cell, veinSequence, indices.Random(world.LocalRandom));
 			else
 				spriteLayer.Clear(cell);
 		}
@@ -382,7 +379,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				yield break;
 
 			var sprite = veinSequence.GetSprite(HeavyIndices[0]);
-			var palette = wr.Palette(info.Palette);
+			var palette = veinPalette;
 
 			yield return new UISpriteRenderable(sprite, WPos.Zero, origin, 0, palette, scale);
 		}
@@ -395,7 +392,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var frame = HeavyIndices[0];
 			var sprite = veinSequence.GetSprite(frame);
 			var alpha = veinSequence.GetAlpha(frame);
-			var palette = wr.Palette(info.Palette);
+			var palette = veinPalette;
 
 			var tintModifiers = veinSequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
 			yield return new SpriteRenderable(sprite, origin, WVec.Zero, 0, palette, veinSequence.Scale, alpha, float3.Ones, tintModifiers, false);

--- a/OpenRA.Mods.Cnc/Traits/World/WithResourceAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/WithResourceAnimation.cs
@@ -42,10 +42,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Randomly select one of these sequences to render.")]
 		public readonly string[] Sequences = ["idle"];
 
-		[PaletteReference]
-		[Desc("Animation palette.")]
-		public readonly string Palette = null;
-
 		public override object Create(ActorInitializer init) { return new WithResourceAnimation(init.Self, this); }
 	}
 
@@ -98,7 +94,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				.Select(world.Map.CenterOfCell);
 
 			foreach (var position in positions)
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(position, w, info.Image, info.Sequences.Random(w.LocalRandom), info.Palette)));
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(position, w, info.Image, info.Sequences.Random(w.LocalRandom), self.Owner)));
 
 			ticks = Common.Util.RandomInRange(world.LocalRandom, info.Interval);
 		}

--- a/OpenRA.Mods.Common/Effects/Beacon.cs
+++ b/OpenRA.Mods.Common/Effects/Beacon.cs
@@ -23,8 +23,6 @@ namespace OpenRA.Mods.Common.Effects
 
 		readonly Player owner;
 		readonly WPos position;
-		readonly bool isPlayerPalette;
-		readonly string beaconPalette, posterPalette;
 		readonly Animation arrow, beacon, circles, clock, poster;
 		readonly int duration;
 
@@ -34,13 +32,11 @@ namespace OpenRA.Mods.Common.Effects
 		int tick;
 
 		// Player-placed beacons are removed after a delay
-		public Beacon(Player owner, WPos position, int duration, string beaconPalette, bool isPlayerPalette,
-			string beaconCollection, string beaconSequence, string arrowSprite, string circleSprite, int delay = 0)
+		public Beacon(Player owner, WPos position, int duration, string beaconCollection, string beaconSequence,
+			string arrowSprite, string circleSprite, int delay = 0)
 		{
 			this.owner = owner;
 			this.position = position;
-			this.beaconPalette = beaconPalette;
-			this.isPlayerPalette = isPlayerPalette;
 			this.duration = duration;
 			this.delay = delay;
 
@@ -64,12 +60,10 @@ namespace OpenRA.Mods.Common.Effects
 		}
 
 		// By default, support power beacons are expected to clean themselves up
-		public Beacon(Player owner, WPos position, bool isPlayerPalette, string palette, string posterCollection, string posterType, string posterPalette,
+		public Beacon(Player owner, WPos position, string posterCollection, string posterType,
 			string beaconSequence, string arrowSequence, string circleSequence, string clockSequence, Func<float> clockFraction, int delay = 0, int duration = -1)
-				: this(owner, position, duration, palette, isPlayerPalette, posterCollection, beaconSequence, arrowSequence, circleSequence, delay)
+				: this(owner, position, duration, posterCollection, beaconSequence, arrowSequence, circleSequence, delay)
 		{
-			this.posterPalette = posterPalette;
-
 			if (posterType != null)
 			{
 				poster = new Animation(owner.World, posterCollection);
@@ -115,27 +109,25 @@ namespace OpenRA.Mods.Common.Effects
 			if (!owner.IsAlliedWith(owner.World.RenderPlayer))
 				yield break;
 
-			var palette = r.Palette(isPlayerPalette ? beaconPalette + owner.InternalName : beaconPalette);
-
 			if (beacon != null)
-				foreach (var a in beacon.Render(position, palette))
+				foreach (var a in beacon.Render(r, position, owner))
 					yield return a;
 
 			if (circles != null)
-				foreach (var a in circles.Render(position, palette))
+				foreach (var a in circles.Render(r, position, owner))
 					yield return a;
 
 			if (arrow != null)
-				foreach (var a in arrow.Render(position + new WVec(0, 0, arrowHeight), palette))
+				foreach (var a in arrow.Render(r, position + new WVec(0, 0, arrowHeight), owner))
 					yield return a;
 
 			if (poster != null)
 			{
-				foreach (var a in poster.Render(position, r.Palette(posterPalette)))
+				foreach (var a in poster.Render(r, position, owner))
 					yield return a;
 
 				if (clock != null)
-					foreach (var a in clock.Render(position, r.Palette(posterPalette)))
+					foreach (var a in clock.Render(r, position, owner))
 						yield return a;
 			}
 		}

--- a/OpenRA.Mods.Common/Effects/FloatingSprite.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingSprite.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Effects
 		readonly WDist[] speed;
 		readonly WDist[] gravity;
 		readonly Animation anim;
+		readonly Player owner;
 
 		readonly bool visibleThroughFog;
 		readonly int turnRate;
 		readonly int randomRate;
-		readonly string palette;
 
 		WPos pos;
 		WVec offset;
@@ -32,11 +32,12 @@ namespace OpenRA.Mods.Common.Effects
 		int ticks;
 		WAngle facing;
 
-		public FloatingSprite(Actor emitter, string image, string[] sequences, string palette, bool isPlayerPalette,
-			int[] lifetime, WDist[] speed, WDist[] gravity, int turnRate, int randomRate, WPos pos, WAngle facing,
-			bool visibleThroughFog = false)
+		public FloatingSprite(Actor emitter, string image, string[] sequences, int[] lifetime, WDist[] speed,
+			WDist[] gravity, int turnRate, int randomRate, WPos pos, WAngle facing, bool visibleThroughFog = false)
 		{
 			var world = emitter.World;
+			owner = emitter.Owner;
+
 			this.pos = pos;
 			this.turnRate = turnRate;
 			this.randomRate = randomRate;
@@ -49,8 +50,6 @@ namespace OpenRA.Mods.Common.Effects
 			anim.PlayRepeating(sequences.Random(world.LocalRandom));
 			world.ScreenMap.Add(this, pos, anim.Image);
 			this.lifetime = Util.RandomInRange(world.LocalRandom, lifetime);
-
-			this.palette = isPlayerPalette ? palette + emitter.Owner.InternalName : palette;
 		}
 
 		public void Tick(World world)
@@ -88,7 +87,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!visibleThroughFog && wr.World.FogObscures(pos))
 				return SpriteRenderable.None;
 
-			return anim.Render(pos, wr.Palette(palette));
+			return anim.Render(wr, pos, owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -94,12 +94,11 @@ namespace OpenRA.Mods.Common.Effects
 			var renderables = SpriteRenderable.None;
 			if (targetLineNodes.Count > 0 && (circles != null || flag != null))
 			{
-				var palette = wr.Palette(rp.PaletteName);
 				if (circles != null)
-					renderables = renderables.Concat(circles.Render(targetLineNodes[^1], palette));
+					renderables = renderables.Concat(circles.Render(wr, targetLineNodes[^1], building.Owner));
 
 				if (flag != null)
-					renderables = renderables.Concat(flag.Render(targetLineNodes[^1], palette));
+					renderables = renderables.Concat(flag.Render(wr, targetLineNodes[^1], building.Owner));
 			}
 
 			return renderables;

--- a/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
@@ -17,13 +17,11 @@ namespace OpenRA.Mods.Common.Effects
 {
 	public class SpriteAnnotation : IEffect, IEffectAnnotation
 	{
-		readonly string palette;
 		readonly Animation anim;
 		readonly WPos pos;
 
-		public SpriteAnnotation(WPos pos, World world, string image, string sequence, string palette)
+		public SpriteAnnotation(WPos pos, World world, string image, string sequence)
 		{
-			this.palette = palette;
 			this.pos = pos;
 			anim = new Animation(world, image);
 			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
@@ -41,7 +39,7 @@ namespace OpenRA.Mods.Common.Effects
 		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
 		{
 			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(pos));
-			return anim.RenderUI(wr, screenPos, WVec.Zero, 0, wr.Palette(palette));
+			return anim.RenderUI(wr, screenPos, WVec.Zero, 0);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Effects
 	public class SpriteEffect : IEffect, ISpatiallyPartitionable
 	{
 		readonly World world;
-		readonly string palette;
+		readonly Player owner;
 		readonly Animation anim;
 		readonly Func<WPos> posFunc;
 		readonly bool visibleThroughFog;
@@ -30,24 +30,24 @@ namespace OpenRA.Mods.Common.Effects
 
 		// Facing is last on these overloads partially for backwards compatibility with previous main ctor revision
 		// and partially because most effects don't need it. The latter is also the reason for placement of 'delay'.
-		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette,
+		public SpriteEffect(WPos pos, World world, string image, string sequence, Player owner = null,
 			bool visibleThroughFog = false, int delay = 0)
-			: this(() => pos, () => WAngle.Zero, world, image, sequence, palette, visibleThroughFog, delay) { }
+			: this(() => pos, () => WAngle.Zero, world, image, sequence, owner, visibleThroughFog, delay) { }
 
-		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette,
+		public SpriteEffect(Actor actor, World world, string image, string sequence, Player owner = null,
 			bool visibleThroughFog = false, int delay = 0)
-			: this(() => actor.CenterPosition, () => WAngle.Zero, world, image, sequence, palette, visibleThroughFog, delay) { }
+			: this(() => actor.CenterPosition, () => WAngle.Zero, world, image, sequence, owner, visibleThroughFog, delay) { }
 
-		public SpriteEffect(WPos pos, WAngle facing, World world, string image, string sequence, string palette,
+		public SpriteEffect(WPos pos, WAngle facing, World world, string image, string sequence, Player owner = null,
 			bool visibleThroughFog = false, int delay = 0)
-			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
+			: this(() => pos, () => facing, world, image, sequence, owner, visibleThroughFog, delay) { }
 
-		public SpriteEffect(Func<WPos> posFunc, Func<WAngle> facingFunc, World world, string image, string sequence, string palette,
+		public SpriteEffect(Func<WPos> posFunc, Func<WAngle> facingFunc, World world, string image, string sequence, Player owner = null,
 			bool visibleThroughFog = false, int delay = 0)
 		{
 			this.world = world;
 			this.posFunc = posFunc;
-			this.palette = palette;
+			this.owner = owner;
 			this.sequence = sequence;
 			this.visibleThroughFog = visibleThroughFog;
 			this.delay = delay;
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!initialized || (!visibleThroughFog && world.FogObscures(pos)))
 				return SpriteRenderable.None;
 
-			return anim.Render(pos, wr.Palette(palette));
+			return anim.Render(wr, pos, owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -115,6 +115,15 @@ namespace OpenRA.Mods.Common.Graphics
 		[Desc("File name pattern to build the sprite to use for this sequence.")]
 		protected static readonly SpriteSequenceField<string> FilenamePattern = new(nameof(FilenamePattern), null);
 
+		[Desc("Palette to use for this sequence.")]
+		protected static readonly SpriteSequenceField<string> Palette = new(nameof(Palette), null);
+
+		[Desc("Palette to use for the shadow.")]
+		protected static readonly SpriteSequenceField<string> ShadowPalette = new(nameof(ShadowPalette), null);
+
+		[Desc("Whether the palette is a player palette.")]
+		protected static readonly SpriteSequenceField<bool> IsPlayerPalette = new(nameof(IsPlayerPalette), false);
+
 		[Desc("Frame index to start from.")]
 		protected static readonly SpriteSequenceField<int> Start = new(nameof(Start), 0);
 
@@ -206,6 +215,9 @@ namespace OpenRA.Mods.Common.Graphics
 		protected Sprite[] shadowSprites;
 		protected bool reverseFacings;
 		protected bool reverses;
+		protected string palette;
+		protected string shadowPalette;
+		protected bool isPlayerPalette;
 
 		protected int start;
 		protected int shadowStart;
@@ -242,6 +254,16 @@ namespace OpenRA.Mods.Common.Graphics
 			}
 		}
 
+		string ISpriteSequence.GetPalette(string owner)
+		{
+			if (isPlayerPalette)
+				return palette + owner;
+
+			return palette;
+		}
+
+		bool ISpriteSequence.IsPlayerPalette => isPlayerPalette;
+		string ISpriteSequence.ShadowPalette => shadowPalette;
 		int ISpriteSequence.Facings => interpolatedFacings ?? facings;
 		int ISpriteSequence.Tick => tick;
 		int ISpriteSequence.ZOffset => zOffset;
@@ -365,6 +387,10 @@ namespace OpenRA.Mods.Common.Graphics
 			this.image = image;
 			Name = sequence;
 			Loader = loader;
+
+			palette = LoadField(Palette, data, defaults);
+			shadowPalette = LoadField(ShadowPalette, data, defaults);
+			isPlayerPalette = LoadField(IsPlayerPalette, data, defaults);
 
 			start = LoadField(Start, data, defaults);
 

--- a/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
@@ -21,26 +21,26 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly Animation animation;
 		readonly Func<WVec> offset;
 		readonly Func<int> zOffset;
-		readonly PaletteReference pr;
+		readonly OwnerInit owner;
 
-		public SpriteActorPreview(Animation animation, Func<WVec> offset, Func<int> zOffset, PaletteReference pr)
+		public SpriteActorPreview(Animation animation, Func<WVec> offset, Func<int> zOffset, OwnerInit owner)
 		{
 			this.animation = animation;
 			this.offset = offset;
 			this.zOffset = zOffset;
-			this.pr = pr;
+			this.owner = owner;
 		}
 
 		void IActorPreview.Tick() { animation.Tick(); }
 
 		IEnumerable<IRenderable> IActorPreview.RenderUI(WorldRenderer wr, int2 pos, float scale)
 		{
-			return animation.RenderUI(wr, pos, offset(), zOffset(), pr, scale);
+			return animation.RenderUI(wr, pos, offset(), zOffset(), owner.InternalName, scale);
 		}
 
 		IEnumerable<IRenderable> IActorPreview.Render(WorldRenderer wr, WPos pos)
 		{
-			return animation.Render(pos, offset(), zOffset(), pr);
+			return animation.Render(wr, pos, offset(), zOffset(), owner);
 		}
 
 		IEnumerable<Rectangle> IActorPreview.ScreenBounds(WorldRenderer wr, WPos pos)

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -12,24 +12,26 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Server;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {
-	sealed class CheckPalettes : ILintRulesPass, ILintServerMapPass
+	sealed class CheckPalettes : ILintServerMapPass, ILintSequencesPass
 	{
-		void ILintRulesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules)
-		{
-			Run(emitError, rules);
-		}
-
 		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)
 		{
-			Run(emitError, mapRules);
+			using (var sequences = new SequenceSet(map, modData, map.TileSet, map.SequenceDefinitions))
+				Run(emitError, mapRules, sequences);
 		}
 
-		static void Run(Action<string> emitError, Ruleset rules)
+		void ILintSequencesPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Ruleset rules, SequenceSet sequences)
+		{
+			Run(emitError, rules, sequences);
+		}
+
+		static void Run(Action<string> emitError, Ruleset rules, SequenceSet sequences)
 		{
 			var palettes = new List<string>();
 			var playerPalettes = new List<string>();
@@ -115,6 +117,32 @@ namespace OpenRA.Mods.Common.Lint
 								emitError($"Undefined palette reference `{reference}` detected at weapon `{weaponInfo.Key}`.");
 						}
 					}
+				}
+			}
+
+			foreach (var (image, sequenceName, sequence) in sequences.AllSequences())
+			{
+				var isPlayerPalette = sequence.IsPlayerPalette;
+				var palette = sequence.GetPalette();
+				var shadowPalette = sequence.ShadowPalette;
+
+				if (palette != null)
+				{
+					if (isPlayerPalette)
+					{
+						if (!playerPalettes.Contains(palette))
+							emitError($"Undefined player palette reference `{palette}` detected at sprite sequence `{image}.{sequenceName}`.");
+					}
+					else
+					{
+						if (!palettes.Contains(palette))
+							emitError($"Undefined palette reference `{palette}` detected at sprite sequence `{image}.{sequenceName}`.");
+					}
+				}
+
+				if (shadowPalette != null && !playerPalettes.Contains(shadowPalette))
+				{
+					emitError($"Undefined player palette reference `{shadowPalette}` detected at sprite sequence `{image}.{sequenceName}`.");
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -43,13 +43,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = ["idle"];
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("The palette used to draw this projectile.")]
-		public readonly string Palette = "effect";
-
-		[Desc("Palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
 
@@ -68,13 +61,6 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
-
-		[PaletteReference(nameof(TrailUsePlayerPalette))]
-		[Desc("Palette used to render the trail sequence.")]
-		public readonly string TrailPalette = "effect";
-
-		[Desc("Use the Player Palette to render the trail sequence.")]
-		public readonly bool TrailUsePlayerPalette = false;
 
 		[Desc("Is this blocked by actors with BlocksProjectiles trait.")]
 		public readonly bool Blockable = true;
@@ -148,7 +134,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly WAngle facing;
 		readonly WAngle angle;
 		readonly WDist speed;
-		readonly string trailPalette;
 
 		readonly float3 shadowColor;
 		readonly float shadowAlpha;
@@ -214,10 +199,6 @@ namespace OpenRA.Mods.Common.Projectiles
 					info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
-			trailPalette = info.TrailPalette;
-			if (info.TrailUsePlayerPalette)
-				trailPalette += args.SourceActor.Owner.InternalName;
-
 			smokeTicks = info.TrailDelay;
 			remainingBounces = info.BounceCount;
 
@@ -269,7 +250,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var delayedPos = WPos.LerpQuadratic(source, target, angle, ticks - info.TrailDelay, length);
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(delayedPos, GetEffectiveFacing(), w,
-					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), trailPalette)));
+					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), Args.SourceActor.Owner)));
 
 				smokeTicks = info.TrailInterval;
 			}
@@ -338,23 +319,17 @@ namespace OpenRA.Mods.Common.Projectiles
 			var world = Args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{
-				var paletteName = info.Palette;
-				if (paletteName != null && info.IsPlayerPalette)
-					paletteName += Args.SourceActor.Owner.InternalName;
-
-				var palette = wr.Palette(paletteName);
-
 				if (info.Shadow)
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in Animation.Render(shadowPos, palette))
+					foreach (var r in Animation.Render(wr, shadowPos, Args.SourceActor.Owner))
 						yield return ((IModifyableRenderable)r)
 							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
 							.WithAlpha(shadowAlpha);
 				}
 
-				foreach (var r in Animation.Render(pos, palette))
+				foreach (var r in Animation.Render(wr, pos, Args.SourceActor.Owner))
 					yield return r;
 			}
 		}

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -30,13 +30,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Sequence to play when launched. Skipped if null or empty.")]
 		public readonly string OpenSequence = null;
 
-		[PaletteReference]
-		[Desc("The palette used to draw this projectile.")]
-		public readonly string Palette = "effect";
-
-		[Desc("Palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
 
@@ -121,23 +114,17 @@ namespace OpenRA.Mods.Common.Projectiles
 			var world = args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{
-				var paletteName = info.Palette;
-				if (paletteName != null && info.IsPlayerPalette)
-					paletteName += args.SourceActor.Owner.InternalName;
-
-				var palette = wr.Palette(paletteName);
-
 				if (info.Shadow)
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, palette))
+					foreach (var r in anim.Render(wr, shadowPos, args.SourceActor.Owner))
 						yield return ((IModifyableRenderable)r)
 							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
 							.WithAlpha(shadowAlpha);
 				}
 
-				foreach (var r in anim.Render(pos, palette))
+				foreach (var r in anim.Render(wr, pos, args.SourceActor.Owner))
 					yield return r;
 			}
 		}

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -85,19 +85,12 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Sequence of impact animation to use.")]
 		public readonly string HitAnimSequence = "idle";
 
-		[PaletteReference]
-		public readonly string HitAnimPalette = "effect";
-
 		[Desc("Image containing launch effect sequence.")]
 		public readonly string LaunchEffectImage = null;
 
 		[SequenceReference(nameof(LaunchEffectImage), allowNullImage: true)]
 		[Desc("Launch effect sequence to play.")]
 		public readonly string LaunchEffectSequence = null;
-
-		[PaletteReference]
-		[Desc("Palette to use for launch effect.")]
-		public readonly string LaunchEffectPalette = "effect";
 
 		public IProjectile Create(ProjectileArgs args)
 		{
@@ -154,7 +147,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (hasLaunchEffect && ticks == 0)
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(args.CurrentSource, args.CurrentMuzzleFacing, world,
-					info.LaunchEffectImage, info.LaunchEffectSequence, info.LaunchEffectPalette)));
+					info.LaunchEffectImage, info.LaunchEffectSequence, args.SourceActor.Owner)));
 
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
@@ -210,7 +203,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			}
 
 			if (showHitAnim)
-				foreach (var r in hitanim.Render(target, wr.Palette(info.HitAnimPalette)))
+				foreach (var r in hitanim.Render(wr, target, args.SourceActor.Owner))
 					yield return r;
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -31,13 +31,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
 		public readonly string[] Sequences = ["idle"];
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Palette used to render the projectile sequence.")]
-		public readonly string Palette = "effect";
-
-		[Desc("Palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
 
@@ -119,13 +112,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		public readonly string[] TrailSequences = ["idle"];
-
-		[PaletteReference(nameof(TrailUsePlayerPalette))]
-		[Desc("Palette used to render the trail sequence.")]
-		public readonly string TrailPalette = "effect";
-
-		[Desc("Use the Player Palette to render the trail sequence.")]
-		public readonly bool TrailUsePlayerPalette = false;
 
 		[Desc("Interval in ticks between spawning trail animation.")]
 		public readonly int TrailInterval = 2;
@@ -215,7 +201,6 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		int ticksToNextSmoke;
 		readonly ContrailRenderable contrail;
-		readonly string trailPalette;
 
 		States state;
 		bool targetPassedBy;
@@ -300,10 +285,6 @@ namespace OpenRA.Mods.Common.Projectiles
 					info.ContrailEndWidth ?? info.ContrailStartWidth,
 					info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
-
-			trailPalette = info.TrailPalette;
-			if (info.TrailUsePlayerPalette)
-				trailPalette += args.SourceActor.Owner.InternalName;
 
 			shadowColor = new float3(info.ShadowColor.R, info.ShadowColor.G, info.ShadowColor.B) / 255f;
 			shadowAlpha = info.ShadowColor.A / 255f;
@@ -902,7 +883,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (!string.IsNullOrEmpty(info.TrailImage) && --ticksToNextSmoke < 0 && (state != States.Freefall || info.TrailWhenDeactivated))
 			{
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos - 3 * move / 2, renderFacing, w,
-					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), trailPalette)));
+					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), args.SourceActor.Owner)));
 
 				ticksToNextSmoke = info.TrailInterval;
 			}
@@ -955,23 +936,17 @@ namespace OpenRA.Mods.Common.Projectiles
 			var world = args.SourceActor.World;
 			if (!world.FogObscures(pos))
 			{
-				var paletteName = info.Palette;
-				if (paletteName != null && info.IsPlayerPalette)
-					paletteName += args.SourceActor.Owner.InternalName;
-
-				var palette = wr.Palette(paletteName);
-
 				if (info.Shadow)
 				{
 					var dat = world.Map.DistanceAboveTerrain(pos);
 					var shadowPos = pos - new WVec(0, 0, dat.Length);
-					foreach (var r in anim.Render(shadowPos, palette))
+					foreach (var r in anim.Render(wr, shadowPos, args.SourceActor.Owner))
 						yield return ((IModifyableRenderable)r)
 							.WithTint(shadowColor, ((IModifyableRenderable)r).TintModifiers | TintModifiers.ReplaceColor)
 							.WithAlpha(shadowAlpha);
 				}
 
-				foreach (var r in anim.Render(pos, palette))
+				foreach (var r in anim.Render(wr, pos, args.SourceActor.Owner))
 					yield return r;
 			}
 		}

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -22,7 +22,6 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Player firedBy;
 		readonly Animation anim;
 		readonly WeaponInfo weapon;
-		readonly string weaponPalette;
 		readonly string upSequence;
 		readonly string downSequence;
 
@@ -36,7 +35,6 @@ namespace OpenRA.Mods.Common.Effects
 		readonly int turn;
 		readonly string trailImage;
 		readonly string[] trailSequences;
-		readonly string trailPalette;
 		readonly int trailInterval;
 		readonly int trailDelay;
 
@@ -46,14 +44,13 @@ namespace OpenRA.Mods.Common.Effects
 		bool isLaunched;
 		bool detonated;
 
-		public NukeLaunch(Player firedBy, string image, WeaponInfo weapon, string weaponPalette, string upSequence, string downSequence,
+		public NukeLaunch(Player firedBy, string image, WeaponInfo weapon, string upSequence, string downSequence,
 			WPos launchPos, WPos targetPos, WDist detonationAltitude, bool removeOnDetonation, WDist velocity, int launchDelay, int impactDelay,
 			bool skipAscent,
-			string trailImage, string[] trailSequences, string trailPalette, bool trailUsePlayerPalette, int trailDelay, int trailInterval)
+			string trailImage, string[] trailSequences, int trailDelay, int trailInterval)
 		{
 			this.firedBy = firedBy;
 			this.weapon = weapon;
-			this.weaponPalette = weaponPalette;
 			this.upSequence = upSequence;
 			this.downSequence = downSequence;
 			this.launchDelay = launchDelay;
@@ -61,9 +58,6 @@ namespace OpenRA.Mods.Common.Effects
 			turn = skipAscent ? 0 : impactDelay / 2;
 			this.trailImage = trailImage;
 			this.trailSequences = trailSequences;
-			this.trailPalette = trailPalette;
-			if (trailUsePlayerPalette)
-				this.trailPalette += firedBy.InternalName;
 
 			this.trailInterval = trailInterval;
 			this.trailDelay = trailDelay;
@@ -121,8 +115,7 @@ namespace OpenRA.Mods.Common.Effects
 				var trailPos = !isDescending ? WPos.LerpQuadratic(ascendSource, ascendTarget, WAngle.Zero, ticks - trailDelay, turn)
 					: WPos.LerpQuadratic(descendSource, descendTarget, WAngle.Zero, ticks - turn - trailDelay, impactDelay - turn);
 
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(trailPos, w, trailImage, trailSequences.Random(world.SharedRandom),
-					trailPalette)));
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(trailPos, w, trailImage, trailSequences.Random(world.SharedRandom), firedBy)));
 
 				trailTicks = trailInterval;
 			}
@@ -164,7 +157,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!isLaunched || anim == null)
 				return [];
 
-			return anim.Render(pos, wr.Palette(weaponPalette));
+			return anim.Render(wr, pos, firedBy);
 		}
 
 		public float FractionComplete => ticks * 1f / impactDelay;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -93,9 +93,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[SequenceReference(nameof(HitAnim), allowNullImage: true)]
 		public readonly string HitAnimSequence = "idle";
 
-		[PaletteReference]
-		public readonly string HitAnimPalette = "effect";
-
 		public IProjectile Create(ProjectileArgs args)
 		{
 			var bc = BeamPlayerColor ? Color.FromArgb(BeamColor.A, args.SourceActor.OwnerColor()) : BeamColor;
@@ -250,7 +247,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			}
 
 			if (hitanim != null)
-				foreach (var r in hitanim.Render(target, wr.Palette(info.HitAnimPalette)))
+				foreach (var r in hitanim.Render(wr, target, args.SourceActor.Owner))
 					yield return r;
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -36,8 +36,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (beacon == null)
 				throw new LuaException("The player actor has no 'PlaceBeacon' trait.");
 
-			var playerBeacon = new Beacon(owner, position, duration, beacon.Palette, beacon.IsPlayerPalette,
-				beacon.BeaconImage, beacon.BeaconSequence, beacon.ArrowSequence, beacon.CircleSequence);
+			var playerBeacon = new Beacon(owner, position, duration, beacon.BeaconImage, beacon.BeaconSequence, beacon.ArrowSequence, beacon.CircleSequence);
 
 			owner.PlayerActor.World.AddFrameEndTask(w => w.Add(playerBeacon));
 

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Terrain
 		public readonly bool EnableDepth = false;
 		public readonly float MinHeightColorBrightness = 1.0f;
 		public readonly float MaxHeightColorBrightness = 1.0f;
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = "terrain";
 
 		[FieldLoader.Ignore]
 		public readonly IReadOnlyDictionary<ushort, TerrainTemplateInfo> Templates;

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -57,10 +57,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Muzzle flash sequence to render")]
 		public readonly string MuzzleSequence = null;
 
-		[PaletteReference]
-		[Desc("Palette to render Muzzle flash sequence in")]
-		public readonly string MuzzlePalette = "effect";
-
 		[GrantedConditionReference]
 		[Desc("Condition to grant while reloading.")]
 		public readonly string ReloadingCondition = null;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -44,9 +44,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public FirePort[] Ports { get; private set; }
 
-		[PaletteReference]
-		public readonly string MuzzlePalette = "effect";
-
 		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.Self, this); }
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
@@ -206,11 +203,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
 		{
-			var pal = wr.Palette(Info.MuzzlePalette);
-
 			// Display muzzle flashes
 			foreach (var m in muzzles)
-				foreach (var r in m.Render(self, pal))
+				foreach (var r in m.Render(wr, self, self.Owner))
 					yield return r;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -38,13 +38,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";
 
-		[PaletteReference(nameof(IconPaletteIsPlayerPalette))]
-		[Desc("Palette used for the production icon.")]
-		public readonly string IconPalette = "chrome";
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IconPaletteIsPlayerPalette = false;
-
 		[Desc("Base build time in frames (-1 indicates to use the unit's Value).")]
 		public readonly int BuildDuration = -1;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
@@ -21,10 +21,6 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Creates a building placement preview showing only the building footprint.")]
 	public class FootprintPlaceBuildingPreviewInfo : TraitInfo<FootprintPlaceBuildingPreview>, IPlaceBuildingPreviewGeneratorInfo
 	{
-		[PaletteReference]
-		[Desc("Palette to use for rendering the placement sprite.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		[Desc("Custom opacity to apply to the placement sprite.")]
 		public readonly float FootprintAlpha = 1f;
 
@@ -53,6 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly int2 topLeftScreenOffset;
 		readonly Sprite validTile, blockedTile;
 		readonly float validAlpha, blockedAlpha;
+		readonly string validPalette, blockedPalette;
 
 		public FootprintPlaceBuildingPreviewPreview(WorldRenderer wr, ActorInfo ai, FootprintPlaceBuildingPreviewInfo info)
 		{
@@ -71,17 +68,20 @@ namespace OpenRA.Mods.Common.Traits
 				var validSequence = sequences.GetSequence("overlay", $"build-valid-{tileset}");
 				validTile = validSequence.GetSprite(0);
 				validAlpha = validSequence.GetAlpha(0);
+				validPalette = validSequence.GetPalette();
 			}
 			else
 			{
 				var validSequence = sequences.GetSequence("overlay", "build-valid");
 				validTile = validSequence.GetSprite(0);
 				validAlpha = validSequence.GetAlpha(0);
+				validPalette = validSequence.GetPalette();
 			}
 
 			var blockedSequence = sequences.GetSequence("overlay", "build-invalid");
 			blockedTile = blockedSequence.GetSprite(0);
 			blockedAlpha = blockedSequence.GetAlpha(0);
+			blockedPalette = blockedSequence.GetPalette();
 		}
 
 		protected virtual void TickInner() { }
@@ -89,7 +89,8 @@ namespace OpenRA.Mods.Common.Traits
 		protected virtual IEnumerable<IRenderable> RenderFootprint(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint,
 			PlaceBuildingCellType filter = PlaceBuildingCellType.Invalid | PlaceBuildingCellType.Valid | PlaceBuildingCellType.LineBuild)
 		{
-			var palette = wr.Palette(info.Palette);
+			var vPalette = wr.Palette(validPalette);
+			var bPalette = wr.Palette(blockedPalette);
 			var topLeftPos = wr.World.Map.CenterOfCell(topLeft);
 			foreach (var c in footprint)
 			{
@@ -97,6 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				var tile = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedTile : validTile;
+				var palette = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? bPalette : vPalette;
 				var sequenceAlpha = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedAlpha : validAlpha;
 				var pos = wr.World.Map.CenterOfCell(c.Key);
 				var offset = new WVec(0, 0, topLeftPos.Z - pos.Z);

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -34,13 +34,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when rally point can be set.")]
 		public readonly string Cursor = "ability";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom indicator palette name")]
-		public readonly string Palette = "player";
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = true;
-
 		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
 		public readonly CVec[] Path = [];
 
@@ -66,7 +59,6 @@ namespace OpenRA.Mods.Common.Traits
 		public List<CPos> Path;
 
 		public RallyPointInfo Info;
-		public string PaletteName { get; private set; }
 		RallyPointIndicator effect;
 
 		public void ResetPath(Actor self)
@@ -78,7 +70,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Info = info;
 			ResetPath(self);
-			PaletteName = info.IsPlayerPalette ? info.Palette + self.Owner.InternalName : info.Palette;
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -88,9 +79,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			if (Info.IsPlayerPalette)
-				PaletteName = Info.Palette + newOwner.InternalName;
-
 			ResetPath(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -51,17 +51,16 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly SequencePlaceBuildingPreviewInfo info;
 		readonly Animation preview;
-		readonly PaletteReference palette;
+		readonly OwnerInit ownerName;
 
 		public SequencePlaceBuildingPreviewPreview(WorldRenderer wr, ActorInfo ai, SequencePlaceBuildingPreviewInfo info, TypeDictionary init)
 			: base(wr, ai, info)
 		{
 			this.info = info;
-			var ownerName = init.Get<OwnerInit>().InternalName;
+			ownerName = init.Get<OwnerInit>();
 			var faction = init.Get<FactionInit>().Value;
 
 			var rsi = ai.TraitInfo<RenderSpritesInfo>();
-			palette = wr.Palette(rsi.Palette ?? rsi.PlayerPalette + ownerName);
 			preview = new Animation(wr.World, rsi.GetImage(ai, faction));
 			preview.PlayRepeating(info.Sequence);
 		}
@@ -78,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 					yield return r;
 
 			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + CenterOffset;
-			foreach (var r in preview.Render(centerPosition, WVec.Zero, 0, palette))
+			foreach (var r in preview.Render(wr, centerPosition, WVec.Zero, 0, ownerName))
 			{
 				if (info.SequenceAlpha < 1f && r is IModifyableRenderable mr)
 					yield return mr.WithAlpha(mr.Alpha * info.SequenceAlpha);

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -97,10 +97,6 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(EffectImage), allowNullImage: true)]
 		public readonly string UncloakEffectSequence = null;
 
-		[PaletteReference(nameof(EffectPaletteIsPlayerPalette))]
-		public readonly string EffectPalette = "effect";
-		public readonly bool EffectPaletteIsPlayerPalette = false;
-
 		[Desc("Offset for the effect played when cloaking or uncloaking.")]
 		public readonly WVec EffectOffset = WVec.Zero;
 
@@ -245,12 +241,8 @@ namespace OpenRA.Mods.Common.Traits
 
 					if (Info.EffectImage != null && Info.CloakEffectSequence != null)
 					{
-						var palette = Info.EffectPalette;
-						if (Info.EffectPaletteIsPlayerPalette)
-							palette += self.Owner.InternalName;
-
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(
-							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.CloakEffectSequence, palette)));
+							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.CloakEffectSequence, self.Owner)));
 					}
 				}
 			}
@@ -270,12 +262,8 @@ namespace OpenRA.Mods.Common.Traits
 
 					if (Info.EffectImage != null && Info.UncloakEffectSequence != null)
 					{
-						var palette = Info.EffectPalette;
-						if (Info.EffectPaletteIsPlayerPalette)
-							palette += self.Owner.InternalName;
-
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(
-							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.UncloakEffectSequence, palette)));
+							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.UncloakEffectSequence, self.Owner)));
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -24,9 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Dig animation sequence to play when transitioning.")]
 		public readonly string SubterraneanTransitionSequence = null;
 
-		[PaletteReference]
-		public readonly string SubterraneanTransitionPalette = "effect";
-
 		[Desc("Dig sound to play when transitioning.")]
 		public readonly string SubterraneanTransitionSound = null;
 
@@ -62,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(Info.SubterraneanTransitionSequence))
 				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.World.Map.CenterOfCell(fromCell), self.World,
 					Info.SubterraneanTransitionImage,
-					Info.SubterraneanTransitionSequence, Info.SubterraneanTransitionPalette)));
+					Info.SubterraneanTransitionSequence, self.Owner)));
 
 			if (!string.IsNullOrEmpty(Info.SubterraneanTransitionSound))
 				Game.Sound.Play(SoundType.World, Info.SubterraneanTransitionSound);

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -28,10 +28,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Animation sequence played when collected. Leave empty for no effect.")]
 		public readonly string Sequence = null;
 
-		[PaletteReference]
-		[Desc("Palette to draw the animation in.")]
-		public readonly string Palette = "effect";
-
 		[Desc("Audio clip to play when the crate is collected.")]
 		public readonly string Sound = null;
 
@@ -99,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			TextNotificationsManager.AddTransientLine(collector.Owner, Info.TextNotification);
 
 			if (Info.Image != null && Info.Sequence != null)
-				collector.World.AddFrameEndTask(w => w.Add(new SpriteEffect(collector, w, Info.Image, Info.Sequence, Info.Palette)));
+				collector.World.AddFrameEndTask(w => w.Add(new SpriteEffect(collector, w, Info.Image, Info.Sequence, collector.Owner)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -36,10 +36,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence for the level up sprite. Needs to be present on LevelUpImage.")]
 		public readonly string LevelUpSequence = "levelup";
 
-		[PaletteReference]
-		[Desc("Palette for the level up sprite.")]
-		public readonly string LevelUpPalette = "effect";
-
 		[Desc("Multiplier to apply to the Conditions keys. Defaults to the actor's value.")]
 		public readonly int ExperienceModifier = -1;
 
@@ -125,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 					TextNotificationsManager.AddTransientLine(self.Owner, info.LevelUpTextNotification);
 
 					if (info.LevelUpImage != null && info.LevelUpSequence != null)
-						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self, w, info.LevelUpImage, info.LevelUpSequence, info.LevelUpPalette)));
+						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self, w, info.LevelUpImage, info.LevelUpSequence, self.Owner)));
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Common/Traits/Minelayer.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class Minelayer : IIssueOrder, IResolveOrder, ISync, IIssueDeployOrder, IOrderVoice, ITick
 	{
 		public readonly MinelayerInfo Info;
-		public readonly Sprite Tile;
+		public readonly ISpriteSequence Tile;
 
 		readonly Actor self;
 
@@ -90,9 +90,9 @@ namespace OpenRA.Mods.Common.Traits
 			var tileset = self.World.Map.Tileset.ToLowerInvariant();
 			var sequences = self.World.Map.Sequences;
 			if (sequences.HasSequence("overlay", $"{Info.TileValidName}-{tileset}"))
-				Tile = sequences.GetSequence("overlay", $"{Info.TileValidName}-{tileset}").GetSprite(0);
+				Tile = sequences.GetSequence("overlay", $"{Info.TileValidName}-{tileset}");
 			else
-				Tile = sequences.GetSequence("overlay", Info.TileValidName).GetSprite(0);
+				Tile = sequences.GetSequence("overlay", Info.TileValidName);
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly List<Actor> minelayers;
 			readonly Minelayer minelayer;
-			readonly Sprite validTile, unknownTile, blockedTile;
+			readonly ISpriteSequence validTile, unknownTile, blockedTile;
 			readonly float validAlpha, unknownAlpha, blockedAlpha;
 			readonly CPos minefieldStart;
 			readonly bool queued;
@@ -239,39 +239,39 @@ namespace OpenRA.Mods.Common.Traits
 				if (sequences.HasSequence("overlay", $"{minelayer.Info.TileValidName}-{tileset}"))
 				{
 					var validSequence = sequences.GetSequence("overlay", $"{minelayer.Info.TileValidName}-{tileset}");
-					validTile = validSequence.GetSprite(0);
+					validTile = validSequence;
 					validAlpha = validSequence.GetAlpha(0);
 				}
 				else
 				{
 					var validSequence = sequences.GetSequence("overlay", minelayer.Info.TileValidName);
-					validTile = validSequence.GetSprite(0);
+					validTile = validSequence;
 					validAlpha = validSequence.GetAlpha(0);
 				}
 
 				if (sequences.HasSequence("overlay", $"{minelayer.Info.TileUnknownName}-{tileset}"))
 				{
 					var unknownSequence = sequences.GetSequence("overlay", $"{minelayer.Info.TileUnknownName}-{tileset}");
-					unknownTile = unknownSequence.GetSprite(0);
+					unknownTile = unknownSequence;
 					unknownAlpha = unknownSequence.GetAlpha(0);
 				}
 				else
 				{
 					var unknownSequence = sequences.GetSequence("overlay", minelayer.Info.TileUnknownName);
-					unknownTile = unknownSequence.GetSprite(0);
+					unknownTile = unknownSequence;
 					unknownAlpha = unknownSequence.GetAlpha(0);
 				}
 
 				if (sequences.HasSequence("overlay", $"{minelayer.Info.TileInvalidName}-{tileset}"))
 				{
 					var blockedSequence = sequences.GetSequence("overlay", $"{minelayer.Info.TileInvalidName}-{tileset}");
-					blockedTile = blockedSequence.GetSprite(0);
+					blockedTile = blockedSequence;
 					blockedAlpha = blockedSequence.GetAlpha(0);
 				}
 				else
 				{
 					var blockedSequence = sequences.GetSequence("overlay", minelayer.Info.TileInvalidName);
-					blockedTile = blockedSequence.GetSprite(0);
+					blockedTile = blockedSequence;
 					blockedAlpha = blockedSequence.GetAlpha(0);
 				}
 
@@ -321,7 +321,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				var movement = minelayer.Trait<IPositionable>();
 				var mobile = movement as Mobile;
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 				foreach (var c in minefield)
 				{
 					var tile = validTile;
@@ -348,7 +347,17 @@ namespace OpenRA.Mods.Common.Traits
 						alpha = blockedAlpha;
 					}
 
-					yield return new SpriteRenderable(tile, world.Map.CenterOfCell(c), WVec.Zero, -511, pal, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(
+						tile.GetSprite(0),
+						world.Map.CenterOfCell(c),
+						WVec.Zero,
+						-511,
+						wr.Palette(tile.GetPalette()),
+						1f,
+						alpha,
+						float3.Ones,
+						TintModifiers.IgnoreWorldTint,
+						true);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/FixedColorPalette.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
-		public readonly string Base = TileSet.TerrainPaletteInternalName;
+		public readonly string Base = "terrain";
 
 		[PaletteDefinition]
 		[Desc("The name of the resulting palette")]

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -32,16 +32,10 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string GroundCorpseSequence = null;
 
-		[PaletteReference]
-		public readonly string GroundCorpsePalette = "effect";
-
 		public readonly string GroundImpactSound = null;
 
 		[SequenceReference(nameof(Image), allowNullImage: true)]
 		public readonly string WaterCorpseSequence = null;
-
-		[PaletteReference]
-		public readonly string WaterCorpsePalette = "effect";
 
 		[Desc("Terrain types on which to display WaterCorpseSequence.")]
 		public readonly HashSet<string> WaterTerrainTypes = ["Water"];
@@ -107,9 +101,8 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Sound.Play(SoundType.World, sound, self.CenterPosition);
 
 			var sequence = onWater ? info.WaterCorpseSequence : info.GroundCorpseSequence;
-			var palette = onWater ? info.WaterCorpsePalette : info.GroundCorpsePalette;
-			if (!string.IsNullOrEmpty(info.Image) && !string.IsNullOrEmpty(sequence) && palette != null)
-				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.OccupiesSpace.CenterPosition, w, info.Image, sequence, palette)));
+			if (!string.IsNullOrEmpty(info.Image) && !string.IsNullOrEmpty(sequence))
+				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.OccupiesSpace.CenterPosition, w, info.Image, sequence, self.Owner)));
 
 			self.Kill(self, info.DamageTypes);
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -25,11 +25,6 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference(typeFromField: "NotificationType")]
 		public readonly string Notification = "Beacon";
 
-		public readonly bool IsPlayerPalette = true;
-
-		[PaletteReference(nameof(IsPlayerPalette))]
-		public readonly string Palette = "player";
-
 		public readonly string BeaconImage = "beacon";
 
 		[SequenceReference(nameof(BeaconImage))]
@@ -68,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (playerBeacon != null)
 					self.World.Remove(playerBeacon);
 
-				playerBeacon = new Beacon(self.Owner, order.Target.CenterPosition, info.Duration, info.Palette, info.IsPlayerPalette,
+				playerBeacon = new Beacon(self.Owner, order.Target.CenterPosition, info.Duration,
 					info.BeaconImage, info.BeaconSequence, info.ArrowSequence, info.CircleSequence);
 
 				self.World.Add(playerBeacon);

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -137,8 +137,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly ActorInfo ActorInfo;
 		public readonly Animation Icon;
-		public readonly string IconPalette;
-		public readonly bool IconPaletteIsPlayerPalette;
 		public readonly int ProductionQueueOrder;
 		public readonly int BuildPaletteOrder;
 		public readonly TooltipInfo TooltipInfo;
@@ -163,8 +161,6 @@ namespace OpenRA.Mods.Common.Traits
 				var image = rsi.GetImage(actorInfo, owner.Faction.InternalName);
 				Icon = new Animation(owner.World, image);
 				Icon.Play(BuildableInfo.Icon);
-				IconPalette = BuildableInfo.IconPalette;
-				IconPaletteIsPlayerPalette = BuildableInfo.IconPaletteIsPlayerPalette;
 				BuildPaletteOrder = BuildableInfo.BuildPaletteOrder;
 				ProductionQueueOrder = queues.Where(q => BuildableInfo.Queue.Contains(q.Type))
 					.Select(q => q.DisplayOrder)

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -34,10 +34,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Width (in pixels) of the queued end node markers.")]
 		public readonly int QueuedMarkerWidth = 2;
 
-		[PaletteReference]
-		[Desc("Palette used for rendering sprites.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		public override object Create(ActorInitializer init) { return new DrawLineToTarget(this); }
 	}
 
@@ -85,15 +81,16 @@ namespace OpenRA.Mods.Common.Traits
 			return RenderAboveShroud(self, wr);
 		}
 
-		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
+		static IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			var pal = wr.Palette(info.Palette);
 			var a = self.CurrentActivity;
 			for (; a != null; a = a.NextActivity)
 				if (!a.IsCanceling)
 					foreach (var n in a.TargetLineNodes(self))
 						if (n.Tile != null && n.Target.Type != TargetType.Invalid)
-							yield return new SpriteRenderable(n.Tile, n.Target.CenterPosition, WVec.Zero, -511, pal, 1f, 1f, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+							yield return new SpriteRenderable(
+								n.Tile.GetSprite(0), n.Target.CenterPosition, WVec.Zero, -511,
+								wr.Palette(n.Tile.GetPalette()), 1f, 1f, float3.Ones, TintModifiers.IgnoreWorldTint, true);
 		}
 
 		bool IRenderAboveShroud.SpatiallyPartitionable => false;

--- a/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
+++ b/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
@@ -56,12 +56,6 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(Image))]
 		public readonly string[] Sequences = ["particles"];
 
-		[Desc("Which palette to use.")]
-		[PaletteReference(nameof(IsPlayerPalette))]
-		public readonly string Palette = "effect";
-
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new FloatingSpriteEmitter(init.Self, this); }
 	}
 
@@ -117,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				ticks = Util.RandomInRange(self.World.LocalRandom, Info.SpawnFrequency);
 
 				var spawnFacing = (!Info.RandomFacing && facing != null) ? facing.Facing : WAngle.FromFacing(self.World.LocalRandom.Next(256));
-				self.World.AddFrameEndTask(w => w.Add(new FloatingSprite(self, Info.Image, Info.Sequences, Info.Palette, Info.IsPlayerPalette,
+				self.World.AddFrameEndTask(w => w.Add(new FloatingSprite(self, Info.Image, Info.Sequences,
 					Info.Lifetime, Info.Speed, Info.Gravity, Info.TurnRate, Info.RandomRate, self.CenterPosition + offset, spawnFacing)));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -26,9 +26,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference(nameof(Image))]
 		public readonly string[] Sequences = ["idle"];
 
-		[PaletteReference]
-		public readonly string Palette = "effect";
-
 		[Desc("Only leave trail on listed terrain types. Leave empty to leave trail on all terrain types.")]
 		public readonly HashSet<string> TerrainTypes = [];
 
@@ -137,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 						self.World.Map.CenterOfCell(spawnCell);
 
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, spawnFacing, self.World, Info.Image,
-						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
+						Info.Sequences.Random(Game.CosmeticRandom), self.Owner, Info.VisibleThroughFog)));
 
 					previouslySpawned = true;
 					previousSpawnCell = spawnCell;

--- a/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionIconOverlayManager.cs
@@ -32,10 +32,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for the overlay (cannot be animated).")]
 		public readonly string Sequence = null;
 
-		[PaletteReference]
-		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
-		public readonly string Palette = "chrome";
-
 		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			if (rules.Actors[SystemActors.Player].TraitInfos<ProductionIconOverlayManagerInfo>().Any(piom => piom != this && piom.Type == Type))
@@ -49,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		readonly Actor self;
 		readonly Sprite sprite;
-		readonly ProductionIconOverlayManagerInfo info;
+		readonly Animation anim;
 
 		// HACK: TechTree doesn't associate Watcher.Key with the registering ITechTreeElement.
 		// So in a situation where multiple ITechTreeElements register Watchers with the same Key,
@@ -63,11 +59,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			self = init.Self;
 
-			var anim = new Animation(self.World, info.Image);
+			anim = new Animation(self.World, info.Image);
 			anim.Play(info.Sequence);
 			sprite = anim.Image;
-
-			this.info = info;
 
 			prefix = info.Type + ".";
 			var ttc = self.Trait<TechTree>();
@@ -80,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		Sprite IProductionIconOverlay.Sprite => sprite;
-		string IProductionIconOverlay.Palette => info.Palette;
+		string IProductionIconOverlay.Palette => anim.Palette(self.Owner);
 
 		float2 IProductionIconOverlay.Offset(float2 iconSize)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 {
 	public interface IRenderActorPreviewSpritesInfo : ITraitInfoInterface
 	{
-		IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p);
+		IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner);
 	}
 
 	[Desc("Render trait fundament that won't work without additional With* render traits.")]
@@ -33,23 +33,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("A dictionary of faction-specific image overrides.")]
 		public readonly Dictionary<string, string> FactionImages = null;
 
-		[PaletteReference]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[PaletteReference(true)]
-		[Desc("Custom PlayerColorPalette: BaseName")]
-		public readonly string PlayerPalette = "player";
-
 		public override object Create(ActorInitializer init) { return new RenderSprites(init, this); }
 
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{
 			var sequences = init.World.Map.Sequences;
 			var faction = init.GetValue<FactionInit, string>(this);
-			var ownerName = init.Get<OwnerInit>().InternalName;
+			var owner = init.Get<OwnerInit>();
 			var image = GetImage(init.Actor, faction);
-			var palette = init.WorldRenderer.Palette(Palette ?? PlayerPalette + ownerName);
 
 			var facings = 0;
 			var body = init.Actor.TraitInfoOrDefault<BodyOrientationInfo>();
@@ -65,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 
 			foreach (var spi in init.Actor.TraitInfos<IRenderActorPreviewSpritesInfo>())
-				foreach (var preview in spi.RenderPreviewSprites(init, image, facings, palette))
+				foreach (var preview in spi.RenderPreviewSprites(init, image, facings, owner))
 					yield return preview;
 		}
 
@@ -78,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class RenderSprites : IRender, ITick, INotifyOwnerChanged, INotifyEffectiveOwnerChanged, IActorPreviewInitModifier
+	public class RenderSprites : IRender, ITick, IActorPreviewInitModifier
 	{
 		static readonly (DamageState DamageState, string Prefix)[] DamagePrefixes =
 		[
@@ -91,31 +82,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		sealed class AnimationWrapper
 		{
 			public readonly AnimationWithOffset Animation;
-			public readonly string Palette;
-			public readonly bool IsPlayerPalette;
-			public PaletteReference PaletteReference { get; private set; }
 
 			bool cachedVisible;
 			WVec cachedOffset;
 			ISpriteSequence cachedSequence;
 
-			public AnimationWrapper(AnimationWithOffset animation, string palette, bool isPlayerPalette)
+			public AnimationWrapper(AnimationWithOffset animation)
 			{
 				Animation = animation;
-				Palette = palette;
-				IsPlayerPalette = isPlayerPalette;
-			}
-
-			public void CachePalette(WorldRenderer wr, Player owner)
-			{
-				PaletteReference = wr.Palette(IsPlayerPalette ? Palette + owner.InternalName : Palette);
-			}
-
-			public void OwnerChanged()
-			{
-				// Update the palette reference next time we draw
-				if (IsPlayerPalette)
-					PaletteReference = null;
 			}
 
 			public bool IsVisible => Animation.DisableFunc == null || !Animation.DisableFunc();
@@ -167,15 +141,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return cachedImage = Info.GetImage(self.Info, faction);
 		}
 
-		public void UpdatePalette()
-		{
-			foreach (var anim in anims)
-				anim.OwnerChanged();
-		}
-
-		public virtual void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UpdatePalette(); }
-		public void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner) { UpdatePalette(); }
-
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			foreach (var a in anims)
@@ -183,13 +148,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				if (!a.IsVisible)
 					continue;
 
-				if (a.PaletteReference == null)
-				{
-					var owner = self.EffectiveOwner != null && self.EffectiveOwner.Disguised ? self.EffectiveOwner.Owner : self.Owner;
-					a.CachePalette(wr, owner);
-				}
-
-				foreach (var r in a.Animation.Render(self, a.PaletteReference))
+				var owner = self.EffectiveOwner != null && self.EffectiveOwner.Disguised ? self.EffectiveOwner.Owner : self.Owner;
+				foreach (var r in a.Animation.Render(wr, self, owner))
 					yield return r;
 			}
 		}
@@ -216,16 +176,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 				self.World.ScreenMap.AddOrUpdate(self);
 		}
 
-		public void Add(AnimationWithOffset anim, string palette = null, bool isPlayerPalette = false)
+		public void Add(AnimationWithOffset anim)
 		{
-			// Use defaults
-			if (palette == null)
-			{
-				palette = Info.Palette ?? Info.PlayerPalette;
-				isPlayerPalette = Info.Palette == null;
-			}
-
-			anims.Add(new AnimationWrapper(anim, palette, isPlayerPalette));
+			anims.Add(new AnimationWrapper(anim));
 		}
 
 		public void Remove(AnimationWithOffset anim)

--- a/OpenRA.Mods.Common/Traits/Render/WithAircraftLandingEffect.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAircraftLandingEffect.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -24,9 +23,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[SequenceReference(nameof(Image))]
 		public readonly string[] Sequences = ["idle"];
-
-		[PaletteReference]
-		public readonly string Palette = "effect";
 
 		[Desc("Should the sprite effect be visible through fog.")]
 		public readonly bool VisibleThroughFog = false;
@@ -51,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			var position = self.CenterPosition - new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(self.CenterPosition));
 			self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(position, self.World, Info.Image,
-				Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog)));
+				Info.Sequences.Random(Game.CosmeticRandom), self.Owner, Info.VisibleThroughFog)));
 		}
 
 		bool ShouldAddEffect(Map map, CPos cell)

--- a/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
@@ -36,9 +36,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for full pips.")]
 		public readonly string FullSequence = "pip-green";
 
-		[PaletteReference]
-		public readonly string Palette = "chrome";
-
 		[Desc("Name(s) of AmmoPool(s) that use this decoration. Leave empty to include all pools.")]
 		public readonly string[] AmmoPools = [];
 
@@ -67,7 +64,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 
-			var palette = wr.Palette(Info.Palette);
 			var pipSize = pips.Image.Size.XY.ToInt2();
 			var pipStride = Info.PipStride != int2.Zero ? Info.PipStride : new int2(pipSize.X, 0);
 			screenPos -= pipSize / 2;
@@ -84,6 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < pipCount; i++)
 			{
 				pips.PlayRepeating(currentAmmo * pipCount > i * totalAmmo ? Info.FullSequence : Info.EmptySequence);
+				var palette = wr.Palette(pips.CurrentSequence.GetPalette(self.Owner.InternalName));
 				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -24,14 +24,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[FieldLoader.Require]
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = null;
-
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public readonly bool IsDecoration = false;
 
 		[Desc("Delay in ticks before overlay starts, either relative to attack preparation or attack.")]
@@ -66,8 +58,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				IsDecoration = info.IsDecoration
 			};
 
-			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !attacking, p => RenderUtils.ZOffsetFromCenter(init.Self, p, 1)),
-				info.Palette, info.IsPlayerPalette);
+			renderSprites.Add(new AnimationWithOffset(overlay, null, () => !attacking, p => RenderUtils.ZOffsetFromCenter(init.Self, p, 1)));
 		}
 
 		void PlayOverlay()

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithBridgeSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequences[0]), () => 0);
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -23,14 +23,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
-
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.Self, this); }
 	}
 
@@ -52,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => !visible || IsTraitDisabled);
 
 			overlay.PlayThen(info.Sequence, () => visible = false);
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override PaletteReference GetPalette(Actor self, WorldRenderer wr)
 		{
-			return wr.Palette(info.IsPlayerPalette ? info.Palette + rb.Repairers[shownPlayer % rb.Repairers.Count].InternalName : info.Palette);
+			return wr.Palette(anim.Palette(rb.Repairers[shownPlayer % rb.Repairers.Count]));
 		}
 
 		void CycleRepairer()

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -38,9 +38,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Pip sequence to use for specific passenger actors.")]
 		public readonly Dictionary<string, string> CustomPipSequences = [];
 
-		[PaletteReference]
-		public readonly string Palette = "chrome";
-
 		public override object Create(ActorInitializer init) { return new WithCargoPipsDecoration(init.Self, this); }
 	}
 
@@ -82,8 +79,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
 		{
 			pips.PlayRepeating(Info.EmptySequence);
-
-			var palette = wr.Palette(Info.Palette);
 			var pipSize = pips.Image.Size.XY.ToInt2();
 			var pipStride = Info.PipStride != int2.Zero ? Info.PipStride : new int2(pipSize.X, 0);
 
@@ -91,6 +86,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < pipCount; i++)
 			{
 				pips.PlayRepeating(GetPipSequence(i));
+				var palette = wr.Palette(pips.Palette(self.Owner));
 				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -21,13 +21,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence to use for the charge levels.")]
 		public readonly string Sequence = "active";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithChargeOverlay(init.Self, this); }
 	}
 
@@ -48,8 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			overlay.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
 				() => int2.Lerp(0, overlay.CurrentSequence.Length, attackCharges.ChargeLevel, attackChargesInfo.ChargeLevel + 1));
 
-			rs.Add(new AnimationWithOffset(overlay, null, () => IsTraitDisabled, 1024),
-				info.Palette, info.IsPlayerPalette);
+			rs.Add(new AnimationWithOffset(overlay, null, () => IsTraitDisabled, 1024));
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeSpriteBody.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		public override object Create(ActorInitializer init) { return new WithChargeSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -37,11 +37,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithCrateBody(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			var anim = new Animation(init.World, image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), IdleSequence));
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -40,13 +40,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			"Two values indicate a random delay range.")]
 		public readonly int[] InitialDelay = [0];
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name.")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName.")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"Leave empty to disable all filtering.")]
 		public readonly BitSet<DamageType> DamageTypes = default;

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -38,26 +38,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string[] ABRampSequences = ["abramp"];
 
-		[SequenceReference]
-		[Desc("Placeholder sequence to use in the map editor.")]
-		public readonly string EditorSequence = "editor";
-
-		[PaletteReference]
-		[Desc("Palette to use for the editor placeholder.")]
-		public readonly string EditorPalette = "terrainalpha";
-
 		public override object Create(ActorInitializer init) { return new WithDeadBridgeSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
 
 			var anim = new Animation(init.World, image);
-			var sequence = init.World.Type == WorldType.Editor ? EditorSequence : Sequence;
-			var palette = init.World.Type == WorldType.Editor ? init.WorldRenderer.Palette(EditorPalette) : p;
-			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), sequence), () => 0);
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, palette);
+			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -24,26 +24,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence prefix to play when this actor is killed by a warhead.")]
 		public readonly string DeathSequence = "die";
 
-		[PaletteReference(nameof(DeathPaletteIsPlayerPalette))]
-		[Desc("The palette used for `DeathSequence`.")]
-		public readonly string DeathSequencePalette = "player";
-
-		[Desc("Custom death animation palette is a player palette BaseName")]
-		public readonly bool DeathPaletteIsPlayerPalette = true;
-
 		[Desc("Should DeathType-specific sequences be used (sequence name = DeathSequence + DeathType).")]
 		public readonly bool UseDeathTypeSuffix = true; // TODO: check the complete sequence with lint rules
 
 		[SequenceReference]
 		[Desc("Sequence to play when this actor is crushed.")]
 		public readonly string CrushedSequence = null;
-
-		[PaletteReference(nameof(CrushedPaletteIsPlayerPalette))]
-		[Desc("The palette used for `CrushedSequence`.")]
-		public readonly string CrushedSequencePalette = "effect";
-
-		[Desc("Custom crushed animation palette is a player palette BaseName")]
-		public readonly bool CrushedPaletteIsPlayerPalette = false;
 
 		[Desc("Death animations to use for each damage type (defined on the warheads).",
 			"Is only used if UseDeathTypeSuffix is `True`.")]
@@ -76,15 +62,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (crushed || IsTraitDisabled)
 				return;
 
-			var palette = Info.DeathSequencePalette;
-			if (Info.DeathPaletteIsPlayerPalette)
-				palette += self.Owner.InternalName;
-
 			// Killed by some non-standard means
 			if (e.Damage.DamageTypes.IsEmpty)
 			{
 				if (Info.FallbackSequence != null)
-					SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.FallbackSequence, palette, Info.Delay);
+					SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.FallbackSequence, Info.Delay);
 
 				return;
 			}
@@ -99,12 +81,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				sequence += Info.DeathTypes[damageType].Random(self.World.SharedRandom);
 			}
 
-			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), sequence, palette, Info.Delay);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), sequence, Info.Delay);
 		}
 
-		public void SpawnDeathAnimation(Actor self, WPos pos, string image, string sequence, string palette, int delay)
+		public void SpawnDeathAnimation(Actor self, WPos pos, string image, string sequence, int delay)
 		{
-			self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, image, sequence, palette, delay: delay)));
+			self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, image, sequence, self.Owner, delay: delay)));
 		}
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)
@@ -114,11 +96,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (Info.CrushedSequence == null)
 				return;
 
-			var crushPalette = Info.CrushedSequencePalette;
-			if (Info.CrushedPaletteIsPlayerPalette)
-				crushPalette += self.Owner.InternalName;
-
-			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.CrushedSequence, crushPalette, Info.Delay);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.CrushedSequence, Info.Delay);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -26,13 +26,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for this decoration (can be animated).")]
 		public readonly string Sequence = null;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
-		public readonly string Palette = "chrome";
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithDecoration(init.Self, this); }
 	}
 
@@ -51,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected virtual PaletteReference GetPalette(Actor self, WorldRenderer wr)
 		{
-			return wr.Palette(Info.IsPlayerPalette ? Info.Palette + self.Owner.InternalName : Info.Palette);
+			return wr.Palette(anim.Palette(self.Owner));
 		}
 
 		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -24,13 +24,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithDockedOverlay(init.Self, this); }
 	}
 
@@ -52,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation))),
 				() => IsTraitDisabled || !docked);
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void PlayDockingOverlay()

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingOverlay.cs
@@ -24,13 +24,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithDockingOverlay(init.Self, this); }
 	}
 
@@ -53,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation))),
 				() => !Visible || IsTraitDisabled);
 
-			rs.Add(WithOffset, info.Palette, info.IsPlayerPalette);
+			rs.Add(WithOffset);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		public override object Create(ActorInitializer init) { return new WithFacingSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image, init.GetFacing());
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithGateSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 
 		string IWallConnectorInfo.GetWallConnectionType()

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -24,9 +24,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		[PaletteReference]
-		public readonly string Palette = "effect";
-
 		public override object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
 	}
 
@@ -51,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(new AnimationWithOffset(anim,
 				() => body.LocalToWorld(info.LocalOffset.Rotate(body.QuantizeOrientation(self.Orientation))),
 				() => !visible,
-				p => ZOffsetFromCenter(self, p, 0)), info.Palette);
+				p => ZOffsetFromCenter(self, p, 0)));
 		}
 
 		void INotifyHarvestAction.Harvested(Actor self, string resourceType)

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -34,24 +34,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public readonly bool IsDecoration = false;
 
 		public override object Create(ActorInitializer init) { return new WithIdleOverlay(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
-
-			if (Palette != null)
-				p = init.WorldRenderer.Palette(IsPlayerPalette ? Palette + init.Get<OwnerInit>().InternalName : Palette);
 
 			Func<WAngle> facing;
 			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();
@@ -79,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return tmpOffset.Y + tmpOffset.Z + 1;
 			}
 
-			yield return new SpriteActorPreview(anim, Offset, ZOffset, p);
+			yield return new SpriteActorPreview(anim, Offset, ZOffset, owner);
 		}
 	}
 
@@ -113,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => IsTraitDisabled,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -39,29 +39,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string[] StandSequences = ["stand"];
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithInfantryBody(init, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
 
 			var anim = new Animation(init.World, image, init.GetFacing());
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), StandSequences[0]));
-
-			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().InternalName);
-			else if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
-
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 
@@ -92,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var rs = self.Trait<RenderSprites>();
 
 			DefaultAnimation = new Animation(init.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
-			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled), info.Palette, info.IsPlayerPalette);
+			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
 			PlayStandAnimation(self);
 
 			move = init.Self.Trait<IMove>();

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeOverlay.cs
@@ -22,13 +22,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use.")]
 		public readonly string Sequence = null;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name.")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName.")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithMakeOverlay(init.Self, this); }
 	}
 
@@ -47,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			overlay.Play(info.Sequence);
 
 			anim = new AnimationWithOffset(overlay, null, () => !visible);
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		public void Forward()

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -90,14 +90,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			foreach (var arm in armaments)
 			{
-				var palette = wr.Palette(arm.Info.MuzzlePalette);
 				foreach (var b in arm.Barrels)
 				{
 					var anim = anims[b];
 					if (anim.DisableFunc != null && anim.DisableFunc())
 						continue;
 
-					foreach (var r in anim.Render(self, palette))
+					foreach (var r in anim.Render(wr, self, self.Owner))
 						yield return r;
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -36,12 +36,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Parachute closing sequence. Defaults to opening sequence played backwards.")]
 		public readonly string ClosingSequence = null;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Palette used to render the parachute.")]
-		public readonly string Palette = "player";
-
-		public readonly bool IsPlayerPalette = true;
-
 		[Desc("Parachute position relative to the paradropped unit.")]
 		public readonly WVec Offset = new(0, 0, 384);
 
@@ -63,17 +57,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithParachute(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
 
 			if (image == null)
 				yield break;
-
-			// For this, image must not be null
-			if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
 
 			Func<WAngle> facing;
 			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();
@@ -97,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return tmpOffset.Y + tmpOffset.Z + 1;
 			}
 
-			yield return new SpriteActorPreview(anim, Offset, ZOffset, p);
+			yield return new SpriteActorPreview(anim, Offset, ZOffset, owner);
 		}
 	}
 
@@ -134,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			var rs = self.Trait<RenderSprites>();
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 
 			shadowColor = new float3(info.ShadowColor.R, info.ShadowColor.G, info.ShadowColor.B) / 255f;
 			shadowAlpha = info.ShadowColor.A / 255f;
@@ -178,8 +168,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var dat = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
 			var pos = self.CenterPosition - new WVec(0, 0, dat.Length);
-			var palette = wr.Palette(info.Palette);
 			var alpha = shadow.CurrentSequence.GetAlpha(shadow.CurrentFrame);
+			var palette = wr.Palette(shadow.CurrentSequence.ShadowPalette);
 			var tintModifiers = shadow.CurrentSequence.IgnoreWorldTint ? TintModifiers.ReplaceColor | TintModifiers.IgnoreWorldTint : TintModifiers.ReplaceColor;
 			return
 			[

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -24,14 +24,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string Sequence = "build-door";
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
 			var bi = init.Actor.TraitInfo<BuildingInfo>();
 			var offset = bi.CenterOffset(init.World).Y + 512; // Additional 512 units move from center -> top of cell
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => offset, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => offset, owner);
 		}
 
 		public override object Create(ActorInitializer init) { return new WithProductionDoorOverlay(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -30,13 +30,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithProductionOverlay(init.Self, this); }
 	}
 
@@ -69,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation))),
 				() => !IsProducing || IsTraitDisabled);
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void CacheQueues(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -33,13 +33,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithRepairOverlay(init.Self, this); }
 	}
 
@@ -63,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => IsTraitDisabled || !visible,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -21,13 +21,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "resources";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name.")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName.")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithResourceLevelOverlay(init.Self, this); }
 	}
 
@@ -52,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				0);
 
 			anim = new AnimationWithOffset(a, null, () => IsTraitDisabled, 1024);
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithResourceLevelSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
@@ -35,9 +35,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for full pips.")]
 		public readonly string FullSequence = "pip-green";
 
-		[PaletteReference]
-		public readonly string Palette = "chrome";
-
 		public override object Create(ActorInitializer init) { return new WithResourceStoragePipsDecoration(init.Self, this); }
 	}
 
@@ -57,7 +54,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 
-			var palette = wr.Palette(Info.Palette);
 			var pipSize = pips.Image.Size.XY.ToInt2();
 			var pipStride = Info.PipStride != int2.Zero ? Info.PipStride : new int2(pipSize.X, 0);
 
@@ -65,6 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < Info.PipCount; i++)
 			{
 				pips.PlayRepeating(player.Resources * Info.PipCount > i * player.ResourceCapacity ? Info.FullSequence : Info.EmptySequence);
+				var palette = wr.Palette(pips.Palette(self.Owner));
 				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithSpriteBarrel(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return -(tmpOffset.Y + tmpOffset.Z) + 1;
 			}
 
-			yield return new SpriteActorPreview(anim, TurretOffset, ZOffset, p);
+			yield return new SpriteActorPreview(anim, TurretOffset, ZOffset, owner);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -35,29 +35,17 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Forces sprite body to be rendered on ground regardless of actor altitude (for example for custom shadow sprites).")]
 		public readonly bool ForceToGround = false;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name.")]
-		public readonly string Palette = null;
-
-		[Desc("Palette is a player palette BaseName.")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithSpriteBody(init, this); }
 
-		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
 
-			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().InternalName);
-			else if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
-
 			var anim = new Animation(init.World, image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 
@@ -84,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				subtractDAT = () => new WVec(0, 0, -self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length);
 
 			DefaultAnimation = new Animation(init.World, rs.GetImage(self), baseFacing, Paused);
-			rs.Add(new AnimationWithOffset(DefaultAnimation, subtractDAT, () => IsTraitDisabled), info.Palette, info.IsPlayerPalette);
+			rs.Add(new AnimationWithOffset(DefaultAnimation, subtractDAT, () => IsTraitDisabled));
 
 			// Cache the bounds from the default sequence to avoid flickering when the animation changes
 			boundsAnimation = new Animation(init.World, rs.GetImage(self), baseFacing, Paused);

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -18,9 +18,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Renders Ctrl groups using pixel art.")]
 	public class WithSpriteControlGroupDecorationInfo : TraitInfo
 	{
-		[PaletteReference]
-		public readonly string Palette = "chrome";
-
 		public readonly string Image = "pips";
 
 		[SequenceReference(nameof(Image))]
@@ -58,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.PlayFetchIndex(Info.GroupSequence, () => (int)group);
 
 			var screenPos = container.GetDecorationOrigin(self, wr, Info.Position, Info.Margin) - (0.5f * anim.Image.Size.XY).ToInt2();
-			var palette = wr.Palette(Info.Palette);
+			var palette = wr.Palette(anim.Palette(self.Owner));
 			return
 			[
 				new UISpriteRenderable(anim.Image, self.CenterPosition, screenPos, 0, palette)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -26,13 +26,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "turret";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
@@ -41,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithSpriteTurret(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -63,12 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return -(tmpOffset.Y + tmpOffset.Z) + 1;
 			}
 
-			if (IsPlayerPalette)
-				p = init.WorldRenderer.Palette(Palette + init.Get<OwnerInit>().InternalName);
-			else if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
-
-			yield return new SpriteActorPreview(anim, Offset, ZOffset, p);
+			yield return new SpriteActorPreview(anim, Offset, ZOffset, owner);
 		}
 	}
 
@@ -94,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(new AnimationWithOffset(DefaultAnimation,
 				() => TurretOffset(self),
 				() => IsTraitDisabled,
-				p => RenderUtils.ZOffsetFromCenter(self, p, 1)), info.Palette, info.IsPlayerPalette);
+				p => RenderUtils.ZOffsetFromCenter(self, p, 1)));
 
 			// Restrict turret facings to match the sprite
 			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;

--- a/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
@@ -40,9 +40,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Pip sequence to use for specific resource types.")]
 		public readonly Dictionary<string, string> ResourceSequences = [];
 
-		[PaletteReference]
-		public readonly string Palette = "chrome";
-
 		public override object Create(ActorInitializer init) { return new WithStoresResourcesPipsDecoration(init.Self, this); }
 	}
 
@@ -83,7 +80,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 
-			var palette = wr.Palette(Info.Palette);
 			var pipSize = pips.Image.Size.XY.ToInt2();
 			var pipStride = Info.PipStride != int2.Zero ? Info.PipStride : new int2(pipSize.X, 0);
 
@@ -91,6 +87,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			for (var i = 0; i < Info.PipCount; i++)
 			{
 				pips.PlayRepeating(GetPipSequence(i));
+				var palette = wr.Palette(pips.Palette(self.Owner));
 				yield return new UISpriteRenderable(pips.Image, self.CenterPosition, screenPos, 0, palette);
 
 				screenPos += pipStride;

--- a/OpenRA.Mods.Common/Traits/Render/WithSupportPowerActivationOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSupportPowerActivationOverlay.cs
@@ -24,13 +24,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithSupportPowerActivationOverlay(init.Self, this); }
 	}
 
@@ -53,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				() => IsTraitDisabled || !visible,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifySupportPower.Charged(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSwitchableOverlay.cs
@@ -39,13 +39,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public readonly bool IsDecoration = false;
 
 		[Desc("How long (1 level = 1 tick) should the switching animation play?")]
@@ -64,13 +57,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			base.RulesetLoaded(rules, ai);
 		}
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
-
-			if (Palette != null)
-				p = init.WorldRenderer.Palette(IsPlayerPalette ? Palette + init.Get<OwnerInit>().InternalName : Palette);
 
 			Func<WAngle> facing;
 			var dynamicfacingInit = init.GetOrDefault<DynamicFacingInit>();
@@ -103,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return tmpOffset.Y + tmpOffset.Z + 1;
 			}
 
-			yield return new SpriteActorPreview(anim, Offset, ZOffset, p);
+			yield return new SpriteActorPreview(anim, Offset, ZOffset, owner);
 		}
 	}
 
@@ -149,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					(Info.DisabledSequence == null && switchingLevel < 0),
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override object Create(ActorInitializer init) { return new WithWallSpriteBody(init, this); }
 
-		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			if (!EnabledByDefault)
 				yield break;
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => adjacent);
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 
 		string IWallConnectorInfo.GetWallConnectionType()

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -188,11 +188,8 @@ namespace OpenRA.Mods.Common.Traits
 					beacon = new Beacon(
 						self.Owner,
 						target - new WVec(0, 0, altitude),
-						Info.BeaconPaletteIsPlayerPalette,
-						Info.BeaconPalette,
 						Info.BeaconImage,
 						Info.BeaconPoster,
-						Info.BeaconPosterPalette,
 						Info.BeaconSequence,
 						Info.ArrowSequence,
 						Info.CircleSequence,

--- a/OpenRA.Mods.Common/Traits/SupportPowers/DirectionalSupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/DirectionalSupportPower.cs
@@ -23,10 +23,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Animation used to render the direction arrows.")]
 		public readonly string DirectionArrowAnimation = null;
-
-		[PaletteReference]
-		[Desc("Palette for direction cursor animation.")]
-		public readonly string DirectionArrowPalette = "chrome";
 	}
 
 	public class DirectionalSupportPower : SupportPower

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -112,8 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 			readonly GrantExternalConditionPower power;
 			readonly char[] footprint;
 			readonly CVec dimensions;
-			readonly Sprite tile;
-			readonly float alpha;
+			readonly ISpriteSequence tile;
 			readonly SupportPowerManager manager;
 			readonly string order;
 
@@ -130,8 +129,7 @@ namespace OpenRA.Mods.Common.Traits
 				dimensions = power.info.Dimensions;
 
 				var sequence = world.Map.Sequences.GetSequence(power.info.FootprintImage, power.info.FootprintSequence);
-				tile = sequence.GetSprite(0);
-				alpha = sequence.GetAlpha(0);
+				tile = sequence;
 			}
 
 			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -165,10 +163,11 @@ namespace OpenRA.Mods.Common.Traits
 			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var pal = wr.Palette(tile.GetPalette());
 
 				foreach (var t in power.CellsMatching(xy, footprint, dimensions))
-					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, alpha, float3.Ones, TintModifiers.IgnoreWorldTint, true);
+					yield return new SpriteRenderable(tile.GetSprite(0), wr.World.Map.CenterOfCell(t),
+						WVec.Zero, -511, pal, 1f, tile.GetAlpha(0), float3.Ones, TintModifiers.IgnoreWorldTint, true);
 			}
 
 			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -50,13 +50,6 @@ namespace OpenRA.Mods.Common.Traits
 			"'False' will make the missile continue until it hits the ground and disappears (without triggering another explosion).")]
 		public readonly bool RemoveMissileOnDetonation = true;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Palette to use for the missile weapon image.")]
-		public readonly string MissilePalette = "effect";
-
-		[Desc("Custom palette is a player palette BaseName.")]
-		public readonly bool IsPlayerPalette = false;
-
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
@@ -69,13 +62,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
-
-		[PaletteReference(nameof(TrailUsePlayerPalette))]
-		[Desc("Palette used to render the trail sequence.")]
-		public readonly string TrailPalette = "effect";
-
-		[Desc("Use the Player Palette to render the trail sequence.")]
-		public readonly bool TrailUsePlayerPalette = false;
 
 		[Desc("Travel time - split equally between ascent and descent.")]
 		public readonly int FlightDelay = 400;
@@ -164,15 +150,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Activate(Actor self, WPos targetPosition)
 		{
-			var palette = info.IsPlayerPalette ? info.MissilePalette + self.Owner.InternalName : info.MissilePalette;
 			var skipAscent = info.SkipAscent || body == null;
 			var launchPos = skipAscent ? WPos.Zero : self.CenterPosition + body.LocalToWorld(info.SpawnOffset);
 
-			var missile = new NukeLaunch(self.Owner, info.MissileImage, info.WeaponInfo, palette, info.MissileUp, info.MissileDown,
+			var missile = new NukeLaunch(self.Owner, info.MissileImage, info.WeaponInfo, info.MissileUp, info.MissileDown,
 				launchPos,
 				targetPosition, info.DetonationAltitude, info.RemoveMissileOnDetonation,
 				info.FlightVelocity, info.MissileDelay, info.FlightDelay, skipAscent,
-				info.TrailImage, info.TrailSequences, info.TrailPalette, info.TrailUsePlayerPalette, info.TrailDelay, info.TrailInterval);
+				info.TrailImage, info.TrailSequences, info.TrailDelay, info.TrailInterval);
 
 			self.World.AddFrameEndTask(w => w.Add(missile));
 
@@ -190,11 +175,8 @@ namespace OpenRA.Mods.Common.Traits
 				var beacon = new Beacon(
 					self.Owner,
 					targetPosition,
-					Info.BeaconPaletteIsPlayerPalette,
-					Info.BeaconPalette,
 					Info.BeaconImage,
 					Info.BeaconPoster,
-					Info.BeaconPosterPalette,
 					Info.BeaconSequence,
 					Info.ArrowSequence,
 					Info.CircleSequence,

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -237,11 +237,8 @@ namespace OpenRA.Mods.Common.Traits
 					beacon = new Beacon(
 						self.Owner,
 						target - new WVec(0, 0, altitude),
-						Info.BeaconPaletteIsPlayerPalette,
-						Info.BeaconPalette,
 						Info.BeaconImage,
 						Info.BeaconPoster,
-						Info.BeaconPosterPalette,
 						Info.BeaconSequence,
 						Info.ArrowSequence,
 						Info.CircleSequence,

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				currentArrow = GetArrow(angle);
 
-				mouseAttachment.SetAttachment(targetLocation, currentArrow.Sprite, info.DirectionArrowPalette);
+				mouseAttachment.SetAttachment(targetLocation, currentArrow.Sprite);
 				dragStarted = true;
 			}
 
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			for (var i = 0; i < noOfDividingPoints; i++)
 			{
-				var sprite = world.Map.Sequences.GetSequence(cursorAnimation, info.Arrows[i]).GetSprite(0);
+				var sprite = world.Map.Sequences.GetSequence(cursorAnimation, info.Arrows[i]);
 
 				var angle = i * partAngle;
 				var direction = WAngle.FromDegrees(angle);
@@ -170,6 +170,6 @@ namespace OpenRA.Mods.Common.Traits
 			return points;
 		}
 
-		sealed record Arrow(Sprite Sprite, double EndAngle, WAngle Direction);
+		sealed record Arrow(ISpriteSequence Sprite, double EndAngle, WAngle Direction);
 	}
 }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -42,11 +42,6 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(EffectImage))]
 		public readonly string EffectSequence = null;
 
-		[PaletteReference(nameof(EffectPaletteIsPlayerPalette))]
-		public readonly string EffectPalette = null;
-
-		public readonly bool EffectPaletteIsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new SpawnActorPower(init.Self, this); }
 	}
 
@@ -71,14 +66,8 @@ namespace OpenRA.Mods.Common.Traits
 				PlayLaunchSounds();
 				Game.Sound.Play(SoundType.World, info.DeploySound, position);
 
-				if (!string.IsNullOrEmpty(info.EffectSequence) && !string.IsNullOrEmpty(info.EffectPalette))
-				{
-					var palette = info.EffectPalette;
-					if (info.EffectPaletteIsPlayerPalette)
-						palette += self.Owner.InternalName;
-
-					w.Add(new SpriteEffect(position, w, info.EffectImage, info.EffectSequence, palette));
-				}
+				if (!string.IsNullOrEmpty(info.EffectSequence))
+					w.Add(new SpriteEffect(position, w, info.EffectImage, info.EffectSequence, self.Owner));
 
 				var actor = w.CreateActor(info.Actor,
 				[

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -25,10 +25,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Icon sprite displayed in the support power palette.")]
 		public readonly string Icon = null;
 
-		[PaletteReference]
-		[Desc("Palette used for the icon.")]
-		public readonly string IconPalette = "chrome";
-
 		[FluentReference(optional: true)]
 		public readonly string Name = null;
 
@@ -117,18 +113,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Beacons are only supported on the Airstrike, Paratroopers, and Nuke powers")]
 		public readonly bool DisplayBeacon = false;
 
-		public readonly bool BeaconPaletteIsPlayerPalette = true;
-
-		[PaletteReference(nameof(BeaconPaletteIsPlayerPalette))]
-		public readonly string BeaconPalette = "player";
-
 		public readonly string BeaconImage = "beacon";
 
 		[SequenceReference(nameof(BeaconImage))]
 		public readonly string BeaconPoster = null;
-
-		[PaletteReference]
-		public readonly string BeaconPosterPalette = "chrome";
 
 		[SequenceReference(nameof(BeaconImage))]
 		public readonly string ClockSequence = null;

--- a/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/BuildableTerrainOverlay.cs
@@ -22,10 +22,6 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		public readonly HashSet<string> AllowedTerrainTypes = null;
 
-		[PaletteReference]
-		[Desc("Palette to use for rendering the sprite.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		[Desc("Sprite definition.")]
 		public readonly string Image = "overlay";
 
@@ -48,6 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly World world;
 		readonly Sprite disabledSprite;
 		readonly float disabledSpriteScale;
+		readonly string paletteName;
 
 		public bool Enabled = false;
 		TerrainSpriteLayer render;
@@ -62,6 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var spriteSequence = self.World.Map.Sequences.GetSequence(info.Image, info.Sequence);
 			disabledSprite = spriteSequence.GetSprite(0);
+			paletteName = spriteSequence.GetPalette();
 			disabledSpriteScale = spriteSequence.Scale;
 		}
 
@@ -76,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				(!info.AllowedTerrainTypes.Contains(w.Map.GetTerrainInfo(c).Type) ||
 				world.Map.Ramp[c] != 0)).ToHashSet();
 
-			palette = wr.Palette(info.Palette);
+			palette = wr.Palette(paletteName);
 
 			foreach (var cell in cells)
 				UpdateTerrainCell(cell);

--- a/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/OrderEffects.cs
@@ -29,9 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		public readonly string TerrainFlashSequence = null;
 
-		[Desc("The palette to use.")]
-		public readonly string TerrainFlashPalette = null;
-
 		[Desc("The type of effect to apply to targeted (frozen) actors. Accepts values Overlay and Tint.")]
 		public readonly ActorFlashType ActorFlashType = ActorFlashType.Overlay;
 
@@ -96,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 				case TargetType.Terrain:
 				{
 					world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(
-						target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence, info.TerrainFlashPalette)));
+						target.CenterPosition, world, info.TerrainFlashImage, info.TerrainFlashSequence)));
 					return true;
 				}
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -33,10 +33,6 @@ namespace OpenRA.Mods.Common.Traits
 			[Desc("Randomly chosen image sequences.")]
 			public readonly string[] Sequences = [];
 
-			[PaletteReference]
-			[Desc("Palette used for rendering the resource sprites.")]
-			public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 			[FieldLoader.Require]
 			[Desc("Resource name used by tooltips.")]
 			[FluentReference]
@@ -173,7 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (rendererCellContents.Type != null)
 				{
 					RenderContents[cell] = rendererCellContents;
-					UpdateRenderedSprite(cell, rendererCellContents);
+					UpdateRenderedSprite(cell, rendererCellContents, wr);
 				}
 			}
 		}
@@ -183,18 +179,18 @@ namespace OpenRA.Mods.Common.Traits
 		protected RendererCellContents CreateRenderCellContents(WorldRenderer wr, ResourceLayerContents contents, CPos cell)
 		{
 			if (contents.Type != null && contents.Density > 0 && Info.ResourceTypes.TryGetValue(contents.Type, out var resourceInfo))
-				return new RendererCellContents(contents.Type, contents.Density, resourceInfo, ChooseVariant(contents.Type, cell), wr.Palette(resourceInfo.Palette));
+				return new RendererCellContents(contents.Type, contents.Density, resourceInfo, ChooseVariant(contents.Type, cell));
 
 			return RendererCellContents.Empty;
 		}
 
-		protected void UpdateSpriteLayers(CPos cell, ISpriteSequence sequence, int frame, PaletteReference palette)
+		protected void UpdateSpriteLayers(CPos cell, ISpriteSequence sequence, int frame, WorldRenderer wr)
 		{
 			// resource.Type is meaningless (and may be null) if resource.Sequence is null
 			if (sequence != null)
 			{
-				shadowLayer?.Update(cell, sequence.GetShadow(frame, WAngle.Zero), palette, 1f, 1f, sequence.IgnoreWorldTint);
-				spriteLayer.Update(cell, sequence, palette, frame);
+				shadowLayer?.Update(cell, sequence.GetShadow(frame, WAngle.Zero), wr.Palette(sequence.ShadowPalette), 1f, 1f, sequence.IgnoreWorldTint);
+				spriteLayer.Update(cell, sequence, frame);
 			}
 			else
 			{
@@ -230,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				RenderContents[cell] = rendererCellContents;
-				UpdateRenderedSprite(cell, rendererCellContents);
+				UpdateRenderedSprite(cell, rendererCellContents, wr);
 				cleanDirty.Enqueue(cell);
 			}
 
@@ -238,13 +234,13 @@ namespace OpenRA.Mods.Common.Traits
 				dirty.Remove(cleanDirty.Dequeue());
 		}
 
-		protected virtual void UpdateRenderedSprite(CPos cell, RendererCellContents content)
+		protected virtual void UpdateRenderedSprite(CPos cell, RendererCellContents content, WorldRenderer wr)
 		{
 			if (content.Density > 0)
 			{
 				var maxDensity = ResourceLayer.GetMaxDensity(content.Type);
 				var frame = int2.Lerp(0, content.Sequence.Length - 1, content.Density, maxDensity);
-				UpdateSpriteLayers(cell, content.Sequence, frame, content.Palette);
+				UpdateSpriteLayers(cell, content.Sequence, frame, wr);
 			}
 			else
 				UpdateSpriteLayers(cell, null, 0, null);
@@ -292,18 +288,17 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Variants.TryGetValue(resourceType, out var variant))
 				yield break;
 
-			if (!Info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo))
+			if (!Info.ResourceTypes.ContainsKey(resourceType))
 				yield break;
 
 			var sequence = variant.First().Value;
 			var sprite = sequence.GetSprite(sequence.Length - 1);
 			var shadow = sequence.GetShadow(sequence.Length - 1, WAngle.Zero);
-			var palette = wr.Palette(resourceInfo.Palette);
 
 			if (shadow != null)
-				yield return new UISpriteRenderable(shadow, WPos.Zero, origin, 0, palette, scale);
+				yield return new UISpriteRenderable(shadow, WPos.Zero, origin, 0, wr.Palette(sequence.ShadowPalette), scale);
 
-			yield return new UISpriteRenderable(sprite, WPos.Zero, origin, 0, palette, scale);
+			yield return new UISpriteRenderable(sprite, WPos.Zero, origin, 0, wr.Palette(sequence.GetPalette()), scale);
 		}
 
 		IEnumerable<IRenderable> IResourceRenderer.RenderPreview(WorldRenderer wr, string resourceType, WPos origin)
@@ -311,20 +306,21 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Variants.TryGetValue(resourceType, out var variant))
 				yield break;
 
-			if (!Info.ResourceTypes.TryGetValue(resourceType, out var resourceInfo))
+			if (!Info.ResourceTypes.ContainsKey(resourceType))
 				yield break;
 
 			var sequence = variant.First().Value;
 			var sprite = sequence.GetSprite(sequence.Length - 1);
 			var shadow = sequence.GetShadow(sequence.Length - 1, WAngle.Zero);
 			var alpha = sequence.GetAlpha(sequence.Length - 1);
-			var palette = wr.Palette(resourceInfo.Palette);
 			var tintModifiers = sequence.IgnoreWorldTint ? TintModifiers.IgnoreWorldTint : TintModifiers.None;
 
 			if (shadow != null)
-				yield return new SpriteRenderable(shadow, origin, WVec.Zero, 0, palette, sequence.Scale, alpha, float3.Ones, tintModifiers, false);
+				yield return new SpriteRenderable(
+					shadow, origin, WVec.Zero, 0, wr.Palette(sequence.ShadowPalette),
+					sequence.Scale, alpha, float3.Ones, tintModifiers, false);
 
-			yield return new SpriteRenderable(sprite, origin, WVec.Zero, 0, palette, sequence.Scale, alpha, float3.Ones, tintModifiers, false);
+			yield return new SpriteRenderable(sprite, origin, WVec.Zero, 0, wr.Palette(sequence.GetPalette()), sequence.Scale, alpha, float3.Ones, tintModifiers, false);
 		}
 
 		event Action<CPos> IRadarTerrainLayer.CellEntryChanged
@@ -356,19 +352,17 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly string Type;
 			public readonly ResourceRendererInfo.ResourceTypeInfo Info;
 			public readonly ISpriteSequence Sequence;
-			public readonly PaletteReference Palette;
 			public readonly byte Density;
 
 			public static readonly RendererCellContents Empty = default;
 
 			public RendererCellContents(string resourceType, byte density, ResourceRendererInfo.ResourceTypeInfo info,
-				ISpriteSequence sequence, PaletteReference palette)
+				ISpriteSequence sequence)
 			{
 				Type = resourceType;
 				Density = density;
 				Info = info;
 				Sequence = sequence;
-				Palette = palette;
 			}
 
 			public RendererCellContents(RendererCellContents contents, byte density)
@@ -377,7 +371,6 @@ namespace OpenRA.Mods.Common.Traits
 				Density = density;
 				Info = contents.Info;
 				Sequence = contents.Sequence;
-				Palette = contents.Palette;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -29,12 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(Sequence))]
 		public readonly string[] FogVariants = ["fog"];
 
-		[PaletteReference]
-		public readonly string ShroudPalette = "shroud";
-
-		[PaletteReference]
-		public readonly string FogPalette = "fog";
-
 		[Desc("Bitfield of shroud directions for each frame. Lower four bits are",
 			"corners clockwise from TL; upper four are edges clockwise from top")]
 		public readonly int[] Index = [12, 9, 8, 3, 1, 6, 4, 2, 13, 11, 7, 14];
@@ -119,6 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 		Func<PPos, Shroud.CellVisibility> cellVisibility;
 		TerrainSpriteLayer shroudLayer, fogLayer;
 		PaletteReference shroudPaletteReference, fogPaletteReference;
+		readonly string shroudPalette, fogPalette;
 		bool disposed;
 
 		public ShroudRenderer(World world, ShroudRendererInfo info)
@@ -155,6 +150,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var shroudSequence = sequences.GetSequence(info.Sequence, info.ShroudVariants[j]);
 				var fogSequence = sequences.GetSequence(info.Sequence, info.FogVariants[j]);
+				shroudPalette = shroudSequence.GetPalette();
+				fogPalette = fogSequence.GetPalette();
 				for (var i = 0; i < info.Index.Length; i++)
 				{
 					shroudSprites[j * variantStride + i] = (shroudSequence.GetSprite(i), shroudSequence.Scale, shroudSequence.GetAlpha(i));
@@ -221,8 +218,8 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Fog sprites must all use the same blend mode.");
 
 			var emptySprite = new Sprite(shroudSprites[0].Sprite.Sheet, Rectangle.Empty, TextureChannel.Alpha);
-			shroudPaletteReference = wr.Palette(info.ShroudPalette);
-			fogPaletteReference = wr.Palette(info.FogPalette);
+			shroudPaletteReference = wr.Palette(shroudPalette);
+			fogPaletteReference = wr.Palette(fogPalette);
 			shroudLayer = new TerrainSpriteLayer(w, wr, emptySprite, shroudBlend, false);
 			fogLayer = new TerrainSpriteLayer(w, wr, emptySprite, fogBlend, false);
 

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -48,12 +48,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Smoke sprite sequences randomly chosen from")]
 		public readonly string[] SmokeSequences = [];
 
-		[PaletteReference]
-		public readonly string SmokePalette = "effect";
-
-		[PaletteReference]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
-
 		[FieldLoader.LoadUsing(nameof(LoadInitialSmudges))]
 		public readonly Dictionary<CPos, MapSmudge> InitialSmudges;
 
@@ -100,7 +94,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool hasSmoke;
 
 		TerrainSpriteLayer render;
-		PaletteReference paletteReference;
 		bool disposed;
 
 		public SmudgeLayer(Actor self, SmudgeLayerInfo info)
@@ -126,7 +119,6 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
-			paletteReference = wr.Palette(Info.Palette);
 			render = new TerrainSpriteLayer(w, wr, emptySprite, blendMode, true);
 
 			// Add map smudges
@@ -145,7 +137,7 @@ namespace OpenRA.Mods.Common.Traits
 				};
 
 				tiles.Add(kv.Key, smudge);
-				render.Update(kv.Key, seq, paletteReference, s.Depth);
+				render.Update(kv.Key, seq, s.Depth);
 			}
 		}
 
@@ -165,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(
-					position, w, Info.SmokeImage, Info.SmokeSequences.Random(Game.CosmeticRandom), Info.SmokePalette)));
+					position, w, Info.SmokeImage, Info.SmokeSequences.Random(Game.CosmeticRandom))));
 			}
 
 			// A null Sequence indicates a deleted smudge.
@@ -217,7 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						var smudge = kv.Value;
 						tiles[kv.Key] = smudge;
-						render.Update(kv.Key, smudge.Sequence, paletteReference, smudge.Depth);
+						render.Update(kv.Key, smudge.Sequence, smudge.Depth);
 					}
 
 					remove.Add(kv.Key);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/MovePalettesToSequences.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/MovePalettesToSequences.cs
@@ -1,0 +1,2241 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class MovePalettesToSequences : UpdateRule, IBeforeUpdateActors, IBeforeUpdateWeapons, IBeforeUpdateSequences
+	{
+		public const string TerrainPaletteInternalName = "terrain";
+
+		public override string Name => "Move Palettes to Sequences";
+		public override string Description => "Moves palette definitions from individual actors to a shared sequence.";
+
+		record struct SequenceDefinitions
+		{
+			public string Sequence;
+			public string Palette;
+			public string ShadowPalette;
+			public bool IsPlayerPalette;
+		}
+
+		readonly Dictionary<string, List<string>> traitRemovals = new()
+		{
+			["RenderSprites"] = ["Palette", "PlayerPalette"],
+			["RenderSpritesEditorOnly"] = ["Palette", "PlayerPalette"],
+			["FootprintPlaceBuildingPreview"] = ["Palette"],
+			["ActorPreviewPlaceBuildingPreview"] = ["Palette"],
+			["SequencePlaceBuildingPreview"] = ["Palette"],
+			["D2kActorPreviewPlaceBuildingPreview"] = ["Palette"],
+			["OrderEffects"] = ["TerrainFlashPalette"],
+			["GpsDot"] = ["IndicatorPalettePrefix"],
+			["WithDeadBridgeSpriteBody"] = ["EditorSequence", "EditorPalette"],
+			["WithIdleOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithInfantryBody"] = ["Palette", "IsPlayerPalette"],
+			["WithParachute"] = ["Palette", "IsPlayerPalette"],
+			["WithSpriteTurret"] = ["Palette", "IsPlayerPalette"],
+			["WithSwitchableOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithSupportPowerActivationOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithChargeSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithFacingSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithResourceLevelSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithWallSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithHarvesterSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithBridgeSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithAttackOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithBuildingPlacedOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithChargeOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithResourceLevelOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithRepairOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithProductionOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithMakeOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithHarvestOverlay"] = ["Palette"],
+			["WithDockingOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithDockedOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithDamageOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithEmbeddedTurretSpriteBody"] = ["Palette", "IsPlayerPalette"],
+			["WithDeliveryOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithSplitAttackPaletteInfantryBody"] = ["Palette", "IsPlayerPalette", "SplitAttackPalette"],
+			["WithDisguisingInfantryBody"] = ["Palette", "IsPlayerPalette"],
+			["WithCrumbleOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithTeslaChargeOverlay"] = ["Palette", "IsPlayerPalette"],
+			["WithDeathAnimation"] = ["DeathSequencePalette", "DeathPaletteIsPlayerPalette", "CrushedSequencePalette", "CrushedPaletteIsPlayerPalette"],
+			["WithResourceAnimation"] = ["Palette"],
+			["GrantConditionOnSubterraneanLayer"] = ["SubterraneanTransitionPalette"],
+			["Parachutable"] = ["GroundCorpsePalette", "WaterCorpsePalette"],
+			["WithAircraftLandingEffect"] = ["Palette"],
+			["SpawnActorPower"] = ["EffectPalette", "EffectPaletteIsPlayerPalette"],
+			["SmudgeLayer"] = ["Palette", "SmokePalette"],
+			["CrateAction"] = ["Palette"],
+			["DuplicateUnitCrateAction"] = ["Palette"],
+			["ExplodeCrateAction"] = ["Palette"],
+			["GiveCashCrateAction"] = ["Palette"],
+			["GiveUnitCrateAction"] = ["Palette"],
+			["GrantExternalConditionCrateAction"] = ["Palette"],
+			["HealActorsCrateAction"] = ["Palette"],
+			["HideMapCrateAction"] = ["Palette"],
+			["LevelUpCrateAction"] = ["Palette"],
+			["RevealMapCrateAction"] = ["Palette"],
+			["SupportPowerCrateAction"] = ["Palette"],
+			["GainsExperience"] = ["LevelUpPalette"],
+			["LeavesTrails"] = ["Palette"],
+			["Cloak"] = ["EffectPalette", "EffectPaletteIsPlayerPalette"],
+			["Buldable"] = ["IconPalette", "IconPaletteIsPlayerPalette"],
+			["RallyPoint"] = ["Palette", "IsPlayerPalette"],
+			["PlaceBeacon"] = ["Palette", "IsPlayerPalette"],
+			["SupportPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["AirstrikePower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette", "DirectionArrowPalette"],
+			["NukePower"] = ["MissilePalette", "IsPlayerPalette", "TrailPalette", "TrailUsePlayerPalette",
+				"IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["GpsPower"] = ["DoorPalette", "DoorPaletteIsPlayerPalette", "SatellitePalette", "SatellitePaletteIsPlayerPalette",
+				"IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["ParatroopersPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette", "DirectionArrowPalette"],
+			["AttackOrderPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["ChronoshiftPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette", "TargetOverlayPalette"],
+			["DropPodsPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette", "EntryEffectPalette"],
+			["GrantPrerequisiteChargeDrainPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["IonCannonPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette", "EffectPalette"],
+			["GrantExternalConditionPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["ProduceActorPower"] = ["IconPalette", "BeaconPalette", "BeaconPaletteIsPlayerPalette", "BeaconPosterPalette"],
+			["Armament"] = ["MuzzlePalette"],
+			["AttackGarrisoned"] = ["MuzzlePalette"],
+			["FloatingSpriteEmitter"] = ["Palette", "IsPlayerPalette"],
+			["TSVeinsRenderer"] = ["Palette"],
+			["DrawLineToTarget"] = ["Palette"],
+			["BuildableTerrainOverlay"] = ["Palette"],
+			["WithDecoration"] = ["Palette", "IsPlayerPalette"],
+			["WithBuildingRepairDecoration"] = ["Palette", "IsPlayerPalette"],
+			["InfiltrateForDecoration"] = ["Palette", "IsPlayerPalette"],
+			["ShroudRenderer"] = ["ShroudPalette", "FogPalette"],
+			["ProductionIconOverlayManager"] = ["Palette"],
+			["WithAmmoPipsDecoration"] = ["Palette"],
+			["WithCargoPipsDecoration"] = ["Palette"],
+			["WithResourceStoragePipsDecoration"] = ["Palette"],
+			["WithSpriteControlGroupDecoration"] = ["Palette"],
+			["WithStoresResourcesPipsDecoration"] = ["Palette"],
+		};
+
+		readonly Dictionary<string, List<string>> projectileRemovals = new()
+		{
+			["TeslaZap"] = ["Palette"],
+			["Bullet"] = ["Palette", "IsPlayerPalette", "TrailPalette", "TrailUsePlayerPalette"],
+			["Missile"] = ["Palette", "IsPlayerPalette", "TrailPalette", "TrailUsePlayerPalette"],
+			["LaserZap"] = ["HitAnimPalette", "LaunchEffectPalette"],
+			["GravityBomb"] = ["Palette", "IsPlayerPalette"],
+			["Railgun"] = ["HitAnimPalette"]
+		};
+
+		readonly Dictionary<string, List<string>> warheadRemovals = new()
+		{
+			["CreateEffect"] = ["ExplosionPalette", "UsePlayerPalette"],
+		};
+
+		readonly Dictionary<string, List<string>> widgetRemovals = new()
+		{
+			["SupportPowers"] = ["ClockPalette"],
+			["ProductionPalette"] = ["ClockPalette", "NotBuildablePalette"],
+		};
+
+		readonly Dictionary<string, HashSet<SequenceDefinitions>> sequenceDefinitions = [];
+		readonly Dictionary<string, string> queuedSequenceDefinitions = [];
+		readonly Dictionary<string, List<MiniYamlNodeBuilder>> globalArmaments = [];
+		List<MiniYamlNodeBuilder> resolvedSequences;
+
+		SequenceDefinitions AddSequenceDefinitions(string image, string sequence, string palette, string shadowPalette = null, bool isPlayerPalette = false)
+		{
+			if (string.IsNullOrEmpty(image) || string.IsNullOrEmpty(sequence) || (string.IsNullOrEmpty(palette) && string.IsNullOrEmpty(shadowPalette)))
+				return default;
+
+			var definition = new SequenceDefinitions
+			{
+				Sequence = sequence,
+				Palette = palette,
+				ShadowPalette = shadowPalette,
+				IsPlayerPalette = isPlayerPalette
+			};
+
+			var lowerImage = image.ToLowerInvariant();
+			if (!sequenceDefinitions.TryGetValue(lowerImage, out var sequences))
+				sequenceDefinitions[lowerImage] = [definition];
+			else
+				sequences.Add(definition);
+
+			return definition;
+		}
+
+		static bool TryGetString(MiniYamlNodeBuilder node, out string value, string propertyName, string defaultValue = null)
+		{
+			var valueNode = node.LastChildMatching(propertyName);
+			if (valueNode == null || valueNode.IsRemoval())
+			{
+				value = defaultValue;
+				return !string.IsNullOrEmpty(value);
+			}
+
+			value = valueNode.Value.Value;
+			return !string.IsNullOrEmpty(value);
+		}
+
+		static bool ParseBool(MiniYamlNodeBuilder node, string propertyName, bool defaultValue)
+		{
+			var valueNode = node.LastChildMatching(propertyName);
+			if (valueNode == null || valueNode.IsRemoval())
+				return defaultValue;
+
+			return FieldLoader.GetValue<bool>(valueNode.Key, valueNode.Value.Value);
+		}
+
+		static string[] ParseStringArray(MiniYamlNodeBuilder node, string propertyName, string[] defaultValue = null)
+		{
+			var valueNode = node.LastChildMatching(propertyName);
+			if (valueNode == null || valueNode.IsRemoval())
+				return defaultValue ?? [];
+
+			return FieldLoader.GetValue<string[]>(valueNode.Key, valueNode.Value.Value);
+		}
+
+		static Dictionary<string, T> ParseDictionary<T>(MiniYamlNodeBuilder node, string propertyName, Dictionary<string, T> defaultValue = null)
+		{
+			var valueNode = node.LastChildMatching(propertyName);
+			if (valueNode == null || valueNode.IsRemoval())
+				return defaultValue ?? [];
+
+			return (Dictionary<string, T>)FieldLoader.GetValue(valueNode.Key, typeof(Dictionary<string, T>), valueNode.Value.Build());
+		}
+
+		IEnumerable<string> IBeforeUpdateActors.BeforeUpdateActors(ModData modData, List<MiniYamlNodeBuilder> resolvedActors)
+		{
+			// We needs all armaments to be able to move MuzzlePalettes.
+			foreach (var actorNode in resolvedActors)
+			{
+				foreach (var armament in actorNode.ChildrenMatching("Armament"))
+				{
+					if (globalArmaments.TryGetValue(actorNode.Key, out var armaments))
+						armaments.Add(armament);
+					else
+						globalArmaments[actorNode.Key] = [armament];
+				}
+			}
+
+			foreach (var actorNode in resolvedActors)
+			{
+				var renderSprites = actorNode.LastChildMatching("RenderSprites")
+					?? actorNode.LastChildMatching("RenderSpritesEditorOnly");
+
+				Dictionary<string, HashSet<SequenceDefinitions>> handledRenderSprites = [];
+
+				if (renderSprites != null && !renderSprites.IsRemoval())
+				{
+					var isPlayerPalette = false;
+					if (!TryGetString(renderSprites, out var actorPalette, "Palette")
+						&& TryGetString(renderSprites, out var actorPlayerPalette, "PlayerPalette", "player"))
+					{
+						actorPalette = actorPlayerPalette;
+						isPlayerPalette = true;
+					}
+
+					var factionImages = ParseDictionary<string>(renderSprites, "FactionImages");
+					if (factionImages.Count > 0)
+					{
+						foreach (var factionImage in factionImages)
+						{
+							handledRenderSprites[factionImage.Value.ToLowerInvariant()] =
+							[
+								new SequenceDefinitions
+								{
+									Sequence = null,
+									Palette = actorPalette,
+									IsPlayerPalette = isPlayerPalette
+								}
+							];
+						}
+					}
+					else if (TryGetString(renderSprites, out var actorImage, "Image", actorNode.Key))
+					{
+						handledRenderSprites[actorImage.ToLowerInvariant()] =
+						[
+							new SequenceDefinitions
+							{
+								Sequence = null,
+								Palette = actorPalette,
+								IsPlayerPalette = isPlayerPalette
+							}
+						];
+					}
+				}
+
+				string[] prefixesPrefixes =
+				[
+					"critical-",
+					"damaged-",
+					"scratched-",
+					"scuffed-"
+				];
+
+				HashSet<SequenceDefinitions> AddRenderSequences(
+					string sequence,
+					string palette,
+					string shadowPalette = null,
+					bool isPlayerPalette = false,
+					string image = null)
+				{
+					var results = new HashSet<SequenceDefinitions>();
+					foreach (var (renderImage, sequences) in handledRenderSprites)
+					{
+						var targetImage = image ?? renderImage;
+						if (palette == null && shadowPalette == null)
+						{
+							foreach (var seq in sequences)
+							{
+								results.Add(AddSequenceDefinitions(targetImage, sequence, seq.Palette, shadowPalette, seq.IsPlayerPalette));
+								foreach (var prefix in prefixesPrefixes)
+									results.Add(AddSequenceDefinitions(targetImage, prefix + sequence, seq.Palette, shadowPalette, seq.IsPlayerPalette));
+							}
+						}
+						else
+						{
+							results.Add(AddSequenceDefinitions(targetImage, sequence, palette, shadowPalette, isPlayerPalette));
+							foreach (var prefix in prefixesPrefixes)
+								results.Add(AddSequenceDefinitions(targetImage, prefix + sequence, palette, shadowPalette, isPlayerPalette));
+						}
+					}
+
+					return results;
+				}
+
+				// Firs pass
+				List<string> spriteBodyPrefixes = [];
+				HashSet<SequenceDefinitions> handledInfantryBodies = [];
+				var spriteBodyPalettes = new Dictionary<string, (string Palette, bool IsPlayerPalette)>();
+				string drawLineToTargetPalette = null;
+				foreach (var traitNode in actorNode.Value.Nodes)
+				{
+					if (traitNode.IsRemoval())
+						continue;
+
+					switch (traitNode.GetKey())
+					{
+						case "WithInfantryBody":
+						case "WithDisguisingInfantryBody":
+						{
+							var (sequences, palette, isPlayerPalette) = HandleWithInfantryBody(traitNode);
+
+							foreach (var seq in sequences)
+								handledInfantryBodies.UnionWith(AddRenderSequences(seq.Sequence, seq.Palette, seq.ShadowPalette, seq.IsPlayerPalette));
+							break;
+						}
+
+						case "WithSplitAttackPaletteInfantryBody":
+						{
+							var (sequences, palette, isPlayerPalette) = HandleWithInfantryBody(traitNode);
+
+							foreach (var seq in sequences)
+								handledInfantryBodies.UnionWith(AddRenderSequences(seq.Sequence, seq.Palette, seq.ShadowPalette, seq.IsPlayerPalette));
+
+							if (!TryGetString(traitNode, out var suffix, "SplitAttackSuffix", "muzzle"))
+								continue;
+
+							TryGetString(traitNode, out var splitAttackPalette, "SplitAttackPalette");
+							if (TryGetString(traitNode, out var defaultAttackSeq, "DefaultAttackSequence"))
+								handledInfantryBodies.UnionWith(AddRenderSequences(defaultAttackSeq + '-' + suffix, splitAttackPalette));
+
+							var attackSeqs = ParseDictionary<string[]>(traitNode, "AttackSequences");
+							foreach (var seq in attackSeqs.Values)
+								foreach (var s in seq)
+									handledInfantryBodies.UnionWith(AddRenderSequences(s + '-' + suffix, splitAttackPalette));
+
+							break;
+						}
+
+						case "WithSpriteBody":
+						case "WithChargeSpriteBody":
+						case "WithFacingSpriteBody":
+						case "WithResourceLevelSpriteBody":
+						case "WithEmbeddedTurretSpriteBody":
+						case "WithDeadBridgeSpriteBody":
+						case "WithWallSpriteBody":
+						{
+							(var sequences, var name, var spriteBodyPalette, var isPlayerPalette) = HandleWithSpriteBody(traitNode);
+							spriteBodyPalettes[name] = (spriteBodyPalette, isPlayerPalette);
+
+							foreach (var seq in sequences)
+								AddRenderSequences(seq.Sequence, spriteBodyPalette, seq.ShadowPalette, seq.IsPlayerPalette);
+
+							break;
+						}
+
+						case "WithGateSpriteBody":
+						{
+							(var sequences, var name, var spriteBodyPalette, var isPlayerPalette) = HandleWithSpriteBody(traitNode);
+							spriteBodyPalettes[name] = (spriteBodyPalette, isPlayerPalette);
+
+							foreach (var seq in sequences)
+								AddRenderSequences(seq.Sequence, spriteBodyPalette, seq.ShadowPalette, seq.IsPlayerPalette);
+
+							if (TryGetString(traitNode, out var openSequence, "OpenSequence"))
+								AddRenderSequences(openSequence, spriteBodyPalette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithHarvesterSpriteBody":
+						{
+							(var sequences, var name, var spriteBodyPalette, var isPlayerPalette) = HandleWithSpriteBody(traitNode);
+							spriteBodyPalettes[name] = (spriteBodyPalette, isPlayerPalette);
+
+							var images = ParseStringArray(traitNode, "ImageByFullness");
+							if (images.Length == 0)
+							{
+								foreach (var seq in sequences)
+									AddRenderSequences(seq.Sequence, spriteBodyPalette, seq.ShadowPalette, seq.IsPlayerPalette);
+							}
+							else
+								foreach (var image in images)
+									foreach (var seq in sequences)
+										AddRenderSequences(seq.Sequence, spriteBodyPalette, seq.ShadowPalette, seq.IsPlayerPalette, image);
+
+							break;
+						}
+
+						case "WithBridgeSpriteBody":
+						{
+							(var bSequences, var name, var spriteBodyPalette, var isPlayerPalette) = HandleWithSpriteBody(traitNode);
+							spriteBodyPalettes[name] = (spriteBodyPalette, isPlayerPalette);
+
+							foreach (var seq in bSequences)
+								AddRenderSequences(seq.Sequence, spriteBodyPalette, seq.ShadowPalette, seq.IsPlayerPalette);
+
+							var sequences = ParseStringArray(traitNode, "Sequences", ["idle"]);
+							foreach (var seq in sequences)
+								AddRenderSequences(seq, spriteBodyPalette, isPlayerPalette: isPlayerPalette);
+
+							var aDestroyedSequences = ParseStringArray(traitNode, "ADestroyedSequences", ["adestroyed"]);
+							foreach (var sequence in aDestroyedSequences)
+								AddRenderSequences(sequence, spriteBodyPalette, isPlayerPalette: isPlayerPalette);
+
+							var bDestroyedSequences = ParseStringArray(traitNode, "BDestroyedSequences", ["bdestroyed"]);
+							foreach (var sequence in bDestroyedSequences)
+								AddRenderSequences(sequence, spriteBodyPalette, isPlayerPalette: isPlayerPalette);
+
+							var abDestroyedSequences = ParseStringArray(traitNode, "ABDestroyedSequences", ["abdestroyed"]);
+							foreach (var sequence in abDestroyedSequences)
+								AddRenderSequences(sequence, spriteBodyPalette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "DrawLineToTarget":
+						{
+							TryGetString(traitNode, out drawLineToTargetPalette, "Palette", TerrainPaletteInternalName);
+							break;
+						}
+
+						case "ScaredyCat":
+						{
+							if (!TryGetString(traitNode, out var prefix, "PanicSequencePrefix", "panic-"))
+								continue;
+
+							spriteBodyPrefixes.Add(prefix);
+							break;
+						}
+
+						case "TakeCover":
+						{
+							if (!TryGetString(traitNode, out var prefix, "ProneSequencePrefix", "prone-"))
+								continue;
+
+							spriteBodyPrefixes.Add(prefix);
+							break;
+						}
+					}
+				}
+
+				foreach (var prefix in spriteBodyPrefixes)
+					foreach (var seq in handledInfantryBodies)
+						AddRenderSequences(prefix + seq.Sequence, seq.Palette, seq.ShadowPalette, seq.IsPlayerPalette);
+
+				// Second pass
+				foreach (var traitNode in actorNode.Value.Nodes)
+				{
+					if (traitNode.IsRemoval())
+						continue;
+
+					switch (traitNode.GetKey())
+					{
+						case "FootprintPlaceBuildingPreview":
+						case "ActorPreviewPlaceBuildingPreview":
+						{
+							HandleFootprintPlaceBuildingPreview(traitNode, modData);
+							break;
+						}
+
+						case "SequencePlaceBuildingPreview":
+						{
+							var palette = HandleFootprintPlaceBuildingPreview(traitNode, modData);
+							if (palette == null)
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "idle"))
+								AddRenderSequences(sequence, palette);
+							break;
+						}
+
+						case "D2kActorPreviewPlaceBuildingPreview":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "overlay"))
+								continue;
+
+							if (TryGetString(traitNode, out var tileValidName, "TileValidName", "build-valid"))
+								AddSequenceDefinitions(image, tileValidName, palette);
+
+							if (TryGetString(traitNode, out var tileInvalidName, "TileInvalidName", "build-invalid"))
+								AddSequenceDefinitions(image, tileInvalidName, palette);
+
+							if (TryGetString(traitNode, out var tileUnsafeName, "TileUnsafeName", "build-unsafe"))
+								AddSequenceDefinitions(image, tileUnsafeName, palette);
+							break;
+						}
+
+						case "OrderEffects":
+						{
+							if (!TryGetString(traitNode, out var palette, "TerrainFlashPalette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "TerrainFlashImage"))
+								continue;
+
+							if (!TryGetString(traitNode, out var sequence, "TerrainFlashSequence"))
+								continue;
+
+							AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "GpsDot":
+						{
+							if (!TryGetString(traitNode, out var palette, "IndicatorPalettePrefix", "player"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "gpsdot"))
+								continue;
+
+							if (!TryGetString(traitNode, out var sequence, "String", "Infantry"))
+								continue;
+
+							AddSequenceDefinitions(image, sequence, palette, isPlayerPalette: true);
+							break;
+						}
+
+						case "WithIdleOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							TryGetString(traitNode, out var image, "Image");
+
+							if (TryGetString(traitNode, out var startSeq, "StartSequence"))
+								AddRenderSequences(startSeq, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							if (TryGetString(traitNode, out var seq, "Sequence", "idle-overlay"))
+								AddRenderSequences(seq, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							break;
+						}
+
+						case "WithProductionDoorOverlay":
+						{
+							if (TryGetString(traitNode, out var sequence, "Sequence", "build-door"))
+								AddRenderSequences(sequence, null);
+							break;
+						}
+
+						case "WithParachute":
+						{
+							if (!TryGetString(traitNode, out var image, "Image"))
+								continue;
+
+							var hasShadowImage = TryGetString(traitNode, out var shadowImage, "ShadowImage");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", true);
+							TryGetString(traitNode, out var palette, "Palette", "player");
+
+							if (TryGetString(traitNode, out var openingSequence, "OpeningSequence"))
+							{
+								AddRenderSequences(openingSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+								if (hasShadowImage)
+									AddRenderSequences(openingSequence, null, palette, image: shadowImage);
+							}
+
+							if (TryGetString(traitNode, out var sequence, "Sequence"))
+							{
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+								if (hasShadowImage)
+									AddRenderSequences(sequence, null, palette, image: shadowImage);
+							}
+
+							if (TryGetString(traitNode, out var closingSequence, "ClosingSequence"))
+							{
+								AddRenderSequences(closingSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+								if (hasShadowImage)
+									AddRenderSequences(closingSequence, null, palette, image: shadowImage);
+							}
+
+							break;
+						}
+
+						case "WithSpriteBarrel":
+						{
+							if (TryGetString(traitNode, out var sequence, "Sequence", "barrel"))
+								AddRenderSequences(sequence, null);
+							break;
+						}
+
+						case "WithSpriteTurret":
+						{
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							TryGetString(traitNode, out var palette, "Palette");
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "turret"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithSwitchableOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							TryGetString(traitNode, out var image, "Image");
+
+							if (TryGetString(traitNode, out var switchingSequence, "SwitchingSequence"))
+								AddRenderSequences(switchingSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							if (TryGetString(traitNode, out var enabledSequence, "EnabledSequence"))
+								AddRenderSequences(enabledSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							if (TryGetString(traitNode, out var disabledSequence, "DisabledSequence"))
+								AddRenderSequences(disabledSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							break;
+						}
+
+						case "WithSupportPowerActivationOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithAttackOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "attack"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithBuildingPlacedOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "crane-overlay"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithChargeOverlay":
+						{
+							if (!TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								continue;
+
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+
+							break;
+						}
+
+						case "WithResourceLevelOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "resources"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithRepairOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+
+							if (TryGetString(traitNode, out var startSequence, "StartSequence"))
+								AddRenderSequences(startSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							if (TryGetString(traitNode, out var endSequence, "EndSequence"))
+								AddRenderSequences(endSequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithProductionOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "production-overlay"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithMakeOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithHarvestOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette", "effect");
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "harvest"))
+								AddRenderSequences(sequence, palette);
+							break;
+						}
+
+						case "WithDockingOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "unload-overlay"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithDockedOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "docking-overlay"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithDamageOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (!TryGetString(traitNode, out var image, "Image", "smoke_m"))
+								continue;
+
+							if (TryGetString(traitNode, out var idleSequence, "IdleSequence", "idle"))
+								AddRenderSequences(idleSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							if (TryGetString(traitNode, out var loopSequence, "LoopSequence", "loop"))
+								AddRenderSequences(loopSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+
+							if (TryGetString(traitNode, out var endSequence, "EndSequence", "end"))
+								AddRenderSequences(endSequence, palette, isPlayerPalette: isPlayerPalette, image: image);
+							break;
+						}
+
+						case "WithBuildingBib":
+						{
+							TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName);
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "bib"))
+								AddRenderSequences(sequence, palette);
+							break;
+						}
+
+						case "WithDeliveryOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithCrumbleOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "crumble-overlay"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithTeslaChargeOverlay":
+						{
+							TryGetString(traitNode, out var palette, "Palette");
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, palette, isPlayerPalette: isPlayerPalette);
+							break;
+						}
+
+						case "WithDeathAnimation":
+						{
+							if (TryGetString(traitNode, out var deathPalette, "DeathSequencePalette", "player"))
+							{
+								var isDeathPlayerPalette = ParseBool(traitNode, "DeathPaletteIsPlayerPalette", true);
+								var useDeathTypeSuffix = ParseBool(traitNode, "UseDeathTypeSuffix", true);
+
+								if (TryGetString(traitNode, out var deathSequence, "DeathSequence", "die"))
+								{
+									var deathTypes = ParseDictionary<string[]>(traitNode, "DeathTypes");
+									if (useDeathTypeSuffix && deathTypes.Count > 0)
+									{
+										foreach (var tulple in deathTypes)
+											foreach (var deathType in tulple.Value)
+												foreach (var actorImage in handledRenderSprites.Keys)
+													AddSequenceDefinitions(actorImage, deathSequence + deathType, deathPalette, isPlayerPalette: isDeathPlayerPalette);
+									}
+									else
+										foreach (var actorImage in handledRenderSprites.Keys)
+											AddSequenceDefinitions(actorImage, deathSequence, deathPalette, isPlayerPalette: isDeathPlayerPalette);
+
+									if (TryGetString(traitNode, out var fallbackSequence, "FallbackSequence"))
+										foreach (var actorImage in handledRenderSprites.Keys)
+											AddSequenceDefinitions(actorImage, fallbackSequence, deathPalette, isPlayerPalette: isDeathPlayerPalette);
+								}
+							}
+
+							if (TryGetString(traitNode, out var crushedPalette, "CrushedSequencePalette", "effect"))
+							{
+								var isCrushedPlayerPalette = ParseBool(traitNode, "CrushedPaletteIsPlayerPalette", false);
+								if (TryGetString(traitNode, out var crushedSequence, "CrushedSequence", "effect"))
+									foreach (var actorImage in handledRenderSprites.Keys)
+										AddSequenceDefinitions(actorImage, crushedSequence, crushedPalette, isPlayerPalette: isCrushedPlayerPalette);
+							}
+
+							break;
+						}
+
+						case "WithResourceAnimation":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image"))
+								continue;
+
+							var sequences = ParseStringArray(traitNode, "Sequences", ["idle"]);
+							foreach (var sequence in sequences)
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "GrantConditionOnSubterraneanLayer":
+						{
+							if (!TryGetString(traitNode, out var palette, "SubterraneanTransitionPalette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "SubterraneanTransitionImage"))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "SubterraneanTransitionSequence"))
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "Parachutable":
+						{
+							if (!TryGetString(traitNode, out var image, "Image", "explosion"))
+								continue;
+
+							if (TryGetString(traitNode, out var palette, "GroundCorpsePalette", "effect")
+								&& TryGetString(traitNode, out var groundCorpseSequence, "GroundCorpseSequence"))
+								AddSequenceDefinitions(image, groundCorpseSequence, palette);
+
+							if (TryGetString(traitNode, out var waterPalette, "WaterCorpsePalette", "effect")
+								&& TryGetString(traitNode, out var waterCorpseSequence, "WaterCorpseSequence"))
+								AddSequenceDefinitions(image, waterCorpseSequence, waterPalette);
+							break;
+						}
+
+						case "WithAircraftLandingEffect":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image"))
+								continue;
+
+							var sequences = ParseStringArray(traitNode, "Sequences", ["idle"]);
+							foreach (var sequence in sequences)
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "SpawnActorPower":
+						{
+							if (!TryGetString(traitNode, out var effectPalette, "EffectPalette"))
+								continue;
+
+							var isEffectPlayerPalette = ParseBool(traitNode, "EffectPaletteIsPlayerPalette", false);
+							if (!TryGetString(traitNode, out var effectImage, "EffectImage"))
+								continue;
+
+							if (TryGetString(traitNode, out var effectSequence, "EffectSequence"))
+								AddSequenceDefinitions(effectImage, effectSequence, effectPalette, isPlayerPalette: isEffectPlayerPalette);
+							break;
+						}
+
+						case "SmudgeLayer":
+						{
+							if (TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName))
+								if (TryGetString(traitNode, out var image, "Sequence", "scorch"))
+									queuedSequenceDefinitions[image] = palette;
+
+							if (TryGetString(traitNode, out var smokePalette, "SmokePalette", "effect"))
+							{
+								if (!TryGetString(traitNode, out var image, "SmokeImage"))
+									continue;
+
+								var sequences = ParseStringArray(traitNode, "SmokeSequences");
+								foreach (var sequence in sequences)
+									AddSequenceDefinitions(image, sequence, smokePalette);
+							}
+
+							break;
+						}
+
+						case "CrateAction":
+						case "DuplicateUnitCrateAction":
+						case "ExplodeCrateAction":
+						case "GiveCashCrateAction":
+						case "GiveUnitCrateAction":
+						case "GrantExternalConditionCrateAction":
+						case "HealActorsCrateAction":
+						case "HideMapCrateAction":
+						case "LevelUpCrateAction":
+						case "RevealMapCrateAction":
+						case "SupportPowerCrateAction":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "crate-effects"))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence"))
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "GainsExperience":
+						{
+							if (!TryGetString(traitNode, out var palette, "LevelUpPalette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "LevelUpImage"))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "LevelUpSequence", "levelup"))
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "LeavesTrails":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image"))
+								continue;
+
+							var sequences = ParseStringArray(traitNode, "Sequences", ["idle"]);
+							foreach (var sequence in sequences)
+								AddSequenceDefinitions(image, sequence, palette);
+							break;
+						}
+
+						case "Cloak":
+						{
+							if (TryGetString(traitNode, out var effectPalette, "EffectPalette", "effect"))
+							{
+								if (!TryGetString(traitNode, out var effectImage, "EffectImage"))
+									continue;
+
+								var isEffectPlayerPalette = ParseBool(traitNode, "EffectPaletteIsPlayerPalette", false);
+								if (TryGetString(traitNode, out var cloakEffect, "CloakEffectSequence"))
+									AddSequenceDefinitions(effectImage, cloakEffect, effectPalette, isPlayerPalette: isEffectPlayerPalette);
+
+								if (TryGetString(traitNode, out var uncloakEffect, "UncloakEffectSequence"))
+									AddSequenceDefinitions(effectImage, uncloakEffect, effectPalette, isPlayerPalette: isEffectPlayerPalette);
+							}
+
+							break;
+						}
+
+						case "GpsPower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var doorPalette, "DoorPalette", "player"))
+							{
+								var isDoorPlayerPalette = ParseBool(traitNode, "DoorPaletteIsPlayerPalette", true);
+								if (TryGetString(traitNode, out var doorImage, "DoorImage", "atek")
+									&& TryGetString(traitNode, out var doorSequence, "DoorSequence", "active"))
+									AddSequenceDefinitions(doorImage, doorSequence, doorPalette, isPlayerPalette: isDoorPlayerPalette);
+							}
+
+							if (TryGetString(traitNode, out var satellitePalette, "SatellitePalette", "player"))
+							{
+								var isSatellitePlayerPalette = ParseBool(traitNode, "SatellitePaletteIsPlayerPalette", true);
+								if (TryGetString(traitNode, out var satelliteImage, "SatelliteImage", "sputnik")
+									&& TryGetString(traitNode, out var satelliteSequence, "SatelliteSequence", "idle"))
+									AddSequenceDefinitions(satelliteImage, satelliteSequence, satellitePalette, isPlayerPalette: isSatellitePlayerPalette);
+							}
+
+							break;
+						}
+
+						case "Buildable":
+						{
+							if (TryGetString(traitNode, out var iconPalette, "IconPalette", "chrome"))
+							{
+								var isIconPlayerPalette = ParseBool(traitNode, "IconPaletteIsPlayerPalette", false);
+								if (TryGetString(traitNode, out var icon, "Icon", "icon"))
+									foreach (var actorImage in handledRenderSprites.Keys)
+										AddSequenceDefinitions(actorImage, icon, iconPalette, isPlayerPalette: isIconPlayerPalette);
+							}
+
+							break;
+						}
+
+						case "RallyPoint":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "player"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "rallypoint"))
+								continue;
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", true);
+							if (TryGetString(traitNode, out var flagSequence, "FlagSequence", "flag"))
+								AddSequenceDefinitions(image, flagSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							if (TryGetString(traitNode, out var circlesSequence, "CirclesSequence", "circles"))
+								AddSequenceDefinitions(image, circlesSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							break;
+						}
+
+						case "PlaceBeacon":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "player"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "BeaconImage", "beacon"))
+								continue;
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", true);
+							if (TryGetString(traitNode, out var beaconSequence, "BeaconSequence"))
+								AddSequenceDefinitions(image, beaconSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							if (TryGetString(traitNode, out var arrowSequence, "ArrowSequence", "arrow"))
+								AddSequenceDefinitions(image, arrowSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							if (TryGetString(traitNode, out var circleSequence, "CircleSequence", "circles"))
+								AddSequenceDefinitions(image, circleSequence, palette, isPlayerPalette: isPlayerPalette);
+
+							break;
+						}
+
+						case "SupportPower":
+						case "AttackOrderPower":
+						case "GrantPrerequisiteChargeDrainPower":
+						case "ProduceActorPower":
+						{
+							HandleSupportPower(traitNode);
+							break;
+						}
+
+						case "ParatroopersPower":
+						case "AirstrikePower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var palette, "DirectionArrowPalette", "chrome")
+								&& TryGetString(traitNode, out var image, "DirectionArrowAnimation"))
+							{
+								var arrowSequences = ParseStringArray(traitNode,
+									"Arrows", ["arrow-t", "arrow-tl", "arrow-l", "arrow-bl", "arrow-b", "arrow-br", "arrow-r", "arrow-tr"]);
+
+								foreach (var sequence in arrowSequences)
+									AddSequenceDefinitions(image, sequence, palette);
+							}
+
+							break;
+						}
+
+						case "ChronoshiftPower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (!TryGetString(traitNode, out var image, "FootprintImage", "overlay"))
+								continue;
+
+							var hasSource = TryGetString(traitNode, out var sourceSeq, "SourceFootprintSequence", "target-select");
+
+							if (hasSource && TryGetString(traitNode, out var palette, "TargetOverlayPalette", TerrainPaletteInternalName))
+							{
+								AddSequenceDefinitions(image, sourceSeq, palette);
+							}
+
+							if (TryGetString(traitNode, out var iconPalette, "IconPalette", "chrome"))
+							{
+								if (TryGetString(traitNode, out var validSeq, "ValidFootprintSequence", "target-valid"))
+								{
+									AddSequenceDefinitions(image, validSeq, iconPalette);
+
+									foreach (var tileset in modData.DefaultTerrainInfo.Values)
+										AddSequenceDefinitions(image, validSeq + '-' + tileset.Id.ToLowerInvariant(), iconPalette);
+								}
+
+								if (hasSource)
+									AddSequenceDefinitions(image, sourceSeq, iconPalette);
+
+								if (TryGetString(traitNode, out var invalidSeq, "InvalidFootprintSequence", "target-invalid"))
+									AddSequenceDefinitions(image, invalidSeq, iconPalette);
+							}
+
+							break;
+						}
+
+						case "DropPodsPower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var entryEffectPalette, "EntryEffectPalette", "effect")
+								&& TryGetString(traitNode, out var entryEffect, "EntryEffect", "podring")
+								&& TryGetString(traitNode, out var entryEffectSequence, "EntryEffectSequence", "idle"))
+							{
+								AddSequenceDefinitions(entryEffect, entryEffectSequence, entryEffectPalette);
+							}
+
+							break;
+						}
+
+						case "IonCannonPower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var effectPalette, "EffectPalette", "effect")
+								&& TryGetString(traitNode, out var effect, "Effect", "ionsfx")
+								&& TryGetString(traitNode, out var effectSequence, "EffectSequence", "idle"))
+							{
+								AddSequenceDefinitions(effect, effectSequence, effectPalette);
+							}
+
+							break;
+						}
+
+						case "GrantExternalConditionPower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var footprintSequence, "FootprintSequence", "target-select")
+								&& TryGetString(traitNode, out var footprintImage, "FootprintImage", "overlay"))
+							{
+								AddSequenceDefinitions(footprintImage, footprintSequence, TerrainPaletteInternalName);
+							}
+
+							if (spriteBodyPalettes.Count > 0 && TryGetString(traitNode, out var sequence, "Sequence", "active"))
+							{
+								var (palette, isPlayerPalette) = spriteBodyPalettes.First().Value;
+								AddRenderSequences(sequence, palette, null, isPlayerPalette);
+							}
+
+							break;
+						}
+
+						case "NukePower":
+						{
+							HandleSupportPower(traitNode);
+
+							if (TryGetString(traitNode, out var missilePalette, "MissilePalette", "effect"))
+							{
+								var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+								if (TryGetString(traitNode, out var missileImage, "MissileImage"))
+								{
+									if (TryGetString(traitNode, out var missileUp, "MissileUp", "up"))
+										AddSequenceDefinitions(missileImage, missileUp, missilePalette, isPlayerPalette: isPlayerPalette);
+
+									if (TryGetString(traitNode, out var missileDown, "MissileDown", "down"))
+										AddSequenceDefinitions(missileImage, missileDown, missilePalette, isPlayerPalette: isPlayerPalette);
+								}
+							}
+
+							if (TryGetString(traitNode, out var trailPalette, "TrailPalette", "effect"))
+							{
+								var isTrailPlayerPalette = ParseBool(traitNode, "TrailUsePlayerPalette", false);
+								if (TryGetString(traitNode, out var trailImage, "TrailImage"))
+								{
+									var trailSequences = ParseStringArray(traitNode, "TrailSequences", ["particles"]);
+									foreach (var sequence in trailSequences)
+										AddSequenceDefinitions(trailImage, sequence, trailPalette, isPlayerPalette: isTrailPlayerPalette);
+								}
+							}
+
+							break;
+						}
+
+						case "WithMuzzleOverlay":
+						{
+							var armaments = globalArmaments[actorNode.Key];
+							foreach (var armament in armaments)
+							{
+								if (TryGetString(armament, out var palette, "MuzzlePalette", "effect")
+									 && TryGetString(armament, out var sequence, "MuzzleSequence"))
+								{
+									foreach (var actorImage in handledRenderSprites.Keys)
+										AddSequenceDefinitions(actorImage, sequence, palette);
+								}
+							}
+
+							break;
+						}
+
+						case "AttackGarrisoned":
+						{
+							if (!TryGetString(traitNode, out var palette, "MuzzlePalette", "effect"))
+								continue;
+
+							foreach (var tuple in globalArmaments)
+								foreach (var armament in tuple.Value)
+									if (TryGetString(armament, out var sequence, "MuzzleSequence"))
+										AddSequenceDefinitions(tuple.Key, sequence, palette);
+
+							break;
+						}
+
+						case "FloatingSpriteEmitter":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "effect"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "smoke"))
+								continue;
+
+							var sequences = ParseStringArray(traitNode, "Sequence", ["particles"]);
+							foreach (var sequence in sequences)
+								AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "TSVeinsRenderer":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "resources"))
+								continue;
+
+							if (!TryGetString(traitNode, out var sequence, "Sequence", "veins"))
+								continue;
+
+							AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "Minelayer":
+						{
+							if (TryGetString(traitNode, out var validSeq, "TileValidName", "build-valid"))
+							{
+								AddSequenceDefinitions("overlay", validSeq, TerrainPaletteInternalName);
+								if (drawLineToTargetPalette != null)
+									AddSequenceDefinitions("overlay", validSeq, drawLineToTargetPalette);
+
+								foreach (var tileset in modData.DefaultTerrainInfo.Values)
+								{
+									AddSequenceDefinitions("overlay", validSeq + '-' + tileset.Id.ToLowerInvariant(), TerrainPaletteInternalName);
+									if (drawLineToTargetPalette != null)
+										AddSequenceDefinitions("overlay", validSeq + '-' + tileset.Id.ToLowerInvariant(), drawLineToTargetPalette);
+								}
+							}
+
+							if (TryGetString(traitNode, out var invalidSeq, "TileInvalidName", "build-invalid"))
+							{
+								AddSequenceDefinitions("overlay", invalidSeq, TerrainPaletteInternalName);
+
+								foreach (var tileset in modData.DefaultTerrainInfo.Values)
+									AddSequenceDefinitions("overlay", invalidSeq + '-' + tileset.Id.ToLowerInvariant(), TerrainPaletteInternalName);
+							}
+
+							if (TryGetString(traitNode, out var unknownSeq, "TileUnknownName", "build-unknown"))
+							{
+								AddSequenceDefinitions("overlay", unknownSeq, TerrainPaletteInternalName);
+
+								foreach (var tileset in modData.DefaultTerrainInfo.Values)
+									AddSequenceDefinitions("overlay", unknownSeq + '-' + tileset.Id.ToLowerInvariant(), TerrainPaletteInternalName);
+							}
+
+							break;
+						}
+
+						case "ResourceRenderer":
+						case "D2kResourceRenderer":
+						{
+							var resources = traitNode.LastChildMatching("ResourceTypes");
+							if (resources == null)
+								continue;
+
+							foreach (var res in resources.Value.Nodes)
+							{
+								if (!TryGetString(res, out var palette, "Palette", TerrainPaletteInternalName))
+									continue;
+
+								if (!TryGetString(res, out var image, "Image", "resources"))
+									continue;
+
+								var sequences = ParseStringArray(res, "Sequences");
+								foreach (var sequence in sequences)
+									AddSequenceDefinitions(image, sequence, palette);
+							}
+
+							break;
+						}
+
+						case "TSTiberiumRenderer":
+						{
+							var resources = traitNode.LastChildMatching("ResourceTypes");
+							if (resources == null)
+								continue;
+
+							var ramp1Dict = ParseDictionary<string[]>(traitNode, "Ramp1Sequences");
+							var ramp2Dict = ParseDictionary<string[]>(traitNode, "Ramp2Sequences");
+							var ramp3Dict = ParseDictionary<string[]>(traitNode, "Ramp3Sequences");
+							var ramp4Dict = ParseDictionary<string[]>(traitNode, "Ramp4Sequences");
+							foreach (var res in resources.Value.Nodes)
+							{
+								if (!TryGetString(res, out var palette, "Palette", TerrainPaletteInternalName))
+									continue;
+
+								if (!TryGetString(res, out var image, "Image", "resources"))
+									continue;
+
+								var sequences = ParseStringArray(res, "Sequences");
+								foreach (var sequence in sequences)
+									AddSequenceDefinitions(image, sequence, palette);
+
+								foreach (var ramp in ramp1Dict)
+									foreach (var sequence in ramp.Value)
+										AddSequenceDefinitions(image, sequence, palette);
+
+								foreach (var ramp in ramp2Dict)
+									foreach (var sequence in ramp.Value)
+										AddSequenceDefinitions(image, sequence, palette);
+
+								foreach (var ramp in ramp3Dict)
+									foreach (var sequence in ramp.Value)
+										AddSequenceDefinitions(image, sequence, palette);
+
+								foreach (var ramp in ramp4Dict)
+									foreach (var sequence in ramp.Value)
+										AddSequenceDefinitions(image, sequence, palette);
+							}
+
+							break;
+						}
+
+						case "BuildableTerrainOverlay":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "overlay"))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "build-invalid"))
+								AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "WithDecoration":
+						case "WithBuildingRepairDecoration":
+						case "InfiltrateForDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+
+							if (TryGetString(traitNode, out var image, "Image")
+								&& TryGetString(traitNode, out var sequence, "Sequence"))
+								AddSequenceDefinitions(image, sequence, palette, isPlayerPalette: isPlayerPalette);
+
+							break;
+						}
+
+						case "ShroudRenderer":
+						{
+							if (!TryGetString(traitNode, out var image, "Sequence", "shroud"))
+								continue;
+
+							if (TryGetString(traitNode, out var palette, "ShroudPalette", "shroud"))
+							{
+								var shroudVariants = ParseStringArray(traitNode, "ShroudVariants", ["shroud"]);
+								foreach (var variant in shroudVariants)
+									AddSequenceDefinitions(image, variant, palette);
+
+								if (TryGetString(traitNode, out var fullShroud, "OverrideFullShroud"))
+									AddSequenceDefinitions(image, fullShroud, palette);
+							}
+
+							if (TryGetString(traitNode, out var fogPalette, "FogPalette", "fog"))
+							{
+								var fogVariants = ParseStringArray(traitNode, "FogVariants", ["fog"]);
+								foreach (var variant in fogVariants)
+									AddSequenceDefinitions(image, variant, fogPalette);
+
+								if (TryGetString(traitNode, out var fullFog, "OverrideFullFog"))
+									AddSequenceDefinitions(image, fullFog, fogPalette);
+							}
+
+							break;
+						}
+
+						case "ProductionIconOverlayManager":
+						{
+							if (TryGetString(traitNode, out var palette, "Palette", "chrome")
+								&& TryGetString(traitNode, out var image, "Image")
+								&& TryGetString(traitNode, out var sequence, "Sequence"))
+							{
+								AddSequenceDefinitions(image, sequence, palette);
+							}
+
+							break;
+						}
+
+						case "WithAmmoPipsDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "pips"))
+								continue;
+
+							if (TryGetString(traitNode, out var emptySequence, "EmptySequence", "pip-empty"))
+								AddSequenceDefinitions(image, emptySequence, palette);
+
+							if (TryGetString(traitNode, out var fullSequence, "FullSequence", "pip-green"))
+								AddSequenceDefinitions(image, fullSequence, palette);
+
+							break;
+						}
+
+						case "WithCargoPipsDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "pips"))
+								continue;
+
+							if (TryGetString(traitNode, out var emptySequence, "EmptySequence", "pip-empty"))
+								AddSequenceDefinitions(image, emptySequence, palette);
+
+							if (TryGetString(traitNode, out var fullSequence, "FullSequence", "pip-green"))
+								AddSequenceDefinitions(image, fullSequence, palette);
+
+							var customPips = ParseDictionary<string>(traitNode, "CustomPipSequences");
+							foreach (var sequence in customPips.Values)
+								AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "WithResourceStoragePipsDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "pips"))
+								continue;
+
+							if (TryGetString(traitNode, out var emptySequence, "EmptySequence", "pip-empty"))
+								AddSequenceDefinitions(image, emptySequence, palette);
+
+							if (TryGetString(traitNode, out var fullSequence, "FullSequence", "pip-green"))
+								AddSequenceDefinitions(image, fullSequence, palette);
+
+							break;
+						}
+
+						case "WithSpriteControlGroupDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "pips"))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "GroupSequence", "groups"))
+								AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "WithStoresResourcesPipsDecoration":
+						{
+							if (!TryGetString(traitNode, out var palette, "Palette", "chrome"))
+								continue;
+
+							if (!TryGetString(traitNode, out var image, "Image", "pips"))
+								continue;
+
+							if (TryGetString(traitNode, out var emptySequence, "EmptySequence", "pip-empty"))
+								AddSequenceDefinitions(image, emptySequence, palette);
+
+							if (TryGetString(traitNode, out var fullSequence, "FullSequence", "pip-green"))
+								AddSequenceDefinitions(image, fullSequence, palette);
+
+							var sequences = ParseDictionary<string>(traitNode, "ResourceSequences");
+							foreach (var sequence in sequences.Values)
+								AddSequenceDefinitions(image, sequence, palette);
+
+							break;
+						}
+
+						case "WithCrateBody":
+						{
+							foreach (var image in (string[])[null, .. ParseStringArray(traitNode, "XmasImages")])
+							{
+								if (TryGetString(traitNode, out var sequence, "IdleSequence", "idle"))
+									AddRenderSequences(sequence, null, image: image);
+
+								if (TryGetString(traitNode, out var waterSequence, "WaterSequence"))
+									AddRenderSequences(waterSequence, null, image: image);
+
+								if (TryGetString(traitNode, out var landSequence, "LandSequence"))
+									AddRenderSequences(landSequence, null, image: image);
+							}
+
+							break;
+						}
+
+						case "WithGunboatBody":
+						{
+							if (TryGetString(traitNode, out var leftSequence, "LeftSequence", "left"))
+								AddRenderSequences(leftSequence, null);
+
+							if (TryGetString(traitNode, out var rightSequence, "RightSequence", "right"))
+								AddRenderSequences(rightSequence, null);
+
+							if (TryGetString(traitNode, out var wakeLeftSequence, "WakeLeftSequence", "wake-left"))
+								AddRenderSequences(wakeLeftSequence, null);
+
+							if (TryGetString(traitNode, out var wakeRightSequence, "WakeRightSequence", "wake-right"))
+								AddRenderSequences(wakeRightSequence, null);
+
+							break;
+						}
+
+						case "ThrowsParticle":
+						{
+							if (TryGetString(traitNode, out var sequence, "Anim"))
+								AddRenderSequences(sequence, null);
+
+							break;
+						}
+
+						case "SpiceBloom":
+						{
+							var growthSequences = ParseStringArray(traitNode, "GrowthSequences", ["grow1", "grow2", "grow3"]);
+							foreach (var sequence in growthSequences)
+								AddRenderSequences(sequence, null);
+
+							if (TryGetString(traitNode, out var sequence2, "SpurtSequence", "spurt"))
+								AddRenderSequences(sequence2, null);
+
+							break;
+						}
+
+						case "WithDockingAnimation":
+						{
+							if (spriteBodyPalettes.Count == 0)
+								break;
+
+							var (palette, isPlayerPalette) = spriteBodyPalettes.First().Value;
+							if (TryGetString(traitNode, out var sequence, "DockSequence", "dock"))
+								AddRenderSequences(sequence, palette, null, isPlayerPalette);
+
+							if (TryGetString(traitNode, out var loopSequence, "DockLoopSequence", "dock-loop"))
+								AddRenderSequences(loopSequence, palette, null, isPlayerPalette);
+
+							break;
+						}
+
+						case "WithHarvestAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "HarvestSequence", "harvest"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "AttackPopupTurreted":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var openingSequence, "OpeningSequence", "opening"))
+								AddRenderSequences(openingSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							if (TryGetString(traitNode, out var closingSequence, "ClosingSequence", "closing"))
+								AddRenderSequences(closingSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							if (TryGetString(traitNode, out var closedIdleSequence, "ClosedIdleSequence", "closed-idle"))
+								AddRenderSequences(closedIdleSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							break;
+						}
+
+						case "Chronoshiftable":
+						case "PortableChrono":
+						case "ConyardChronoReturn":
+						{
+							if (spriteBodyPalettes.Count == 0)
+								break;
+
+							var (palette, isPlayerPalette) = spriteBodyPalettes.First().Value;
+							AddRenderSequences("active", palette, null, isPlayerPalette);
+							break;
+						}
+
+						case "WithLandingCraftAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var openSequence, "OpenSequence", "open"))
+								AddRenderSequences(openSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							if (TryGetString(traitNode, out var closeSequence, "CloseSequence", "close"))
+								AddRenderSequences(closeSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							if (TryGetString(traitNode, out var unloadSequence, "UnloadSequence", "unload"))
+								AddRenderSequences(unloadSequence, vals.Palette, null, vals.IsPlayerPalette);
+
+							break;
+						}
+
+						case "WithTeslaChargeAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "ChargeSequence", "active"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithAcceptDeliveredCashAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithDeliveryAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "ActiveSequence", "active"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithBuildingPlacedAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "build"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithAttackAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithAimAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithMakeAnimation":
+						{
+							if (!TryGetString(traitNode, out var sequence, "Sequence", "make"))
+								continue;
+
+							var bodies = ParseStringArray(traitNode, "Bodies", ["body"]);
+							foreach (var body in bodies)
+							{
+								if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+									continue;
+
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							}
+
+							break;
+						}
+
+						case "WithResupplyAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							if (TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithIdleAnimation":
+						{
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							var sequences = ParseStringArray(traitNode, "Sequences", ["active"]);
+							foreach (var sequence in sequences)
+								AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+
+						case "WithSupportPowerActivationAnimation":
+						{
+							if (!TryGetString(traitNode, out var sequence, "Sequence", "active"))
+								continue;
+
+							if (!TryGetString(traitNode, out var body, "Body", "body"))
+								continue;
+
+							if (!spriteBodyPalettes.TryGetValue(body, out var vals))
+								continue;
+
+							AddRenderSequences(sequence, vals.Palette, null, vals.IsPlayerPalette);
+							break;
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+
+		string HandleFootprintPlaceBuildingPreview(MiniYamlNodeBuilder traitNode, ModData modData)
+		{
+			if (!TryGetString(traitNode, out var palette, "Palette", TerrainPaletteInternalName))
+				return null;
+
+			AddSequenceDefinitions("overlay", "build-valid", palette);
+			AddSequenceDefinitions("overlay", "build-invalid", palette);
+
+			foreach (var tileset in modData.DefaultTerrainInfo.Values)
+				AddSequenceDefinitions("overlay", $"build-invalid-{tileset.Id.ToLowerInvariant()}", palette);
+
+			return palette;
+		}
+
+		static (HashSet<SequenceDefinitions> Sequences, string Name, string Palette, bool IsPlayerPalette) HandleWithSpriteBody(MiniYamlNodeBuilder traitNode)
+		{
+			TryGetString(traitNode, out var palette, "Palette");
+#pragma warning disable CA1507 // Use nameof instead of string literal
+			TryGetString(traitNode, out var name, "Name", "body");
+#pragma warning restore CA1507 // Use nameof instead of string literal
+
+			var sequences = new HashSet<SequenceDefinitions>();
+			var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+			if (TryGetString(traitNode, out var startSequence, "StartSequence"))
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = startSequence,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+
+			if (TryGetString(traitNode, out var idleSequence, "Sequence", "idle"))
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = idleSequence,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+
+			return (sequences, name, palette, isPlayerPalette);
+		}
+
+		static (HashSet<SequenceDefinitions> Sequences, string Palette, bool IsPlayerPalette) HandleWithInfantryBody(MiniYamlNodeBuilder traitNode)
+		{
+			// We need the rest of information even if palette is not set.
+			TryGetString(traitNode, out var palette, "Palette");
+
+			var isPlayerPalette = ParseBool(traitNode, "IsPlayerPalette", false);
+			var sequences = new HashSet<SequenceDefinitions>();
+
+			if (TryGetString(traitNode, out var moveSeq, "MoveSequence", "run"))
+			{
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = moveSeq,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+			}
+
+			var idleSeqs = ParseStringArray(traitNode, "IdleSequences");
+			foreach (var seq in idleSeqs)
+			{
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = seq,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+			}
+
+			var standSeqs = ParseStringArray(traitNode, "StandSequences", ["stand"]);
+			foreach (var seq in standSeqs)
+			{
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = seq,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+			}
+
+			var attackSeqs = ParseDictionary<string[]>(traitNode, "AttackSequences");
+			foreach (var seq in attackSeqs.Values)
+			{
+				foreach (var s in seq)
+				{
+					sequences.Add(new SequenceDefinitions
+					{
+						Sequence = s,
+						Palette = palette,
+						IsPlayerPalette = isPlayerPalette
+					});
+				}
+			}
+
+			if (TryGetString(traitNode, out var defaultAttackSeq, "DefaultAttackSequence"))
+			{
+				sequences.Add(new SequenceDefinitions
+				{
+					Sequence = defaultAttackSeq,
+					Palette = palette,
+					IsPlayerPalette = isPlayerPalette
+				});
+			}
+
+			return (sequences, palette, isPlayerPalette);
+		}
+
+		void HandleSupportPower(MiniYamlNodeBuilder traitNode)
+		{
+			if (TryGetString(traitNode, out var iconPalette, "IconPalette", "chrome")
+				&& TryGetString(traitNode, out var iconImage, "IconImage", "icon")
+				&& TryGetString(traitNode, out var icon, "Icon"))
+			{
+				AddSequenceDefinitions(iconImage, icon, iconPalette);
+			}
+
+			if (!TryGetString(traitNode, out var beaconImage, "BeaconImage", "beacon"))
+				return;
+
+			if (TryGetString(traitNode, out var beaconPalette, "BeaconPalette", "player"))
+			{
+				var isPlayerPalette = ParseBool(traitNode, "BeaconPaletteIsPlayerPalette", true);
+				if (TryGetString(traitNode, out var beaconSequence, "BeaconSequence"))
+					AddSequenceDefinitions(beaconImage, beaconSequence, beaconPalette, isPlayerPalette: isPlayerPalette);
+
+				if (TryGetString(traitNode, out var circleClockSequence, "CircleSequence"))
+					AddSequenceDefinitions(beaconImage, circleClockSequence, beaconPalette, isPlayerPalette: isPlayerPalette);
+
+				if (TryGetString(traitNode, out var arrowSequence, "ArrowSequence", "arrow"))
+					AddSequenceDefinitions(beaconImage, arrowSequence, beaconPalette, isPlayerPalette: isPlayerPalette);
+			}
+
+			if (TryGetString(traitNode, out var beaconPosterPalette, "BeaconPosterPalette", "chrome"))
+			{
+				if (TryGetString(traitNode, out var clockSequence, "ClockSequence"))
+					AddSequenceDefinitions(beaconImage, clockSequence, beaconPosterPalette);
+
+				if (TryGetString(traitNode, out var beaconPosterSequence, "BeaconPoster"))
+					AddSequenceDefinitions(beaconImage, beaconPosterSequence, beaconPosterPalette);
+			}
+		}
+
+		IEnumerable<string> IBeforeUpdateWeapons.BeforeUpdateWeapons(ModData modData, List<MiniYamlNodeBuilder> resolvedWeapons)
+		{
+			foreach (var weapon in resolvedWeapons)
+			{
+				var projectileNode = weapon.LastChildMatching("Projectile");
+				if (projectileNode?.Value?.Value != null)
+				{
+					switch (projectileNode.Value.Value)
+					{
+						case "TeslaZap":
+						{
+							if (!TryGetString(projectileNode, out var palette, "Palette", "effect"))
+								continue;
+
+							if (!TryGetString(projectileNode, out var image, "Image", "litning"))
+								continue;
+
+							if (TryGetString(projectileNode, out var brightSequence, "BrightSequence", "bright"))
+								AddSequenceDefinitions(image, brightSequence, palette);
+
+							if (TryGetString(projectileNode, out var dimSequence, "DimSequence", "dim"))
+								AddSequenceDefinitions(image, dimSequence, palette);
+							break;
+						}
+
+						case "Bullet":
+						case "Missile":
+						case "GravityBomb":
+						{
+							if (TryGetString(projectileNode, out var image, "Image"))
+							{
+								if (TryGetString(projectileNode, out var palette, "Palette", "effect"))
+								{
+									var isPlayerPalette = ParseBool(projectileNode, "IsPlayerPalette", false);
+									var sequences = ParseStringArray(projectileNode, "Sequences", ["idle"]);
+									foreach (var sequence in sequences)
+										AddSequenceDefinitions(image, sequence, palette, isPlayerPalette: isPlayerPalette);
+
+									if (TryGetString(projectileNode, out var openSequence, "OpenSequence"))
+										AddSequenceDefinitions(image, openSequence, palette, isPlayerPalette: isPlayerPalette);
+								}
+							}
+
+							if (TryGetString(projectileNode, out var trailPalette, "TrailPalette", "effect"))
+							{
+								if (TryGetString(projectileNode, out var trailImage, "TrailImage"))
+								{
+									var isTrailPlayerPalette = ParseBool(projectileNode, "TrailUsePlayerPalette", false);
+									var trailSequences = ParseStringArray(projectileNode, "TrailSequences", ["idle"]);
+
+									foreach (var sequence in trailSequences)
+										AddSequenceDefinitions(trailImage, sequence, trailPalette, isPlayerPalette: isTrailPlayerPalette);
+								}
+							}
+
+							break;
+						}
+
+						case "LaserZap":
+						{
+							if (TryGetString(projectileNode, out var hitAnim, "HitAnim")
+								&& TryGetString(projectileNode, out var hitAnimPalette, "HitAnimPalette", "effect")
+								&& TryGetString(projectileNode, out var hitAnimSequence, "HitAnimSequence", "idle"))
+							{
+								AddSequenceDefinitions(hitAnim, hitAnimSequence, hitAnimPalette);
+							}
+
+							if (TryGetString(projectileNode, out var launchEffectImage, "LaunchEffectImage")
+								&& TryGetString(projectileNode, out var launchEffectPalette, "LaunchEffectPalette", "effect")
+								&& TryGetString(projectileNode, out var launchEffectSequence, "LaunchEffectSequence"))
+							{
+								AddSequenceDefinitions(launchEffectImage, launchEffectSequence, launchEffectPalette);
+							}
+
+							break;
+						}
+
+						case "Railgun":
+						{
+							if (!TryGetString(projectileNode, out var palette, "HitAnimPalette", "effect"))
+								continue;
+
+							if (TryGetString(projectileNode, out var hitAnim, "HitAnim")
+								&& TryGetString(projectileNode, out var hitAnimSequence, "HitAnimSequence", "idle"))
+							{
+								AddSequenceDefinitions(hitAnim, hitAnimSequence, palette);
+							}
+
+							break;
+						}
+					}
+				}
+
+				foreach (var warheadNode in weapon.ChildrenMatching("Warhead"))
+				{
+					if (warheadNode?.Value?.Value == null)
+						continue;
+
+					switch (warheadNode.Value.Value)
+					{
+						case "CreateEffect":
+						{
+							if (!TryGetString(warheadNode, out var palette, "ExplosionPalette", "effect"))
+								continue;
+
+							if (!TryGetString(warheadNode, out var image, "Image", "explosion"))
+								continue;
+
+							var explosions = ParseStringArray(warheadNode, "Explosions", []);
+							var usePlayerPalette = ParseBool(warheadNode, "UsePlayerPalette", false);
+
+							foreach (var explosion in explosions)
+								AddSequenceDefinitions(image, explosion, palette, isPlayerPalette: usePlayerPalette);
+
+							break;
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+
+		IEnumerable<string> IBeforeUpdateSequences.BeforeUpdateSequences(ModData modData, List<MiniYamlNodeBuilder> resolvedSequences)
+		{
+			foreach (var sequence in resolvedSequences)
+			{
+				if (queuedSequenceDefinitions.TryGetValue(sequence.Key, out var palette))
+				{
+					foreach (var seq in sequence.Value.Nodes)
+					{
+						AddSequenceDefinitions(sequence.Key, seq.Key, palette);
+					}
+				}
+			}
+
+			this.resolvedSequences = resolvedSequences;
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNodeBuilder weaponNode)
+		{
+			if (weaponNode?.Value?.Nodes == null)
+				yield break;
+
+			var projectileNode = weaponNode.LastChildMatching("Projectile");
+			if (projectileNode?.Value?.Value != null && projectileRemovals.TryGetValue(projectileNode.Value.Value, out var fieldsToRemove))
+			{
+				foreach (var field in fieldsToRemove)
+					projectileNode?.RemoveNodes(field);
+			}
+
+			foreach (var warheadNode in weaponNode.ChildrenMatching("Warhead"))
+			{
+				if (warheadNode?.Value?.Value != null && warheadRemovals.TryGetValue(warheadNode.Value.Value, out fieldsToRemove))
+				{
+					foreach (var field in fieldsToRemove)
+						warheadNode?.RemoveNodes(field);
+				}
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			if (actorNode?.Value?.Nodes == null)
+				yield break;
+
+			foreach (var traitNode in actorNode.Value.Nodes)
+			{
+				var key = traitNode.GetKey();
+				switch (key)
+				{
+					case "ResourceRenderer":
+					case "D2kResourceRenderer":
+					case "TSTiberiumRenderer":
+						var resources = traitNode.LastChildMatching("ResourceTypes");
+						if (resources != null)
+							foreach (var res in resources.Value.Nodes)
+								res.RemoveNodes("Palette");
+
+						continue;
+				}
+
+				if (traitNode.Key == null || !traitRemovals.TryGetValue(key, out var fieldsToRemove))
+					continue;
+
+				foreach (var field in fieldsToRemove)
+					traitNode.RemoveNodes(field);
+			}
+		}
+
+		public override IEnumerable<string> UpdateSequenceNode(ModData modData, MiniYamlNodeBuilder sequenceNode)
+		{
+			if (sequenceNode?.Key == null)
+				yield break;
+
+			var fullSequence = resolvedSequences.First(s => s.Key == sequenceNode.Key);
+
+			if (!sequenceDefinitions.TryGetValue(fullSequence.Key.ToLowerInvariant(), out var definitions))
+				yield break;
+
+			var addedPalette = false;
+			var addedShadowPalette = false;
+
+			foreach (var def in definitions)
+			{
+				// If the sequence does not exist, skip it.
+				if (!fullSequence.ChildrenMatching(def.Sequence).Any())
+					continue;
+
+				var seqNode = sequenceNode.LastChildMatching(def.Sequence);
+				var wasEmpty = seqNode == null;
+				seqNode ??= new MiniYamlNodeBuilder(def.Sequence, string.Empty);
+
+				if (def.Palette != null && !seqNode.ChildrenMatching("Palette").ToArray().Any(p => p.Value.Value == def.Palette))
+				{
+					var newPaletteNode = new MiniYamlNodeBuilder("Palette", def.Palette);
+					seqNode.AddNode(newPaletteNode);
+					seqNode.AddNode(new MiniYamlNodeBuilder(FieldSaver.SaveField(def, "IsPlayerPalette")));
+
+					if (addedPalette)
+						yield return $"Sequence {sequenceNode.Key}.{def.Sequence} had a duplicated Palette nodes added";
+
+					addedPalette = true;
+				}
+
+				if (def.ShadowPalette != null && !seqNode.ChildrenMatching("ShadowPalette").Any(p => p.Value.Value == def.ShadowPalette))
+				{
+					var newShadowPaletteNode = new MiniYamlNodeBuilder("ShadowPalette", def.ShadowPalette);
+					seqNode.AddNode(newShadowPaletteNode);
+
+					if (addedShadowPalette)
+						yield return $"Sequence {sequenceNode.Key}.{def.Sequence} had a duplicated ShadowPalette nodes added";
+
+					addedShadowPalette = true;
+				}
+
+				if (wasEmpty && (addedPalette || addedShadowPalette))
+					sequenceNode.AddNode(seqNode);
+			}
+		}
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNodeBuilder chromeNode)
+		{
+			var key = chromeNode.GetKey();
+			if (string.IsNullOrEmpty(key))
+				yield break;
+
+			switch (key)
+			{
+				case "SupportPowers":
+					if (!TryGetString(chromeNode, out var palette, "ClockPalette", "chrome"))
+						yield break;
+
+					if (!TryGetString(chromeNode, out var iconImage, "ClockAnimation", "clock"))
+						yield break;
+
+					if (!TryGetString(chromeNode, out var clockSequence, "ClockSequence", "idle"))
+						yield break;
+
+					AddSequenceDefinitions(iconImage, clockSequence, palette);
+					break;
+				case "ProductionPalette":
+					if (TryGetString(chromeNode, out var notBuildablePalette, "NotBuildablePalette", "chrome")
+						&& TryGetString(chromeNode, out var notBuildableImage, "NotBuildableAnimation", "clock")
+						&& TryGetString(chromeNode, out var notBuildableSequence, "NotBuildableSequence", "idle"))
+						AddSequenceDefinitions(notBuildableImage, notBuildableSequence, notBuildablePalette);
+
+					if (TryGetString(chromeNode, out var clockPalette, "ClockPalette", "chrome")
+						&& TryGetString(chromeNode, out var clockAnimation, "ClockAnimation", "clock")
+						&& TryGetString(chromeNode, out clockSequence, "ClockSequence", "idle"))
+						AddSequenceDefinitions(clockAnimation, clockSequence, clockPalette);
+
+					break;
+			}
+
+			if (widgetRemovals.TryGetValue(key, out var fieldsToRemove))
+				foreach (var field in fieldsToRemove)
+					chromeNode.RemoveNodes(field);
+
+			var childrenNode = chromeNode.LastChildMatching("Children");
+			if (childrenNode != null)
+				foreach (var childNode in childrenNode.Value.Nodes)
+					foreach (var result in UpdateChromeProviderNode(modData, childNode))
+						yield return result;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBuildingInfoAllowPlacementOnResources.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveBuildingInfoAllowPlacementOnResources.cs
@@ -14,10 +14,6 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-	/// <summary>
-	/// Replaces the BaseAttackNotifier with a new AttackNotifier that uses the
-	/// new attack system.
-	/// </summary>
 	public class RemoveBuildingInfoAllowPlacementOnResources : UpdateRule, IBeforeUpdateActors
 	{
 		public override string Name => "Remove AllowPlacementOnResources from BuildingInfo";

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -251,6 +251,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			manualSteps.AddRange(rule.BeforeUpdate(modData));
 
+			manualSteps.AddRange(ApplyChromeTransform(modData, modChromeLayout, rule.UpdateChromeNode));
+
 			if (rule is IBeforeUpdateActors beforeActors)
 			{
 				var resolvedActors = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Rules, null)
@@ -279,7 +281,6 @@ namespace OpenRA.Mods.Common.UpdateRules
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modSequences, rule.UpdateSequenceNode));
 
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modTilesets, rule.UpdateTilesetNode));
-			manualSteps.AddRange(ApplyChromeTransform(modData, modChromeLayout, rule.UpdateChromeNode));
 			manualSteps.AddRange(ApplyTopLevelTransform(modData, modChromeProvider, rule.UpdateChromeProviderNode));
 			manualSteps.AddRange(rule.AfterUpdate(modData));
 
@@ -455,13 +456,21 @@ namespace OpenRA.Mods.Common.UpdateRules
 			if (node.Key == null)
 				return false;
 
-			var atPosition = node.Key.IndexOf('@');
-			var relevantPart = ignoreSuffix && atPosition > 0 ? node.Key[..atPosition] : node.Key;
-
+			var relevantPart = ignoreSuffix ? node.GetKey() : node.Key;
 			if (relevantPart.Contains(match) && (includeRemovals || !node.IsRemoval()))
 				return true;
 
 			return false;
+		}
+
+		/// <summary>Returns the key of the node, excluding any suffix.</summary>
+		public static string GetKey(this MiniYamlNodeBuilder node)
+		{
+			if (node.Key == null)
+				return string.Empty;
+
+			var atPosition = node.Key.IndexOf('@');
+			return atPosition > 0 ? node.Key[..atPosition] : node.Key;
 		}
 
 		/// <summary>Returns children with keys equal to [match] or [match]@[arbitrary suffix].</summary>

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -28,13 +28,6 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Image containing explosion effect sequence.")]
 		public readonly string Image = "explosion";
 
-		[PaletteReference(nameof(UsePlayerPalette))]
-		[Desc("Palette to use for explosion effect.")]
-		public readonly string ExplosionPalette = "effect";
-
-		[Desc("Remap explosion effect to player color, if art supports it.")]
-		public readonly bool UsePlayerPalette = false;
-
 		[Desc("Display explosion effect at ground level, regardless of explosion altitude.")]
 		public readonly bool ForceDisplayAtGroundLevel = false;
 
@@ -122,11 +115,7 @@ namespace OpenRA.Mods.Common.Warheads
 					pos -= new WVec(0, 0, dat.Length);
 				}
 
-				var palette = ExplosionPalette;
-				if (UsePlayerPalette)
-					palette += firedBy.Owner.InternalName;
-
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, Image, explosion, palette)));
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, Image, explosion, firedBy.Owner)));
 			}
 
 			var impactSound = ImpactSounds.RandomOrDefault(world.LocalRandom);

--- a/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
@@ -18,10 +18,9 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public bool ClickThrough = true;
 
-		Sprite sprite;
+		ISpriteSequence sprite;
 		readonly WorldRenderer worldRenderer;
 		readonly GraphicSettings graphicSettings;
-		string palette;
 		int2 location;
 
 		[ObjectCreator.UseCtor]
@@ -33,28 +32,26 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			if (sprite != null && palette != null)
+			if (sprite != null)
 			{
-				var directionPalette = worldRenderer.Palette(palette);
+				var directionPalette = worldRenderer.Palette(sprite.GetPalette());
 
 				// Cursor is rendered in native window coordinates
 				// Apply same scaling rules as hardware cursors
 				var scale = (graphicSettings.CursorDouble ? 2 : 1) * (Game.Renderer.NativeWindowScale > 1.5f ? 2 : 1);
-				WidgetUtils.DrawSpriteCentered(sprite, directionPalette, ChildOrigin, scale / Game.Renderer.WindowScale);
+				WidgetUtils.DrawSpriteCentered(sprite.GetSprite(0), directionPalette, ChildOrigin, scale / Game.Renderer.WindowScale);
 			}
 		}
 
-		public void SetAttachment(int2 location, Sprite sprite, string palette)
+		public void SetAttachment(int2 location, ISpriteSequence sprite)
 		{
 			this.sprite = sprite;
 			this.location = location;
-			this.palette = palette;
 		}
 
 		public void Reset()
 		{
 			sprite = null;
-			palette = null;
 		}
 
 		public override int2 ChildOrigin => location;

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -108,8 +108,11 @@ namespace OpenRA.Mods.Common.Widgets
 				var iconTopLeft = RenderOrigin + topLeftOffset;
 				var centerPosition = iconTopLeft;
 
-				var palette = unit.IconPaletteIsPlayerPalette ? unit.IconPalette + player.InternalName : unit.IconPalette;
-				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(palette), centerPosition + 0.5f * iconSize, 0.5f);
+				WidgetUtils.DrawSpriteCentered(
+					icon.Image,
+					worldRenderer.Palette(icon.Palette(player)),
+					centerPosition + 0.5f * iconSize,
+					0.5f);
 
 				armyIcons.Add(new ArmyIcon
 				{

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -145,8 +145,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var iconTopLeft = RenderOrigin + topLeftOffset;
 				var centerPosition = iconTopLeft + 0.5f * iconSize;
 
-				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + player.InternalName : bi.IconPalette;
-				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(palette), centerPosition, 0.5f);
+				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(player.InternalName), centerPosition, 0.5f);
 
 				var rect = new Rectangle((int)iconTopLeft.X, (int)iconTopLeft.Y, (int)iconSize.X, (int)iconSize.Y);
 				productionIcons.Add(new ProductionIcon

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Widgets
 				supportPowerIconsIcons.Add(new SupportPowersWidget.SupportPowerIcon { Power = item, Pos = location });
 				supportPowerIconsBounds.Add(new Rectangle((int)location.X, (int)location.Y, (int)iconSize.X, (int)iconSize.Y));
 
-				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(item.Info.IconPalette), location + 0.5f * iconSize, 0.5f);
+				WidgetUtils.DrawSpriteCentered(icon.Image, worldRenderer.Palette(icon.Palette(player)), location + 0.5f * iconSize, 0.5f);
 
 				var clock = clocks[power.a.Key];
 				clock.PlayFetchIndex(ClockSequence,

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -31,8 +31,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public HotkeyReference Hotkey;
 		public Sprite Sprite;
 		public PaletteReference Palette;
-		public PaletteReference IconClockPalette;
-		public PaletteReference IconDarkenPalette;
 		public float2 Pos;
 		public List<ProductionItem> Queued;
 		public ProductionQueue ProductionQueue;
@@ -66,11 +64,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly string ClockAnimation = "clock";
 		public readonly string ClockSequence = "idle";
-		public readonly string ClockPalette = "chrome";
 
 		public readonly string NotBuildableAnimation = "clock";
 		public readonly string NotBuildableSequence = "idle";
-		public readonly string NotBuildablePalette = "chrome";
 
 		public readonly string OverlayFont = "TinyBold";
 		public readonly string SymbolsFont = "Symbols";
@@ -517,17 +513,13 @@ namespace OpenRA.Mods.Common.Widgets
 				var bi = item.TraitInfo<BuildableInfo>();
 				icon.Play(bi.Icon);
 
-				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + producer.Actor.Owner.InternalName : bi.IconPalette;
-
 				var pi = new ProductionIcon()
 				{
 					Actor = item,
 					Name = item.Name,
 					Hotkey = DisplayedIconCount < HotkeyCount ? hotkeys[DisplayedIconCount] : null,
 					Sprite = icon.Image,
-					Palette = worldRenderer.Palette(palette),
-					IconClockPalette = worldRenderer.Palette(ClockPalette),
-					IconDarkenPalette = worldRenderer.Palette(NotBuildablePalette),
+					Palette = worldRenderer.Palette(icon.Palette(producer.Actor.Owner)),
 					Pos = new float2(rect.Location),
 					Queued = currentQueue.AllQueued().Where(a => a.Item == item.Name).ToList(),
 					ProductionQueue = currentQueue
@@ -571,10 +563,10 @@ namespace OpenRA.Mods.Common.Widgets
 							* (clock.CurrentSequence.Length - 1) / first.TotalTime);
 					clock.Tick();
 
-					WidgetUtils.DrawSpriteCentered(clock.Image, icon.IconClockPalette, icon.Pos + iconOffset);
+					WidgetUtils.DrawSpriteCentered(clock.Image, worldRenderer.Palette(clock.Palette()), icon.Pos + iconOffset);
 				}
 				else if (!buildableItems.Any(a => a.Name == icon.Name))
-					WidgetUtils.DrawSpriteCentered(cantBuild.Image, icon.IconDarkenPalette, icon.Pos + iconOffset);
+					WidgetUtils.DrawSpriteCentered(cantBuild.Image, worldRenderer.Palette(cantBuild.Palette()), icon.Pos + iconOffset);
 			}
 
 			Game.Renderer.DisableAntialiasingFilter();

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly string ClockAnimation = "clock";
 		public readonly string ClockSequence = "idle";
-		public readonly string ClockPalette = "chrome";
 
 		public readonly bool Horizontal = false;
 
@@ -126,7 +125,6 @@ namespace OpenRA.Mods.Common.Widgets
 			public float2 Pos;
 			public Sprite Sprite;
 			public PaletteReference Palette;
-			public PaletteReference IconClockPalette;
 			public HotkeyReference Hotkey;
 		}
 
@@ -156,8 +154,7 @@ namespace OpenRA.Mods.Common.Widgets
 					Power = p,
 					Pos = new float2(rect.Location),
 					Sprite = icon.Image,
-					Palette = worldRenderer.Palette(p.Info.IconPalette),
-					IconClockPalette = worldRenderer.Palette(ClockPalette),
+					Palette = worldRenderer.Palette(icon.Palette()),
 					Hotkey = IconCount < HotkeyCount ? hotkeys[IconCount] : null,
 				};
 
@@ -218,7 +215,7 @@ namespace OpenRA.Mods.Common.Widgets
 					* (clock.CurrentSequence.Length - 1) / sp.TotalTicks);
 
 				clock.Tick();
-				WidgetUtils.DrawSpriteCentered(clock.Image, p.IconClockPalette, p.Pos + iconOffset);
+				WidgetUtils.DrawSpriteCentered(clock.Image, worldRenderer.Palette(clock.CurrentSequence.GetPalette()), p.Pos + iconOffset);
 			}
 
 			Game.Renderer.DisableAntialiasingFilter();

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -62,6 +62,7 @@ namespace OpenRA.Mods.D2k.Traits
 		readonly bool checkUnsafeTiles;
 		readonly Sprite validTile, unsafeTile, blockedTile;
 		readonly float validAlpha, unsafeAlpha, blockedAlpha;
+		readonly string validPalette, unsafePalette, blockedPalette;
 		readonly CachedTransform<CPos, List<CPos>> unpathableCells;
 
 		public D2kActorPreviewPlaceBuildingPreviewPreview(WorldRenderer wr, ActorInfo ai, D2kActorPreviewPlaceBuildingPreviewInfo info, TypeDictionary init)
@@ -78,14 +79,17 @@ namespace OpenRA.Mods.D2k.Traits
 			var validSequence = sequences.GetSequence(info.Image, info.TileValidName);
 			validTile = validSequence.GetSprite(0);
 			validAlpha = validSequence.GetAlpha(0);
+			validPalette = validSequence.GetPalette();
 
 			var unsafeSequence = sequences.GetSequence(info.Image, info.TileUnsafeName);
 			unsafeTile = unsafeSequence.GetSprite(0);
 			unsafeAlpha = unsafeSequence.GetAlpha(0);
+			unsafePalette = unsafeSequence.GetPalette();
 
 			var blockedSequence = sequences.GetSequence(info.Image, info.TileInvalidName);
 			blockedTile = blockedSequence.GetSprite(0);
 			blockedAlpha = blockedSequence.GetAlpha(0);
+			blockedPalette = blockedSequence.GetPalette();
 
 			var buildingInfo = ai.TraitInfo<BuildingInfo>();
 			unpathableCells = new CachedTransform<CPos, List<CPos>>(topLeft => buildingInfo.OccupiedTiles(topLeft).ToList());
@@ -94,7 +98,9 @@ namespace OpenRA.Mods.D2k.Traits
 		protected override IEnumerable<IRenderable> RenderFootprint(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint,
 			PlaceBuildingCellType filter = PlaceBuildingCellType.Invalid | PlaceBuildingCellType.Valid | PlaceBuildingCellType.LineBuild)
 		{
-			var palette = wr.Palette(info.Palette);
+			var vPalette = wr.Palette(validPalette);
+			var bPalette = wr.Palette(blockedPalette);
+			var uPalette = wr.Palette(unsafePalette);
 			var topLeftPos = wr.World.Map.CenterOfCell(topLeft);
 
 			var candidateSafeTiles = unpathableCells.Update(topLeft);
@@ -110,6 +116,7 @@ namespace OpenRA.Mods.D2k.Traits
 					info.UnsafeTerrainTypes.Contains(wr.World.Map.GetTerrainInfo(c.Key).Type);
 
 				var tile = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedTile : isUnsafe ? unsafeTile : validTile;
+				var palette = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? bPalette : isUnsafe ? uPalette : vPalette;
 				var sequenceAlpha = (c.Value & PlaceBuildingCellType.Invalid) != 0 ? blockedAlpha : isUnsafe ? unsafeAlpha : validAlpha;
 
 				var pos = wr.World.Map.CenterOfCell(c.Key);

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -23,13 +23,6 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		[Desc("Sequence name to use")]
 		public readonly string Sequence = "crumble-overlay";
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithCrumbleOverlay(init, this); }
 	}
 
@@ -59,7 +52,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 			if (overlay == null)
 				return;
 
-			renderSprites.Add(animation, info.Palette, info.IsPlayerPalette);
+			renderSprites.Add(animation);
 
 			// Remove the animation once it is complete
 			overlay.PlayThen(info.Sequence, () => self.World.AddFrameEndTask(w => renderSprites.Remove(animation)));

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -26,13 +26,6 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
-		[PaletteReference(nameof(IsPlayerPalette))]
-		[Desc("Custom palette name")]
-		public readonly string Palette = null;
-
-		[Desc("Custom palette is a player palette BaseName")]
-		public readonly bool IsPlayerPalette = false;
-
 		public override object Create(ActorInitializer init) { return new WithDeliveryOverlay(init.Self, this); }
 	}
 
@@ -57,7 +50,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self.Orientation))),
 				() => IsTraitDisabled || !delivering);
 
-			rs.Add(anim, info.Palette, info.IsPlayerPalette);
+			rs.Add(anim);
 		}
 
 		void PlayDeliveryOverlay()

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -53,12 +53,12 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public override object Create(ActorInitializer init) { return new SpiceBloom(init.Self, this); }
 
-		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, PaletteReference p)
+		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, string image, int facings, OwnerInit owner)
 		{
 			var anim = new Animation(init.World, image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), GrowthSequences[0]));
 
-			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p);
+			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, owner);
 		}
 	}
 

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -23,8 +23,9 @@ namespace OpenRA.Mods.D2k.Traits
 	[TraitLocation(SystemActors.World)]
 	public class BuildableTerrainLayerInfo : TraitInfo, Requires<ITiledTerrainRendererInfo>
 	{
+		[PaletteReference]
 		[Desc("Palette to render the layer sprites in.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = "terrain";
 
 		[Desc("The hitpoints, which can be reduced by the DamagesConcreteWarhead.")]
 		public readonly int MaxStrength = 9000;

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -130,20 +131,20 @@ namespace OpenRA.Mods.D2k.Traits
 			return ret;
 		}
 
-		protected override void UpdateRenderedSprite(CPos cell, RendererCellContents content)
+		protected override void UpdateRenderedSprite(CPos cell, RendererCellContents content, WorldRenderer wr)
 		{
-			UpdateRenderedSpriteInner(cell, content);
+			UpdateRenderedSpriteInner(cell, content, wr);
 
 			var directions = CVec.Directions;
 			for (var i = 0; i < directions.Length; i++)
 			{
 				var neighbour = cell + directions[i];
 				if (RenderContents.Contains(neighbour))
-					UpdateRenderedSpriteInner(neighbour, RenderContents[neighbour]);
+					UpdateRenderedSpriteInner(neighbour, RenderContents[neighbour], wr);
 			}
 		}
 
-		void UpdateRenderedSpriteInner(CPos cell, RendererCellContents content)
+		void UpdateRenderedSpriteInner(CPos cell, RendererCellContents content, WorldRenderer wr)
 		{
 			if (content.Density > 0)
 			{
@@ -153,11 +154,11 @@ namespace OpenRA.Mods.D2k.Traits
 				{
 					var maxDensity = ResourceLayer.GetMaxDensity(content.Type);
 					var index = content.Density > maxDensity / 2 ? 1 : 0;
-					UpdateSpriteLayers(cell, content.Sequence, index, content.Palette);
+					UpdateSpriteLayers(cell, content.Sequence, index, wr);
 				}
 				else if (SpriteMap.TryGetValue(clear, out var index))
 				{
-					UpdateSpriteLayers(cell, content.Sequence, index, content.Palette);
+					UpdateSpriteLayers(cell, content.Sequence, index, wr);
 				}
 				else
 					throw new InvalidOperationException($"SpriteMap does not contain an index for ClearSides type '{clear}'");

--- a/mods/cnc/maps/nod02b/rules.yaml
+++ b/mods/cnc/maps/nod02b/rules.yaml
@@ -20,28 +20,24 @@ World:
 		GenericVisibility: Enemy
 		ShowOwnerRow: false
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Tank:
 	Tooltip:
 		GenericVisibility: Enemy
 		ShowOwnerRow: false
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Helicopter:
 	Tooltip:
 		GenericVisibility: Enemy
 		ShowOwnerRow: false
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Infantry:
 	Tooltip:
 		GenericVisibility: Enemy
 		ShowOwnerRow: false
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Plane:
 	Tooltip:
@@ -68,7 +64,6 @@ World:
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	RenderSprites:
-		PlayerPalette: player-units
 
 NUK2:
 	Buildable:
@@ -130,19 +125,15 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 	RenderSprites:
-		PlayerPalette: player
 
 MCV.Husk:
 	RenderSprites:
-		PlayerPalette: player
 
 HARV:
 	RenderSprites:
-		PlayerPalette: player
 
 HARV.Husk:
 	RenderSprites:
-		PlayerPalette: player
 
 SAM:
 	Buildable:

--- a/mods/cnc/maps/twist-of-fate/rules.yaml
+++ b/mods/cnc/maps/twist-of-fate/rules.yaml
@@ -91,7 +91,6 @@ Astk.proxy:
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
-		BeaconPosterPalette: beaconposter
 		DisplayRadarPing: True
 		CameraActor: camera
 		ArrowSequence: arrow

--- a/mods/cnc/rules/campaign-palettes.yaml
+++ b/mods/cnc/rules/campaign-palettes.yaml
@@ -47,29 +47,22 @@
 
 ^Vehicle:
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Tank:
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Helicopter:
 	RenderSprites:
-		PlayerPalette: player-units
 
 ^Infantry:
 	RenderSprites:
-		PlayerPalette: player-units
 	WithDeathAnimation:
-		DeathSequencePalette: player-units
 
 ^CommonHuskDefaults:
 	RenderSprites:
-		PlayerPalette: player-units
 
 C17:
 	RenderSprites:
-		PlayerPalette: player-units
 	Contrail@1:
 		StartColorUsePlayerColor: False
 	Contrail@2:
@@ -81,16 +74,12 @@ C17:
 
 HARV:
 	RenderSprites:
-		PlayerPalette: player
 
 MCV:
 	RenderSprites:
-		PlayerPalette: player
 
 HARV.Husk:
 	RenderSprites:
-		PlayerPalette: player
 
 MCV.Husk:
 	RenderSprites:
-		PlayerPalette: player

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -91,7 +91,6 @@
 	WithDecoration@RANK-1:
 		Image: rank
 		Sequence: rank-veteran-1
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -99,7 +98,6 @@
 	WithDecoration@RANK-2:
 		Image: rank
 		Sequence: rank-veteran-2
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -107,7 +105,6 @@
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -367,8 +364,6 @@
 			FireDeath: 5
 			TiberiumDeath: 6
 		CrushedSequence: die-crushed
-		CrushedSequencePalette: player
-		CrushedPaletteIsPlayerPalette: true
 	AttackMove:
 	Passenger:
 		CargoType: Infantry
@@ -544,7 +539,6 @@
 		TargetTypes: Ground, Creep
 	HiddenUnderFog:
 	RenderSprites:
-		Palette: terrain
 	QuantizeFacingsFromSequence:
 		Sequence: stand
 	WithInfantryBody:
@@ -774,8 +768,6 @@
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 
 ^CivBuilding:
 	Inherits: ^Building
@@ -831,8 +823,6 @@
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 
 ^CivField:
 	Inherits: ^CivBuilding
@@ -845,7 +835,6 @@
 	-SoundOnDamageTransition:
 	-Demolishable:
 	RenderSprites:
-		Palette: terrain
 
 ^CivHaystackOrIgloo:
 	Inherits: ^CivField
@@ -877,7 +866,6 @@
 		GenericVisibility: None
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: terrain
 	WithSpriteBody:
 	FrozenUnderFog:
 	MapEditorData:
@@ -932,7 +920,6 @@
 	LineBuildNode:
 		Types: wall
 	RenderSprites:
-		Palette: staticterrain
 	WithWallSpriteBody:
 	Sellable:
 		SellSounds: cashturn.aud
@@ -955,7 +942,6 @@
 		Name: meta-tree-name
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: staticterrain
 	WithSpriteBody:
 	Building:
 		Footprint: __ x_
@@ -1033,7 +1019,6 @@
 		Name: meta-tibtree-name
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: staticterrain
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -1057,7 +1042,6 @@
 		Name: meta-rock-name
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: staticterrain
 	WithSpriteBody:
 	Building:
 		Footprint: __ x_
@@ -1177,7 +1161,6 @@
 	Crate:
 		TerrainTypes: Clear, Rough, Road, Tiberium, BlueTiberium, Beach
 	RenderSprites:
-		Palette: effect
 		Image: scrate
 	WithCrateBody:
 		XmasImages: xcratea, xcrateb, xcratec, xcrated

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -332,8 +332,6 @@ STEG:
 	Armament:
 		Weapon: tail
 	WithDeathAnimation:
-		DeathSequencePalette: terrain
-		DeathPaletteIsPlayerPalette: false
 	Buildable:
 		Description: actor-steg.description
 

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -83,7 +83,6 @@ fact.colorpicker:
 	-Encyclopedia:
 	RenderSprites:
 		Image: fact
-		Palette: colorpicker
 
 CAMERA:
 	Interactable:
@@ -129,7 +128,6 @@ FLARE:
 		Type: CenterPosition
 	RenderSprites:
 		Image: smokland
-		Palette: terrain
 	WithSpriteBody:
 		StartSequence: open
 	HiddenUnderFog:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -762,7 +762,6 @@ HQ:
 		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
-		BeaconPosterPalette: beaconposter
 		DisplayRadarPing: True
 		CameraActor: camera
 		ArrowSequence: arrow
@@ -957,7 +956,6 @@ TMPL:
 		SpawnOffset: 3c0,0,-1c512
 		DisplayBeacon: True
 		BeaconPoster: atomic
-		BeaconPosterPalette: beaconposter
 		DisplayRadarPing: True
 		CameraRange: 10c0
 		ArrowSequence: arrow

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -30,7 +30,6 @@ V19:
 	GrantConditionOnCombatantOwner:
 		Condition: enabled
 	RenderSprites:
-		PlayerPalette: derrick
 
 V19.Husk:
 	Inherits: ^CivBuildingHusk
@@ -46,7 +45,6 @@ V19.Husk:
 	Tooltip:
 		Name: actor-v19-husk-name
 	RenderSprites:
-		PlayerPalette: derrick
 
 HOSP:
 	Inherits: ^TechBuilding

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -15,7 +15,6 @@
 		OverrideFullShroud: shroud-full
 		FogVariants: fog-typea, fog-typeb, fog-typec, fog-typed
 		OverrideFullFog: fog-full
-		FogPalette: shroud
 	Locomotor@FOOT:
 		Name: foot
 		Crushes: crate
@@ -141,11 +140,9 @@
 		ResourceTypes:
 			Tiberium:
 				Sequences: ti1, ti2, ti3, ti4, ti5, ti6, ti7, ti8, ti9, ti10, ti11, ti12
-				Palette: staticterrain
 				Name: resource-tiberium
 			BlueTiberium:
 				Sequences: ti1, ti2, ti3, ti4, ti5, ti6, ti7, ti8, ti9, ti10, ti11, ti12
-				Palette: bluetiberium
 				Name: resource-tiberium
 
 World:
@@ -277,7 +274,6 @@ World:
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
-		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/cnc/sequences/aircraft.yaml
+++ b/mods/cnc/sequences/aircraft.yaml
@@ -46,7 +46,6 @@ tran:
 	icon:
 		Filename: tranicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 heli:
 	idle:
@@ -71,11 +70,9 @@ heli:
 		Length: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: heliicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 orca:
 	Defaults:
@@ -91,7 +88,6 @@ orca:
 	icon:
 		Filename: orcaicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 a10:
 	idle:

--- a/mods/cnc/sequences/aircraft.yaml
+++ b/mods/cnc/sequences/aircraft.yaml
@@ -3,6 +3,8 @@ c17:
 		Filename: c17.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: c17icnh.shp
 
@@ -12,20 +14,30 @@ tran:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: lrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	rotor2:
 		Filename: rrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: lrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor2:
 		Filename: rrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Start: 32
 		Length: 4
@@ -33,25 +45,37 @@ tran:
 		Start: 35
 	icon:
 		Filename: tranicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 heli:
 	idle:
 		Filename: heli.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: lrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: lrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: heliicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 orca:
 	Defaults:
@@ -59,17 +83,23 @@ orca:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	move:
 		Start: 32
 		Facings: 32
 	icon:
 		Filename: orcaicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 a10:
 	idle:
 		Filename: a10.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6

--- a/mods/cnc/sequences/campaign.yaml
+++ b/mods/cnc/sequences/campaign.yaml
@@ -4,6 +4,8 @@ lst:
 		Start: 0
 		Facings: 1
 		ZOffset: -1024
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: lsticnh.tem
 
@@ -12,31 +14,47 @@ boat:
 		Filename: boat.shp
 	left:
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	damaged-left:
 		Start: 32
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	critical-left:
 		Start: 64
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	wake-left:
 		Filename: wake.shp
 		Start: 6
 		Length: 6
 		Offset: 1,2
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	right:
 		Start: 96
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	damaged-right:
 		Start: 128
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	critical-right:
 		Start: 160
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	wake-right:
 		Filename: wake.shp
 		Length: 6
 		Offset: -1,2
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: boaticnh.tem

--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -3,29 +3,43 @@ c1:
 		Filename: c1.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 189
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 199
 		Length: 6
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 205
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 200
 		Length: 3
@@ -35,81 +49,515 @@ c1:
 		Start: 329
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 337
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 337
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 345
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 357
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Start: 182
 		Length: 4
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
+		Palette: player
+		IsPlayerPalette: True
 
 c2:
 	Inherits: c1
 	Defaults:
 		Filename: c2.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c3:
 	Inherits: c1
 	Defaults:
 		Filename: c3.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c4:
 	Inherits: c1
 	Defaults:
 		Filename: c4.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c5:
 	Inherits: c1
 	Defaults:
 		Filename: c5.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c6:
 	Inherits: c1
 	Defaults:
 		Filename: c6.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c7:
 	Inherits: c1
 	Defaults:
 		Filename: c7.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c8:
 	Inherits: c1
 	Defaults:
 		Filename: c8.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c9:
 	Inherits: c1
 	Defaults:
 		Filename: c9.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 c10:
 	Inherits: c1
 	Defaults:
 		Filename: c10.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 delphi:
 	Inherits: c1
 	Defaults:
 		Filename: delphi.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	shoot:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 moebius:
 	Defaults:
@@ -117,47 +565,112 @@ moebius:
 		Tick: 80
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 104
 		Length: 15
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 120
 		Length: 20
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 212
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 220
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 220
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 228
 		Length: 12
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 240
 		Length: 17
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Start: 214
 		Length: 3
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
+		Palette: player
+		IsPlayerPalette: True
 
 chan:
 	Inherits: moebius
 	Defaults:
 		Filename: chan.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die1:
+		Palette: player
+		IsPlayerPalette: True
+	die2:
+		Palette: player
+		IsPlayerPalette: True
+	die3:
+		Palette: player
+		IsPlayerPalette: True
+	die4:
+		Palette: player
+		IsPlayerPalette: True
+	die5:
+		Palette: player
+		IsPlayerPalette: True
+	die6:
+		Palette: player
+		IsPlayerPalette: True
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -9,16 +9,13 @@ split2:
 		Length: 30
 		Tick: 120
 		Palette: staticterrain
-		IsPlayerPalette: False
 	active:
 		Start: 30
 		Length: 24
 		Palette: staticterrain
-		IsPlayerPalette: False
 	idle:
 		Start: 54
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 split3:
 	Defaults:
@@ -32,58 +29,48 @@ split3:
 		Length: 30
 		Tick: 120
 		Palette: staticterrain
-		IsPlayerPalette: False
 	active:
 		Start: 30
 		Length: 24
 		Palette: staticterrain
-		IsPlayerPalette: False
 	idle:
 		Start: 54
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock1:
 	idle:
 		Filename: rock1.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock2:
 	idle:
 		Filename: rock2.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock3:
 	idle:
 		Filename: rock3.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock4:
 	idle:
 		Filename: rock4.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock5:
 	idle:
 		Filename: rock5.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock6:
 	idle:
 		Filename: rock6.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 rock7:
 	idle:
 		Filename: rock7.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc04:
 	Defaults:
@@ -93,7 +80,6 @@ tc04:
 			SNOW: tc04.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc04.husk:
 	Defaults:
@@ -114,7 +100,6 @@ tc05:
 			SNOW: tc05.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc05.husk:
 	Defaults:
@@ -135,7 +120,6 @@ tc03:
 			SNOW: tc03.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc03.husk:
 	Defaults:
@@ -156,7 +140,6 @@ tc02:
 			SNOW: tc02.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc02.husk:
 	Defaults:
@@ -177,7 +160,6 @@ tc01:
 			SNOW: tc01.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 tc01.husk:
 	Defaults:
@@ -194,7 +176,6 @@ t18:
 	idle:
 		Filename: t18.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t18.husk:
 	idle:
@@ -211,7 +192,6 @@ t17:
 			SNOW: t17.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t17.husk:
 	Defaults:
@@ -232,7 +212,6 @@ t16:
 			SNOW: t16.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t16.husk:
 	Defaults:
@@ -253,7 +232,6 @@ t15:
 			SNOW: t15.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t15.husk:
 	Defaults:
@@ -274,7 +252,6 @@ t14:
 			SNOW: t14.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t14.husk:
 	Defaults:
@@ -295,7 +272,6 @@ t13:
 			SNOW: t13.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t13.husk:
 	Defaults:
@@ -316,7 +292,6 @@ t12:
 			SNOW: t12.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t12.husk:
 	Defaults:
@@ -337,7 +312,6 @@ t11:
 			SNOW: t11.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t11.husk:
 	Defaults:
@@ -358,7 +332,6 @@ t10:
 			SNOW: t10.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t10.husk:
 	Defaults:
@@ -375,7 +348,6 @@ t09:
 	idle:
 		Filename: t09.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t09.husk:
 	idle:
@@ -393,7 +365,6 @@ t08:
 			TEMPERAT: t08.tem
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t08.husk:
 	Defaults:
@@ -415,7 +386,6 @@ t07:
 			SNOW: t07.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t07.husk:
 	Defaults:
@@ -436,7 +406,6 @@ t06:
 			SNOW: t06.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t06.husk:
 	Defaults:
@@ -457,7 +426,6 @@ t05:
 			SNOW: t05.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t05.husk:
 	Defaults:
@@ -474,7 +442,6 @@ t04:
 	idle:
 		Filename: t04.des
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t04.husk:
 	idle:
@@ -491,7 +458,6 @@ t03:
 			SNOW: t03.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t03.husk:
 	Defaults:
@@ -512,7 +478,6 @@ t02:
 			SNOW: t02.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t02.husk:
 	Defaults:
@@ -533,7 +498,6 @@ t01:
 			SNOW: t01.sno
 	idle:
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 t01.husk:
 	Defaults:
@@ -819,12 +783,10 @@ v12:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v12.husk:
 	idle:
@@ -835,7 +797,6 @@ v12.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v13:
 	Defaults:
@@ -846,12 +807,10 @@ v13:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v13.husk:
 	idle:
@@ -862,7 +821,6 @@ v13.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v14:
 	Defaults:
@@ -873,12 +831,10 @@ v14:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v14.husk:
 	idle:
@@ -889,7 +845,6 @@ v14.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v15:
 	Defaults:
@@ -900,12 +855,10 @@ v15:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v15.husk:
 	idle:
@@ -916,7 +869,6 @@ v15.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v16:
 	Defaults:
@@ -927,12 +879,10 @@ v16:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v16.husk:
 	idle:
@@ -943,7 +893,6 @@ v16.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v17:
 	Defaults:
@@ -954,12 +903,10 @@ v17:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v17.husk:
 	idle:
@@ -970,7 +917,6 @@ v17.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v18:
 	Defaults:
@@ -981,12 +927,10 @@ v18:
 	idle:
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v18.husk:
 	idle:
@@ -997,7 +941,6 @@ v18.husk:
 		Start: 2
 		ZOffset: -2c512
 		Palette: terrain
-		IsPlayerPalette: False
 
 v19:
 	Defaults:

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -8,11 +8,17 @@ split2:
 	make:
 		Length: 30
 		Tick: 120
+		Palette: staticterrain
+		IsPlayerPalette: False
 	active:
 		Start: 30
 		Length: 24
+		Palette: staticterrain
+		IsPlayerPalette: False
 	idle:
 		Start: 54
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 split3:
 	Defaults:
@@ -25,39 +31,59 @@ split3:
 	make:
 		Length: 30
 		Tick: 120
+		Palette: staticterrain
+		IsPlayerPalette: False
 	active:
 		Start: 30
 		Length: 24
+		Palette: staticterrain
+		IsPlayerPalette: False
 	idle:
 		Start: 54
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock1:
 	idle:
 		Filename: rock1.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock2:
 	idle:
 		Filename: rock2.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock3:
 	idle:
 		Filename: rock3.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock4:
 	idle:
 		Filename: rock4.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock5:
 	idle:
 		Filename: rock5.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock6:
 	idle:
 		Filename: rock6.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 rock7:
 	idle:
 		Filename: rock7.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc04:
 	Defaults:
@@ -66,6 +92,8 @@ tc04:
 			WINTER: tc04.win
 			SNOW: tc04.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc04.husk:
 	Defaults:
@@ -75,6 +103,8 @@ tc04.husk:
 			SNOW: tc04.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 tc05:
 	Defaults:
@@ -83,6 +113,8 @@ tc05:
 			WINTER: tc05.win
 			SNOW: tc05.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc05.husk:
 	Defaults:
@@ -92,6 +124,8 @@ tc05.husk:
 			SNOW: tc05.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 tc03:
 	Defaults:
@@ -100,6 +134,8 @@ tc03:
 			WINTER: tc03.win
 			SNOW: tc03.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc03.husk:
 	Defaults:
@@ -109,6 +145,8 @@ tc03.husk:
 			SNOW: tc03.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 tc02:
 	Defaults:
@@ -117,6 +155,8 @@ tc02:
 			WINTER: tc02.win
 			SNOW: tc02.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc02.husk:
 	Defaults:
@@ -126,6 +166,8 @@ tc02.husk:
 			SNOW: tc02.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 tc01:
 	Defaults:
@@ -134,6 +176,8 @@ tc01:
 			WINTER: tc01.win
 			SNOW: tc01.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 tc01.husk:
 	Defaults:
@@ -143,15 +187,21 @@ tc01.husk:
 			SNOW: tc01.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t18:
 	idle:
 		Filename: t18.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t18.husk:
 	idle:
 		Filename: t18.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t17:
 	Defaults:
@@ -160,6 +210,8 @@ t17:
 			WINTER: t17.win
 			SNOW: t17.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t17.husk:
 	Defaults:
@@ -169,6 +221,8 @@ t17.husk:
 			SNOW: t17.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t16:
 	Defaults:
@@ -177,6 +231,8 @@ t16:
 			WINTER: t16.win
 			SNOW: t16.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t16.husk:
 	Defaults:
@@ -186,6 +242,8 @@ t16.husk:
 			SNOW: t16.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t15:
 	Defaults:
@@ -194,6 +252,8 @@ t15:
 			WINTER: t15.win
 			SNOW: t15.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t15.husk:
 	Defaults:
@@ -203,6 +263,8 @@ t15.husk:
 			SNOW: t15.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t14:
 	Defaults:
@@ -211,6 +273,8 @@ t14:
 			WINTER: t14.win
 			SNOW: t14.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t14.husk:
 	Defaults:
@@ -220,6 +284,8 @@ t14.husk:
 			SNOW: t14.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t13:
 	Defaults:
@@ -228,6 +294,8 @@ t13:
 			WINTER: t13.win
 			SNOW: t13.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t13.husk:
 	Defaults:
@@ -237,6 +305,8 @@ t13.husk:
 			SNOW: t13.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t12:
 	Defaults:
@@ -245,6 +315,8 @@ t12:
 			WINTER: t12.win
 			SNOW: t12.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t12.husk:
 	Defaults:
@@ -254,6 +326,8 @@ t12.husk:
 			SNOW: t12.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t11:
 	Defaults:
@@ -262,6 +336,8 @@ t11:
 			WINTER: t11.win
 			SNOW: t11.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t11.husk:
 	Defaults:
@@ -271,6 +347,8 @@ t11.husk:
 			SNOW: t11.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t10:
 	Defaults:
@@ -279,6 +357,8 @@ t10:
 			WINTER: t10.win
 			SNOW: t10.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t10.husk:
 	Defaults:
@@ -288,15 +368,21 @@ t10.husk:
 			SNOW: t10.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t09:
 	idle:
 		Filename: t09.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t09.husk:
 	idle:
 		Filename: t09.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t08:
 	Defaults:
@@ -306,6 +392,8 @@ t08:
 			SNOW: t08.sno
 			TEMPERAT: t08.tem
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t08.husk:
 	Defaults:
@@ -316,6 +404,8 @@ t08.husk:
 			TEMPERAT: t08.tem
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t07:
 	Defaults:
@@ -324,6 +414,8 @@ t07:
 			WINTER: t07.win
 			SNOW: t07.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t07.husk:
 	Defaults:
@@ -333,6 +425,8 @@ t07.husk:
 			SNOW: t07.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t06:
 	Defaults:
@@ -341,6 +435,8 @@ t06:
 			WINTER: t06.win
 			SNOW: t06.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t06.husk:
 	Defaults:
@@ -350,6 +446,8 @@ t06.husk:
 			SNOW: t06.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t05:
 	Defaults:
@@ -358,6 +456,8 @@ t05:
 			WINTER: t05.win
 			SNOW: t05.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t05.husk:
 	Defaults:
@@ -367,15 +467,21 @@ t05.husk:
 			SNOW: t05.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t04:
 	idle:
 		Filename: t04.des
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t04.husk:
 	idle:
 		Filename: t04.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t03:
 	Defaults:
@@ -384,6 +490,8 @@ t03:
 			WINTER: t03.win
 			SNOW: t03.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t03.husk:
 	Defaults:
@@ -393,6 +501,8 @@ t03.husk:
 			SNOW: t03.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t02:
 	Defaults:
@@ -401,6 +511,8 @@ t02:
 			WINTER: t02.win
 			SNOW: t02.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t02.husk:
 	Defaults:
@@ -410,6 +522,8 @@ t02.husk:
 			SNOW: t02.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 t01:
 	Defaults:
@@ -418,6 +532,8 @@ t01:
 			WINTER: t01.win
 			SNOW: t01.sno
 	idle:
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 t01.husk:
 	Defaults:
@@ -427,6 +543,8 @@ t01.husk:
 			SNOW: t01.sno
 	idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v01:
 	Defaults:
@@ -435,8 +553,12 @@ v01:
 			WINTER: v01.win
 			SNOW: v01.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v01.husk:
 	idle:
@@ -445,6 +567,8 @@ v01.husk:
 			WINTER: v01.win
 			SNOW: v01.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v02:
 	Defaults:
@@ -453,8 +577,12 @@ v02:
 			WINTER: v02.win
 			SNOW: v02.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v02.husk:
 	idle:
@@ -463,6 +591,8 @@ v02.husk:
 			WINTER: v02.win
 			SNOW: v02.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v03:
 	Defaults:
@@ -471,8 +601,12 @@ v03:
 			WINTER: v03.win
 			SNOW: v03.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v03.husk:
 	idle:
@@ -481,6 +615,8 @@ v03.husk:
 			WINTER: v03.win
 			SNOW: v03.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v04:
 	Defaults:
@@ -489,8 +625,12 @@ v04:
 			WINTER: v04.win
 			SNOW: v04.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v04.husk:
 	idle:
@@ -499,6 +639,8 @@ v04.husk:
 			WINTER: v04.win
 			SNOW: v04.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v05:
 	Defaults:
@@ -507,8 +649,12 @@ v05:
 			WINTER: v05.win
 			SNOW: v05.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v05.husk:
 	idle:
@@ -517,6 +663,8 @@ v05.husk:
 			WINTER: v05.win
 			SNOW: v05.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v06:
 	Defaults:
@@ -525,8 +673,12 @@ v06:
 			WINTER: v06.win
 			SNOW: v06.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v06.husk:
 	idle:
@@ -535,6 +687,8 @@ v06.husk:
 			WINTER: v06.win
 			SNOW: v06.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v07:
 	Defaults:
@@ -543,8 +697,12 @@ v07:
 			WINTER: v07.win
 			SNOW: v07.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v07.husk:
 	idle:
@@ -553,6 +711,8 @@ v07.husk:
 			WINTER: v07.win
 			SNOW: v07.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v08:
 	Defaults:
@@ -561,8 +721,12 @@ v08:
 			WINTER: v08.win
 			SNOW: v08.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v08.husk:
 	idle:
@@ -571,6 +735,8 @@ v08.husk:
 			WINTER: v08.win
 			SNOW: v08.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v09:
 	Defaults:
@@ -579,8 +745,12 @@ v09:
 			WINTER: v09.win
 			SNOW: v09.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v09.husk:
 	idle:
@@ -589,6 +759,8 @@ v09.husk:
 			WINTER: v09.win
 			SNOW: v09.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v10:
 	Defaults:
@@ -597,8 +769,12 @@ v10:
 			WINTER: v10.win
 			SNOW: v10.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v10.husk:
 	idle:
@@ -607,6 +783,8 @@ v10.husk:
 			WINTER: v10.win
 			SNOW: v10.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v11:
 	Defaults:
@@ -615,8 +793,12 @@ v11:
 			WINTER: v11.win
 			SNOW: v11.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v11.husk:
 	idle:
@@ -625,6 +807,8 @@ v11.husk:
 			WINTER: v11.win
 			SNOW: v11.sno
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v12:
 	Defaults:
@@ -634,9 +818,13 @@ v12:
 			SNOW: v12.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v12.husk:
 	idle:
@@ -646,6 +834,8 @@ v12.husk:
 			SNOW: v12.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v13:
 	Defaults:
@@ -655,9 +845,13 @@ v13:
 			SNOW: v13.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v13.husk:
 	idle:
@@ -667,6 +861,8 @@ v13.husk:
 			SNOW: v13.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v14:
 	Defaults:
@@ -676,9 +872,13 @@ v14:
 			SNOW: v14.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v14.husk:
 	idle:
@@ -688,6 +888,8 @@ v14.husk:
 			SNOW: v14.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v15:
 	Defaults:
@@ -697,9 +899,13 @@ v15:
 			SNOW: v15.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v15.husk:
 	idle:
@@ -709,6 +915,8 @@ v15.husk:
 			SNOW: v15.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v16:
 	Defaults:
@@ -718,9 +926,13 @@ v16:
 			SNOW: v16.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v16.husk:
 	idle:
@@ -730,6 +942,8 @@ v16.husk:
 			SNOW: v16.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v17:
 	Defaults:
@@ -739,9 +953,13 @@ v17:
 			SNOW: v17.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v17.husk:
 	idle:
@@ -751,6 +969,8 @@ v17.husk:
 			SNOW: v17.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v18:
 	Defaults:
@@ -760,9 +980,13 @@ v18:
 			SNOW: v18.sno
 	idle:
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v18.husk:
 	idle:
@@ -772,6 +996,8 @@ v18.husk:
 			SNOW: v18.sno
 		Start: 2
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 v19:
 	Defaults:
@@ -779,267 +1005,391 @@ v19:
 	idle:
 		Length: 14
 		Tick: 120
+		Palette: derrick
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 14
 		Length: 14
 		Tick: 120
+		Palette: derrick
+		IsPlayerPalette: True
 
 v19.husk:
 	idle:
 		Filename: v19.shp
 		Start: 28
+		Palette: derrick
+		IsPlayerPalette: True
 	fire-start:
 		Filename: flmspt.shp
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
+		Palette: derrick
+		IsPlayerPalette: True
 	fire-loop:
 		Filename: flmspt.shp
 		Start: 50
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
+		Palette: derrick
+		IsPlayerPalette: True
 
 v20:
 	idle:
 		Filename: v20.des
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v20.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 
 v20.husk:
 	idle:
 		Filename: v20.des
 		Start: 6
+		Palette: player
+		IsPlayerPalette: True
 
 v21:
 	idle:
 		Filename: v21.des
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v21.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 
 v21.husk:
 	idle:
 		Filename: v21.des
 		Start: 6
+		Palette: player
+		IsPlayerPalette: True
 
 v22:
 	idle:
 		Filename: v22.des
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v22.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 
 v22.husk:
 	idle:
 		Filename: v22.des
 		Start: 6
+		Palette: player
+		IsPlayerPalette: True
 
 v23:
 	idle:
 		Filename: v23.des
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v23.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 
 v23.husk:
 	idle:
 		Filename: v23.des
 		Start: 6
+		Palette: player
+		IsPlayerPalette: True
 
 v24:
 	idle:
 		Filename: v24.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v24.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v24.husk:
 	idle:
 		Filename: v24.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v25:
 	idle:
 		Filename: v25.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v25.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v25.husk:
 	idle:
 		Filename: v25.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v26:
 	idle:
 		Filename: v26.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v26.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v26.husk:
 	idle:
 		Filename: v26.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v27:
 	idle:
 		Filename: v27.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v27.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v27.husk:
 	idle:
 		Filename: v27.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v28:
 	idle:
 		Filename: v28.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v28.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v28.husk:
 	idle:
 		Filename: v28.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v29:
 	idle:
 		Filename: v29.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v29.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v29.husk:
 	idle:
 		Filename: v29.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v30:
 	idle:
 		Filename: v30.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v30.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v30.husk:
 	idle:
 		Filename: v30.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v31:
 	idle:
 		Filename: v31.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v31.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v31.husk:
 	idle:
 		Filename: v31.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v32:
 	idle:
 		Filename: v32.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v32.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v32.husk:
 	idle:
 		Filename: v32.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v33:
 	idle:
 		Filename: v33.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v33.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v33.husk:
 	idle:
 		Filename: v33.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v34:
 	idle:
 		Filename: v34.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v34.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v34.husk:
 	idle:
 		Filename: v34.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v35:
 	idle:
 		Filename: v35.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v35.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v35.husk:
 	idle:
 		Filename: v35.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v36:
 	idle:
 		Filename: v36.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v36.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v36.husk:
 	idle:
 		Filename: v36.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 v37:
 	idle:
 		Filename: v37.des
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: v37.des
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 v37.husk:
 	idle:
 		Filename: v37.des
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 arco:
 	Defaults:
 		Filename: arco.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 
 arco.husk:
 	idle:
 		Filename: arco.shp
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/cnc/sequences/funpark.yaml
+++ b/mods/cnc/sequences/funpark.yaml
@@ -4,7 +4,6 @@ steg:
 	stand:
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -13,22 +12,18 @@ steg:
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 12
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	die:
 		Start: 176
 		Length: 22
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: stegicnh.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 trex:
 	Defaults:
@@ -36,7 +31,6 @@ trex:
 	stand:
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -45,13 +39,11 @@ trex:
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	die:
 		Start: 144
 		Length: 40
@@ -60,7 +52,6 @@ trex:
 	icon:
 		Filename: trexicnh.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 tric:
 	Defaults:
@@ -68,7 +59,6 @@ tric:
 	stand:
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -77,13 +67,11 @@ tric:
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 12
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	die:
 		Start: 176
 		Length: 20
@@ -92,7 +80,6 @@ tric:
 	icon:
 		Filename: tricicnh.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 rapt:
 	Defaults:
@@ -100,7 +87,6 @@ rapt:
 	stand:
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -109,13 +95,11 @@ rapt:
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 8
 		Facings: 8
 		Palette: terrain
-		IsPlayerPalette: False
 	die:
 		Start: 144
 		Length: 40
@@ -124,4 +108,3 @@ rapt:
 	icon:
 		Filename: rapticnh.shp
 		Palette: chrome
-		IsPlayerPalette: False

--- a/mods/cnc/sequences/funpark.yaml
+++ b/mods/cnc/sequences/funpark.yaml
@@ -3,6 +3,8 @@ steg:
 		Filename: steg.shp
 	stand:
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -10,21 +12,31 @@ steg:
 		Start: 16
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 12
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	die:
 		Start: 176
 		Length: 22
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: stegicnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 trex:
 	Defaults:
 		Filename: trex.shp
 	stand:
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -32,21 +44,31 @@ trex:
 		Start: 16
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	die:
 		Start: 144
 		Length: 40
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: trexicnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 tric:
 	Defaults:
 		Filename: tric.shp
 	stand:
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -54,21 +76,31 @@ tric:
 		Start: 16
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 12
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	die:
 		Start: 176
 		Length: 20
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: tricicnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 rapt:
 	Defaults:
 		Filename: rapt.shp
 	stand:
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	stand2:
 		Start: 8
 		Facings: 8
@@ -76,12 +108,20 @@ rapt:
 		Start: 16
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	attack:
 		Start: 80
 		Length: 8
 		Facings: 8
+		Palette: terrain
+		IsPlayerPalette: False
 	die:
 		Start: 144
 		Length: 40
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: rapticnh.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -41,7 +41,6 @@ vice:
 		Facings: 8
 		Length: 13
 		Palette: effect
-		IsPlayerPalette: False
 	die:
 		Filename: chemball.shp
 		Length: *
@@ -60,13 +59,11 @@ pvice:
 		IsPlayerPalette: True
 	muzzle:
 		Palette: effect
-		IsPlayerPalette: False
 	die:
 		Palette: player
 		IsPlayerPalette: True
 	icon:
 		Palette: chrome
-		IsPlayerPalette: False
 
 e1:
 	Defaults:
@@ -211,7 +208,6 @@ e1:
 	icon:
 		Filename: e1icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 e2:
 	Defaults:
@@ -343,7 +339,6 @@ e2:
 	icon:
 		Filename: e2icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 e3:
 	Defaults:
@@ -475,7 +470,6 @@ e3:
 	icon:
 		Filename: e3icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 e4:
 	Defaults:
@@ -642,11 +636,9 @@ e4:
 		Facings: 8
 		Length: 13
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: e4icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 e5:
 	Defaults:
@@ -813,11 +805,9 @@ e5:
 		Facings: 8
 		Length: 13
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: e5icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 e6:
 	Defaults:
@@ -937,7 +927,6 @@ e6:
 	icon:
 		Filename: e6icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 rmbo:
 	Defaults:
@@ -1075,4 +1064,3 @@ rmbo:
 	icon:
 		Filename: rmboicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False

--- a/mods/cnc/sequences/infantry.yaml
+++ b/mods/cnc/sequences/infantry.yaml
@@ -2,6 +2,8 @@ vice:
 	idle:
 		Filename: vice.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Combine:
 			0:
@@ -38,10 +40,14 @@ vice:
 				Offset: -3,2
 		Facings: 8
 		Length: 13
+		Palette: effect
+		IsPlayerPalette: False
 	die:
 		Filename: chemball.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: viceicnh.shp
 
@@ -49,37 +55,63 @@ pvice:
 	Inherits: vice
 	Defaults:
 		Filename: pvice.shp
+	idle:
+		Palette: player
+		IsPlayerPalette: True
+	muzzle:
+		Palette: effect
+		IsPlayerPalette: False
+	die:
+		Palette: player
+		IsPlayerPalette: True
+	icon:
+		Palette: chrome
+		IsPlayerPalette: False
 
 e1:
 	Defaults:
 		Filename: e1.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 128
@@ -94,18 +126,26 @@ e1:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 257
 		Length: 15
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 272
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle3:
 		Start: 289
 		Length: 22
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 460
 		Length: 3
@@ -116,62 +156,88 @@ e1:
 		Start: 517
 		Length: 9
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	# Shot
 	die1:
 		Start: 381
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 390
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 398
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 406
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 418
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 366
 		Length: 11
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e1icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 e2:
 	Defaults:
 		Filename: e2.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	throw:
 		Start: 64
 		Length: 20
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 224
@@ -186,27 +252,39 @@ e2:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 240
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	prone-throw:
 		Start: 288
 		Length: 12
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 400
 		Length: 13
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 588
 		Length: 3
@@ -217,57 +295,81 @@ e2:
 		Start: 509
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 518
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 526
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 534
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 546
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 494
 		Length: 11
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e2rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e2icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 e3:
 	Defaults:
 		Filename: e3.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 128
@@ -282,27 +384,39 @@ e3:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 192
 		Length: 10
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 274
 		Length: 12
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 289
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 476
 		Length: 3
@@ -313,57 +427,81 @@ e3:
 		Start: 397
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 406
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 414
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 422
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 434
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 382
 		Length: 11
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e3rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e3icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 e4:
 	Defaults:
 		Filename: e4.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 192
@@ -378,27 +516,39 @@ e4:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 400
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 588
 		Length: 3
@@ -409,37 +559,51 @@ e4:
 		Start: 509
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 518
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 526
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 534
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 546
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 494
 		Length: 10
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e4rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename:
 		Combine:
@@ -477,26 +641,38 @@ e4:
 				Offset: -7,8
 		Facings: 8
 		Length: 13
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: e4icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 e5:
 	Defaults:
 		Filename: e5.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 192
@@ -511,27 +687,39 @@ e5:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 400
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 588
 		Length: 3
@@ -542,37 +730,51 @@ e5:
 		Start: 509
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 518
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 526
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 534
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 546
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 494
 		Length: 10
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e4rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename:
 		Combine:
@@ -610,22 +812,32 @@ e5:
 				Offset: -3,2
 		Facings: 8
 		Length: 13
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: e5icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 e6:
 	Defaults:
 		Filename: e6.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 66
@@ -640,23 +852,33 @@ e6:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 82
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 114
 		Length: 6
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 200
 		Length: 6
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 200
 		Length: 3
@@ -667,57 +889,81 @@ e6:
 		Start: 146
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 154
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 162
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 170
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 182
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 130
 		Length: 4
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e6icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 rmbo:
 	Defaults:
 		Filename: rmbo.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	# stand -> prone transition
 	liedown:
 		Start: 96
@@ -732,31 +978,45 @@ rmbo:
 		Start: 112
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 112
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 112
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 160
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 192
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 208
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle3:
 		Start: 224
 		Length: 15
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	cheer:
 		Start: 396
 		Length: 3
@@ -767,36 +1027,52 @@ rmbo:
 		Start: 318
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Explode
 	die2:
 		Start: 326
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly and explode in air
 	die3:
 		Start: 334
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Fly through air squish on ground
 	die4:
 		Start: 342
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Burn
 	die5:
 		Start: 354
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	# Tib
 	die6:
 		Start: 308
 		Length: 4
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: e1rot.shp
 		Start: 16
 		Length: 4
 		Tick: 1600
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: rmboicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -10,6 +10,8 @@ fire:
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	2:
 		Filename: fire2.shp
 		Length: *
@@ -26,10 +28,14 @@ burn-l:
 		Start: 16
 		Length: 44
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 burn-m:
 	Defaults:
@@ -41,10 +47,14 @@ burn-m:
 		Start: 16
 		Length: 44
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 burn-s:
 	Defaults:
@@ -56,15 +66,21 @@ burn-s:
 		Start: 12
 		Length: 46
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 	end:
 		Start: 59
 		Length: 5
 		ZOffset: 512
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 120mm:
 	idle:
 		Filename: 120mm.shp
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 smoke_m:
 	Defaults:
@@ -73,6 +89,10 @@ smoke_m:
 		Length: *
 		Offset: 2, -5
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	start:
 		Length: 49
 		Offset: 2, -5
@@ -82,6 +102,8 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 
 scorch_flames:
 	large_flame:
@@ -142,6 +164,8 @@ scorch_flames:
 				Length: 42
 				Offset: 2, -5
 				Scale: 0.25
+		Palette: effect
+		IsPlayerPalette: False
 	medium_flame:
 		Length: *
 		Combine:
@@ -187,6 +211,8 @@ scorch_flames:
 				Length: 42
 				Offset: 2, -5
 				Scale: 0.25
+		Palette: effect
+		IsPlayerPalette: False
 	small_flame:
 		Combine:
 			0:
@@ -228,6 +254,8 @@ scorch_flames:
 				Scale: 0.25
 		Length: *
 		Offset: 0,-3
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_flame:
 		Combine:
 			0:
@@ -300,30 +328,40 @@ laserfire:
 		Filename: veh-hit3.shp
 		Length: *
 		ZOffset: 511
+		Palette: effect
+		IsPlayerPalette: False
 
 dragon:
 	idle:
 		Filename: dragon.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 smokey:
 	idle:
 		Filename: smokey.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 bomb:
 	idle:
 		Filename: bomb.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 missile:
 	idle:
 		Filename: missile.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 patriot:
 	idle:
@@ -337,48 +375,84 @@ explosion:
 		ZOffset: 2047
 	nuke_explosion:
 		Filename: atomsfx.shp
+		Palette: effect
+		IsPlayerPalette: False
 	piff:
 		Filename: piff.shp
+		Palette: effect
+		IsPlayerPalette: False
 	piffs:
 		Filename: piffpiff.shp
+		Palette: effect
+		IsPlayerPalette: False
 	chemball:
 		Filename: chemball.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_napalm:
 		Filename: napalm1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	med_napalm:
 		Filename: napalm2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	big_napalm:
 		Filename: napalm3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_frag:
 		Filename: veh-hit3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	med_frag:
 		Filename: frag1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	big_frag:
 		Filename: frag3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_poof:
 		Filename: veh-hit2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	poof:
 		Filename: art-exp1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_building:
 		Filename: veh-hit1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	building:
 		Filename: fball1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	building_napalm:
 		Filename: napalm2.shp
 		FlipX: true
+		Palette: effect
+		IsPlayerPalette: False
 
 rank:
 	Defaults:
 		Filename: rank.shp
 		Offset: 0, 3
 	rank-veteran-1:
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-2:
 		Start: 1
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-3:
 		Start: 2
 	rank-elite:
 		Start: 3
 		Offset: 1, 3
+		Palette: effect
+		IsPlayerPalette: False
 
 rallypoint:
 	flag:
@@ -386,10 +460,14 @@ rallypoint:
 		Length: *
 		Offset: 10,-5
 		ZOffset: 2535
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 beacon:
 	Defaults:
@@ -398,20 +476,30 @@ beacon:
 		Filename: mouse2.shp
 		Start: 5
 		Offset: 1,-12
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 	airstrike:
 		Filename: bombicon.shp
 		Offset: 0,-42
+		Palette: beaconposter
+		IsPlayerPalette: False
 	atomic:
 		Filename: atomicon.shp
 		Offset: 0,-42
+		Palette: beaconposter
+		IsPlayerPalette: False
 	clock:
 		Filename: beaconclock.shp
 		Length: *
 		Offset: 0,-42
+		Palette: beaconposter
+		IsPlayerPalette: False
 
 select:
 	repair:
@@ -424,41 +512,55 @@ allyrepair:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 scrate:
 	idle:
 		Filename: scrate.shp
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 wcrate:
 	idle:
 		Filename: wcrate.shp
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcratea:
 	idle:
 		Filename: xcrate.shp
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcrateb:
 	idle:
 		Filename: xcrate.shp
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcratec:
 	idle:
 		Filename: xcrate.shp
 		Start: 2
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcrated:
 	idle:
 		Filename: xcrate.shp
 		Start: 3
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -472,6 +574,8 @@ crate-effects:
 		Filename: dollar.shp
 	reveal-map:
 		Filename: radarcrate.shp
+		Palette: effect
+		IsPlayerPalette: False
 	hide-map:
 		Filename: empulse.shp
 	heal:
@@ -482,9 +586,13 @@ crate-effects:
 		Filename: rapid.shp
 	cloak:
 		Filename: cloakcrate.shp
+		Palette: effect
+		IsPlayerPalette: False
 	levelup:
 		Filename: levelup.shp
 		Tick: 200
+		Palette: effect
+		IsPlayerPalette: False
 	firepowerup:
 		Filename: firepowercrate.shp
 	armorup:
@@ -498,8 +606,12 @@ atomic:
 		ZOffset: 1023
 	up:
 		Filename: atomicup.shp
+		Palette: effect
+		IsPlayerPalette: False
 	down:
 		Filename: atomicdn.shp
+		Palette: effect
+		IsPlayerPalette: False
 
 ionsfx:
 	idle:
@@ -507,65 +619,99 @@ ionsfx:
 		Length: *
 		Offset: 0, -78
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 bomblet:
 	idle:
 		Filename: bomblet.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 mpspawn:
 	idle:
 		Filename: mpspawn.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 waypoint:
 	idle:
 		Filename: waypoint.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 camera:
 	idle:
 		Filename: camera.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 clock:
 	idle:
 		Filename: hclock.shp
 		Length: *
+		Palette: chrome
+		IsPlayerPalette: False
 
 pips:
 	Defaults:
 		Filename: pips.shp
 	pip-empty:
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-green:
 		Start: 1
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-yellow:
 		Start: 2
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-gray:
 		Start: 3
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-red:
 		Start: 4
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-blue:
 		Start: 5
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-heal:
 		Filename: pip-heal.shp
 		Offset: -1, 1
+		Palette: chrome
+		IsPlayerPalette: False
 	groups:
 		Filename: pdigits.shp
 		Length: *
 		Offset: 9, 5
 		Frames: 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-hazmat:
 		Filename: pip-hazmat.shp
 		Offset: -3, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 overlay:
 	Defaults:
 		Filename: trans.icn
 	build-valid:
+		Palette: terrain
+		IsPlayerPalette: False
 	build-invalid:
 		Start: 2
+		Palette: terrain
+		IsPlayerPalette: False
 	target-valid:
 	target-select:
 		Start: 1
@@ -589,10 +735,16 @@ poweroff:
 icon:
 	airstrike:
 		Filename: bombicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 	ioncannon:
 		Filename: ionicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 	abomb:
 		Filename: atomicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 moveflsh:
 	idle:
@@ -600,6 +752,8 @@ moveflsh:
 		Length: *
 		Tick: 80
 		ZOffset: 2047
+		Palette: moveflash
+		IsPlayerPalette: False
 
 resources:
 	Defaults:
@@ -610,184 +764,280 @@ resources:
 			WINTER: ti1.win
 			SNOW: ti1.sno
 			TEMPERAT: ti1.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti2:
 		TilesetFilenames:
 			DESERT: ti2.des
 			WINTER: ti2.win
 			SNOW: ti2.sno
 			TEMPERAT: ti2.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti3:
 		TilesetFilenames:
 			DESERT: ti3.des
 			WINTER: ti3.win
 			SNOW: ti3.sno
 			TEMPERAT: ti3.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti4:
 		TilesetFilenames:
 			DESERT: ti4.des
 			WINTER: ti4.win
 			SNOW: ti4.sno
 			TEMPERAT: ti4.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti5:
 		TilesetFilenames:
 			DESERT: ti5.des
 			WINTER: ti5.win
 			SNOW: ti5.sno
 			TEMPERAT: ti5.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti6:
 		TilesetFilenames:
 			DESERT: ti6.des
 			WINTER: ti6.win
 			SNOW: ti6.sno
 			TEMPERAT: ti6.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti7:
 		TilesetFilenames:
 			DESERT: ti7.des
 			WINTER: ti7.win
 			SNOW: ti7.sno
 			TEMPERAT: ti7.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti8:
 		TilesetFilenames:
 			DESERT: ti8.des
 			WINTER: ti8.win
 			SNOW: ti8.sno
 			TEMPERAT: ti8.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti9:
 		TilesetFilenames:
 			DESERT: ti9.des
 			WINTER: ti9.win
 			SNOW: ti9.sno
 			TEMPERAT: ti9.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti10:
 		TilesetFilenames:
 			DESERT: ti10.des
 			WINTER: ti10.win
 			SNOW: ti10.sno
 			TEMPERAT: ti10.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti11:
 		TilesetFilenames:
 			DESERT: ti11.des
 			WINTER: ti11.win
 			SNOW: ti11.sno
 			TEMPERAT: ti11.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	ti12:
 		TilesetFilenames:
 			DESERT: ti12.des
 			WINTER: ti12.win
 			SNOW: ti12.sno
 			TEMPERAT: ti12.tem
+		Palette: staticterrain
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 
 shroud:
 	Defaults:
 		Filename: shadow.shp
 		Length: 12
 	shroud-typea:
+		Palette: shroud
+		IsPlayerPalette: False
 	shroud-typeb:
 		Start: 12
+		Palette: shroud
+		IsPlayerPalette: False
 	shroud-typec:
 		Start: 24
+		Palette: shroud
+		IsPlayerPalette: False
 	shroud-typed:
 		Start: 36
+		Palette: shroud
+		IsPlayerPalette: False
 	shroud-full:
 		Filename: fullshroud.shp
 		Length: 1
+		Palette: shroud
+		IsPlayerPalette: False
 	fog-typea:
 		Alpha: 0.5
+		Palette: shroud
+		IsPlayerPalette: False
 	fog-typeb: shadow
 		Alpha: 0.5
 		Start: 12
+		Palette: shroud
+		IsPlayerPalette: False
 	fog-typec: shadow
 		Alpha: 0.5
 		Start: 24
+		Palette: shroud
+		IsPlayerPalette: False
 	fog-typed: shadow
 		Alpha: 0.5
 		Start: 36
+		Palette: shroud
+		IsPlayerPalette: False
 	fog-full:
 		Filename: fullshroud.shp
 		Length: 1
 		Alpha: 0.5
+		Palette: shroud
+		IsPlayerPalette: False
 
 # Note: The order of smudges and craters determines
 # the index that is mapped to them in maps
 scorches:
 	Defaults:
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	sc1:
 		TilesetFilenames:
 			DESERT: sc1.des
 			WINTER: sc1.win
 			SNOW: sc1.sno
 			TEMPERAT: sc1.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	sc2:
 		TilesetFilenames:
 			DESERT: sc2.des
 			WINTER: sc2.win
 			SNOW: sc2.sno
 			TEMPERAT: sc2.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	sc3:
 		TilesetFilenames:
 			DESERT: sc3.des
 			WINTER: sc3.win
 			SNOW: sc3.sno
 			TEMPERAT: sc3.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	sc4:
 		TilesetFilenames:
 			DESERT: sc4.des
 			WINTER: sc4.win
 			SNOW: sc4.sno
 			TEMPERAT: sc4.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	sc5:
 		TilesetFilenames:
 			DESERT: sc5.des
 			WINTER: sc5.win
 			SNOW: sc5.sno
 			TEMPERAT: sc5.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	sc6:
 		TilesetFilenames:
 			DESERT: sc6.des
 			WINTER: sc6.win
 			SNOW: sc6.sno
 			TEMPERAT: sc6.tem
+		Palette: terrain
+		IsPlayerPalette: False
 
 craters:
 	Defaults:
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	cr1:
 		TilesetFilenames:
 			DESERT: cr1.des
 			WINTER: cr1.win
 			SNOW: cr1.sno
 			TEMPERAT: cr1.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	cr2:
 		TilesetFilenames:
 			DESERT: cr2.des
 			WINTER: cr2.win
 			SNOW: cr2.sno
 			TEMPERAT: cr2.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	cr3:
 		TilesetFilenames:
 			DESERT: cr3.des
 			WINTER: cr3.win
 			SNOW: cr3.sno
 			TEMPERAT: cr3.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	cr4:
 		TilesetFilenames:
 			DESERT: cr4.des
 			WINTER: cr4.win
 			SNOW: cr4.sno
 			TEMPERAT: cr4.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	cr5:
 		TilesetFilenames:
 			DESERT: cr5.des
 			WINTER: cr5.win
 			SNOW: cr5.sno
 			TEMPERAT: cr5.tem
+		Palette: terrain
+		IsPlayerPalette: False
 	cr6:
 		TilesetFilenames:
 			DESERT: cr6.des
 			WINTER: cr6.win
 			SNOW: cr6.sno
 			TEMPERAT: cr6.tem
+		Palette: terrain
+		IsPlayerPalette: False
 
 smokland:
 	Defaults:
@@ -796,42 +1046,62 @@ smokland:
 		Length: 72
 		Tick: 120
 		ZOffset: 1023
+		Palette: terrain
+		IsPlayerPalette: False
 	idle:
 		Start: 72
 		Length: 20
 		Tick: 120
 		ZOffset: 1023
+		Palette: terrain
+		IsPlayerPalette: False
 
 airstrikedirection:
 	arrow-t:
 		Filename: mouse2.shp
 		Start: 1
 		Offset: 0, -15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tr:
 		Filename: mouse2.shp
 		Start: 2
 		Offset: 7, -7, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-r:
 		Filename: mouse2.shp
 		Start: 3
 		Offset: 12, 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-br:
 		Filename: mouse2.shp
 		Start: 4
 		Offset: 7, 7, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-b:
 		Filename: mouse2.shp
 		Start: 5
 		Offset: 0, 15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-bl:
 		Filename: mouse2.shp
 		Start: 6
 		Offset: -7, 7, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-l:
 		Filename: mouse2.shp
 		Start: 7
 		Offset: -12, 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tl:
 		Filename: mouse2.shp
 		Start: 8
 		Offset: -7, -7, 0
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -29,13 +29,11 @@ burn-l:
 		Length: 44
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 burn-m:
 	Defaults:
@@ -48,13 +46,11 @@ burn-m:
 		Length: 44
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 burn-s:
 	Defaults:
@@ -67,20 +63,17 @@ burn-s:
 		Length: 46
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 	end:
 		Start: 59
 		Length: 5
 		ZOffset: 512
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 120mm:
 	idle:
 		Filename: 120mm.shp
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 smoke_m:
 	Defaults:
@@ -90,9 +83,6 @@ smoke_m:
 		Offset: 2, -5
 		ZOffset: 512
 		Palette: effect
-		IsPlayerPalette: False
-		Palette: player
-		IsPlayerPalette: True
 	start:
 		Length: 49
 		Offset: 2, -5
@@ -102,8 +92,7 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
-		Palette: player
-		IsPlayerPalette: True
+		Palette: effect
 
 scorch_flames:
 	large_flame:
@@ -165,7 +154,6 @@ scorch_flames:
 				Offset: 2, -5
 				Scale: 0.25
 		Palette: effect
-		IsPlayerPalette: False
 	medium_flame:
 		Length: *
 		Combine:
@@ -212,7 +200,6 @@ scorch_flames:
 				Offset: 2, -5
 				Scale: 0.25
 		Palette: effect
-		IsPlayerPalette: False
 	small_flame:
 		Combine:
 			0:
@@ -255,7 +242,6 @@ scorch_flames:
 		Length: *
 		Offset: 0,-3
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_flame:
 		Combine:
 			0:
@@ -329,7 +315,6 @@ laserfire:
 		Length: *
 		ZOffset: 511
 		Palette: effect
-		IsPlayerPalette: False
 
 dragon:
 	idle:
@@ -337,7 +322,6 @@ dragon:
 		Facings: 32
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 smokey:
 	idle:
@@ -345,7 +329,6 @@ smokey:
 		Length: *
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 bomb:
 	idle:
@@ -353,7 +336,6 @@ bomb:
 		Length: *
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 missile:
 	idle:
@@ -361,7 +343,6 @@ missile:
 		Facings: 32
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 patriot:
 	idle:
@@ -376,64 +357,49 @@ explosion:
 	nuke_explosion:
 		Filename: atomsfx.shp
 		Palette: effect
-		IsPlayerPalette: False
 	piff:
 		Filename: piff.shp
 		Palette: effect
-		IsPlayerPalette: False
 	piffs:
 		Filename: piffpiff.shp
 		Palette: effect
-		IsPlayerPalette: False
 	chemball:
 		Filename: chemball.shp
 		Palette: effect
-		IsPlayerPalette: False
 	small_napalm:
 		Filename: napalm1.shp
 		Palette: effect
-		IsPlayerPalette: False
 	med_napalm:
 		Filename: napalm2.shp
 		Palette: effect
-		IsPlayerPalette: False
 	big_napalm:
 		Filename: napalm3.shp
 		Palette: effect
-		IsPlayerPalette: False
 	small_frag:
 		Filename: veh-hit3.shp
 		Palette: effect
-		IsPlayerPalette: False
 	med_frag:
 		Filename: frag1.shp
 		Palette: effect
-		IsPlayerPalette: False
 	big_frag:
 		Filename: frag3.shp
 		Palette: effect
-		IsPlayerPalette: False
 	small_poof:
 		Filename: veh-hit2.shp
 		Palette: effect
-		IsPlayerPalette: False
 	poof:
 		Filename: art-exp1.shp
 		Palette: effect
-		IsPlayerPalette: False
 	small_building:
 		Filename: veh-hit1.shp
 		Palette: effect
-		IsPlayerPalette: False
 	building:
 		Filename: fball1.shp
 		Palette: effect
-		IsPlayerPalette: False
 	building_napalm:
 		Filename: napalm2.shp
 		FlipX: true
 		Palette: effect
-		IsPlayerPalette: False
 
 rank:
 	Defaults:
@@ -441,18 +407,15 @@ rank:
 		Offset: 0, 3
 	rank-veteran-1:
 		Palette: effect
-		IsPlayerPalette: False
 	rank-veteran-2:
 		Start: 1
 		Palette: effect
-		IsPlayerPalette: False
 	rank-veteran-3:
 		Start: 2
 	rank-elite:
 		Start: 3
 		Offset: 1, 3
 		Palette: effect
-		IsPlayerPalette: False
 
 rallypoint:
 	flag:
@@ -488,18 +451,15 @@ beacon:
 		Filename: bombicon.shp
 		Offset: 0,-42
 		Palette: beaconposter
-		IsPlayerPalette: False
 	atomic:
 		Filename: atomicon.shp
 		Offset: 0,-42
 		Palette: beaconposter
-		IsPlayerPalette: False
 	clock:
 		Filename: beaconclock.shp
 		Length: *
 		Offset: 0,-42
 		Palette: beaconposter
-		IsPlayerPalette: False
 
 select:
 	repair:
@@ -521,7 +481,6 @@ scrate:
 		Start: 1
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 wcrate:
 	idle:
@@ -529,14 +488,12 @@ wcrate:
 		Start: 1
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 xcratea:
 	idle:
 		Filename: xcrate.shp
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 xcrateb:
 	idle:
@@ -544,7 +501,6 @@ xcrateb:
 		Start: 1
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 xcratec:
 	idle:
@@ -552,7 +508,6 @@ xcratec:
 		Start: 2
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 xcrated:
 	idle:
@@ -560,7 +515,6 @@ xcrated:
 		Start: 3
 		ZOffset: -511
 		Palette: effect
-		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -575,7 +529,6 @@ crate-effects:
 	reveal-map:
 		Filename: radarcrate.shp
 		Palette: effect
-		IsPlayerPalette: False
 	hide-map:
 		Filename: empulse.shp
 	heal:
@@ -587,12 +540,10 @@ crate-effects:
 	cloak:
 		Filename: cloakcrate.shp
 		Palette: effect
-		IsPlayerPalette: False
 	levelup:
 		Filename: levelup.shp
 		Tick: 200
 		Palette: effect
-		IsPlayerPalette: False
 	firepowerup:
 		Filename: firepowercrate.shp
 	armorup:
@@ -607,11 +558,9 @@ atomic:
 	up:
 		Filename: atomicup.shp
 		Palette: effect
-		IsPlayerPalette: False
 	down:
 		Filename: atomicdn.shp
 		Palette: effect
-		IsPlayerPalette: False
 
 ionsfx:
 	idle:
@@ -620,7 +569,6 @@ ionsfx:
 		Offset: 0, -78
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 bomblet:
 	idle:
@@ -628,7 +576,6 @@ bomblet:
 		Length: *
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 mpspawn:
 	idle:
@@ -656,62 +603,50 @@ clock:
 		Filename: hclock.shp
 		Length: *
 		Palette: chrome
-		IsPlayerPalette: False
 
 pips:
 	Defaults:
 		Filename: pips.shp
 	pip-empty:
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-green:
 		Start: 1
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-yellow:
 		Start: 2
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-gray:
 		Start: 3
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-red:
 		Start: 4
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-blue:
 		Start: 5
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-heal:
 		Filename: pip-heal.shp
 		Offset: -1, 1
 		Palette: chrome
-		IsPlayerPalette: False
 	groups:
 		Filename: pdigits.shp
 		Length: *
 		Offset: 9, 5
 		Frames: 1, 2, 3, 4, 5, 6, 7, 8, 9, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-hazmat:
 		Filename: pip-hazmat.shp
 		Offset: -3, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 overlay:
 	Defaults:
 		Filename: trans.icn
 	build-valid:
 		Palette: terrain
-		IsPlayerPalette: False
 	build-invalid:
 		Start: 2
 		Palette: terrain
-		IsPlayerPalette: False
 	target-valid:
 	target-select:
 		Start: 1
@@ -736,15 +671,12 @@ icon:
 	airstrike:
 		Filename: bombicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 	ioncannon:
 		Filename: ionicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 	abomb:
 		Filename: atomicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 moveflsh:
 	idle:
@@ -753,7 +685,6 @@ moveflsh:
 		Tick: 80
 		ZOffset: 2047
 		Palette: moveflash
-		IsPlayerPalette: False
 
 resources:
 	Defaults:
@@ -764,120 +695,84 @@ resources:
 			WINTER: ti1.win
 			SNOW: ti1.sno
 			TEMPERAT: ti1.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti2:
 		TilesetFilenames:
 			DESERT: ti2.des
 			WINTER: ti2.win
 			SNOW: ti2.sno
 			TEMPERAT: ti2.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti3:
 		TilesetFilenames:
 			DESERT: ti3.des
 			WINTER: ti3.win
 			SNOW: ti3.sno
 			TEMPERAT: ti3.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti4:
 		TilesetFilenames:
 			DESERT: ti4.des
 			WINTER: ti4.win
 			SNOW: ti4.sno
 			TEMPERAT: ti4.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti5:
 		TilesetFilenames:
 			DESERT: ti5.des
 			WINTER: ti5.win
 			SNOW: ti5.sno
 			TEMPERAT: ti5.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti6:
 		TilesetFilenames:
 			DESERT: ti6.des
 			WINTER: ti6.win
 			SNOW: ti6.sno
 			TEMPERAT: ti6.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti7:
 		TilesetFilenames:
 			DESERT: ti7.des
 			WINTER: ti7.win
 			SNOW: ti7.sno
 			TEMPERAT: ti7.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti8:
 		TilesetFilenames:
 			DESERT: ti8.des
 			WINTER: ti8.win
 			SNOW: ti8.sno
 			TEMPERAT: ti8.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti9:
 		TilesetFilenames:
 			DESERT: ti9.des
 			WINTER: ti9.win
 			SNOW: ti9.sno
 			TEMPERAT: ti9.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti10:
 		TilesetFilenames:
 			DESERT: ti10.des
 			WINTER: ti10.win
 			SNOW: ti10.sno
 			TEMPERAT: ti10.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti11:
 		TilesetFilenames:
 			DESERT: ti11.des
 			WINTER: ti11.win
 			SNOW: ti11.sno
 			TEMPERAT: ti11.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	ti12:
 		TilesetFilenames:
 			DESERT: ti12.des
 			WINTER: ti12.win
 			SNOW: ti12.sno
 			TEMPERAT: ti12.tem
-		Palette: staticterrain
-		IsPlayerPalette: False
 		Palette: bluetiberium
-		IsPlayerPalette: False
 
 shroud:
 	Defaults:
@@ -885,49 +780,39 @@ shroud:
 		Length: 12
 	shroud-typea:
 		Palette: shroud
-		IsPlayerPalette: False
 	shroud-typeb:
 		Start: 12
 		Palette: shroud
-		IsPlayerPalette: False
 	shroud-typec:
 		Start: 24
 		Palette: shroud
-		IsPlayerPalette: False
 	shroud-typed:
 		Start: 36
 		Palette: shroud
-		IsPlayerPalette: False
 	shroud-full:
 		Filename: fullshroud.shp
 		Length: 1
 		Palette: shroud
-		IsPlayerPalette: False
 	fog-typea:
 		Alpha: 0.5
 		Palette: shroud
-		IsPlayerPalette: False
 	fog-typeb: shadow
 		Alpha: 0.5
 		Start: 12
 		Palette: shroud
-		IsPlayerPalette: False
 	fog-typec: shadow
 		Alpha: 0.5
 		Start: 24
 		Palette: shroud
-		IsPlayerPalette: False
 	fog-typed: shadow
 		Alpha: 0.5
 		Start: 36
 		Palette: shroud
-		IsPlayerPalette: False
 	fog-full:
 		Filename: fullshroud.shp
 		Length: 1
 		Alpha: 0.5
 		Palette: shroud
-		IsPlayerPalette: False
 
 # Note: The order of smudges and craters determines
 # the index that is mapped to them in maps
@@ -935,7 +820,6 @@ scorches:
 	Defaults:
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	sc1:
 		TilesetFilenames:
 			DESERT: sc1.des
@@ -943,7 +827,6 @@ scorches:
 			SNOW: sc1.sno
 			TEMPERAT: sc1.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	sc2:
 		TilesetFilenames:
 			DESERT: sc2.des
@@ -951,7 +834,6 @@ scorches:
 			SNOW: sc2.sno
 			TEMPERAT: sc2.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	sc3:
 		TilesetFilenames:
 			DESERT: sc3.des
@@ -959,7 +841,6 @@ scorches:
 			SNOW: sc3.sno
 			TEMPERAT: sc3.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	sc4:
 		TilesetFilenames:
 			DESERT: sc4.des
@@ -967,7 +848,6 @@ scorches:
 			SNOW: sc4.sno
 			TEMPERAT: sc4.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	sc5:
 		TilesetFilenames:
 			DESERT: sc5.des
@@ -975,7 +855,6 @@ scorches:
 			SNOW: sc5.sno
 			TEMPERAT: sc5.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	sc6:
 		TilesetFilenames:
 			DESERT: sc6.des
@@ -983,13 +862,11 @@ scorches:
 			SNOW: sc6.sno
 			TEMPERAT: sc6.tem
 		Palette: terrain
-		IsPlayerPalette: False
 
 craters:
 	Defaults:
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	cr1:
 		TilesetFilenames:
 			DESERT: cr1.des
@@ -997,7 +874,6 @@ craters:
 			SNOW: cr1.sno
 			TEMPERAT: cr1.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	cr2:
 		TilesetFilenames:
 			DESERT: cr2.des
@@ -1005,7 +881,6 @@ craters:
 			SNOW: cr2.sno
 			TEMPERAT: cr2.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	cr3:
 		TilesetFilenames:
 			DESERT: cr3.des
@@ -1013,7 +888,6 @@ craters:
 			SNOW: cr3.sno
 			TEMPERAT: cr3.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	cr4:
 		TilesetFilenames:
 			DESERT: cr4.des
@@ -1021,7 +895,6 @@ craters:
 			SNOW: cr4.sno
 			TEMPERAT: cr4.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	cr5:
 		TilesetFilenames:
 			DESERT: cr5.des
@@ -1029,7 +902,6 @@ craters:
 			SNOW: cr5.sno
 			TEMPERAT: cr5.tem
 		Palette: terrain
-		IsPlayerPalette: False
 	cr6:
 		TilesetFilenames:
 			DESERT: cr6.des
@@ -1037,7 +909,6 @@ craters:
 			SNOW: cr6.sno
 			TEMPERAT: cr6.tem
 		Palette: terrain
-		IsPlayerPalette: False
 
 smokland:
 	Defaults:
@@ -1047,14 +918,12 @@ smokland:
 		Tick: 120
 		ZOffset: 1023
 		Palette: terrain
-		IsPlayerPalette: False
 	idle:
 		Start: 72
 		Length: 20
 		Tick: 120
 		ZOffset: 1023
 		Palette: terrain
-		IsPlayerPalette: False
 
 airstrikedirection:
 	arrow-t:
@@ -1062,46 +931,38 @@ airstrikedirection:
 		Start: 1
 		Offset: 0, -15, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-tr:
 		Filename: mouse2.shp
 		Start: 2
 		Offset: 7, -7, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-r:
 		Filename: mouse2.shp
 		Start: 3
 		Offset: 12, 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-br:
 		Filename: mouse2.shp
 		Start: 4
 		Offset: 7, 7, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-b:
 		Filename: mouse2.shp
 		Start: 5
 		Offset: 0, 15, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-bl:
 		Filename: mouse2.shp
 		Start: 6
 		Offset: -7, 7, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-l:
 		Filename: mouse2.shp
 		Start: 7
 		Offset: -12, 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-tl:
 		Filename: mouse2.shp
 		Start: 8
 		Offset: -7, -7, 0
 		Palette: chrome
-		IsPlayerPalette: False

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -5,24 +5,46 @@ fact:
 		Start: 4
 		Length: 20
 		Tick: 100
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Length: 4
 		Tick: 100
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 24
 		Length: 4
 		Tick: 100
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build:
 		Start: 28
 		Length: 20
 		Tick: 100
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 48
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: factmake.shp
 		Length: *
 		Tick: 80
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib2.des
@@ -30,8 +52,12 @@ fact:
 			SNOW: bib2.sno
 			TEMPERAT: bib2.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: facticnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 nuke:
 	Defaults:
@@ -39,17 +65,25 @@ nuke:
 	idle:
 		Length: 4
 		Tick: 1000
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 4
 		Length: 4
 		Tick: 1000
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 8
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: nukemake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -57,8 +91,12 @@ nuke:
 			SNOW: bib3.sno
 			TEMPERAT: bib3.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: nukeicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 proc:
 	Defaults:
@@ -67,29 +105,41 @@ proc:
 		Length: 6
 		Tick: 120
 		Offset: 2,4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 30
 		Length: 6
 		Tick: 120
 		Offset: 2,4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 60
 		Tick: 800
 		Offset: 2,4
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: procmake.shp
 		Length: *
 		Tick: 80
 		Offset: 2,4
+		Palette: player
+		IsPlayerPalette: True
 	resources:
 		Filename: proctwr.shp
 		Length: 6
 		Offset: -30,-17
+		Palette: player
+		IsPlayerPalette: True
 	damaged-resources:
 		Filename: proctwr.shp
 		Start: 6
 		Length: 6
 		Offset: -30,-17
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib2.des
@@ -97,8 +147,12 @@ proc:
 			SNOW: bib2.sno
 			TEMPERAT: bib2.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: procicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 silo:
 	Defaults:
@@ -112,41 +166,61 @@ silo:
 		Start: 10
 		Offset: 0,-1
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	stages:
 		Length: 5
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		Start: 5
 		Length: 5
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: silomake.shp
 		Length: *
 		Tick: 80
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: mbSILO.tem
 		TilesetFilenames:
 			DESERT: mbSILO.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: siloicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 hand:
 	Defaults:
 		Filename: hand.shp
 		Offset: 0,-8
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: handmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -155,9 +229,13 @@ hand:
 			TEMPERAT: bib3.tem
 		Length: *
 		Offset: 0,0
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: handicnh.tem
 		Offset: 0,0
+		Palette: chrome
+		IsPlayerPalette: False
 
 pyle:
 	Defaults:
@@ -166,18 +244,26 @@ pyle:
 		Length: 10
 		Tick: 100
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
 		Tick: 100
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 20
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: pylemake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -185,8 +271,12 @@ pyle:
 			SNOW: bib3.sno
 			TEMPERAT: bib3.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: pyleicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 weap:
 	Defaults:
@@ -194,28 +284,42 @@ weap:
 		Offset: 0,-12
 	idle:
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	build-top:
 		Filename: weap2.shp
 		Length: 10
 		ZOffset: -1024
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build-top:
 		Filename: weap2.shp
 		Start: 10
 		Length: 10
 		ZOffset: -1024
+		Palette: player
+		IsPlayerPalette: True
 	place:
 		Filename: weapmake.shp
 		Start: 19
+		Palette: terrain
+		IsPlayerPalette: False
 	make:
 		Filename: weapmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib2.des
@@ -224,9 +328,13 @@ weap:
 			TEMPERAT: bib2.tem
 		Length: *
 		Offset: 0,0
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: weapicnh.tem
 		Offset: 0,0
+		Palette: chrome
+		IsPlayerPalette: False
 
 afld:
 	Defaults:
@@ -234,36 +342,52 @@ afld:
 	idle:
 		Tick: 120
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Tick: 120
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 16
 		Tick: 120
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 16
 		Length: 16
 		Tick: 120
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		Filename: afld_d.shp
 		Length: 16
 		Tick: 160
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-dish:
 		Filename: afld_d.shp
 		Start: 16
 		Length: 16
 		Tick: 160
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 32
 		ZOffset: -1023
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: afldmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib1.des
@@ -271,8 +395,12 @@ afld:
 			SNOW: bib1.sno
 			TEMPERAT: bib1.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: afldicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 hq:
 	Defaults:
@@ -280,17 +408,25 @@ hq:
 	idle:
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 32
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hqmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -298,8 +434,12 @@ hq:
 			SNOW: bib3.sno
 			TEMPERAT: bib3.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: hqicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 nuk2:
 	Defaults:
@@ -307,17 +447,25 @@ nuk2:
 	idle:
 		Length: 4
 		Tick: 1000
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 4
 		Length: 4
 		Tick: 1000
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 8
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: nuk2make.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -325,69 +473,103 @@ nuk2:
 			SNOW: bib3.sno
 			TEMPERAT: bib3.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: nuk2icnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 hpad:
 	Defaults:
 		Filename: hpad.shp
 	idle:
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Start: 1
 		Length: 6
 		Tick: 100
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 8
 		Length: 6
 		Tick: 100
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 14
 		ZOffset: -1023
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hpadmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: hpadicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 fix:
 	Defaults:
 		Filename: fix.shp
 	idle:
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 7
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 7
 		Length: 7
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 14
 		ZOffset: -1c511
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: fixmake.shp
 		Length: 14
 		Tick: 60
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: mbFIX.tem
 		TilesetFilenames:
 			DESERT: mbFIX.des
 		Length: *
 		Offset: 0,-9
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: fixicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 eye:
 	Defaults:
@@ -395,17 +577,25 @@ eye:
 	idle:
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 32
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: eyemake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib3.des
@@ -413,33 +603,51 @@ eye:
 			SNOW: bib3.sno
 			TEMPERAT: bib3.tem
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: eyeicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 tmpl:
 	Defaults:
 		Filename: tmpl.shp
 		Offset: 0,-12
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 5
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 5
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	smoke:
 		Filename: atomdoor.shp
 		Length: *
 		Offset: -1,-47
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 5
 		Length: 5
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 10
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: tmplmake.shp
 		Length: *
 		Tick: 60
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			DESERT: bib2.des
@@ -448,9 +656,13 @@ tmpl:
 			TEMPERAT: bib2.tem
 		Length: *
 		Offset: 0,0
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: tmplicnh.tem
 		Offset: 0,0
+		Palette: chrome
+		IsPlayerPalette: False
 
 obli:
 	Defaults:
@@ -462,85 +674,127 @@ obli:
 	active:
 		Length: 4
 		Tick: 680
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 4
 		Length: 4
 		Tick: 680
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 8
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: oblimake.shp
 		Length: 13
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: mbOBLI.tem
 		TilesetFilenames:
 			DESERT: mbOBLI.des
 		Length: *
 		Offset: -1,-3
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: obliicnh.tem
 		Offset: 0,0
+		Palette: chrome
+		IsPlayerPalette: False
 
 brik:
 	Defaults:
 		Filename: brik.shp
 	idle:
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	scratched-idle:
 		Start: 16
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 32
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	icon:
 		Filename: brikicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 sbag:
 	idle:
 		Filename: sbag.shp
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	icon:
 		Filename: sbagicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 cycl:
 	Defaults:
 		Filename: cycl.shp
 	idle:
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	icon:
 		Filename: cyclicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 barb:
 	Defaults:
 		Filename: barb.shp
 	idle:
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 wood:
 	Defaults:
 		Filename: wood.shp
 	idle:
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: staticterrain
+		IsPlayerPalette: False
 
 gun:
 	Defaults:
 		Filename: gun.shp
 	idle: # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
 		Filename: gunmake.shp
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	recoil:
 		Start: 32
 		Facings: 32
@@ -549,6 +803,8 @@ gun:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	damaged-recoil:
 		Start: 96
 		Facings: 32
@@ -557,106 +813,162 @@ gun:
 		Filename: gunmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	bib:
 		Filename: mbGUN.tem
 		TilesetFilenames:
 			DESERT: mbGUN.des
 		Length: *
 		Offset: -1,-1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: gunicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 sam:
 	Defaults:
 		Filename: sam.shp
 	closed-idle:
 		Start: 0
+		Palette: player
+		IsPlayerPalette: True
 	opening:
 		Start: 1
 		Length: 16
 		Tick: 30
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Start: 17
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	closing:
 		Start: 50
 		Length: 14
 		Tick: 30
+		Palette: player
+		IsPlayerPalette: True
 	damaged-closed-idle:
 		Start: 64
+		Palette: player
+		IsPlayerPalette: True
 	damaged-opening:
 		Start: 65
 		Length: 16
 		Tick: 30
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 81
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	damaged-closing:
 		Start: 114
 		Length: 14
 		Tick: 30
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 128
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	place:
 		Start: 0
+		Palette: terrain
+		IsPlayerPalette: False
 	make:
 		Filename: sammake.shp
 		Length: 20
 		Tick: 50
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: samfire.shp
 		Length: 18
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: samicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 gtwr:
 	Defaults:
 		Filename: gtwr.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: gtwrmake.shp
 		Frames: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 19
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	bib:
 		Filename: mbGTWR.tem
 		TilesetFilenames:
 			DESERT: mbGTWR.des
 		Length: *
 		Offset: 0,-2
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: gtwricnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 atwr:
 	Defaults:
 		Filename: atwr.shp
 		Offset: 0,-13
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: atwrmake.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
@@ -666,9 +978,13 @@ atwr:
 			DESERT: mbGTWR.des
 		Length: *
 		Offset: -3,0
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: atwricnh.tem
 		Offset: 0,0
+		Palette: chrome
+		IsPlayerPalette: False
 
 hosp:
 	Defaults:
@@ -677,10 +993,14 @@ hosp:
 		Length: 4
 		Tick: 100
 		Offset: 0,-2
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 4
 		Length: 4
 		Offset: 0,-2
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hospmake.shp
 		Length: *
@@ -692,24 +1012,34 @@ hosp:
 			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 
 hosp.husk:
 	idle:
 		Filename: hosp.shp
 		Start: 8
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: mbHOSP.tem
 		TilesetFilenames:
 			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 
 bio:
 	Defaults:
 		Filename: bio.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: biomake.shp
 		Length: *
@@ -719,28 +1049,40 @@ bio.husk:
 	idle:
 		Filename: bio.shp
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 
 miss:
 	Defaults:
 		Filename: miss.shp
 	idle:
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: missmake.shp
 		Length: *
 		Tick: 80
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: mbMISS.tem
 		TilesetFilenames:
 			DESERT: mbMISS.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: missicnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 miss.husk:
 	idle:

--- a/mods/cnc/sequences/structures.yaml
+++ b/mods/cnc/sequences/structures.yaml
@@ -5,31 +5,23 @@ fact:
 		Start: 4
 		Length: 20
 		Tick: 100
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	idle:
 		Length: 4
 		Tick: 100
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	damaged-idle:
 		Start: 24
 		Length: 4
 		Tick: 100
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	damaged-build:
 		Start: 28
 		Length: 20
 		Tick: 100
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	dead:
@@ -41,8 +33,6 @@ fact:
 		Filename: factmake.shp
 		Length: *
 		Tick: 80
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	bib:
@@ -53,10 +43,14 @@ fact:
 			TEMPERAT: bib2.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: facticnh.shp
 		Palette: chrome
+
+fact.colorpicker:
+	Inherits: fact
+	idle:
+		Palette: colorpicker
 		IsPlayerPalette: False
 
 nuke:
@@ -92,11 +86,9 @@ nuke:
 			TEMPERAT: bib3.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: nukeicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 proc:
 	Defaults:
@@ -148,11 +140,9 @@ proc:
 			TEMPERAT: bib2.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: procicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 silo:
 	Defaults:
@@ -193,11 +183,9 @@ silo:
 		Length: *
 		Offset: 0,1
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: siloicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 hand:
 	Defaults:
@@ -230,12 +218,10 @@ hand:
 		Length: *
 		Offset: 0,0
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: handicnh.tem
 		Offset: 0,0
 		Palette: chrome
-		IsPlayerPalette: False
 
 pyle:
 	Defaults:
@@ -272,11 +258,9 @@ pyle:
 			TEMPERAT: bib3.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: pyleicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 weap:
 	Defaults:
@@ -313,7 +297,6 @@ weap:
 		Filename: weapmake.shp
 		Start: 19
 		Palette: terrain
-		IsPlayerPalette: False
 	make:
 		Filename: weapmake.shp
 		Length: *
@@ -329,12 +312,10 @@ weap:
 		Length: *
 		Offset: 0,0
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: weapicnh.tem
 		Offset: 0,0
 		Palette: chrome
-		IsPlayerPalette: False
 
 afld:
 	Defaults:
@@ -396,11 +377,9 @@ afld:
 			TEMPERAT: bib1.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: afldicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 hq:
 	Defaults:
@@ -435,11 +414,9 @@ hq:
 			TEMPERAT: bib3.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: hqicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 nuk2:
 	Defaults:
@@ -474,11 +451,9 @@ nuk2:
 			TEMPERAT: bib3.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: nuk2icnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 hpad:
 	Defaults:
@@ -521,7 +496,6 @@ hpad:
 	icon:
 		Filename: hpadicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 fix:
 	Defaults:
@@ -565,11 +539,9 @@ fix:
 		Length: *
 		Offset: 0,-9
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: fixicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 eye:
 	Defaults:
@@ -604,11 +576,9 @@ eye:
 			TEMPERAT: bib3.tem
 		Length: *
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: eyeicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 tmpl:
 	Defaults:
@@ -657,12 +627,10 @@ tmpl:
 		Length: *
 		Offset: 0,0
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: tmplicnh.tem
 		Offset: 0,0
 		Palette: chrome
-		IsPlayerPalette: False
 
 obli:
 	Defaults:
@@ -700,12 +668,10 @@ obli:
 		Length: *
 		Offset: -1,-3
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: obliicnh.tem
 		Offset: 0,0
 		Palette: chrome
-		IsPlayerPalette: False
 
 brik:
 	Defaults:
@@ -713,32 +679,26 @@ brik:
 	idle:
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	scratched-idle:
 		Start: 16
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 32
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	icon:
 		Filename: brikicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 sbag:
 	idle:
 		Filename: sbag.shp
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	icon:
 		Filename: sbagicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 cycl:
 	Defaults:
@@ -746,16 +706,13 @@ cycl:
 	idle:
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	icon:
 		Filename: cyclicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 barb:
 	Defaults:
@@ -763,12 +720,10 @@ barb:
 	idle:
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 wood:
 	Defaults:
@@ -776,12 +731,10 @@ wood:
 	idle:
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
 		Palette: staticterrain
-		IsPlayerPalette: False
 
 gun:
 	Defaults:
@@ -819,7 +772,6 @@ gun:
 		Filename: gunfire2.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	bib:
 		Filename: mbGUN.tem
 		TilesetFilenames:
@@ -827,11 +779,9 @@ gun:
 		Length: *
 		Offset: -1,-1
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: gunicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 sam:
 	Defaults:
@@ -888,7 +838,6 @@ sam:
 	place:
 		Start: 0
 		Palette: terrain
-		IsPlayerPalette: False
 	make:
 		Filename: sammake.shp
 		Length: 20
@@ -900,11 +849,9 @@ sam:
 		Length: 18
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: samicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 gtwr:
 	Defaults:
@@ -933,7 +880,6 @@ gtwr:
 		Length: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	bib:
 		Filename: mbGTWR.tem
 		TilesetFilenames:
@@ -941,11 +887,9 @@ gtwr:
 		Length: *
 		Offset: 0,-2
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: gtwricnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 atwr:
 	Defaults:
@@ -979,12 +923,10 @@ atwr:
 		Length: *
 		Offset: -3,0
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: atwricnh.tem
 		Offset: 0,0
 		Palette: chrome
-		IsPlayerPalette: False
 
 hosp:
 	Defaults:
@@ -1013,7 +955,6 @@ hosp:
 		Length: *
 		Offset: 0,1
 		Palette: terrain
-		IsPlayerPalette: False
 
 hosp.husk:
 	idle:
@@ -1028,7 +969,6 @@ hosp.husk:
 		Length: *
 		Offset: 0,1
 		Palette: terrain
-		IsPlayerPalette: False
 
 bio:
 	Defaults:
@@ -1078,11 +1018,9 @@ miss:
 		Length: *
 		Offset: 0,1
 		Palette: terrain
-		IsPlayerPalette: False
 	icon:
 		Filename: missicnh.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 miss.husk:
 	idle:

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -8,7 +8,6 @@ mcv:
 	icon:
 		Filename: mcvicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 mcv.destroyed:
 	idle:
@@ -47,7 +46,6 @@ harv:
 	icon:
 		Filename: harvicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 harv.destroyed:
 	idle:
@@ -77,11 +75,9 @@ bggy:
 		Length: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: bggyicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 bggy.destroyed:
 	idle:
@@ -116,11 +112,9 @@ mtnk:
 		Filename: gunfire2.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: mtnkicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 mtnk.destroyed:
 	idle:
@@ -157,11 +151,9 @@ ltnk:
 		Filename: gunfire2.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: ltnkicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 ltnk.destroyed:
 	idle:
@@ -198,11 +190,9 @@ htnk:
 		Filename: gunfire2.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: htnkicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 htnk.destroyed:
 	idle:
@@ -240,11 +230,9 @@ jeep:
 		Length: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: jeepicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 jeep.destroyed:
 	idle:
@@ -271,7 +259,6 @@ bike:
 	icon:
 		Filename: bikeicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 bike.destroyed:
 	idle:
@@ -326,11 +313,9 @@ ftnk:
 		Facings: 8
 		Length: 13
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: ftnkicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 ftnk.destroyed:
 	idle:
@@ -357,7 +342,6 @@ mhq:
 	icon:
 		Filename: mhqicnh.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 msam:
 	Defaults:
@@ -384,7 +368,6 @@ msam:
 	icon:
 		Filename: msamicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 msam.destroyed:
 	idle:
@@ -432,7 +415,6 @@ mlrs:
 	icon:
 		Filename: mlrsicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 mlrs.destroyed:
 	idle:
@@ -461,7 +443,6 @@ stnk:
 	icon:
 		Filename: stnkicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 stnk.destroyed:
 	idle:
@@ -483,11 +464,9 @@ arty:
 		Filename: gunfire2.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: artyicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 arty.destroyed:
 	idle:
@@ -522,14 +501,12 @@ apc:
 		Length: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	muzzle-air:
 		Filename: apcmuz.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
 		Palette: effect
-		IsPlayerPalette: False
 	close:
 		Start: 32
 		Length: 3
@@ -538,7 +515,6 @@ apc:
 	icon:
 		Filename: apcicnh.tem
 		Palette: chrome
-		IsPlayerPalette: False
 
 apc.destroyed:
 	idle:
@@ -563,7 +539,6 @@ truck:
 	icon:
 		Filename: truckicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 truck.destroyed:
 	idle:

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -3,8 +3,12 @@ mcv:
 		Filename: mcv.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mcvicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 mcv.destroyed:
 	idle:
@@ -12,6 +16,8 @@ mcv.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 harv:
 	Defaults:
@@ -19,19 +25,29 @@ harv:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	harvest:
 		Start: 32
 		Length: 4
 		Facings: 8
 		Tick: 60
+		Palette: player
+		IsPlayerPalette: True
 	dock:
 		Filename: harvdump.shp
 		Length: 7
+		Palette: player
+		IsPlayerPalette: True
 	dock-loop:
 		Filename: harvdump.shp
 		Start: 7
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: harvicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 harv.destroyed:
 	idle:
@@ -39,6 +55,8 @@ harv.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 bggy:
 	Defaults:
@@ -46,16 +64,24 @@ bggy:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: bggyicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 bggy.destroyed:
 	idle:
@@ -63,6 +89,8 @@ bggy.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: bggy.shp
 		Start: 32
@@ -76,15 +104,23 @@ mtnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: mtnkicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 mtnk.destroyed:
 	idle:
@@ -92,12 +128,16 @@ mtnk.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: mtnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 ltnk:
 	Defaults:
@@ -105,15 +145,23 @@ ltnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: ltnkicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 ltnk.destroyed:
 	idle:
@@ -121,12 +169,16 @@ ltnk.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: ltnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 htnk:
 	Defaults:
@@ -134,15 +186,23 @@ htnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: htnkicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 htnk.destroyed:
 	idle:
@@ -150,12 +210,16 @@ htnk.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: htnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 jeep:
 	Defaults:
@@ -163,16 +227,24 @@ jeep:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: jeepicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 jeep.destroyed:
 	idle:
@@ -180,6 +252,8 @@ jeep.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: jeep.shp
 		Start: 32
@@ -192,8 +266,12 @@ bike:
 		Filename: bike.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: bikeicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 bike.destroyed:
 	idle:
@@ -201,12 +279,16 @@ bike.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 ftnk:
 	idle:
 		Filename: ftnk.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Combine:
 			0:
@@ -243,8 +325,12 @@ ftnk:
 				Offset: -7,8
 		Facings: 8
 		Length: 13
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: ftnkicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 ftnk.destroyed:
 	idle:
@@ -252,6 +338,8 @@ ftnk.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 mhq:
 	Defaults:
@@ -259,11 +347,17 @@ mhq:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	spinner:
 		Start: 32
 		Length: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mhqicnh.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 msam:
 	Defaults:
@@ -271,10 +365,14 @@ msam:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	empty-aim:
 		Start: 64
 		Facings: 32
@@ -285,6 +383,8 @@ msam:
 		UseClassicFacings: True
 	icon:
 		Filename: msamicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 msam.destroyed:
 	idle:
@@ -292,12 +392,16 @@ msam.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: msam.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 mlrs:
 	Defaults:
@@ -305,20 +409,30 @@ mlrs:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret1:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret0:
 		Start: 96
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mlrsicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 mlrs.destroyed:
 	idle:
@@ -326,20 +440,28 @@ mlrs.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: mlrs.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 stnk:
 	idle:
 		Filename: stnk.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: stnkicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 stnk.destroyed:
 	idle:
@@ -347,17 +469,25 @@ stnk.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 arty:
 	idle:
 		Filename: arty.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: artyicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 arty.destroyed:
 	idle:
@@ -365,6 +495,8 @@ arty.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 apc:
 	Defaults:
@@ -372,22 +504,32 @@ apc:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: apctur.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	turret-air:
 		Filename: apctur.shp
 		Start: 32
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	muzzle-air:
 		Filename: apcmuz.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	close:
 		Start: 32
 		Length: 3
@@ -395,6 +537,8 @@ apc:
 		Start: 32
 	icon:
 		Filename: apcicnh.tem
+		Palette: chrome
+		IsPlayerPalette: False
 
 apc.destroyed:
 	idle:
@@ -402,6 +546,8 @@ apc.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: apctur.shp
 		Facings: 32
@@ -412,8 +558,12 @@ truck:
 		Filename: truck.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: truckicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 truck.destroyed:
 	idle:
@@ -421,3 +571,5 @@ truck.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/d2k/maps/atreides-04/rules.yaml
+++ b/mods/d2k/maps/atreides-04/rules.yaml
@@ -81,7 +81,6 @@ tile475:
 	Immobile:
 		OccupiesSpace: false
 	RenderSprites:
-		Palette: d2k
 	WithIdleOverlay@2:
 		Sequence: idle2
 	WithIdleOverlay@3:

--- a/mods/d2k/maps/atreides-04/sequences.yaml
+++ b/mods/d2k/maps/atreides-04/sequences.yaml
@@ -5,19 +5,15 @@ tile475:
 		Start: 706
 		Offset: -16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 	idle2:
 		Start: 707
 		Offset: 16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 	idle3:
 		Start: 726
 		Offset: -16,16
 		Palette: d2k
-		IsPlayerPalette: False
 	idle4:
 		Start: 727
 		Offset: 16,16
 		Palette: d2k
-		IsPlayerPalette: False

--- a/mods/d2k/maps/atreides-04/sequences.yaml
+++ b/mods/d2k/maps/atreides-04/sequences.yaml
@@ -4,12 +4,20 @@ tile475:
 	idle:
 		Start: 706
 		Offset: -16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 	idle2:
 		Start: 707
 		Offset: 16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 	idle3:
 		Start: 726
 		Offset: -16,16
+		Palette: d2k
+		IsPlayerPalette: False
 	idle4:
 		Start: 727
 		Offset: 16,16
+		Palette: d2k
+		IsPlayerPalette: False

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -119,7 +119,6 @@ sandworm:
 	LeavesTrails:
 		Image: sandtrail
 		Sequences: traila, trailb, trailc
-		Palette: effect
 		Type: CenterPosition
 		TerrainTypes: Sand, Dune, SpiceSand, Spice
 		MovingInterval: 3

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -95,28 +95,24 @@
 	WithDecoration@RANK-1:
 		Image: rank
 		Sequence: rank-veteran-1
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		RequiresCondition: rank-veteran == 1
 	WithDecoration@RANK-2:
 		Image: rank
 		Sequence: rank-veteran-2
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		RequiresCondition: rank-veteran == 2
 	WithDecoration@RANK-3:
 		Image: rank
 		Sequence: rank-veteran-3
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		RequiresCondition: rank-veteran == 3
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		RequiresCondition: rank-elite
@@ -575,8 +571,6 @@
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 
 ^Defense:
 	Inherits: ^Building
@@ -635,7 +629,6 @@
 	WithDecoration@POWERDOWN:
 		Image: poweroff
 		Sequence: offline
-		Palette: chrome
 		RequiresCondition: powerdown
 		Position: Center
 		Offsets:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -174,7 +174,7 @@ carryall.colorpicker:
 	-MapEditorData:
 	-Encyclopedia:
 	RenderSprites:
-		Image: carryall
+		Image: carryall.colorpicker
 
 camera:
 	Interactable:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -131,7 +131,6 @@ crate:
 		Units: mcv
 	QuantizeFacingsFromSequence:
 	RenderSprites:
-		Palette: effect
 	WithCrateBody:
 	Passenger:
 	MapEditorData:
@@ -176,7 +175,6 @@ carryall.colorpicker:
 	-Encyclopedia:
 	RenderSprites:
 		Image: carryall
-		Palette: colorpicker
 
 camera:
 	Interactable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -108,7 +108,6 @@ construction_yard:
 			corrino: conyard.harkonnen
 	WithBuildingPlacedOverlay:
 		RequiresCondition: !build-incomplete
-		Palette: d2k
 	PrimaryBuilding:
 		ProductionQueues: Building
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -14,8 +14,6 @@
 	ShroudRenderer:
 		ShroudVariants: shrouda, shroudb, shroudc, shroudd
 		FogVariants: foga, fogb, fogc, fogd
-		ShroudPalette: d2k
-		FogPalette: d2k
 		Index: 11, 3, 7, 9, 6, 13, 12, 14, 4, 8, 2, 1, 5, 10
 		OverrideFullShroud: shroudfull
 		OverrideFullFog: fogfull
@@ -113,7 +111,6 @@
 		ResourceTypes:
 			Spice:
 				Sequences: spicea, spiceb, spicec, spiced
-				Palette: d2k
 				Name: resource-spice
 
 World:
@@ -257,7 +254,6 @@ World:
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
-		TerrainFlashPalette: effect
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -4,10 +4,16 @@ carryall:
 		Start: 1923
 		Facings: -32
 		Remap: 54F94B
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4290
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 ornithopter:
 	idle:
@@ -18,10 +24,14 @@ ornithopter:
 		Tick: 120
 		Transpose: true
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4292
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 frigate:
 	idle:
@@ -29,3 +39,5 @@ frigate:
 		Start: 2517
 		Facings: 1
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -4,8 +4,6 @@ carryall:
 		Start: 1923
 		Facings: -32
 		Remap: 54F94B
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	icon:
@@ -13,6 +11,11 @@ carryall:
 		Start: 4290
 		Offset: -30,-24
 		Palette: chrome
+
+carryall.colorpicker:
+	Inherits: carryall
+	idle:
+		Palette: colorpicker
 		IsPlayerPalette: False
 
 ornithopter:
@@ -31,7 +34,6 @@ ornithopter:
 		Start: 4292
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 frigate:
 	idle:

--- a/mods/d2k/sequences/arrakis.yaml
+++ b/mods/d2k/sequences/arrakis.yaml
@@ -2,39 +2,55 @@ rockpass01_left:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_1.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_right:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_2.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_top:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_3.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_bottom:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_0.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 
 rockpass01_destroyed_left:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_5.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_destroyed_right:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_6.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_destroyed_top:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_7.png
 		ZOffset: -2512
+		Palette: player
+		IsPlayerPalette: True
 
 rockpass01_destroyed_bottom:
 	idle:
 		Filename: bits/destroyabletiles/destroyabletile_4.png
 		ZOffset: -2048
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -6,16 +6,22 @@ light_inf:
 		Start: 206
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 387, 394, 401, 408, 415, 422, 429, 436
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 388, 395, 402, 409, 416, 423, 430, 437
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 214
@@ -23,17 +29,23 @@ light_inf:
 		Facings: -8
 		Tick: 110
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Filename: DATA.R16
 		Start: 254
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Filename: DATA.R16
 		Start: 310
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 310
@@ -41,6 +53,8 @@ light_inf:
 		Facings: -8
 		Transpose: true
 		Tick: 110
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 302
@@ -53,26 +67,36 @@ light_inf:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 382, 389, 396, 403, 410, 417, 424, 431, 438, 443, 448, 453
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 383, 390, 397, 404, 411, 418, 425, 432, 439, 444, 449, 454
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 384, 391, 398, 405, 412, 419, 426, 433, 440, 445, 450, 455
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 385, 392, 399, 406, 413, 420, 427, 434, 441, 446, 451, 456
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 386, 393, 400, 407, 414, 421, 428, 435, 442, 447, 452, 457
@@ -80,11 +104,15 @@ light_inf:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4272
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 trooper:
 	Defaults:
@@ -94,16 +122,22 @@ trooper:
 		Start: 458
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 639, 646, 653, 660, 667, 674, 681, 688
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 640, 647, 654, 661, 668, 675, 682, 689
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 466
@@ -111,17 +145,23 @@ trooper:
 		Facings: -8
 		Tick: 120
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Filename: DATA.R16
 		Start: 506
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Filename: DATA.R16
 		Start: 562
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 570
@@ -129,6 +169,8 @@ trooper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 554
@@ -140,26 +182,36 @@ trooper:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 634, 641, 648, 655, 662, 669, 676, 683, 690, 691, 692, 693
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 635, 642, 649, 656, 663, 670, 677, 684
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 636, 643, 650, 657, 664, 671, 678, 685
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 637, 644, 651, 658, 665, 672, 679, 686
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 638, 645, 652, 659, 666, 673, 680, 687
@@ -167,11 +219,15 @@ trooper:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4273
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 engineer:
 	Defaults:
@@ -181,16 +237,22 @@ engineer:
 		Start: 1166
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 1347, 1354, 1361, 1368, 1375, 1382, 1389, 1396
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 1348, 1355, 1362, 1369, 1376, 1383, 1390, 1397
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 1174
@@ -198,6 +260,8 @@ engineer:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 1262
@@ -209,6 +273,8 @@ engineer:
 		Start: 1270
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 1278
@@ -216,26 +282,36 @@ engineer:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 1342, 1349, 1356, 1363, 1370, 1377, 1384, 1391, 1398, 1399, 1400, 1401
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 1343, 1350, 1357, 1364, 1371, 1378, 1385, 1392
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 1344, 1351, 1358, 1365, 1372, 1379, 1386, 1393
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 1345, 1352, 1359, 1366, 1373, 1380, 1387, 1394
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 1346, 1353, 1360, 1367, 1374, 1381, 1388, 1395
@@ -243,11 +319,15 @@ engineer:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4274
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 thumper:
 	Defaults:
@@ -257,16 +337,22 @@ thumper:
 		Start: 1402
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 1548, 1555, 1562, 1569, 1576, 1583, 1590, 1597
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 1549, 1556, 1563, 1570, 1577, 1584, 1591, 1598
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 1410
@@ -274,6 +360,8 @@ thumper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 1462
@@ -285,6 +373,8 @@ thumper:
 		Start: 1470
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 1478
@@ -292,15 +382,21 @@ thumper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	deploy:
 		Filename: DATA.R16
 		Start: 1458
 		Length: 5
+		Palette: player
+		IsPlayerPalette: True
 	thump:
 		Filename: DATA.R16
 		Start: 1458
 		Length: 5
 		Tick: 480
+		Palette: player
+		IsPlayerPalette: True
 	thump-sand:
 		Filename: DATA.R16
 		Frames: 3882, 3883, 3879, 3880, 3881
@@ -308,26 +404,36 @@ thumper:
 		Tick: 480
 		BlendMode: Multiply
 		Remap: 00000000
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 1543, 1550, 1557, 1564, 1571, 1578, 1585, 1592, 1599, 1600, 1601, 1602
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 1544, 1551, 1558, 1565, 1572, 1579, 1586, 1593
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 1546, 1552, 1559, 1566, 1573, 1580, 1587, 1594
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 1547, 1553, 1560, 1567, 1574, 1581, 1588, 1595
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 1548, 1554, 1561, 1568, 1575, 1582, 1589, 1596
@@ -335,11 +441,15 @@ thumper:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4275
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 fremen:
 	Defaults:
@@ -349,16 +459,22 @@ fremen:
 		Start: 694
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 875, 882, 889, 896, 903, 910, 917, 924
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 876, 883, 890, 897, 904, 911, 918, 925
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 702
@@ -366,17 +482,23 @@ fremen:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Filename: DATA.R16
 		Start: 742
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Filename: DATA.R16
 		Start: 798
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 806
@@ -384,6 +506,8 @@ fremen:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 790
@@ -396,26 +520,36 @@ fremen:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 870, 877, 884, 891, 898, 905, 912, 919, 926, 927, 928, 929
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 871, 878, 885, 892, 899, 906, 913, 920
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 872, 879, 886, 893, 900, 907, 914, 921
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 873, 880, 887, 894, 901, 908, 915, 922
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 874, 881, 888, 895, 902, 909, 916, 923
@@ -423,11 +557,15 @@ fremen:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 saboteur:
 	Defaults:
@@ -437,16 +575,22 @@ saboteur:
 		Start: 2149
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 2330, 2337, 2344, 2351, 2358, 2365, 2372, 2379
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 2331, 2338, 2345, 2352, 2359, 2366, 2373, 2380
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 2157
@@ -454,11 +598,15 @@ saboteur:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Filename: DATA.R16
 		Start: 2253
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 2261
@@ -466,38 +614,52 @@ saboteur:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 2245
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 3839
 		Length: 14
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 2325, 2332, 2339, 2346, 2353, 2360, 2367, 2374, 2381, 2383, 2385, 2387
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 2326, 2333, 2340, 2347, 2354, 2361, 2368, 2375, 2382, 2384, 2386, 2388
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 2327, 2334, 2341, 2348, 2355, 2362, 2369, 2376
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 2328, 2335, 2342, 2349, 2356, 2363, 2370, 2377
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 2329, 2336, 2343, 2350, 2357, 2364, 2371, 2378
@@ -505,11 +667,15 @@ saboteur:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 sardaukar:
 	Defaults:
@@ -519,18 +685,24 @@ sardaukar:
 		Start: 930
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 1111, 1118, 1125, 1132, 1139, 1146, 1153, 1160
 		Length: 8
 		Tick: 80
 		Offset: -1,0
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 1112, 1119, 1126, 1133, 1140, 1147, 1154, 1161
 		Length: 8
 		Tick: 80
 		Offset: -1,0
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 938
@@ -538,17 +710,23 @@ sardaukar:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Filename: DATA.R16
 		Start: 978
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Filename: DATA.R16
 		Start: 1034
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 1042
@@ -556,6 +734,8 @@ sardaukar:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Filename: DATA.R16
 		Start: 1026
@@ -568,26 +748,36 @@ sardaukar:
 		Length: 6
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 1106, 1113, 1120, 1127, 1134, 1141, 1148, 1155, 1162, 1163, 1164, 1165
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 1107, 1114, 1121, 1128, 1135, 1142, 1149, 1156
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 1108, 1115, 1122, 1129, 1136, 1143, 1150, 1157
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 1109, 1116, 1123, 1130, 1137, 1144, 1151, 1158
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 1110, 1117, 1124, 1131, 1138, 1145, 1152, 1159
@@ -595,11 +785,15 @@ sardaukar:
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4276
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 grenadier:
 	Defaults:
@@ -609,14 +803,20 @@ grenadier:
 		Start: 2606
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Filename: DATA.R16
 		Frames: 2700, 2707, 2714, 2721, 2728, 2735, 2742, 2749
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Filename: DATA.R16
 		Frames: 2699, 2706, 2713, 2720, 2727, 2734, 2741, 2748
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: DATA.R16
 		Start: 2526
@@ -624,6 +824,8 @@ grenadier:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	throw:
 		Filename: DATA.R16
 		Start: 2574
@@ -631,33 +833,47 @@ grenadier:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Filename: DATA.R16
 		Frames: 2694, 2701, 2708, 2715, 2722, 2729, 2736, 2743
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Filename: DATA.R16
 		Frames: 2695, 2702, 2709, 2716, 2723, 2730, 2737, 2744
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Filename: DATA.R16
 		Frames: 2696, 2703, 2710, 2717, 2724, 2731, 2738, 2745
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Filename: DATA.R16
 		Frames: 2697, 2704, 2711, 2718, 2725, 2732, 2738, 2746
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: DATA.R16
 		Frames: 2698, 2705, 2712, 2719, 2726, 2733, 2740, 2747
 		Tick: 800
 		ZOffset: -511
 		Remap: 00000000
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Filename: DATA.R16
 		Start: 2622
 		Facings: -8
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Filename: DATA.R16
 		Start: 2622
@@ -665,6 +881,8 @@ grenadier:
 		Facings: -8
 		Tick: 120
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	prone-throw:
 		Filename: DATA.R16
 		Start: 2654
@@ -672,11 +890,15 @@ grenadier:
 		Facings: -8
 		Tick: 120
 		Transpose: true
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4297
 		Offset: -30,-24
 		Remap: 00000000
+		Palette: chrome
+		IsPlayerPalette: False
 
 sandworm:
 	mouth:
@@ -684,50 +906,68 @@ sandworm:
 		Start: 3802
 		Length: 15
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	sand:
 		Filename: DATA.R16
 		Start: 3818
 		Length: 20
 		Tick: 100
 		Alpha: 0.5
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: DATA.R16
 		Start: 39
+		Palette: player
+		IsPlayerPalette: True
 	lightninga:
 		Filename: DATA.R16
 		Start: 3844
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	lightningb:
 		Filename: DATA.R16
 		Start: 3849
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	lightningc:
 		Filename: DATA.R16
 		Start: 3854
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	lightningd:
 		Filename: DATA.R16
 		Start: 3859
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	lightninge:
 		Filename: DATA.R16
 		Start: 3864
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	lightningf:
 		Filename: DATA.R16
 		Start: 3869
 		Length: 5
 		Tick: 80
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: wormicon.shp

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -105,14 +105,12 @@ light_inf:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4272
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 trooper:
 	Defaults:
@@ -220,14 +218,12 @@ trooper:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4273
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 engineer:
 	Defaults:
@@ -320,14 +316,12 @@ engineer:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4274
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 thumper:
 	Defaults:
@@ -442,14 +436,12 @@ thumper:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4275
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 fremen:
 	Defaults:
@@ -558,14 +550,12 @@ fremen:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 saboteur:
 	Defaults:
@@ -668,14 +658,12 @@ saboteur:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 sardaukar:
 	Defaults:
@@ -786,14 +774,12 @@ sardaukar:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4276
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 grenadier:
 	Defaults:
@@ -866,7 +852,6 @@ grenadier:
 		ZOffset: -511
 		Remap: 00000000
 		Palette: effect
-		IsPlayerPalette: False
 	prone-stand:
 		Filename: DATA.R16
 		Start: 2622
@@ -898,7 +883,6 @@ grenadier:
 		Offset: -30,-24
 		Remap: 00000000
 		Palette: chrome
-		IsPlayerPalette: False
 
 sandworm:
 	mouth:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -14,56 +14,47 @@ explosion:
 		Start: 3682
 		Length: 4
 		Palette: effect
-		IsPlayerPalette: False
 	small_explosion:
 		Filename: DATA.R16
 		Start: 3656
 		Length: 15
 		Palette: effect
-		IsPlayerPalette: False
 	med_explosion:
 		Filename: DATA.R16
 		Start: 3643
 		Length: 12
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_explosion:
 		Filename: DATA.R16
 		Start: 3639
 		Length: 4
 		Palette: effect
-		IsPlayerPalette: False
 	nuke:
 		Filename: DATA.R16
 		Start: 4218
 		Length: 14
 		Palette: effect
-		IsPlayerPalette: False
 	self_destruct:
 		Filename: DATA.R16
 		Start: 3686
 		Length: 15
 		BlendMode: Alpha
 		Palette: effect
-		IsPlayerPalette: False
 	building:
 		Filename: DATA.R16
 		Start: 3701
 		Length: 22
 		Palette: effect
-		IsPlayerPalette: False
 	large_explosion:
 		Filename: DATA.R16
 		Start: 4241
 		Length: 22
 		Palette: effect
-		IsPlayerPalette: False
 	small_napalm:
 		Filename: DATA.R16
 		Start: 3674
 		Length: 8
 		Palette: effect
-		IsPlayerPalette: False
 	rocket_explosion:
 		Filename: DATA.R16
 		Start: 3634
@@ -71,14 +62,12 @@ explosion:
 		BlendMode: Alpha
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 	shockwave:
 		Filename: DATA.R16
 		Start: 3940
 		Length: 6
 		Tick: 120
 		Palette: effect
-		IsPlayerPalette: False
 	deviator:
 		Filename: DATA.R16
 		Start: 3765
@@ -103,14 +92,12 @@ explosion:
 		Tick: 120
 		BlendMode: Alpha
 		Palette: effect
-		IsPlayerPalette: False
 	devastator:
 		Filename: DATA.R16
 		Start: 3947
 		Length: 17
 		Tick: 120
 		Palette: effect
-		IsPlayerPalette: False
 
 large_trail:
 	idle:
@@ -121,7 +108,6 @@ large_trail:
 		BlendMode: Additive
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 small_trail:
 	idle:
@@ -133,7 +119,6 @@ small_trail:
 		ZOffset: 1023
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 
 small_trail2:
 	idle:
@@ -145,7 +130,6 @@ small_trail2:
 		ZOffset: 1023
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 
 bazooka_trail:
 	idle:
@@ -165,7 +149,6 @@ bazooka_trail2:
 		ZOffset: 1023
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 
 deviator_trail:
 	idle:
@@ -196,17 +179,14 @@ sandtrail:
 	traila:
 		Filename: sandtrail.shp
 		Palette: effect
-		IsPlayerPalette: False
 	trailb:
 		Filename: sandtrail.shp
 		Frames: 2, 6, 4, 5, 0, 1, 3, 7
 		Palette: effect
-		IsPlayerPalette: False
 	trailc:
 		Filename: sandtrail.shp
 		Frames: 7, 4, 6, 5, 2, 0, 3, 1
 		Palette: effect
-		IsPlayerPalette: False
 
 pips:
 	groups:
@@ -215,36 +195,30 @@ pips:
 		Frames: 18, 19, 20, 21, 22, 23, 24, 25, 26, 17
 		Offset: 3, 3
 		Palette: chrome
-		IsPlayerPalette: False
 	pickup-indicator:
 		Filename: DATA.R16
 		Start: 112
 		Offset: -9, -9
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-empty:
 		Filename: DATA.R16
 		Start: 15
 		Palette: chrome
-		IsPlayerPalette: False
 	pip-green:
 		Filename: DATA.R16
 		Start: 16
 		Palette: chrome
-		IsPlayerPalette: False
 	tag-upgraded:
 		Filename: DATA.R16
 		Start: 110
 		Offset: -8,-8
 		Palette: chrome
-		IsPlayerPalette: False
 
 clock:
 	idle:
 		Filename: clock.shp
 		Length: *
 		Palette: chrome
-		IsPlayerPalette: False
 
 powerdown:
 	disabled:
@@ -259,28 +233,23 @@ poweroff:
 		Tick: 160
 		ZOffset: 2047
 		Palette: chrome
-		IsPlayerPalette: False
 
 rank:
 	rank-veteran-1:
 		Filename: rank.shp
 		Palette: effect
-		IsPlayerPalette: False
 	rank-veteran-2:
 		Filename: rank.shp
 		Start: 1
 		Palette: effect
-		IsPlayerPalette: False
 	rank-veteran-3:
 		Filename: rank.shp
 		Start: 2
 		Palette: effect
-		IsPlayerPalette: False
 	rank-elite:
 		Filename: rank.shp
 		Start: 3
 		Palette: effect
-		IsPlayerPalette: False
 
 overlay:
 	Defaults:
@@ -288,16 +257,13 @@ overlay:
 		Offset: -16,-16
 	build-valid:
 		Palette: terrain
-		IsPlayerPalette: False
 	build-unsafe:
 		Filename: concfoot.shp
 		Offset: 0, 0
 		Palette: terrain
-		IsPlayerPalette: False
 	build-invalid:
 		Start: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	target-select:
 		Start: 2
 	target-valid:
@@ -349,7 +315,6 @@ rpg:
 		Facings: -32
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 120mm:
 	idle:
@@ -358,7 +323,6 @@ rpg:
 		BlendMode: Additive
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 155mm:
 	idle:
@@ -366,7 +330,6 @@ rpg:
 		Start: 3329
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -381,19 +344,16 @@ crate-effects:
 		Length: 18
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 	hide-map:
 		Filename: DATA.R16
 		Frames: 4217, 4216, 4215, 4214, 4213, 4212, 4211, 4210, 4209, 4208, 4207, 4206, 4205, 4204, 4203, 4202, 4201, 4200
 		Length: 18
 		Palette: effect
-		IsPlayerPalette: False
 	levelup:
 		Filename: levelup.shp
 		Length: *
 		Tick: 200
 		Palette: effect
-		IsPlayerPalette: False
 	cloak:
 		Filename: DATA.R16
 		Start: 4164
@@ -417,7 +377,6 @@ missile:
 		Facings: -32
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 missile2:
 	idle:
@@ -426,7 +385,6 @@ missile2:
 		Facings: -32
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 deathhand:
 	up:
@@ -434,23 +392,18 @@ deathhand:
 		Start: 2147
 		ZOffset: 1023
 		Offset: 2,0
-		Palette: player
-		IsPlayerPalette: True
 		Palette: effect
-		IsPlayerPalette: False
 	down:
 		Filename: DATA.R16
 		Start: 2148
 		ZOffset: 1023
 		Offset: -1,0
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4296
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 fire:
 	1:
@@ -518,7 +471,6 @@ smoke3:
 		Tick: 140
 		BlendMode: Subtractive
 		Palette: effect
-		IsPlayerPalette: False
 
 bombs:
 	idle:
@@ -527,7 +479,6 @@ bombs:
 		Length: 4
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 grenade:
 	idle:
@@ -537,7 +488,6 @@ grenade:
 		Tick: 80
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 shrapnel:
 	idle:
@@ -546,7 +496,6 @@ shrapnel:
 		Length: 4
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 shrapnel2:
 	idle:
@@ -555,7 +504,6 @@ shrapnel2:
 		Length: 1
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 shrapnel3:
 	idle:
@@ -564,7 +512,6 @@ shrapnel3:
 		Length: 8
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 shrapnel4:
 	idle:
@@ -573,7 +520,6 @@ shrapnel4:
 		Length: 1
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 mpspawn:
 	idle:
@@ -627,7 +573,6 @@ doubleblastbullet:
 		BlendMode: Additive
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 icon:
 	ornistrike:
@@ -635,25 +580,21 @@ icon:
 		Start: 4292
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	fremen:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	saboteur:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	deathhand:
 		Filename: DATA.R16
 		Start: 4296
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 crate:
 	idle:
@@ -662,7 +603,6 @@ crate:
 		ZOffset: -511
 		Offset: -16,-16
 		Palette: effect
-		IsPlayerPalette: False
 
 spicebloom:
 	grow0:
@@ -726,7 +666,6 @@ moveflsh:
 		BlendMode: Subtractive
 		ZOffset: 2047
 		Palette: effect
-		IsPlayerPalette: False
 
 resources:
 	spicea:
@@ -735,28 +674,24 @@ resources:
 		Length: 51
 		Offset: -16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 	spiceb:
 		Filename: BLOXBASE.R16
 		Frames: 749, 301, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 301
 		Length: 51
 		Offset: -16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 	spicec:
 		Filename: BLOXBASE.R16
 		Frames: 793, 320, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 320
 		Length: 51
 		Offset: -16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 	spiced:
 		Filename: BLOXBASE.R16
 		Frames: 748, 321, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 321
 		Length: 51
 		Offset: -16,-16
 		Palette: d2k
-		IsPlayerPalette: False
 
 shroud:
 	Defaults:
@@ -768,54 +703,44 @@ shroud:
 	shrouda:
 		Start: 40
 		Palette: d2k
-		IsPlayerPalette: False
 	shroudb:
 		Start: 56
 		Palette: d2k
-		IsPlayerPalette: False
 	shroudc:
 		Start: 72
 		Palette: d2k
-		IsPlayerPalette: False
 	shroudd:
 		Start: 88
 		Palette: d2k
-		IsPlayerPalette: False
 	shroudfull:
 		Filename: shroud.png
 		Length: 1
 		Palette: d2k
-		IsPlayerPalette: False
 	foga:
 		Start: 40
 		ConvertShroudToFog: true
 		BlendMode: Multiply
 		Palette: d2k
-		IsPlayerPalette: False
 	fogb:
 		Start: 56
 		ConvertShroudToFog: true
 		BlendMode: Multiply
 		Palette: d2k
-		IsPlayerPalette: False
 	fogc:
 		Start: 72
 		ConvertShroudToFog: true
 		BlendMode: Multiply
 		Palette: d2k
-		IsPlayerPalette: False
 	fogd:
 		Start: 88
 		ConvertShroudToFog: true
 		BlendMode: Multiply
 		Palette: d2k
-		IsPlayerPalette: False
 	fogfull:
 		Filename: fog.png
 		Length: 1
 		BlendMode: Multiply
 		Palette: d2k
-		IsPlayerPalette: False
 
 rockcraters:
 	rockcrater1:
@@ -824,14 +749,12 @@ rockcraters:
 		Length: 16
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	rockcrater2:
 		Filename: DATA.R16
 		Start: 130
 		Length: 16
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 
 sandcraters:
 	sandcrater1:
@@ -840,14 +763,12 @@ sandcraters:
 		Length: 16
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	sandcrater2:
 		Filename: DATA.R16
 		Start: 162
 		Length: 16
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 
 ornidirection:
 	arrow-t:
@@ -855,49 +776,41 @@ ornidirection:
 		Start: 112
 		Offset: -25, -53, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-tr:
 		Filename: MOUSE.R16
 		Start: 120
 		Offset: 6, -47, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-r:
 		Filename: MOUSE.R16
 		Start: 128
 		Offset: 17, -26, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-br:
 		Filename: MOUSE.R16
 		Start: 136
 		Offset: 6, -1, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-b:
 		Filename: MOUSE.R16
 		Start: 148
 		Offset: -25, 7, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-bl:
 		Filename: MOUSE.R16
 		Start: 156
 		Offset: -52, -3, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-l:
 		Filename: MOUSE.R16
 		Start: 164
 		Offset: -61, -26, 0
 		Palette: chrome
-		IsPlayerPalette: False
 	arrow-tl:
 		Filename: MOUSE.R16
 		Start: 172
 		Offset: -52, -44, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 null:
 	idle:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -13,50 +13,72 @@ explosion:
 		Filename: DATA.R16
 		Start: 3682
 		Length: 4
+		Palette: effect
+		IsPlayerPalette: False
 	small_explosion:
 		Filename: DATA.R16
 		Start: 3656
 		Length: 15
+		Palette: effect
+		IsPlayerPalette: False
 	med_explosion:
 		Filename: DATA.R16
 		Start: 3643
 		Length: 12
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_explosion:
 		Filename: DATA.R16
 		Start: 3639
 		Length: 4
+		Palette: effect
+		IsPlayerPalette: False
 	nuke:
 		Filename: DATA.R16
 		Start: 4218
 		Length: 14
+		Palette: effect
+		IsPlayerPalette: False
 	self_destruct:
 		Filename: DATA.R16
 		Start: 3686
 		Length: 15
 		BlendMode: Alpha
+		Palette: effect
+		IsPlayerPalette: False
 	building:
 		Filename: DATA.R16
 		Start: 3701
 		Length: 22
+		Palette: effect
+		IsPlayerPalette: False
 	large_explosion:
 		Filename: DATA.R16
 		Start: 4241
 		Length: 22
+		Palette: effect
+		IsPlayerPalette: False
 	small_napalm:
 		Filename: DATA.R16
 		Start: 3674
 		Length: 8
+		Palette: effect
+		IsPlayerPalette: False
 	rocket_explosion:
 		Filename: DATA.R16
 		Start: 3634
 		Length: 5
 		BlendMode: Alpha
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 	shockwave:
 		Filename: DATA.R16
 		Start: 3940
 		Length: 6
 		Tick: 120
+		Palette: effect
+		IsPlayerPalette: False
 	deviator:
 		Filename: DATA.R16
 		Start: 3765
@@ -66,6 +88,8 @@ explosion:
 		Offset: 12, -10
 		Tick: 120
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	corpse:
 		Filename: DATA.R16
 		ZOffset: -511
@@ -78,11 +102,15 @@ explosion:
 		Length: 8
 		Tick: 120
 		BlendMode: Alpha
+		Palette: effect
+		IsPlayerPalette: False
 	devastator:
 		Filename: DATA.R16
 		Start: 3947
 		Length: 17
 		Tick: 120
+		Palette: effect
+		IsPlayerPalette: False
 
 large_trail:
 	idle:
@@ -92,6 +120,8 @@ large_trail:
 		Tick: 120
 		BlendMode: Additive
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 small_trail:
 	idle:
@@ -102,6 +132,8 @@ small_trail:
 		BlendMode: Additive
 		ZOffset: 1023
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 
 small_trail2:
 	idle:
@@ -112,6 +144,8 @@ small_trail2:
 		BlendMode: Additive
 		ZOffset: 1023
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 
 bazooka_trail:
 	idle:
@@ -130,6 +164,8 @@ bazooka_trail2:
 		Tick: 80
 		ZOffset: 1023
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 
 deviator_trail:
 	idle:
@@ -140,6 +176,8 @@ deviator_trail:
 		ZOffset: 1023
 		Alpha: 0.5
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 laserfire:
 	idle:
@@ -157,12 +195,18 @@ sandtrail:
 		ZOffset: -512
 	traila:
 		Filename: sandtrail.shp
+		Palette: effect
+		IsPlayerPalette: False
 	trailb:
 		Filename: sandtrail.shp
 		Frames: 2, 6, 4, 5, 0, 1, 3, 7
+		Palette: effect
+		IsPlayerPalette: False
 	trailc:
 		Filename: sandtrail.shp
 		Frames: 7, 4, 6, 5, 2, 0, 3, 1
+		Palette: effect
+		IsPlayerPalette: False
 
 pips:
 	groups:
@@ -170,25 +214,37 @@ pips:
 		Length: 10
 		Frames: 18, 19, 20, 21, 22, 23, 24, 25, 26, 17
 		Offset: 3, 3
+		Palette: chrome
+		IsPlayerPalette: False
 	pickup-indicator:
 		Filename: DATA.R16
 		Start: 112
 		Offset: -9, -9
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-empty:
 		Filename: DATA.R16
 		Start: 15
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-green:
 		Filename: DATA.R16
 		Start: 16
+		Palette: chrome
+		IsPlayerPalette: False
 	tag-upgraded:
 		Filename: DATA.R16
 		Start: 110
 		Offset: -8,-8
+		Palette: chrome
+		IsPlayerPalette: False
 
 clock:
 	idle:
 		Filename: clock.shp
 		Length: *
+		Palette: chrome
+		IsPlayerPalette: False
 
 powerdown:
 	disabled:
@@ -202,30 +258,46 @@ poweroff:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: chrome
+		IsPlayerPalette: False
 
 rank:
 	rank-veteran-1:
 		Filename: rank.shp
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-2:
 		Filename: rank.shp
 		Start: 1
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-3:
 		Filename: rank.shp
 		Start: 2
+		Palette: effect
+		IsPlayerPalette: False
 	rank-elite:
 		Filename: rank.shp
 		Start: 3
+		Palette: effect
+		IsPlayerPalette: False
 
 overlay:
 	Defaults:
 		Filename: DATA.R16
 		Offset: -16,-16
 	build-valid:
+		Palette: terrain
+		IsPlayerPalette: False
 	build-unsafe:
 		Filename: concfoot.shp
 		Offset: 0, 0
+		Palette: terrain
+		IsPlayerPalette: False
 	build-invalid:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	target-select:
 		Start: 2
 	target-valid:
@@ -246,10 +318,14 @@ rallypoint:
 		Length: *
 		Offset: 11,-5
 		ZOffset: 2535
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 beacon:
 	arrow:
@@ -257,10 +333,14 @@ beacon:
 		Start: 148
 		Offset: -24,-24
 		ZOffset: 2535
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 rpg:
 	idle:
@@ -268,6 +348,8 @@ rpg:
 		Start: 3263
 		Facings: -32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 120mm:
 	idle:
@@ -275,12 +357,16 @@ rpg:
 		Start: 3262
 		BlendMode: Additive
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 155mm:
 	idle:
 		Filename: DATA.R16
 		Start: 3329
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -294,14 +380,20 @@ crate-effects:
 		Start: 4200
 		Length: 18
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 	hide-map:
 		Filename: DATA.R16
 		Frames: 4217, 4216, 4215, 4214, 4213, 4212, 4211, 4210, 4209, 4208, 4207, 4206, 4205, 4204, 4203, 4202, 4201, 4200
 		Length: 18
+		Palette: effect
+		IsPlayerPalette: False
 	levelup:
 		Filename: levelup.shp
 		Length: *
 		Tick: 200
+		Palette: effect
+		IsPlayerPalette: False
 	cloak:
 		Filename: DATA.R16
 		Start: 4164
@@ -315,6 +407,8 @@ allyrepair:
 		Tick: 300
 		Offset: -11,-10
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 missile:
 	idle:
@@ -322,6 +416,8 @@ missile:
 		Start: 3336
 		Facings: -32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 missile2:
 	idle:
@@ -329,6 +425,8 @@ missile2:
 		Start: 3554
 		Facings: -32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 deathhand:
 	up:
@@ -336,15 +434,23 @@ deathhand:
 		Start: 2147
 		ZOffset: 1023
 		Offset: 2,0
+		Palette: player
+		IsPlayerPalette: True
+		Palette: effect
+		IsPlayerPalette: False
 	down:
 		Filename: DATA.R16
 		Start: 2148
 		ZOffset: 1023
 		Offset: -1,0
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4296
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 fire:
 	1:
@@ -355,6 +461,8 @@ fire:
 		ZOffset: 3023
 		Tick: 100
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	2:
 		Filename: DATA.R16
 		Start: 3976
@@ -363,6 +471,8 @@ fire:
 		ZOffset: 3023
 		Tick: 100
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	3:
 		Filename: DATA.R16
 		Start: 4138
@@ -379,6 +489,8 @@ fire:
 		ZOffset: 1023
 		Tick: 100
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 
 smoke_m:
 	Defaults:
@@ -405,6 +517,8 @@ smoke3:
 		Length: 7
 		Tick: 140
 		BlendMode: Subtractive
+		Palette: effect
+		IsPlayerPalette: False
 
 bombs:
 	idle:
@@ -412,6 +526,8 @@ bombs:
 		Start: 3528
 		Length: 4
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 grenade:
 	idle:
@@ -420,6 +536,8 @@ grenade:
 		Length: 4
 		Tick: 80
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 shrapnel:
 	idle:
@@ -427,6 +545,8 @@ shrapnel:
 		Start: 3538
 		Length: 4
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 shrapnel2:
 	idle:
@@ -434,6 +554,8 @@ shrapnel2:
 		Start: 3542
 		Length: 1
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 shrapnel3:
 	idle:
@@ -441,6 +563,8 @@ shrapnel3:
 		Start: 3543
 		Length: 8
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 shrapnel4:
 	idle:
@@ -448,32 +572,44 @@ shrapnel4:
 		Start: 3551
 		Length: 1
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 mpspawn:
 	idle:
 		Filename: mpspawn.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 waypoint:
 	idle:
 		Filename: waypoint.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 camera:
 	idle:
 		Filename: camera.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 wormspawner:
 	idle:
 		Filename: wormspawner.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 sietch:
 	idle:
 		Filename: DATA.R16
 		Start: 3246
 		Offset: -32,32
+		Palette: player
+		IsPlayerPalette: True
 
 doubleblast:
 	idle:
@@ -490,24 +626,34 @@ doubleblastbullet:
 		Facings: -16
 		BlendMode: Additive
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 icon:
 	ornistrike:
 		Filename: DATA.R16
 		Start: 4292
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	fremen:
 		Filename: DATA.R16
 		Start: 4293
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	saboteur:
 		Filename: DATA.R16
 		Start: 4295
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	deathhand:
 		Filename: DATA.R16
 		Start: 4296
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 crate:
 	idle:
@@ -515,6 +661,8 @@ crate:
 		Start: 102
 		ZOffset: -511
 		Offset: -16,-16
+		Palette: effect
+		IsPlayerPalette: False
 
 spicebloom:
 	grow0:
@@ -529,18 +677,24 @@ spicebloom:
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
+		Palette: player
+		IsPlayerPalette: True
 	grow2:
 		Filename: DATA.R16
 		Start: 108
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
+		Palette: player
+		IsPlayerPalette: True
 	grow3:
 		Filename: DATA.R16
 		Start: 109
 		Length: 1
 		ZOffset: -1023
 		Offset: -16,-16
+		Palette: player
+		IsPlayerPalette: True
 	spurt:
 		Filename: DATA.R16
 		Start: 4233
@@ -549,6 +703,8 @@ spicebloom:
 		BlendMode: Additive
 		ZOffset: 511
 		Offset: 0, -16
+		Palette: player
+		IsPlayerPalette: True
 
 spicebloom.editor:
 	idle:
@@ -558,6 +714,8 @@ spicebloom.editor:
 		ZOffset: -1023
 		Offset: -16,-16
 		Alpha: 0.5
+		Palette: player
+		IsPlayerPalette: True
 
 moveflsh:
 	idle:
@@ -567,6 +725,8 @@ moveflsh:
 		Tick: 80
 		BlendMode: Subtractive
 		ZOffset: 2047
+		Palette: effect
+		IsPlayerPalette: False
 
 resources:
 	spicea:
@@ -574,21 +734,29 @@ resources:
 		Frames: 748, 300, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 300
 		Length: 51
 		Offset: -16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 	spiceb:
 		Filename: BLOXBASE.R16
 		Frames: 749, 301, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 301
 		Length: 51
 		Offset: -16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 	spicec:
 		Filename: BLOXBASE.R16
 		Frames: 793, 320, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 320
 		Length: 51
 		Offset: -16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 	spiced:
 		Filename: BLOXBASE.R16
 		Frames: 748, 321, 750, 751, 752, 753, 754, 755, 756, 757, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 321
 		Length: 51
 		Offset: -16,-16
+		Palette: d2k
+		IsPlayerPalette: False
 
 shroud:
 	Defaults:
@@ -599,35 +767,55 @@ shroud:
 		Length: 14
 	shrouda:
 		Start: 40
+		Palette: d2k
+		IsPlayerPalette: False
 	shroudb:
 		Start: 56
+		Palette: d2k
+		IsPlayerPalette: False
 	shroudc:
 		Start: 72
+		Palette: d2k
+		IsPlayerPalette: False
 	shroudd:
 		Start: 88
+		Palette: d2k
+		IsPlayerPalette: False
 	shroudfull:
 		Filename: shroud.png
 		Length: 1
+		Palette: d2k
+		IsPlayerPalette: False
 	foga:
 		Start: 40
 		ConvertShroudToFog: true
 		BlendMode: Multiply
+		Palette: d2k
+		IsPlayerPalette: False
 	fogb:
 		Start: 56
 		ConvertShroudToFog: true
 		BlendMode: Multiply
+		Palette: d2k
+		IsPlayerPalette: False
 	fogc:
 		Start: 72
 		ConvertShroudToFog: true
 		BlendMode: Multiply
+		Palette: d2k
+		IsPlayerPalette: False
 	fogd:
 		Start: 88
 		ConvertShroudToFog: true
 		BlendMode: Multiply
+		Palette: d2k
+		IsPlayerPalette: False
 	fogfull:
 		Filename: fog.png
 		Length: 1
 		BlendMode: Multiply
+		Palette: d2k
+		IsPlayerPalette: False
 
 rockcraters:
 	rockcrater1:
@@ -635,11 +823,15 @@ rockcraters:
 		Start: 114
 		Length: 16
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	rockcrater2:
 		Filename: DATA.R16
 		Start: 130
 		Length: 16
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 
 sandcraters:
 	sandcrater1:
@@ -647,45 +839,65 @@ sandcraters:
 		Start: 146
 		Length: 16
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	sandcrater2:
 		Filename: DATA.R16
 		Start: 162
 		Length: 16
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 
 ornidirection:
 	arrow-t:
 		Filename: MOUSE.R16
 		Start: 112
 		Offset: -25, -53, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tr:
 		Filename: MOUSE.R16
 		Start: 120
 		Offset: 6, -47, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-r:
 		Filename: MOUSE.R16
 		Start: 128
 		Offset: 17, -26, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-br:
 		Filename: MOUSE.R16
 		Start: 136
 		Offset: 6, -1, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-b:
 		Filename: MOUSE.R16
 		Start: 148
 		Offset: -25, 7, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-bl:
 		Filename: MOUSE.R16
 		Start: 156
 		Offset: -52, -3, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-l:
 		Filename: MOUSE.R16
 		Start: 164
 		Offset: -61, -26, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tl:
 		Filename: MOUSE.R16
 		Start: 172
 		Offset: -52, -44, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 null:
 	idle:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -3,15 +3,21 @@ concretea:
 		Filename: DATA.R16
 		Start: 4314
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	preview:
 		Filename: BLOXBASE.R16
 		Start: 657
+		Palette: player
+		IsPlayerPalette: True
 
 concreteb:
 	icon:
 		Filename: DATA.R16
 		Start: 4317
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 wall:
 	idle:
@@ -19,32 +25,44 @@ wall:
 		Frames: 2775, 2778, 2776, 2786, 2779, 2780, 2790, 2783, 2777, 2787, 2781, 2782, 2788, 2784, 2785, 2789
 		Length: 16
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Frames: 2791, 2794, 2792, 2802, 2795, 2796, 2806, 2799, 2793, 2803, 2797, 2798, 2804, 2800, 2801, 2805
 		Length: 16
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4327
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 medium_gun_turret:
 	invisible:
 		Filename: DATA.R16
 		Start: 38
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: DATA.R16
 		Frames: 2821, 2824, 2822, 2832, 2825, 2826, 2836, 2829, 2823, 2833, 2827, 2828, 2834, 2830, 2831, 2835
 		Length: 16
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Frames: 2869, 2872, 2870, 2880, 2873, 2874, 2884, 2877, 2871, 2881, 2875, 2876, 2882, 2878, 2879, 2883
 		Length: 16
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4577
@@ -52,6 +70,8 @@ medium_gun_turret:
 		Offset: -16,16
 		ZOffset: 1024
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4585
@@ -59,12 +79,16 @@ medium_gun_turret:
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2837
 		Facings: -32
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 4028
@@ -72,27 +96,37 @@ medium_gun_turret:
 		Facings: -32
 		Offset: 0,2
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4333
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 large_gun_turret:
 	invisible:
 		Filename: DATA.R16
 		Start: 38
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: DATA.R16
 		Frames: 2821, 2824, 2822, 2832, 2825, 2826, 2836, 2829, 2823, 2833, 2827, 2828, 2834, 2830, 2831, 2835
 		Length: 16
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Frames: 2869, 2872, 2870, 2880, 2873, 2874, 2884, 2877, 2871, 2881, 2875, 2876, 2882, 2878, 2879, 2883
 		Length: 16
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4577
@@ -100,6 +134,8 @@ large_gun_turret:
 		Offset: -16,16
 		ZOffset: 1024
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4585
@@ -107,16 +143,22 @@ large_gun_turret:
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2885
 		Facings: -32
 		Offset: -24,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4339
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 conyard.atreides:
 	idle:
@@ -124,23 +166,31 @@ conyard.atreides:
 		Start: 2807
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4373
 		Length: 30
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2808
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crane-overlay:
 		Filename: DATA.R16
 		Start: 4700
@@ -148,6 +198,8 @@ conyard.atreides:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4700
@@ -155,11 +207,15 @@ conyard.atreides:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -169,6 +225,8 @@ conyard.atreides:
 		Filename: DATA.R16
 		Start: 4310
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 repair_pad.atreides:
 	make:
@@ -177,30 +235,40 @@ repair_pad.atreides:
 		Length: 11
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4645
 		Length: 10
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: DATA.R16
 		Start: 2819
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2820
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 5010
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 5010
@@ -208,10 +276,14 @@ repair_pad.atreides:
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4360
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 repair_pad.harkonnen:
 	make:
@@ -220,30 +292,40 @@ repair_pad.harkonnen:
 		Length: 11
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4645
 		Length: 10
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: DATA.R16
 		Start: 2979
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2980
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 5010
 		Length: 14
 		Offset: -48,48
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 5010
@@ -251,10 +333,14 @@ repair_pad.harkonnen:
 		Tick: 60
 		Offset: -48,48
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4361
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 repair_pad.ordos:
 	make:
@@ -306,12 +392,16 @@ starport.atreides:
 		ZOffset: -1c511
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2920
 		ZOffset: -1c511
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 4986
@@ -319,6 +409,8 @@ starport.atreides:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 4986
@@ -326,18 +418,24 @@ starport.atreides:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4611
 		Length: 12
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
@@ -352,6 +450,8 @@ starport.atreides:
 		Filename: DATA.R16
 		Start: 4356
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 power.atreides:
 	idle:
@@ -359,40 +459,54 @@ power.atreides:
 		Start: 2771
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4415
 		Length: 11
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4426
 		Length: 13
 		Offset: -32,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2772
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-zaps:
 		Filename: DATA.R16
 		Start: 4756
 		Length: 10
 		Offset: -32,64
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-zaps:
 		Filename: DATA.R16
 		Start: 4761
 		Length: 5
 		Offset: -32,64
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -402,6 +516,8 @@ power.atreides:
 		Filename: DATA.R16
 		Start: 4320
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 barracks.atreides:
 	idle:
@@ -409,28 +525,38 @@ barracks.atreides:
 		Start: 2773
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4439
 		Length: 11
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4450
 		Length: 9
 		Offset: -32,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2774
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -440,6 +566,8 @@ barracks.atreides:
 		Filename: DATA.R16
 		Start: 4323
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 outpost.atreides:
 	idle:
@@ -447,12 +575,16 @@ outpost.atreides:
 		Start: 2769
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4518
 		Length: 11
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4529
@@ -460,21 +592,29 @@ outpost.atreides:
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2770
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		Filename: DATA.R16
 		Start: 4786
 		Length: 30
 		Offset: -48,64
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -484,6 +624,8 @@ outpost.atreides:
 		Filename: DATA.R16
 		Start: 4336
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 refinery.atreides:
 	idle:
@@ -491,12 +633,16 @@ refinery.atreides:
 		Start: 2809
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4495
 		Length: 11
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4506
@@ -504,26 +650,36 @@ refinery.atreides:
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2809
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 2810
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 2811
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -533,6 +689,8 @@ refinery.atreides:
 		Filename: DATA.R16
 		Start: 4330
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	smoke:
 		Filename: DATA.R16
 		Start: 4138
@@ -540,6 +698,8 @@ refinery.atreides:
 		Offset: 13,-16
 		Tick: 100
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 
 silo.atreides:
 	idle:
@@ -557,16 +717,22 @@ silo.atreides:
 		Start: 2814
 		Length: 4
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		Filename: DATA.R16
 		Start: 2818
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4577
 		Length: 8
 		Offset: -16,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4585
@@ -574,10 +740,14 @@ silo.atreides:
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4348
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 hightech.atreides:
 	Defaults:
@@ -586,20 +756,28 @@ hightech.atreides:
 		Filename: DATA.R16
 		Start: 2812
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4538
 		Length: 11
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4549
 		Length: 10
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2813
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4878
@@ -607,6 +785,8 @@ hightech.atreides:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	damaged-production-welding:
 		Filename: DATA.R16
 		Frames: 4878, 4879, 4880, 4881, 4882, 4884, 4885, 4886, 4887
@@ -614,11 +794,15 @@ hightech.atreides:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -628,6 +812,8 @@ hightech.atreides:
 		Filename: DATA.R16
 		Start: 4342
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 research.atreides:
 	idle:
@@ -635,34 +821,46 @@ research.atreides:
 		Start: 2917
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4655
 		Length: 11
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4666
 		Length: 11
 		Offset: -48,80
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2918
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		Filename: DATA.R16
 		Start: 5024
 		Length: 60
 		Tick: 80
 		Offset: -48,80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -672,6 +870,8 @@ research.atreides:
 		Filename: DATA.R16
 		Start: 4363
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 research.harkonnen:
 	idle:
@@ -679,34 +879,46 @@ research.harkonnen:
 		Start: 3077
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4655
 		Length: 11
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4666
 		Length: 11
 		Offset: -48,80
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3078
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		Filename: DATA.R16
 		Start: 5024
 		Length: 60
 		Tick: 80
 		Offset: -48,80
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -716,6 +928,8 @@ research.harkonnen:
 		Filename: DATA.R16
 		Start: 4364
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 research.ordos:
 	idle:
@@ -767,32 +981,44 @@ palace.atreides:
 		Start: 2924
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 2924
 		Offset: -48,48
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4677
 		Length: 13
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2925
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -802,6 +1028,8 @@ palace.atreides:
 		Filename: DATA.R16
 		Start: 4366
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 light.atreides:
 	idle:
@@ -809,12 +1037,16 @@ light.atreides:
 		Start: 2921
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4559
 		Length: 9
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4568
@@ -822,23 +1054,31 @@ light.atreides:
 		Offset: -48,64
 		ZOffset: 897
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2921
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 2922
 		Offset: -48,64
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 2923
 		Offset: -48,64
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4908
@@ -847,6 +1087,8 @@ light.atreides:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	damaged-production-welding:
 		Filename: DATA.R16
 		Frames: 4908, 4909, 4910, 4912, 4914, 4917
@@ -855,11 +1097,15 @@ light.atreides:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -869,6 +1115,8 @@ light.atreides:
 		Filename: DATA.R16
 		Start: 4345
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 heavy.atreides:
 	idle:
@@ -876,12 +1124,16 @@ heavy.atreides:
 		Start: 2766
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4592
 		Length: 10
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4602
@@ -889,23 +1141,31 @@ heavy.atreides:
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2766
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 2767
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 2768
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4938
@@ -914,11 +1174,15 @@ heavy.atreides:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -928,6 +1192,8 @@ heavy.atreides:
 		Filename: DATA.R16
 		Start: 4351
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 conyard.harkonnen:
 	idle:
@@ -935,23 +1201,31 @@ conyard.harkonnen:
 		Start: 2967
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4373
 		Length: 30
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2968
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crane-overlay:
 		Filename: DATA.R16
 		Start: 4714
@@ -959,6 +1233,8 @@ conyard.harkonnen:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4714
@@ -966,11 +1242,15 @@ conyard.harkonnen:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -980,6 +1260,8 @@ conyard.harkonnen:
 		Filename: DATA.R16
 		Start: 4311
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 starport.harkonnen:
 	idle:
@@ -988,12 +1270,16 @@ starport.harkonnen:
 		ZOffset: -1c511
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3080
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 4993
@@ -1001,6 +1287,8 @@ starport.harkonnen:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 4993
@@ -1008,18 +1296,24 @@ starport.harkonnen:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4611
 		Length: 12
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
@@ -1034,6 +1328,8 @@ starport.harkonnen:
 		Filename: DATA.R16
 		Start: 4357
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 power.harkonnen:
 	idle:
@@ -1041,40 +1337,54 @@ power.harkonnen:
 		Start: 2931
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4415
 		Length: 11
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4426
 		Length: 13
 		Offset: -32,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2932
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-zaps:
 		Filename: DATA.R16
 		Start: 4766
 		Length: 10
 		Offset: -32,64
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-zaps:
 		Filename: DATA.R16
 		Start: 4771
 		Length: 5
 		Offset: -32,64
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -1084,6 +1394,8 @@ power.harkonnen:
 		Filename: DATA.R16
 		Start: 4321
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 barracks.harkonnen:
 	idle:
@@ -1091,28 +1403,38 @@ barracks.harkonnen:
 		Start: 2933
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4477
 		Length: 9
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4486
 		Length: 9
 		Offset: -32,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2934
 		Offset: -32,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 617, 618, 637, 638
 		Length: 4
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -1122,6 +1444,8 @@ barracks.harkonnen:
 		Filename: DATA.R16
 		Start: 4324
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 outpost.harkonnen:
 	idle:
@@ -1129,12 +1453,16 @@ outpost.harkonnen:
 		Start: 2929
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4518
 		Length: 11
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4529
@@ -1142,21 +1470,29 @@ outpost.harkonnen:
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2930
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		Filename: DATA.R16
 		Start: 4817
 		Length: 30
 		Offset: -48,64
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1166,6 +1502,8 @@ outpost.harkonnen:
 		Filename: DATA.R16
 		Start: 4337
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 refinery.harkonnen:
 	idle:
@@ -1173,12 +1511,16 @@ refinery.harkonnen:
 		Start: 2969
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4495
 		Length: 11
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4506
@@ -1186,26 +1528,36 @@ refinery.harkonnen:
 		Offset: -48,64
 		ZOffset: 1024
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2969
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 2970
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 2971
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1215,6 +1567,8 @@ refinery.harkonnen:
 		Filename: DATA.R16
 		Start: 4331
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 	smoke:
 		Filename: DATA.R16
 		Start: 4138
@@ -1222,6 +1576,8 @@ refinery.harkonnen:
 		Offset: 13,-16
 		Tick: 100
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 
 silo.harkonnen:
 	idle:
@@ -1239,16 +1595,22 @@ silo.harkonnen:
 		Start: 2974
 		Length: 4
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		Filename: DATA.R16
 		Start: 2978
 		Offset: -16,16
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4577
 		Length: 8
 		Offset: -16,16
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4585
@@ -1256,10 +1618,14 @@ silo.harkonnen:
 		Offset: -16,16
 		Tick: 100
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4349
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 hightech.harkonnen:
 	Defaults:
@@ -1268,20 +1634,28 @@ hightech.harkonnen:
 		Filename: DATA.R16
 		Start: 2972
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4538
 		Length: 11
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4549
 		Length: 10
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2973
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4888
@@ -1289,11 +1663,15 @@ hightech.harkonnen:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1303,6 +1681,8 @@ hightech.harkonnen:
 		Filename: DATA.R16
 		Start: 4343
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 palace.harkonnen:
 	idle:
@@ -1310,38 +1690,52 @@ palace.harkonnen:
 		Start: 3084
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4677
 		Length: 13
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3085
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 5084
 		Length: 20
 		Offset: -48,48
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 5084
 		Length: 20
 		Offset: -48,48
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -1351,6 +1745,8 @@ palace.harkonnen:
 		Filename: DATA.R16
 		Start: 4367
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 light.harkonnen:
 	idle:
@@ -1358,12 +1754,16 @@ light.harkonnen:
 		Start: 3081
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4559
 		Length: 9
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4568
@@ -1371,23 +1771,31 @@ light.harkonnen:
 		Offset: -48,64
 		ZOffset: 897
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3081
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 3082
 		Offset: -48,64
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 3083
 		Offset: -48,64
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4918
@@ -1396,11 +1804,15 @@ light.harkonnen:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1410,6 +1822,8 @@ light.harkonnen:
 		Filename: DATA.R16
 		Start: 4346
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 heavy.harkonnen:
 	idle:
@@ -1417,12 +1831,16 @@ heavy.harkonnen:
 		Start: 2926
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4592
 		Length: 10
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4602
@@ -1430,23 +1848,31 @@ heavy.harkonnen:
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 2926
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 2927
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 2928
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4948
@@ -1455,11 +1881,15 @@ heavy.harkonnen:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1469,6 +1899,8 @@ heavy.harkonnen:
 		Filename: DATA.R16
 		Start: 4352
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 conyard.ordos:
 	idle:
@@ -1476,23 +1908,31 @@ conyard.ordos:
 		Start: 3127
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4373
 		Length: 30
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4403
 		Length: 12
 		Offset: -48,64
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3128
 		Offset: -48,64
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crane-overlay:
 		Filename: DATA.R16
 		Start: 4728
@@ -1500,6 +1940,8 @@ conyard.ordos:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4728
@@ -1507,11 +1949,15 @@ conyard.ordos:
 		Offset: -48,64
 		Tick: 80
 		ZOffset: 1023
+		Palette: d2k
+		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1521,6 +1967,8 @@ conyard.ordos:
 		Filename: DATA.R16
 		Start: 4312
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 starport.ordos:
 	idle:
@@ -2011,20 +2459,28 @@ palace.corrino:
 		Start: 3252
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 3252
 		Offset: -48,48
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3253
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 631, 632, 633
 		Length: 3
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -2032,18 +2488,24 @@ palace.corrino:
 		Offset: -16,-16
 	icon:
 		Filename: palacecicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	make:
 		Filename: DATA.R16
 		Start: 4677
 		Length: 13
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4690
 		Length: 10
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 
 starport.smuggler:
 	idle:
@@ -2052,12 +2514,16 @@ starport.smuggler:
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3248
 		Offset: -48,48
 		ZOffset: -1c511
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: DATA.R16
 		Start: 5002
@@ -2065,6 +2531,8 @@ starport.smuggler:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Filename: DATA.R16
 		Start: 5002
@@ -2072,18 +2540,24 @@ starport.smuggler:
 		ZOffset: -1c511
 		Offset: -48,48
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4611
 		Length: 12
 		Offset: -48,48
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4623
 		Length: 11
 		Offset: -48,48
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
@@ -2098,6 +2572,8 @@ starport.smuggler:
 		Filename: DATA.R16
 		Start: 4358
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 heavy.mercenary:
 	idle:
@@ -2105,12 +2581,16 @@ heavy.mercenary:
 		Start: 3249
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: DATA.R16
 		Start: 4592
 		Length: 10
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	crumble-overlay:
 		Filename: DATA.R16
 		Start: 4602
@@ -2118,23 +2598,31 @@ heavy.mercenary:
 		Offset: -48,80
 		ZOffset: 897
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: DATA.R16
 		Start: 3249
 		Offset: -48,80
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		Filename: DATA.R16
 		Start: 3250
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: DATA.R16
 		Start: 3251
 		Offset: -48,80
 		ZOffset: 896
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	production-welding:
 		Filename: DATA.R16
 		Start: 4968
@@ -2143,6 +2631,8 @@ heavy.mercenary:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	damaged-production-welding:
 		Filename: DATA.R16
 		Frames: 4968, 4970, 4972, 4973, 4974, 4975, 4976
@@ -2151,11 +2641,15 @@ heavy.mercenary:
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
+		Palette: terrain
+		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -2165,6 +2659,8 @@ heavy.mercenary:
 		Filename: DATA.R16
 		Start: 4353
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 plates: # TODO: unused
 	idle:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -4,7 +4,6 @@ concretea:
 		Start: 4314
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	preview:
 		Filename: BLOXBASE.R16
 		Start: 657
@@ -17,7 +16,6 @@ concreteb:
 		Start: 4317
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 wall:
 	idle:
@@ -39,7 +37,6 @@ wall:
 		Start: 4327
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 medium_gun_turret:
 	invisible:
@@ -97,13 +94,11 @@ medium_gun_turret:
 		Offset: 0,2
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4333
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 large_gun_turret:
 	invisible:
@@ -158,7 +153,6 @@ large_gun_turret:
 		Start: 4339
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 conyard.atreides:
 	idle:
@@ -199,7 +193,6 @@ conyard.atreides:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4700
@@ -208,14 +201,12 @@ conyard.atreides:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -226,7 +217,6 @@ conyard.atreides:
 		Start: 4310
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 repair_pad.atreides:
 	make:
@@ -283,7 +273,6 @@ repair_pad.atreides:
 		Start: 4360
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 repair_pad.harkonnen:
 	make:
@@ -340,7 +329,6 @@ repair_pad.harkonnen:
 		Start: 4361
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 repair_pad.ordos:
 	make:
@@ -451,7 +439,6 @@ starport.atreides:
 		Start: 4356
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 power.atreides:
 	idle:
@@ -506,7 +493,6 @@ power.atreides:
 		Length: 4
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -517,7 +503,6 @@ power.atreides:
 		Start: 4320
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 barracks.atreides:
 	idle:
@@ -556,7 +541,6 @@ barracks.atreides:
 		Length: 4
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -567,7 +551,6 @@ barracks.atreides:
 		Start: 4323
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 outpost.atreides:
 	idle:
@@ -614,7 +597,6 @@ outpost.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -625,7 +607,6 @@ outpost.atreides:
 		Start: 4336
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 refinery.atreides:
 	idle:
@@ -679,7 +660,6 @@ refinery.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -690,7 +670,6 @@ refinery.atreides:
 		Start: 4330
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	smoke:
 		Filename: DATA.R16
 		Start: 4138
@@ -747,7 +726,6 @@ silo.atreides:
 		Start: 4348
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 hightech.atreides:
 	Defaults:
@@ -802,7 +780,6 @@ hightech.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -813,7 +790,6 @@ hightech.atreides:
 		Start: 4342
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 research.atreides:
 	idle:
@@ -860,7 +836,6 @@ research.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -871,7 +846,6 @@ research.atreides:
 		Start: 4363
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 research.harkonnen:
 	idle:
@@ -918,7 +892,6 @@ research.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -929,7 +902,6 @@ research.harkonnen:
 		Start: 4364
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 research.ordos:
 	idle:
@@ -1018,7 +990,6 @@ palace.atreides:
 		Length: 3
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -1029,7 +1000,6 @@ palace.atreides:
 		Start: 4366
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 light.atreides:
 	idle:
@@ -1105,7 +1075,6 @@ light.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1116,7 +1085,6 @@ light.atreides:
 		Start: 4345
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 heavy.atreides:
 	idle:
@@ -1182,7 +1150,6 @@ heavy.atreides:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1193,7 +1160,6 @@ heavy.atreides:
 		Start: 4351
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 conyard.harkonnen:
 	idle:
@@ -1234,7 +1200,6 @@ conyard.harkonnen:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4714
@@ -1243,14 +1208,12 @@ conyard.harkonnen:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1261,7 +1224,6 @@ conyard.harkonnen:
 		Start: 4311
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 starport.harkonnen:
 	idle:
@@ -1329,7 +1291,6 @@ starport.harkonnen:
 		Start: 4357
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 power.harkonnen:
 	idle:
@@ -1384,7 +1345,6 @@ power.harkonnen:
 		Length: 4
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -1395,7 +1355,6 @@ power.harkonnen:
 		Start: 4321
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 barracks.harkonnen:
 	idle:
@@ -1434,7 +1393,6 @@ barracks.harkonnen:
 		Length: 4
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 649, 650, 669, 670
@@ -1445,7 +1403,6 @@ barracks.harkonnen:
 		Start: 4324
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 outpost.harkonnen:
 	idle:
@@ -1492,7 +1449,6 @@ outpost.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1503,7 +1459,6 @@ outpost.harkonnen:
 		Start: 4337
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 refinery.harkonnen:
 	idle:
@@ -1557,7 +1512,6 @@ refinery.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1568,7 +1522,6 @@ refinery.harkonnen:
 		Start: 4331
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	smoke:
 		Filename: DATA.R16
 		Start: 4138
@@ -1625,7 +1578,6 @@ silo.harkonnen:
 		Start: 4349
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 hightech.harkonnen:
 	Defaults:
@@ -1671,7 +1623,6 @@ hightech.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1682,7 +1633,6 @@ hightech.harkonnen:
 		Start: 4343
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 palace.harkonnen:
 	idle:
@@ -1735,7 +1685,6 @@ palace.harkonnen:
 		Length: 3
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -1746,7 +1695,6 @@ palace.harkonnen:
 		Start: 4367
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 light.harkonnen:
 	idle:
@@ -1812,7 +1760,6 @@ light.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1823,7 +1770,6 @@ light.harkonnen:
 		Start: 4346
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 heavy.harkonnen:
 	idle:
@@ -1889,7 +1835,6 @@ heavy.harkonnen:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1900,7 +1845,6 @@ heavy.harkonnen:
 		Start: 4352
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 conyard.ordos:
 	idle:
@@ -1941,7 +1885,6 @@ conyard.ordos:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	damaged-crane-overlay:
 		Filename: DATA.R16
 		Start: 4728
@@ -1950,14 +1893,12 @@ conyard.ordos:
 		Tick: 80
 		ZOffset: 1023
 		Palette: d2k
-		IsPlayerPalette: False
 	bib:
 		Filename: BLOXBASE.R16
 		Frames: 611, 612, 613, 631, 632, 633
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -1968,7 +1909,6 @@ conyard.ordos:
 		Start: 4312
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 starport.ordos:
 	idle:
@@ -2480,7 +2420,6 @@ palace.corrino:
 		Length: 3
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 663, 664, 665
@@ -2489,7 +2428,6 @@ palace.corrino:
 	icon:
 		Filename: palacecicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	make:
 		Filename: DATA.R16
 		Start: 4677
@@ -2573,7 +2511,6 @@ starport.smuggler:
 		Start: 4358
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 heavy.mercenary:
 	idle:
@@ -2649,7 +2586,6 @@ heavy.mercenary:
 		Length: 6
 		Offset: -16,-16
 		Palette: terrain
-		IsPlayerPalette: False
 	bib-Concrete:
 		Filename: BLOXBASE.R16
 		Frames: 643, 644, 645, 663, 664, 665
@@ -2660,7 +2596,6 @@ heavy.mercenary:
 		Start: 4353
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 plates: # TODO: unused
 	idle:

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -4,10 +4,14 @@ mcv:
 		Start: 1795
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4284
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 mcv.husk:
 	idle:
@@ -16,6 +20,8 @@ mcv.husk:
 		Facings: -32
 		ZOffset: -1023
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 harvester:
 	idle:
@@ -23,6 +29,8 @@ harvester:
 		Start: 1699
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	harvest:
 		Filename: DATA.R16
 		Start: 3884
@@ -31,19 +39,27 @@ harvester:
 		Tick: 80
 		ZOffset: 1
 		Alpha: 0.5
+		Palette: effect
+		IsPlayerPalette: False
 	dock:
 		Filename: DATA.R16
 		Start: 3623
 		Length: 10
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	dock-loop:
 		Filename: DATA.R16
 		Start: 3633
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4280
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 harvester.husk:
 	idle:
@@ -52,6 +68,8 @@ harvester.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 trike:
 	idle:
@@ -59,6 +77,8 @@ trike:
 		Start: 1635
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Combine:
 			0:
@@ -193,10 +213,14 @@ trike:
 		Facings: -32
 		Length: 7
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4277
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 quad:
 	idle:
@@ -204,10 +228,14 @@ quad:
 		Start: 1667
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4279
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 siege_tank:
 	idle:
@@ -215,20 +243,28 @@ siege_tank:
 		Start: 1763
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 1891
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 3671
 		Length: 3
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4287
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 siege_tank.husk:
 	idle:
@@ -237,12 +273,16 @@ siege_tank.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 1891
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 missile_tank:
 	idle:
@@ -250,10 +290,14 @@ missile_tank:
 		Start: 1603
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4285
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 missile_tank.husk:
 	idle:
@@ -262,24 +306,36 @@ missile_tank.husk:
 		Facings: -16
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		FilenamePattern: missiletankhusk/missiletankhuskturret-{0:D4}.png
 			Count: 16
 		Facings: -16
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris01:
 		Filename: missiletankhusk/missiletankhuskdebris-0000.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris02:
 		Filename: missiletankhusk/missiletankhuskdebris-0001.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris03:
 		Filename: missiletankhusk/missiletankhuskdebris-0002.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris04:
 		Filename: missiletankhusk/missiletankhuskdebris-0003.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 sonic_tank:
 	idle:
@@ -287,10 +343,14 @@ sonic_tank:
 		Start: 1827
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4288
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 sonic_tank.husk:
 	idle:
@@ -299,24 +359,36 @@ sonic_tank.husk:
 		Facings: -16
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		FilenamePattern: sonictankhusk/sonictankhuskturret-{0:D4}.png
 			Count: 4
 		Facings: -4
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris01:
 		Filename: sonictankhusk/sonictankhuskdebris-0000.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris02:
 		Filename: sonictankhusk/sonictankhuskdebris-0001.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris03:
 		Filename: sonictankhusk/sonictankhuskdebris-0002.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris04:
 		Filename: sonictankhusk/sonictankhuskdebris-0003.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 combat_tank_a:
 	idle:
@@ -324,21 +396,29 @@ combat_tank_a:
 		Start: 1731
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 1859
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4281
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 combat_tank_a.husk:
 	idle:
@@ -347,12 +427,16 @@ combat_tank_a.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 1859
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 combat_tank_h:
 	idle:
@@ -360,21 +444,29 @@ combat_tank_h:
 		Start: 2051
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2115
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4282
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 combat_tank_h.husk:
 	idle:
@@ -383,12 +475,16 @@ combat_tank_h.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2115
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 combat_tank_o:
 	idle:
@@ -396,21 +492,29 @@ combat_tank_o:
 		Start: 2453
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2485
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 4028
 		Tick: 60
 		Facings: -32
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4283
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 combat_tank_o.husk:
 	idle:
@@ -419,12 +523,16 @@ combat_tank_o.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: DATA.R16
 		Start: 2485
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 devastator:
 	idle:
@@ -432,28 +540,38 @@ devastator:
 		Start: 2083
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: DATA.R16
 		Start: 4060
 		Tick: 80
 		Facings: -32
 		BlendMode: Additive
+		Palette: effect
+		IsPlayerPalette: False
 	active:
 		Filename: DATA.R16
 		Start: 3839
 		Length: 14
 		Tick: 130
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	active-2:
 		Filename: DATA.R16
 		Start: 4152
 		Length: 12
 		Tick: 110
 		BlendMode: Additive
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4289
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 devastator.husk:
 	idle:
@@ -462,6 +580,8 @@ devastator.husk:
 		Facings: -32
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 
 raider:
 	Inherits: trike
@@ -470,10 +590,17 @@ raider:
 		Start: 2421
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4278
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
+	muzzle:
+		Palette: effect
+		IsPlayerPalette: False
 
 stealth_raider:
 	Inherits: trike
@@ -482,10 +609,17 @@ stealth_raider:
 		Start: 2421
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4298
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
+	muzzle:
+		Palette: effect
+		IsPlayerPalette: False
 
 deviator:
 	idle:
@@ -493,10 +627,14 @@ deviator:
 		Start: 2389
 		Facings: -32
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: DATA.R16
 		Start: 4286
 		Offset: -30,-24
+		Palette: chrome
+		IsPlayerPalette: False
 
 deviator.husk:
 	idle:
@@ -505,21 +643,33 @@ deviator.husk:
 		Facings: -16
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		FilenamePattern: deviatorhusk/deviatorhuskturret-{0:D4}.png
 			Count: 16
 		Facings: -4
 		ZOffset: -512
 		Remap: 54F94B
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris01:
 		Filename: deviatorhusk/deviatordebris-0000.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris02:
 		Filename: deviatorhusk/deviatordebris-0001.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris03:
 		Filename: deviatorhusk/deviatordebris-0002.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	tankdebris04:
 		Filename: deviatorhusk/deviatordebris-0003.png
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/d2k/sequences/vehicles.yaml
+++ b/mods/d2k/sequences/vehicles.yaml
@@ -11,7 +11,6 @@ mcv:
 		Start: 4284
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 mcv.husk:
 	idle:
@@ -40,7 +39,6 @@ harvester:
 		ZOffset: 1
 		Alpha: 0.5
 		Palette: effect
-		IsPlayerPalette: False
 	dock:
 		Filename: DATA.R16
 		Start: 3623
@@ -59,7 +57,6 @@ harvester:
 		Start: 4280
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 harvester.husk:
 	idle:
@@ -214,13 +211,11 @@ trike:
 		Length: 7
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4277
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 quad:
 	idle:
@@ -235,7 +230,6 @@ quad:
 		Start: 4279
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 siege_tank:
 	idle:
@@ -258,13 +252,11 @@ siege_tank:
 		Length: 3
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4287
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 siege_tank.husk:
 	idle:
@@ -297,7 +289,6 @@ missile_tank:
 		Start: 4285
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 missile_tank.husk:
 	idle:
@@ -350,7 +341,6 @@ sonic_tank:
 		Start: 4288
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 sonic_tank.husk:
 	idle:
@@ -412,13 +402,11 @@ combat_tank_a:
 		Facings: -32
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4281
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 combat_tank_a.husk:
 	idle:
@@ -460,13 +448,11 @@ combat_tank_h:
 		Facings: -32
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4282
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 combat_tank_h.husk:
 	idle:
@@ -508,13 +494,11 @@ combat_tank_o:
 		Facings: -32
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: DATA.R16
 		Start: 4283
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 combat_tank_o.husk:
 	idle:
@@ -549,7 +533,6 @@ devastator:
 		Facings: -32
 		BlendMode: Additive
 		Palette: effect
-		IsPlayerPalette: False
 	active:
 		Filename: DATA.R16
 		Start: 3839
@@ -571,7 +554,6 @@ devastator:
 		Start: 4289
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 devastator.husk:
 	idle:
@@ -597,10 +579,8 @@ raider:
 		Start: 4278
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	muzzle:
 		Palette: effect
-		IsPlayerPalette: False
 
 stealth_raider:
 	Inherits: trike
@@ -616,10 +596,8 @@ stealth_raider:
 		Start: 4298
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 	muzzle:
 		Palette: effect
-		IsPlayerPalette: False
 
 deviator:
 	idle:
@@ -634,7 +612,6 @@ deviator:
 		Start: 4286
 		Offset: -30,-24
 		Palette: chrome
-		IsPlayerPalette: False
 
 deviator.husk:
 	idle:

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -142,8 +142,6 @@ DeviatorMissile:
 		Inaccuracy: 96
 		Image: MISSILE
 		TrailImage: deviator_trail
-		TrailPalette: player
-		TrailUsePlayerPalette: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 2000
 		Spread: 480
@@ -160,8 +158,6 @@ DeviatorMissile:
 	-Warhead@2Smu:
 	Warhead@3Eff: CreateEffect
 		Explosions: deviator
-		ExplosionPalette: player
-		UsePlayerPalette: true
 		-ImpactSounds:
 	Warhead@5OwnerChange: ChangeOwner
 		Range: 512

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -466,5 +466,3 @@ DeviatorGas:
 		InvalidTargets: Infantry, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: deviator
-		ExplosionPalette: player
-		UsePlayerPalette: true

--- a/mods/ra/maps/ant-01/rules.yaml
+++ b/mods/ra/maps/ant-01/rules.yaml
@@ -42,15 +42,12 @@ World:
 
 WarriorAnt:
 	RenderSprites:
-		PlayerPalette: warriorant
 
 ScoutAnt:
 	RenderSprites:
-		PlayerPalette: scoutant
 
 FireAnt:
 	RenderSprites:
-		PlayerPalette: fireant
 
 SPY:
 	Buildable:

--- a/mods/ra/maps/bomber-john/sequences.yaml
+++ b/mods/ra/maps/bomber-john/sequences.yaml
@@ -4,8 +4,12 @@ miner:
 		Length: *
 		Tick: 400
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: jmin.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 brick:
 	idle:

--- a/mods/ra/maps/drop-zone-w/sequences.yaml
+++ b/mods/ra/maps/drop-zone-w/sequences.yaml
@@ -10,3 +10,18 @@ lst:
 		Filename: mgun.shp
 		Start: 0
 		Facings: 32
+	idle:
+		Palette: player
+		IsPlayerPalette: True
+	icon:
+		Palette: chrome
+		IsPlayerPalette: False
+	open:
+		Palette: player
+		IsPlayerPalette: True
+	close:
+		Palette: player
+		IsPlayerPalette: True
+	unload:
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -305,10 +305,11 @@ SNIPER:
 		Weapon: Sniper
 		MuzzleSequence: garrison-muzzle
 	WithInfantryBody:
-		DefaultAttackSequence: shoot
 		RequiresCondition: !parachute
+		DefaultAttackSequence: shoot
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
+		StandSequences: stand-noshadow
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -309,8 +309,6 @@ SNIPER:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Cloak:
 		InitialDelay: 250
 		CloakDelay: 120

--- a/mods/ra/maps/fort-lonestar/sequences.yaml
+++ b/mods/ra/maps/fort-lonestar/sequences.yaml
@@ -3,31 +3,53 @@ sniper:
 		Filename: sniper.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	liedown:
 		Start: 192
 		Length: 2
@@ -40,34 +62,50 @@ sniper:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 399
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 416
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 424
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 432
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 440
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 452
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -75,6 +113,8 @@ sniper:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -82,10 +122,16 @@ sniper:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	garrison-muzzle:
 		Filename: minigun.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: snipericon.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/maps/fort-lonestar/sequences.yaml
+++ b/mods/ra/maps/fort-lonestar/sequences.yaml
@@ -5,6 +5,8 @@ sniper:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	stand2:
@@ -19,8 +21,6 @@ sniper:
 		Tick: 100
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
@@ -32,8 +32,6 @@ sniper:
 		Stride: 4
 		Facings: 8
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
@@ -47,8 +45,6 @@ sniper:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	liedown:
 		Start: 192

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -102,7 +102,6 @@ TRUK.Hijackable:
 	-DeliversCash:
 	RenderSprites:
 		Image: TRUK
-		Palette: truk-soviets
 	RevealsShroud:
 		Range: 6c0
 	Voiced:

--- a/mods/ra/maps/oil-spill/rules.yaml
+++ b/mods/ra/maps/oil-spill/rules.yaml
@@ -24,8 +24,6 @@ FCOM:
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 	ProductionBar@Building:
 		ProductionType: Building
 	ProductionBar@Defense:

--- a/mods/ra/maps/oil-spill/sequences.yaml
+++ b/mods/ra/maps/oil-spill/sequences.yaml
@@ -3,3 +3,5 @@ oilb.husk: oilb
 		Filename: oilb.shp
 		Start: 1
 		Offset: 0,-6
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/ra/maps/proving-grounds/rules.yaml
+++ b/mods/ra/maps/proving-grounds/rules.yaml
@@ -32,7 +32,7 @@ powerproxy.paratroopers:
 		DropItems: E1,E1,E1,E2,E2
 		DisplayBeacon: false
 		ReinforcementsArrivedSpeechNotification: ReinforcementsArrived
-		ReinforcementsArrivedTextNotification: notification-reinforcements-have-arrived	
+		ReinforcementsArrivedTextNotification: notification-reinforcements-have-arrived
 	KillsSelf:
 		RemoveInstead: true
 		Delay: 5

--- a/mods/ra/maps/proving-grounds/sequences.yaml
+++ b/mods/ra/maps/proving-grounds/sequences.yaml
@@ -1,3 +1,5 @@
 iconchevrons:
 	veteran:
 		Start: 1
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/maps/proving-grounds/weapons.yaml
+++ b/mods/ra/maps/proving-grounds/weapons.yaml
@@ -13,6 +13,5 @@ TorpTubeNuclear:
 		HorizontalRateOfTurn: 4
 		RangeLimit: 11c819
 		BoundToTerrainType: Water
-		Palette: shadow
 		MaximumLaunchAngle: 0
 		CruiseAltitude: 0

--- a/mods/ra/maps/top-o-the-world/rules.yaml
+++ b/mods/ra/maps/top-o-the-world/rules.yaml
@@ -37,7 +37,6 @@ AGUN:
 TRUK:
 	-SpawnActorOnDeath:
 	RenderSprites:
-		PlayerPalette: truk
 
 GNRL:
 	Armament:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -102,8 +102,6 @@ FCOM:
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 
 MISS:
 	RevealsShroud:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -7,10 +7,7 @@ C2:
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian2
 	WithDeathAnimation:
-		DeathSequencePalette: civilian2
-		DeathPaletteIsPlayerPalette: false
 
 C3:
 	Inherits: ^CivInfantry
@@ -26,10 +23,7 @@ C4:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 	WithInfantryBody:
-		Palette: civilian4
 	WithDeathAnimation:
-		DeathSequencePalette: civilian4
-		DeathPaletteIsPlayerPalette: false
 
 C5:
 	Inherits: ^CivInfantry
@@ -38,20 +32,14 @@ C5:
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
 	WithInfantryBody:
-		Palette: civilian5
 	WithDeathAnimation:
-		DeathSequencePalette: civilian5
-		DeathPaletteIsPlayerPalette: false
 
 C6:
 	Inherits: ^CivInfantry
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian6
 	WithDeathAnimation:
-		DeathSequencePalette: civilian6
-		DeathPaletteIsPlayerPalette: false
 
 C7:
 	Inherits@1: ^CivInfantry
@@ -59,30 +47,21 @@ C7:
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian7
 	WithDeathAnimation:
-		DeathSequencePalette: civilian7
-		DeathPaletteIsPlayerPalette: false
 
 C8:
 	Inherits: ^CivInfantry
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian8
 	WithDeathAnimation:
-		DeathSequencePalette: civilian8
-		DeathPaletteIsPlayerPalette: false
 
 C9:
 	Inherits: ^CivInfantry
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian9
 	WithDeathAnimation:
-		DeathSequencePalette: civilian9
-		DeathPaletteIsPlayerPalette: false
 
 C10:
 	Inherits: ^CivInfantry
@@ -91,10 +70,7 @@ C10:
 	Tooltip:
 		Name: actor-c10-name
 	WithInfantryBody:
-		Palette: civilian10
 	WithDeathAnimation:
-		DeathSequencePalette: civilian10
-		DeathPaletteIsPlayerPalette: false
 
 C11:
 	Inherits: ^CivInfantry
@@ -119,10 +95,7 @@ TECN2:
 	RenderSprites:
 		Image: C1
 	WithInfantryBody:
-		Palette: civilian7
 	WithDeathAnimation:
-		DeathSequencePalette: civilian7
-		DeathPaletteIsPlayerPalette: false
 
 FCOM:
 	Inherits: ^TechBuilding
@@ -353,7 +326,6 @@ V18:
 V19:
 	Inherits: ^CivBuilding
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-v19-name
 	SpawnActorOnDeath:
@@ -364,7 +336,6 @@ V19:
 V19.Husk:
 	Inherits: ^CivBuilding
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-v19-husk-name
 	WithSpriteBody:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -4,8 +4,6 @@ C1:
 
 C2:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C1
 	WithInfantryBody:
 	WithDeathAnimation:
 
@@ -13,64 +11,34 @@ C3:
 	Inherits: ^CivInfantry
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
-	RenderSprites:
-		Image: C2
 
 C4:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C2
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C5:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C2
 	Voiced:
 		VoiceSet: CivilianFemaleVoice
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C6:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C1
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C7:
 	Inherits@1: ^CivInfantry
 	Inherits@2: ^ArmedCivilian
-	RenderSprites:
-		Image: C1
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C8:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C1
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C9:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C1
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C10:
 	Inherits: ^CivInfantry
-	RenderSprites:
-		Image: C1
 	Tooltip:
 		Name: actor-c10-name
-	WithInfantryBody:
-	WithDeathAnimation:
 
 C11:
 	Inherits: ^CivInfantry
@@ -93,9 +61,7 @@ TECN2:
 	Selectable:
 		Class: Technician
 	RenderSprites:
-		Image: C1
-	WithInfantryBody:
-	WithDeathAnimation:
+		Image: C7
 
 FCOM:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -243,7 +243,6 @@ BOXES09:
 ICE01:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -256,7 +255,6 @@ ICE01:
 ICE02:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Building:
 		Footprint: x x
 		Dimensions: 1,2
@@ -269,7 +267,6 @@ ICE02:
 ICE03:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
@@ -282,7 +279,6 @@ ICE03:
 ICE04:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-ice04-name
 	MapEditorData:
@@ -292,7 +288,6 @@ ICE04:
 ICE05:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-ice05-name
 	MapEditorData:
@@ -344,7 +339,6 @@ ROCK7:
 UTILPOL1:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-utilpol1-name
 	MapEditorData:
@@ -353,7 +347,6 @@ UTILPOL1:
 UTILPOL2:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: actor-utilpol2-name
 	MapEditorData:
@@ -362,7 +355,6 @@ UTILPOL2:
 TANKTRAP1:
 	Inherits: ^Rock
 	RenderSprites:
-		Palette: player
 	Building:
 		Footprint: x
 		Dimensions: 1,1
@@ -374,7 +366,6 @@ TANKTRAP1:
 TANKTRAP2:
 	Inherits: ^Rock
 	RenderSprites:
-		Palette: player
 	Building:
 		Footprint: x
 		Dimensions: 1,1

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -115,7 +115,6 @@
 	WithDecoration@RANK-1:
 		Image: rank
 		Sequence: rank-veteran-1
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -123,7 +122,6 @@
 	WithDecoration@RANK-2:
 		Image: rank
 		Sequence: rank-veteran-2
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -131,7 +129,6 @@
 	WithDecoration@RANK-3:
 		Image: rank
 		Sequence: rank-veteran-3
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -139,7 +136,6 @@
 	WithDecoration@RANK-ELITE:
 		Image: rank
 		Sequence: rank-elite
-		Palette: effect
 		Position: BottomRight
 		Margin: 5, 6
 		ValidRelationships: Ally, Enemy, Neutral
@@ -766,8 +762,6 @@
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: player
-		IsPlayerPalette: True
 
 ^ScienceBuilding:
 	Inherits: ^Building
@@ -827,7 +821,6 @@
 		TargetTypes: GroundActor, DetonateAttack, Wall, NoAutoTarget
 	-GivesExperience:
 	RenderSprites:
-		Palette: effect
 	WithWallSpriteBody:
 	Sellable:
 		SellSounds: cashturn.aud
@@ -913,7 +906,6 @@
 ^CivBuilding:
 	Inherits: ^TechBuilding
 	RenderSprites:
-		Palette: player
 	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Civilian building
@@ -965,7 +957,6 @@
 		Name: meta-tree-name
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: terrain
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -984,7 +975,6 @@
 	WithDamageOverlay@SmallBurn:
 		DamageTypes: Incendiary
 		Image: burn-s
-		Palette: effect
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 		StartSequence: start
@@ -994,7 +984,6 @@
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
-		Palette: effect
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 		StartSequence: start
@@ -1004,7 +993,6 @@
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
-		Palette: effect
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 		StartSequence: start
@@ -1022,7 +1010,6 @@
 	Inherits@1: ^SpriteActor
 	Interactable:
 	RenderSprites:
-		Palette: terrain
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Tree
@@ -1044,7 +1031,6 @@
 ^Box:
 	Inherits: ^Tree
 	RenderSprites:
-		Palette: player
 	Tooltip:
 		Name: meta-box-name
 	MapEditorData:
@@ -1182,7 +1168,6 @@
 		Name: meta-rock-name
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: desert
 	WithSpriteBody:
 	Building:
 		Footprint: __ x_
@@ -1202,7 +1187,6 @@
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding
 	RenderSprites:
-		Palette: desert
 	MapEditorData:
 		RequireTilesets: DESERT
 
@@ -1219,7 +1203,6 @@
 		Duration: 4500
 		TerrainTypes: Clear, Rough, Road, Ore, Beach, Water
 	RenderSprites:
-		Palette: effect
 		Image: scrate
 	WithCrateBody:
 		XmasImages: xcratea, xcrateb, xcratec, xcrated
@@ -1298,7 +1281,6 @@
 	WithDecoration@POWERDOWN:
 		Image: poweroff
 		Sequence: offline
-		Palette: chrome
 		RequiresCondition: powerdown
 		Position: Center
 		Offsets:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -58,8 +58,6 @@ DOG:
 		RequiresCondition: run && !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	SpeedMultiplier:
 		Modifier: 150
 		RequiresCondition: run
@@ -99,8 +97,6 @@ E1:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 	WithProductionIconOverlay:
@@ -156,8 +152,6 @@ E2:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -208,8 +202,6 @@ E3:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
@@ -268,8 +260,6 @@ E4:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 	WithProductionIconOverlay:
@@ -296,8 +286,6 @@ E6:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Passenger:
 		CustomPipType: yellow
 	InstantlyRepairs:
@@ -366,14 +354,11 @@ SPY:
 		RequiresCondition: !parachute
 	WithDisguisingInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	WithDecoration@disguise:
 		Position: Top
 		Margin: 0, -6
 		Image: pips
 		Sequence: tag-spy
-		Palette: effect
 		RequiresCondition: disguise
 	IgnoresDisguise:
 	Armament:
@@ -441,8 +426,6 @@ E7:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	ExternalCondition@PRODUCED:
 		Condition: produced
 	VoiceAnnouncement:
@@ -492,8 +475,6 @@ MEDI:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: MedicVoice
 	AutoTarget:
@@ -548,8 +529,6 @@ MECH:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: MechanicVoice
 	AutoTarget:
@@ -614,8 +593,6 @@ GNRL:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 
 THF:
 	Inherits: ^Soldier
@@ -655,8 +632,6 @@ THF:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Crushable:
 		WarnProbability: 95
 	Cloak:
@@ -717,8 +692,6 @@ SHOK:
 	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: ShokVoice
 	ProducibleWithLevel:
@@ -754,8 +727,6 @@ Zombie:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
 		RequiresCondition: parachute
-		Palette: player-noshadow
-		IsPlayerPalette: true
 	Armament:
 		Weapon: claw
 	Voiced:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -57,6 +57,7 @@ DOG:
 		MoveSequence: run
 		RequiresCondition: run && !parachute
 	WithInfantryBody@PARACHUTE:
+		IdleSequences: stand-noshadow
 		RequiresCondition: parachute
 	SpeedMultiplier:
 		Modifier: 150
@@ -425,6 +426,7 @@ E7:
 		StandSequences: stand
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 	ExternalCondition@PRODUCED:
 		Condition: produced
@@ -474,6 +476,7 @@ MEDI:
 		DefaultAttackSequence: heal
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 	Voiced:
 		VoiceSet: MedicVoice
@@ -528,6 +531,7 @@ MECH:
 		StandSequences: stand
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 	Voiced:
 		VoiceSet: MechanicVoice
@@ -592,6 +596,7 @@ GNRL:
 		IdleSequences: idle1
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 
 THF:
@@ -631,6 +636,7 @@ THF:
 		StandSequences: stand
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 	Crushable:
 		WarnProbability: 95
@@ -726,6 +732,7 @@ Zombie:
 		IdleSequences: idle1
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
+		StandSequences: stand-noshadow
 		RequiresCondition: parachute
 	Armament:
 		Weapon: claw

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -436,7 +436,7 @@ fact.colorpicker:
 	-MapEditorData:
 	-BaseBuilding:
 	RenderSprites:
-		Image: fact
+		Image: fact.colorpicker
 
 CTFLAG:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -244,7 +244,6 @@ MINE:
 	Tooltip:
 		Name: actor-mine-name
 	RenderSprites:
-		Palette: terrain
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -267,7 +266,6 @@ GMINE:
 	Tooltip:
 		Name: actor-gmine-name
 	RenderSprites:
-		Palette: player
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -291,7 +289,6 @@ RAILMINE:
 	Tooltip:
 		Name: actor-railmine-name
 	RenderSprites:
-		Palette: player
 	WithSpriteBody:
 	Building:
 		Footprint: xx
@@ -329,7 +326,6 @@ LAR1:
 		Footprint: x
 		Dimensions: 1,1
 	RenderSprites:
-		Palette: terrain
 	WithSpriteBody:
 	AppearsOnRadar:
 	MapEditorData:
@@ -376,7 +372,6 @@ powerproxy.sonarpulse:
 		LifeTime: 250
 		DeploySound: sonpulse.aud
 		EffectImage: moveflsh
-		EffectPalette: moveflash
 		SupportPowerPaletteOrder: 80
 		EffectSequence: idle
 		BlockedCursor: move-blocked
@@ -442,7 +437,6 @@ fact.colorpicker:
 	-BaseBuilding:
 	RenderSprites:
 		Image: fact
-		Palette: colorpicker
 
 CTFLAG:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1337,7 +1337,7 @@ PROC:
 			BottomRight: -512, 1280
 	-ActorPreviewPlaceBuildingPreview:
 	SequencePlaceBuildingPreview:
-		Sequence: idle
+		Sequence: place
 		SequenceAlpha: 0.65
 	WithResourceStoragePipsDecoration:
 		Position: BottomLeft

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -90,7 +90,6 @@
 	TerrainRenderer:
 	ChronoVortexRenderer:
 	ShroudRenderer:
-		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
 		UseExtendedIndex: true
 	Faction@allies:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -150,11 +150,9 @@
 		ResourceTypes:
 			Ore:
 				Sequences: gold01, gold02, gold03, gold04
-				Palette: player
 				Name: resource-minerals
 			Gems:
 				Sequences: gem01, gem02, gem03, gem04
-				Palette: player
 				Name: resource-minerals
 
 World:
@@ -215,7 +213,6 @@ World:
 		Types: Gems
 		Image: twinkle
 		Sequences: twinkle1, twinkle2, twinkle3
-		Palette: effect
 	WarheadDebugOverlay:
 	SpawnMapActors:
 	MapBuildRadius:
@@ -295,7 +292,6 @@ World:
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
-		TerrainFlashPalette: moveflash
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -3,74 +3,112 @@ mig:
 		Filename: mig.shp
 		Facings: 16
 		InterpolatedFacings: 64
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: migicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 yak:
 	idle:
 		Filename: yak.shp
 		Facings: 16
 		InterpolatedFacings: 64
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: yakicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 heli:
 	idle:
 		Filename: heli.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: lrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: lrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: heliicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 hind:
 	idle:
 		Filename: hind.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: lrotorlg.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: lrotorlg.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: hindicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 tran:
 	idle:
 		Filename: tran2.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: lrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	rotor2:
 		Filename: rrotor.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: lrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor2:
 		Filename: rrotor.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Filename: tran2.shp
 		Start: 32
@@ -80,42 +118,62 @@ tran:
 		Start: 35
 	icon:
 		Filename: tranicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 tran1husk:
 	idle:
 		Filename: tran1husk.shp
+		Palette: player
+		IsPlayerPalette: True
 
 tran2husk:
 	idle:
 		Filename: tran2husk.shp
+		Palette: player
+		IsPlayerPalette: True
 
 u2:
 	idle:
 		Filename: u2.shp
 		Facings: 16
 		InterpolatedFacings: 64
+		Palette: player
+		IsPlayerPalette: True
 
 badr:
 	idle:
 		Filename: badr.shp
 		Facings: 16
 		InterpolatedFacings: 64
+		Palette: player
+		IsPlayerPalette: True
 
 mh60:
 	idle:
 		Filename: mh60.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	rotor:
 		Filename: yrotorlg.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: yrotorlg.shp
 		Start: 4
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: mh60icon.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/sequences/decorations.yaml
+++ b/mods/ra/sequences/decorations.yaml
@@ -4,6 +4,8 @@ tc04:
 		TilesetFilenames:
 			SNOW: tc04.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 tc04.husk:
 	Defaults:
@@ -12,6 +14,8 @@ tc04.husk:
 			SNOW: tc04.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -23,6 +27,8 @@ tc05:
 		TilesetFilenames:
 			SNOW: tc05.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 tc05.husk:
 	Defaults:
@@ -31,6 +37,8 @@ tc05.husk:
 			SNOW: tc05.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -42,6 +50,8 @@ tc03:
 		TilesetFilenames:
 			SNOW: tc03.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 tc03.husk:
 	Defaults:
@@ -50,6 +60,8 @@ tc03.husk:
 			SNOW: tc03.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -61,6 +73,8 @@ tc02:
 		TilesetFilenames:
 			SNOW: tc02.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 tc02.husk:
 	Defaults:
@@ -69,6 +83,8 @@ tc02.husk:
 			SNOW: tc02.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -81,6 +97,8 @@ tc01:
 			SNOW: tc01.sno
 			DESERT: tc01.des
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 tc01.husk:
 	Defaults:
@@ -90,6 +108,8 @@ tc01.husk:
 			DESERT: tc01.des
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -101,6 +121,8 @@ t17:
 		TilesetFilenames:
 			SNOW: t17.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t17.husk:
 	Defaults:
@@ -109,6 +131,8 @@ t17.husk:
 			SNOW: t17.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -120,6 +144,8 @@ t16:
 		TilesetFilenames:
 			SNOW: t16.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t16.husk:
 	Defaults:
@@ -128,6 +154,8 @@ t16.husk:
 			SNOW: t16.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -139,6 +167,8 @@ t15:
 		TilesetFilenames:
 			SNOW: t15.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t15.husk:
 	Defaults:
@@ -147,6 +177,8 @@ t15.husk:
 			SNOW: t15.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -158,6 +190,8 @@ t14:
 		TilesetFilenames:
 			SNOW: t14.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t14.husk:
 	Defaults:
@@ -166,6 +200,8 @@ t14.husk:
 			SNOW: t14.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -177,6 +213,8 @@ t13:
 		TilesetFilenames:
 			SNOW: t13.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t13.husk:
 	Defaults:
@@ -185,6 +223,8 @@ t13.husk:
 			SNOW: t13.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -196,6 +236,8 @@ t12:
 		TilesetFilenames:
 			SNOW: t12.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t12.husk:
 	Defaults:
@@ -204,6 +246,8 @@ t12.husk:
 			SNOW: t12.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -215,6 +259,8 @@ t11:
 		TilesetFilenames:
 			SNOW: t11.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t11.husk:
 	Defaults:
@@ -223,6 +269,8 @@ t11.husk:
 			SNOW: t11.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -234,6 +282,8 @@ t10:
 		TilesetFilenames:
 			SNOW: t10.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t10.husk:
 	Defaults:
@@ -242,6 +292,8 @@ t10.husk:
 			SNOW: t10.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -254,6 +306,8 @@ t08:
 			SNOW: t08.sno
 			DESERT: t08.des
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t08.husk:
 	Defaults:
@@ -263,6 +317,8 @@ t08.husk:
 			DESERT: t08.des
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -274,6 +330,8 @@ t07:
 		TilesetFilenames:
 			SNOW: t07.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t07.husk:
 	Defaults:
@@ -282,6 +340,8 @@ t07.husk:
 			SNOW: t07.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -293,6 +353,8 @@ t06:
 		TilesetFilenames:
 			SNOW: t06.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t06.husk:
 	Defaults:
@@ -301,6 +363,8 @@ t06.husk:
 			SNOW: t06.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -312,6 +376,8 @@ t05:
 		TilesetFilenames:
 			SNOW: t05.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t05.husk:
 	Defaults:
@@ -320,6 +386,8 @@ t05.husk:
 			SNOW: t05.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -331,6 +399,8 @@ t03:
 		TilesetFilenames:
 			SNOW: t03.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t03.husk:
 	Defaults:
@@ -339,6 +409,8 @@ t03.husk:
 			SNOW: t03.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -350,6 +422,8 @@ t02:
 		TilesetFilenames:
 			SNOW: t02.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t02.husk:
 	Defaults:
@@ -358,6 +432,8 @@ t02.husk:
 			SNOW: t02.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -369,6 +445,8 @@ t01:
 		TilesetFilenames:
 			SNOW: t01.sno
 	idle:
+		Palette: terrain
+		IsPlayerPalette: False
 
 t01.husk:
 	Defaults:
@@ -377,6 +455,8 @@ t01.husk:
 			SNOW: t01.sno
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Length: 8
@@ -386,26 +466,36 @@ ice01:
 	idle:
 		Filename: ice01.sno
 		Length: *
+		Palette: player
+		IsPlayerPalette: False
 
 ice02:
 	idle:
 		Filename: ice02.sno
 		Length: *
+		Palette: player
+		IsPlayerPalette: False
 
 ice03:
 	idle:
 		Filename: ice03.sno
 		Length: *
+		Palette: player
+		IsPlayerPalette: False
 
 ice04:
 	idle:
 		Filename: ice04.sno
 		Length: *
+		Palette: player
+		IsPlayerPalette: False
 
 ice05:
 	idle:
 		Filename: ice05.sno
 		Length: *
+		Palette: player
+		IsPlayerPalette: False
 
 v01:
 	Defaults:
@@ -413,8 +503,12 @@ v01:
 		TilesetFilenames:
 			SNOW: v01.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v02:
 	Defaults:
@@ -422,8 +516,12 @@ v02:
 		TilesetFilenames:
 			SNOW: v02.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v03:
 	Defaults:
@@ -431,8 +529,12 @@ v03:
 		TilesetFilenames:
 			SNOW: v03.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v04:
 	Defaults:
@@ -440,8 +542,12 @@ v04:
 		TilesetFilenames:
 			SNOW: v04.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: False
 	active:
 		Start: 1
 	damaged-active:
@@ -453,8 +559,12 @@ v05:
 		TilesetFilenames:
 			SNOW: v05.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: False
 
 v06:
 	Defaults:
@@ -462,8 +572,12 @@ v06:
 		TilesetFilenames:
 			SNOW: v06.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v07:
 	Defaults:
@@ -471,8 +585,12 @@ v07:
 		TilesetFilenames:
 			SNOW: v07.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: False
 
 v08:
 	Defaults:
@@ -480,8 +598,12 @@ v08:
 		TilesetFilenames:
 			SNOW: v08.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v09:
 	Defaults:
@@ -489,8 +611,12 @@ v09:
 		TilesetFilenames:
 			SNOW: v09.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v10:
 	Defaults:
@@ -498,8 +624,12 @@ v10:
 		TilesetFilenames:
 			SNOW: v10.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v11:
 	Defaults:
@@ -507,8 +637,12 @@ v11:
 		TilesetFilenames:
 			SNOW: v11.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v12:
 	Defaults:
@@ -517,9 +651,13 @@ v12:
 			SNOW: v12.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v13:
 	Defaults:
@@ -527,8 +665,12 @@ v13:
 		TilesetFilenames:
 			SNOW: v13.sno
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 v14:
 	Defaults:
@@ -537,9 +679,13 @@ v14:
 			SNOW: v14.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v15:
 	Defaults:
@@ -548,9 +694,13 @@ v15:
 			SNOW: v15.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v16:
 	Defaults:
@@ -559,9 +709,13 @@ v16:
 			SNOW: v16.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v17:
 	Defaults:
@@ -570,9 +724,13 @@ v17:
 			SNOW: v17.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v18:
 	Defaults:
@@ -581,46 +739,66 @@ v18:
 			SNOW: v18.sno
 	idle:
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 rice:
 	idle:
 		Filename: rice.tem
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: rice.tem
 		Start: 1
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 v19:
 	idle:
 		Filename: v19.shp
 		Length: 14
+		Palette: player
+		IsPlayerPalette: False
 
 v19.husk:
 	idle:
 		Filename: v19.shp
 		Start: 28
+		Palette: player
+		IsPlayerPalette: False
 	fire-start:
 		Filename: flmspt.shp
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
+		Palette: player
+		IsPlayerPalette: False
 	fire-loop:
 		Filename: flmspt.shp
 		Start: 50
 		Length: *
 		Offset: 7,-15
 		ZOffset: 1
+		Palette: player
+		IsPlayerPalette: False
 
 utilpol1:
 	Defaults:
 		Filename: utilpol1.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 	dead:
 		Start: 1
 
@@ -628,146 +806,216 @@ utilpol2:
 	Defaults:
 		Filename: utilpol2.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 	dead:
 		Start: 1
 
 ammobox1:
 	idle:
 		Filename: ammobox1.shp
+		Palette: player
+		IsPlayerPalette: True
 
 ammobox2:
 	idle:
 		Filename: ammobox2.shp
+		Palette: player
+		IsPlayerPalette: True
 
 ammobox3:
 	idle:
 		Filename: ammobox3.shp
+		Palette: player
+		IsPlayerPalette: True
 
 tanktrap1:
 	idle:
 		Filename: tanktrap1.shp
+		Palette: player
+		IsPlayerPalette: False
 
 tanktrap2:
 	idle:
 		Filename: tanktrap2.shp
+		Palette: player
+		IsPlayerPalette: False
 
 rushouse:
 	Defaults:
 		Filename: rushouse.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 asianhut:
 	Defaults:
 		Filename: asianhut.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: False
 
 barb:
 	Defaults:
 		Filename: barb.shp
 	idle:
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 
 wood:
 	Defaults:
 		Filename: wood.shp
 	idle:
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 
 barl:
 	idle:
 		Filename: barl.shp
+		Palette: player
+		IsPlayerPalette: True
 
 brl3:
 	idle:
 		Filename: brl3.shp
+		Palette: player
+		IsPlayerPalette: True
 
 # Interior Terrain
 boxes01:
 	idle:
 		Filename: boxes01.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes02:
 	idle:
 		Filename: boxes02.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes03:
 	idle:
 		Filename: boxes03.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes04:
 	idle:
 		Filename: boxes04.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes05:
 	idle:
 		Filename: boxes05.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes06:
 	idle:
 		Filename: boxes06.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes07:
 	idle:
 		Filename: boxes07.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes08:
 	idle:
 		Filename: boxes08.int
+		Palette: player
+		IsPlayerPalette: False
 
 boxes09:
 	idle:
 		Filename: boxes09.int
+		Palette: player
+		IsPlayerPalette: False
 
 # Desert Terrain Expansion
 rock1:
 	idle:
 		Filename: rock1.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock2:
 	idle:
 		Filename: rock2.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock3:
 	idle:
 		Filename: rock3.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock4:
 	idle:
 		Filename: rock4.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock5:
 	idle:
 		Filename: rock5.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock6:
 	idle:
 		Filename: rock6.des
+		Palette: desert
+		IsPlayerPalette: False
 
 rock7:
 	idle:
 		Filename: rock7.des
+		Palette: desert
+		IsPlayerPalette: False
 
 t04:
 	idle:
 		Filename: t04.des
+		Palette: terrain
+		IsPlayerPalette: False
 
 t04.husk:
 	Defaults:
 		Filename: t04.des
 	idle:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Filename: t04.des
 		Start: 2
@@ -777,11 +1025,15 @@ t04.husk:
 t09:
 	idle:
 		Filename: t09.des
+		Palette: terrain
+		IsPlayerPalette: False
 
 t09.husk:
 	idle:
 		Filename: t09.des
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	dead:
 		Filename: t09.des
 		Start: 2
@@ -793,142 +1045,214 @@ v20:
 		Filename: v20.des
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v20.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 
 v21:
 	idle:
 		Filename: v21.des
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v21.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 
 v22:
 	idle:
 		Filename: v22.des
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v22.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 
 v23:
 	idle:
 		Filename: v23.des
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v23.des
 		Start: 3
 		Length: 3
 		Tick: 120
+		Palette: desert
+		IsPlayerPalette: False
 
 v24:
 	idle:
 		Filename: v24.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v24.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v25:
 	idle:
 		Filename: v25.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v25.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v26:
 	idle:
 		Filename: v26.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v26.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v27:
 	idle:
 		Filename: v27.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v27.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v28:
 	idle:
 		Filename: v28.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v28.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v29:
 	idle:
 		Filename: v29.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v29.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v30:
 	idle:
 		Filename: v30.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v30.des
 		Start: 2
+		Palette: desert
+		IsPlayerPalette: False
 
 v31:
 	idle:
 		Filename: v31.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v31.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v32:
 	idle:
 		Filename: v32.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v32.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v33:
 	idle:
 		Filename: v33.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v33.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v34:
 	idle:
 		Filename: v34.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v34.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v35:
 	idle:
 		Filename: v35.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v35.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v36:
 	idle:
 		Filename: v36.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v36.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 v37:
 	idle:
 		Filename: v37.des
+		Palette: desert
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: v37.des
 		Start: 1
+		Palette: desert
+		IsPlayerPalette: False
 
 snowhut:
 	Defaults:
@@ -938,9 +1262,13 @@ snowhut:
 	idle:
 		Length: 3
 		Tick: 360
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 3
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: False
 
 lhus:
 	Defaults:
@@ -949,10 +1277,14 @@ lhus:
 	idle:
 		Length: 16
 		Tick: 180
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Tick: 180
 		Length: 8
+		Palette: player
+		IsPlayerPalette: False
 
 windmill:
 	Defaults:
@@ -961,7 +1293,11 @@ windmill:
 	idle:
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 8
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: False

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -3,31 +3,49 @@ e1:
 		Filename: e1.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	liedown:
 		Start: 128
 		Length: 2
@@ -40,36 +58,54 @@ e1:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	parachute:
 		Start: 377
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 256
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 272
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 288
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 296
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 304
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 312
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 324
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -77,6 +113,8 @@ e1:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -84,6 +122,8 @@ e1:
 		Length: *
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	garrison-muzzle: minigun
 		Filename:
 		Length: 12
@@ -121,56 +161,86 @@ e1:
 				Filename: minigun.shp
 				Length: 12
 				Frames: 42,43,44,45,46,47,42,43,44,45,46,47
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: e1icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 e3:
 	Defaults:
 		Filename: e3.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	parachute:
 		Start: 393
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 272
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 287
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 304
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 312
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 320
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 328
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 340
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -178,6 +248,8 @@ e3:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -185,69 +257,107 @@ e3:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 192
 		Length: 10
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e3icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 e6:
 	Defaults:
 		Filename: e6.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	parachute:
 		Start: 210
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 121
 		Length: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 130
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 146
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 154
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 162
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 170
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 182
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -255,6 +365,8 @@ e6:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -262,36 +374,58 @@ e6:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 82
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 82
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	icon:
 		Filename: e6icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 medi:
 	Defaults:
 		Filename: medi.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	heal:
 		Start: 56
 		Length: 58
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Start: 114
 		Length: 2
@@ -300,26 +434,38 @@ medi:
 		Start: 178
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 193
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 201
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 209
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 217
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 229
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -327,6 +473,8 @@ medi:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -334,32 +482,54 @@ medi:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 130
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	icon:
 		Filename: mediicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mech:
 	Defaults:
 		Filename: mech.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	repair:
 		Start: 56
 		Length: 58
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Start: 114
 		Length: 2
@@ -368,26 +538,38 @@ mech:
 		Start: 178
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 193
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 201
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 209
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 217
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 229
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -395,6 +577,8 @@ mech:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -402,65 +586,103 @@ mech:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 130
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	icon:
 		Filename: mechicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 e2:
 	Defaults:
 		Filename: e2.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	throw:
 		Start: 64
 		Length: 20
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	parachute:
 		Start: 505
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 399
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 416
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 424
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 432
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 440
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 452
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -468,6 +690,8 @@ e2:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -475,78 +699,120 @@ e2:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 240
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 240
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-throw:
 		Start: 288
 		Length: 12
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e2icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 dog:
 	Defaults:
 		Filename: dog.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	walk:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	eat:
 		Start: 104
 		Length: 14
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 216
 		Length: 7
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 224
 		Length: 11
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 236
 		Length: 6
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 242
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 236
 		Length: 6
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 242
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 251
 		Length: 14
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electdog.shp
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -554,58 +820,88 @@ dog:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	jump:
 		Filename: dogbullt.shp
 		Length: 4
 		Facings: 8
 	icon:
 		Filename: dogicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 spy:
 	Defaults:
 		Filename: spy.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 256
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 271
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 288
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 296
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 304
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 312
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 324
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -613,6 +909,8 @@ spy:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -620,60 +918,96 @@ spy:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 144
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 192
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: spyicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 thf:
 	Defaults:
 		Filename: thf.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle:
 		Start: 120
 		Length: 19
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 139
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 147
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 155
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 163
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 175
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -681,6 +1015,8 @@ thf:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -688,6 +1024,8 @@ thf:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 72
 		Stride: 4
@@ -699,17 +1037,27 @@ thf:
 		Tick: 80
 	icon:
 		Filename: thficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 e7:
 	Defaults:
 		Filename: e7.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot-left:
 		Filename:
 		Combine:
@@ -738,6 +1086,8 @@ e7:
 				Offset: 0, -2
 		Length: 2
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	shoot-right:
 		Filename:
 		Combine:
@@ -766,34 +1116,50 @@ e7:
 				Offset: 0, -2
 		Length: 2
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 233
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 248
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 262
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 270
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 278
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 286
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 298
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -801,6 +1167,8 @@ e7:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -808,78 +1176,122 @@ e7:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 128
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-run:
 		Start: 128
 		Length: 4
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-shoot-left:
 		Frames: 179, 177, 185, 184, 192, 191, 200, 198, 206, 205, 213, 212, 220, 219, 228, 226
 		Length: 2
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-shoot-right:
 		Frames: 178, 177, 186, 184, 193, 191, 199, 198, 207, 205, 214, 212, 221, 219, 227, 226
 		Length: 2
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	garrison-muzzle:
 		Filename: minigun.shp
 		Length: 3
 		Stride: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: e7icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 e4:
 	Defaults:
 		Filename: e4.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	parachute:
 		Start: 528
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 399
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 416
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 424
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 432
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 440
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 452
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -887,6 +1299,8 @@ e4:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -894,49 +1308,81 @@ e4:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	prone-stand:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-shoot:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: e4icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gnrl:
 	Defaults:
 		Filename: gnrl.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 56
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 104
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	prone-run:
 		Start: 104
 		Length: 4
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	standup:
 		Start: 136
 		Length: 2
@@ -945,30 +1391,44 @@ gnrl:
 		Start: 152
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 184
 		Length: 26
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 210
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 218
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 226
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 234
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 246
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -976,6 +1436,8 @@ gnrl:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -983,37 +1445,57 @@ gnrl:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 shok:
 	Defaults:
 		Filename: shok.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-stand2:
 		Start: 208
 		Stride: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	prone-run:
 		Start: 208
 		Length: 4
 		Facings: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	liedown:
 		Start: 192
 		Length: 2
@@ -1026,36 +1508,54 @@ shok:
 		Start: 256
 		Length: 16
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	parachute:
 		Start: 528
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	idle1:
 		Start: 384
 		Length: 14
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 399
 		Length: 16
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 416
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 424
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 432
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 440
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 452
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1063,6 +1563,8 @@ shok:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1070,52 +1572,190 @@ shok:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: shokicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 c1:
 	Defaults:
 		Filename: c1.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	shoot:
 		Start: 120
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian7
+		IsPlayerPalette: False
 	idle1:
 		Start: 104
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	idle2:
 		Start: 114
 		Length: 6
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian7
+		IsPlayerPalette: False
 	die1:
 		Start: 152
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die2:
 		Start: 160
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die3:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die4:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die5:
 		Start: 180
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1123,6 +1763,20 @@ c1:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1130,23 +1784,57 @@ c1:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian2
+		IsPlayerPalette: False
+		Palette: civilian6
+		IsPlayerPalette: False
+		Palette: civilian7
+		IsPlayerPalette: False
+		Palette: civilian8
+		IsPlayerPalette: False
+		Palette: civilian9
+		IsPlayerPalette: False
+		Palette: civilian10
+		IsPlayerPalette: False
 
 c2:
 	Defaults:
 		Filename: c2.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	shoot:
 		Start: 120
 		Length: 4
@@ -1155,6 +1843,12 @@ c2:
 		Start: 104
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	idle2:
 		Start: 114
 		Length: 6
@@ -1163,22 +1857,52 @@ c2:
 		Start: 152
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die2:
 		Start: 160
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die3:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die4:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die5:
 		Start: 180
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1186,6 +1910,12 @@ c2:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1193,23 +1923,37 @@ c2:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
+		Palette: civilian4
+		IsPlayerPalette: False
+		Palette: civilian5
+		IsPlayerPalette: False
 
 c11:
 	Defaults:
 		Filename: c11.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 120
 		Length: 4
@@ -1218,6 +1962,8 @@ c11:
 		Start: 104
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 114
 		Length: 6
@@ -1226,22 +1972,32 @@ c11:
 		Start: 152
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 160
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 168
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 180
 		Length: 18
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1249,6 +2005,8 @@ c11:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1256,52 +2014,76 @@ c11:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 
 einstein:
 	Defaults:
 		Filename: einstein.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 104
 		Length: 15
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 120
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 128
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 136
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 136
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 148
 		Length: 17
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1309,6 +2091,8 @@ einstein:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1316,27 +2100,39 @@ einstein:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 delphi:
 	Defaults:
 		Filename: delphi.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 189
 		Length: 9
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle2:
 		Start: 199
 		Length: 6
@@ -1345,22 +2141,32 @@ delphi:
 		Start: 329
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 337
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 345
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 345
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 357
 		Length: 17
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1368,6 +2174,8 @@ delphi:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1375,47 +2183,69 @@ delphi:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 chan:
 	Defaults:
 		Filename: chan.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 56
 		Length: 6
 		Facings: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 104
 		Length: 15
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 120
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 128
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 136
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 136
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 148
 		Length: 17
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1423,6 +2253,8 @@ chan:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1430,48 +2262,74 @@ chan:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 zombie:
 	Defaults:
 		Filename: zombie.shp
 	stand:
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Start: 16
 		Length: 6
 		Facings: 8
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-noshadow
+		IsPlayerPalette: True
 	bite:
 		Start: 64
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	idle1:
 		Start: 96
 		Length: 10
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	die1:
 		Start: 106
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die2:
 		Start: 106
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die3:
 		Start: 106
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die4:
 		Start: 106
 		Length: 8
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die5:
 		Start: 114
 		Length: 19
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1479,6 +2337,8 @@ zombie:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1486,89 +2346,129 @@ zombie:
 		Length: 6
 		Tick: 1600
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: zombicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 ant:
 	stand:
 		Filename: ant1.shp
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: ant1.shp
 		Start: 8
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	bite:
 		Filename: ant1.shp
 		Start: 72
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	die:
 		Filename: ant1.shp
 		Start: 104
 		Length: 8
 		Tick: 300
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: ant1.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: anticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 fireant:
 	stand:
 		Filename: ant2.shp
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: ant2.shp
 		Start: 8
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	bite:
 		Filename: ant2.shp
 		Start: 72
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	die:
 		Filename: ant2.shp
 		Start: 104
 		Length: 8
 		Tick: 300
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: ant2.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: anticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 scoutant:
 	stand:
 		Filename: ant3.shp
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Filename: ant3.shp
 		Start: 8
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	bite:
 		Filename: ant3.shp
 		Start: 72
 		Length: 4
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	die:
 		Filename: ant3.shp
 		Start: 104
 		Length: 8
 		Tick: 300
+		Palette: player
+		IsPlayerPalette: True
 	die-crushed:
 		Filename: ant3.shp
 		Start: 104
 		Length: 8
 		Tick: 400
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: anticon.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -17,8 +17,6 @@ e1:
 		Tick: 100
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
@@ -43,8 +41,6 @@ e1:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	liedown:
 		Start: 128
@@ -187,8 +183,6 @@ e3:
 		Tick: 120
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 8
@@ -278,8 +272,6 @@ e3:
 		Tick: 120
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-shoot:
 		Start: 192
 		Length: 10
@@ -309,8 +301,6 @@ e6:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	parachute:
 		Start: 210
@@ -395,8 +385,6 @@ e6:
 		Tick: 100
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	icon:
 		Filename: e6icon.shp
 		Palette: chrome
@@ -409,6 +397,8 @@ medi:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	run:
@@ -417,8 +407,6 @@ medi:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	heal:
 		Start: 56
@@ -490,16 +478,12 @@ medi:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	icon:
 		Filename: mediicon.shp
@@ -513,6 +497,8 @@ mech:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	run:
@@ -521,8 +507,6 @@ mech:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	repair:
 		Start: 56
@@ -594,16 +578,12 @@ mech:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-run:
 		Start: 130
 		Length: 4
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	icon:
 		Filename: mechicon.shp
@@ -628,8 +608,6 @@ e2:
 		Facings: 8
 		Tick: 80
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	throw:
 		Start: 64
@@ -720,8 +698,6 @@ e2:
 		Tick: 80
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-throw:
 		Start: 288
 		Length: 12
@@ -740,6 +716,8 @@ dog:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	walk:
@@ -755,8 +733,6 @@ dog:
 		Facings: 8
 		Tick: 80
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	eat:
 		Start: 104
@@ -838,8 +814,6 @@ spy:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	stand2:
 		Start: 8
 		Facings: 8
@@ -851,8 +825,6 @@ spy:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	shoot:
 		Start: 64
@@ -926,8 +898,6 @@ spy:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-stand2:
 		Start: 144
 		Stride: 4
@@ -940,8 +910,6 @@ spy:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	prone-shoot:
 		Start: 192
@@ -961,6 +929,8 @@ thf:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	run:
@@ -969,8 +939,6 @@ thf:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	idle:
 		Start: 120
@@ -1047,6 +1015,8 @@ e7:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	run:
@@ -1055,8 +1025,6 @@ e7:
 		Facings: 8
 		Tick: 80
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	shoot-left:
 		Filename:
@@ -1184,16 +1152,12 @@ e7:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-run:
 		Start: 128
 		Length: 4
 		Facings: 8
 		Tick: 80
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	prone-shoot-left:
 		Frames: 179, 177, 185, 184, 192, 191, 200, 198, 206, 205, 213, 212, 220, 219, 228, 226
@@ -1237,8 +1201,6 @@ e4:
 		Facings: 8
 		Tick: 120
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	shoot:
 		Start: 64
@@ -1329,8 +1291,6 @@ e4:
 		Tick: 120
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-shoot:
 		Start: 256
 		Length: 16
@@ -1349,6 +1309,8 @@ gnrl:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	run:
@@ -1357,8 +1319,6 @@ gnrl:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	shoot:
 		Start: 56
@@ -1372,16 +1332,12 @@ gnrl:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	prone-run:
 		Start: 104
 		Length: 4
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	standup:
 		Start: 136
@@ -1467,8 +1423,6 @@ shok:
 		Tick: 120
 		Palette: player
 		IsPlayerPalette: True
-		Palette: player-noshadow
-		IsPlayerPalette: True
 	shoot:
 		Start: 64
 		Length: 16
@@ -1493,8 +1447,6 @@ shok:
 		Facings: 8
 		Tick: 120
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	liedown:
 		Start: 192
@@ -1582,180 +1534,48 @@ shok:
 c1:
 	Defaults:
 		Filename: c1.shp
+		Palette: player
+		IsPlayerPalette: True
 	stand:
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	panic-stand:
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	shoot:
 		Start: 120
 		Length: 4
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian7
-		IsPlayerPalette: False
 	idle1:
 		Start: 104
 		Length: 9
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	idle2:
 		Start: 114
 		Length: 6
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian7
-		IsPlayerPalette: False
 	die1:
 		Start: 152
 		Length: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die2:
 		Start: 160
 		Length: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die3:
 		Start: 168
 		Length: 12
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die4:
 		Start: 168
 		Length: 12
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die5:
 		Start: 180
 		Length: 18
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1763,20 +1583,6 @@ c1:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1791,50 +1597,26 @@ c1:
 		Length: 6
 		Facings: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian2
-		IsPlayerPalette: False
-		Palette: civilian6
-		IsPlayerPalette: False
-		Palette: civilian7
-		IsPlayerPalette: False
-		Palette: civilian8
-		IsPlayerPalette: False
-		Palette: civilian9
-		IsPlayerPalette: False
-		Palette: civilian10
-		IsPlayerPalette: False
 
 c2:
+	Inherits: c1
+	Defaults:
+		Palette: civilian2
+		IsPlayerPalette: False
+
+c3:
 	Defaults:
 		Filename: c2.shp
+		Palette: player
+		IsPlayerPalette: True
 	stand:
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	panic-stand:
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	panic-run:
 		Start: 8
 		Length: 6
 		Facings: 8
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	shoot:
 		Start: 120
 		Length: 4
@@ -1843,12 +1625,6 @@ c2:
 		Start: 104
 		Length: 9
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	idle2:
 		Start: 114
 		Length: 6
@@ -1857,52 +1633,22 @@ c2:
 		Start: 152
 		Length: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die2:
 		Start: 160
 		Length: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die3:
 		Start: 168
 		Length: 12
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die4:
 		Start: 168
 		Length: 12
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die5:
 		Start: 180
 		Length: 18
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die6:
 		Filename: electro.tem
 		TilesetFilenames:
@@ -1910,12 +1656,6 @@ c2:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
-		Palette: civilian4
-		IsPlayerPalette: False
-		Palette: civilian5
-		IsPlayerPalette: False
 	die-crushed:
 		Filename: corpse1.tem
 		TilesetFilenames:
@@ -1930,11 +1670,46 @@ c2:
 		Length: 6
 		Facings: 8
 		Tick: 80
-		Palette: player
-		IsPlayerPalette: True
+
+c4:
+	Inherits: c3
+	Defaults:
 		Palette: civilian4
 		IsPlayerPalette: False
+
+c5:
+	Inherits: c3
+	Defaults:
 		Palette: civilian5
+		IsPlayerPalette: False
+
+c6:
+	Inherits: c1
+	Defaults:
+		Palette: civilian6
+		IsPlayerPalette: False
+
+c7:
+	Inherits: c1
+	Defaults:
+		Palette: civilian7
+		IsPlayerPalette: False
+
+c8:
+	Inherits: c1
+	Defaults:
+		Palette: civilian8
+		IsPlayerPalette: False
+c9:
+	Inherits: c1
+	Defaults:
+		Palette: civilian9
+		IsPlayerPalette: False
+
+c10:
+	Inherits: c1
+	Defaults:
+		Palette: civilian10
 		IsPlayerPalette: False
 
 c11:
@@ -2272,6 +2047,8 @@ zombie:
 		Facings: 8
 		Palette: player
 		IsPlayerPalette: True
+	stand-noshadow:
+		Facings: 8
 		Palette: player-noshadow
 		IsPlayerPalette: True
 	stand2:
@@ -2285,8 +2062,6 @@ zombie:
 		Facings: 8
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: True
-		Palette: player-noshadow
 		IsPlayerPalette: True
 	bite:
 		Start: 64

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -334,8 +334,6 @@ smoke_m:
 		ZOffset: 512
 		Palette: effect
 		IsPlayerPalette: False
-		Palette: player
-		IsPlayerPalette: True
 	start:
 		Length: 49
 		Offset: 2, -5
@@ -345,8 +343,8 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
-		Palette: player
-		IsPlayerPalette: True
+		Palette: effect
+		IsPlayerPalette: False
 
 scorch_flames:
 	large_flame:
@@ -1172,17 +1170,15 @@ overlay:
 		Palette: terrain
 		IsPlayerPalette: False
 	target-valid:
-		Palette: chrome
+		Palette: terrain
 		IsPlayerPalette: False
 	target-select:
 		Start: 1
 		Palette: terrain
 		IsPlayerPalette: False
-		Palette: chrome
-		IsPlayerPalette: False
 	target-invalid:
 		Start: 2
-		Palette: chrome
+		Palette: terrain
 		IsPlayerPalette: False
 
 editor-overlay:
@@ -1250,6 +1246,9 @@ shroud:
 		Length: *
 		Palette: shroud
 		IsPlayerPalette: False
+	fog:
+		Filename: shadow.shp
+		Length: *
 		Palette: fog
 		IsPlayerPalette: False
 

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -2,6 +2,8 @@ clock:
 	idle:
 		Filename: clock.shp
 		Length: *
+		Palette: chrome
+		IsPlayerPalette: False
 
 powerdown:
 	disabled:
@@ -13,11 +15,15 @@ powerdown:
 	idle:
 		Filename: 120mm.shp
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 50cal:
 	idle:
 		Filename: 50cal.shp
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 explosion:
 	Defaults:
@@ -25,60 +31,106 @@ explosion:
 		ZOffset: 2047
 	piff:
 		Filename: piff.shp
+		Palette: effect
+		IsPlayerPalette: False
 	piffs:
 		Filename: piffpiff.shp
+		Palette: effect
+		IsPlayerPalette: False
 	water_piff:
 		Filename: wpiff.shp
+		Palette: effect
+		IsPlayerPalette: False
 	water_piffs:
 		Filename: wpifpif.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_explosion:
 		Filename: veh-hit3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	med_explosion:
 		Filename: veh-hit2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	flak_explosion_ground:
 		Filename: flak.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_explosion_air:
 		Filename: flak.shp
 		ZOffset: 511 # only used by AA weapons, so a high ZOffset to overlay buildings isn't needed
+		Palette: effect
+		IsPlayerPalette: False
 	med_explosion_air:
 		Filename: veh-hit1.shp
 		ZOffset: 511 # only used by AA weapons, so a high ZOffset to overlay buildings isn't needed
+		Palette: effect
+		IsPlayerPalette: False
 	large_splash:
 		Filename: h2o_exp1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	napalm:
 		Filename: napalm2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	building_napalm:
 		Filename: napalm2.shp
 		FlipX: true
+		Palette: effect
+		IsPlayerPalette: False
 	nuke:
 		Filename: atomsfx.shp
+		Palette: effect
+		IsPlayerPalette: False
 	med_splash:
 		Filename: h2o_exp2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	self_destruct:
 		Filename: art-exp1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	artillery_explosion:
 		Filename: art-exp1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	building:
 		Filename: fball1.shp
 		Offset: 0,-9
+		Palette: effect
+		IsPlayerPalette: False
 	small_splash:
 		Filename: h2o_exp3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	large_explosion:
 		Filename: frag1.shp
 		Offset: -2,0
+		Palette: effect
+		IsPlayerPalette: False
 	small_napalm:
 		Filename: napalm1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	offset_napalm: # Used for E4 Explosion
 		Filename: napalm1.shp
 		Offset: 0, -6
+		Palette: effect
+		IsPlayerPalette: False
 	large_napalm:
 		Filename: napalm3.shp
+		Palette: effect
+		IsPlayerPalette: False
 	corpse:
 		Filename: corpse1.tem
 		TilesetFilenames:
 			SNOW: corpse1.sno
 		ZOffset: -512
 		Tick: 1600
+		Palette: effect
+		IsPlayerPalette: False
 
 burn-l:
 	Defaults:
@@ -90,10 +142,14 @@ burn-l:
 		Start: 16
 		Length: 44
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 
 burn-m:
 	Defaults:
@@ -105,10 +161,14 @@ burn-m:
 		Start: 16
 		Length: 44
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 	end:
 		Start: 60
 		Length: 6
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 
 burn-s:
 	Defaults:
@@ -120,10 +180,14 @@ burn-s:
 		Start: 12
 		Length: 46
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 	end:
 		Start: 59
 		Length: 5
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
 
 pips:
 	Defaults:
@@ -132,9 +196,13 @@ pips:
 		Length: 10
 		Frames: 9, 10, 11, 12, 13, 14, 15, 16, 17, 8
 		Offset: 9, 5
+		Palette: chrome
+		IsPlayerPalette: False
 	medic:
 		Start: 20
 		Offset: 15, 1
+		Palette: chrome
+		IsPlayerPalette: False
 	#ready:
 	#	Start: 3
 	#hold:
@@ -142,28 +210,46 @@ pips:
 	tag-fake:
 		Start: 18
 		Offset: 0, 2
+		Palette: chrome
+		IsPlayerPalette: False
 	tag-primary:
 		Start: 2
 		Offset: 0, 2
+		Palette: chrome
+		IsPlayerPalette: False
 	tag-spy:
 		Filename: tag-spy.shp
+		Palette: effect
+		IsPlayerPalette: False
 	pip-empty:
 		Filename: pips2.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-green:
 		Filename: pips2.shp
 		Start: 1
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-yellow:
 		Filename: pips2.shp
 		Start: 2
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-gray:
 		Filename: pips2.shp
 		Start: 3
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-red:
 		Filename: pips2.shp
 		Start: 4
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-blue:
 		Filename: pips2.shp
 		Start: 5
+		Palette: chrome
+		IsPlayerPalette: False
 	pip-disguise:
 		Filename: pip-disguise.shp
 		Length: *
@@ -175,6 +261,8 @@ v2:
 		Filename: v2.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 rallypoint:
 	flag:
@@ -182,10 +270,14 @@ rallypoint:
 		Length: *
 		Offset: 11,-5
 		ZOffset: 2535
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 beacon:
 	Defaults:
@@ -194,30 +286,44 @@ beacon:
 		Filename: mouse.shp
 		Start: 5
 		Offset: 1,-12
+		Palette: player
+		IsPlayerPalette: True
 	circles:
 		Filename: fpls.shp
 		Length: *
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 	atomicon:
 		Filename: lores|atomicon.shp
 		Length: *
 		Offset: 0,-42
+		Palette: chrome
+		IsPlayerPalette: False
 	pbmbicon:
 		Filename: lores|pbmbicon.shp
 		Length: *
 		Offset: 0,-42
+		Palette: chrome
+		IsPlayerPalette: False
 	camicon:
 		Filename: lores|camicon.shp
 		Length: *
 		Offset: 0,-42
+		Palette: chrome
+		IsPlayerPalette: False
 	pinficon:
 		Filename: lores|pinficon.shp
 		Length: *
 		Offset: 0,-42
+		Palette: chrome
+		IsPlayerPalette: False
 	clock:
 		Filename: beaconclock.shp
 		Length: *
 		Offset: 0,-42
+		Palette: chrome
+		IsPlayerPalette: False
 
 smoke_m:
 	Defaults:
@@ -226,6 +332,10 @@ smoke_m:
 		Length: *
 		Offset: 2, -5
 		ZOffset: 512
+		Palette: effect
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	start:
 		Length: 49
 		Offset: 2, -5
@@ -235,6 +345,8 @@ smoke_m:
 		Length: 42
 		Offset: 2, -5
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 
 scorch_flames:
 	large_flame:
@@ -295,6 +407,8 @@ scorch_flames:
 				Length: 42
 				Offset: 2, -5
 				Scale: 0.25
+		Palette: effect
+		IsPlayerPalette: False
 	medium_flame:
 		Length: *
 		Combine:
@@ -340,6 +454,8 @@ scorch_flames:
 				Length: 42
 				Offset: 2, -5
 				Scale: 0.25
+		Palette: effect
+		IsPlayerPalette: False
 	small_flame:
 		Combine:
 			0:
@@ -381,6 +497,8 @@ scorch_flames:
 				Scale: 0.25
 		Length: *
 		Offset: 0,-3
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_flame:
 		Combine:
 			0:
@@ -453,30 +571,40 @@ dragon:
 		Filename: dragon.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 smokey:
 	idle:
 		Filename: smokey.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 bomb:
 	idle:
 		Filename: bomb.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 missile:
 	idle:
 		Filename: missile.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 torpedo:
 	idle:
 		Filename: missile.shp
 		Facings: 32
 		ZOffset: -1023
+		Palette: shadow
+		IsPlayerPalette: False
 
 litning:
 	Defaults:
@@ -484,16 +612,22 @@ litning:
 	bright:
 		Length: 4
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 	dim:
 		Start: 4
 		Length: 4
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 fb1:
 	idle:
 		Filename: fb1.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 moveflsh:
 	idle:
@@ -504,6 +638,8 @@ moveflsh:
 		Length: *
 		Tick: 80
 		ZOffset: 2047
+		Palette: moveflash
+		IsPlayerPalette: False
 
 select:
 	repair:
@@ -516,6 +652,8 @@ poweroff:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: chrome
+		IsPlayerPalette: False
 
 allyrepair:
 	repair:
@@ -523,6 +661,8 @@ allyrepair:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: player
+		IsPlayerPalette: True
 
 tabs:
 	Defaults:
@@ -537,6 +677,8 @@ sputnik:
 		Length: *
 		Offset: -4,0
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 
 dd-crnr:
 	Defaults:
@@ -556,98 +698,140 @@ fb2:
 		Filename: fb2.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 fb3:
 	idle:
 		Filename: fb3.shp
 		Facings: 32
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 fb4:
 	idle:
 		Filename: fb4.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 scrate:
 	Defaults:
 		Filename: scrate.shp
 		ZOffset: -511
 	idle:
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Start: 2
 		Length: 4
 		Tick: 500
+		Palette: effect
+		IsPlayerPalette: False
 
 wcrate:
 	Defaults:
 		Filename: wcrate.shp
 		ZOffset: -511
 	idle:
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Filename: wwcrate.shp
 		Length: *
 		Tick: 500
+		Palette: effect
+		IsPlayerPalette: False
 
 xcratea:
 	Defaults:
 		Filename: xcratea.shp
 	idle:
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Start: 2
 		Length: 4
 		Tick: 500
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcrateb:
 	Defaults:
 		Filename: xcrateb.shp
 	idle:
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Start: 2
 		Length: 4
 		Tick: 500
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcratec:
 	Defaults:
 		Filename: xcratec.shp
 	idle:
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Start: 2
 		Length: 4
 		Tick: 500
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 xcrated:
 	Defaults:
 		Filename: xcrated.shp
 	idle:
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	land:
 		Start: 1
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 	water:
 		Start: 2
 		Length: 4
 		Tick: 500
 		ZOffset: -511
+		Palette: effect
+		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -659,16 +843,24 @@ crate-effects:
 		Filename: dollar.shp
 	reveal-map:
 		Filename: earth.shp
+		Palette: effect
+		IsPlayerPalette: False
 	hide-map:
 		Filename: empulse.shp
+		Palette: effect
+		IsPlayerPalette: False
 	fpower:
 		Filename: fpower.shp
 	gps:
 		Filename: gpsbox.shp
 	invuln:
 		Filename: invulbox.shp
+		Palette: effect
+		IsPlayerPalette: False
 	heal:
 		Filename: invun.shp
+		Palette: effect
+		IsPlayerPalette: False
 	nuke:
 		Filename: missile2.shp
 	parabombs:
@@ -688,26 +880,35 @@ crate-effects:
 	levelup:
 		Filename: levelup.shp
 		Tick: 200
+		Palette: effect
+		IsPlayerPalette: False
 
 parach:
 	Defaults:
 		Filename: parach.shp
 	open:
 		Length: 5
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Start: 5
 		Length: 11
+		Palette: player
+		IsPlayerPalette: True
 
 parach-shadow:
 	idle:
 		Filename: parach-shadow.shp
 		Length: *
+		ShadowPalette: player
 
 bomblet:
 	idle:
 		Filename: bomblet.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 parabomb:
 	Defaults:
@@ -715,10 +916,14 @@ parabomb:
 	open:
 		Length: 8
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 	idle:
 		Start: 8
 		Length: 5
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 smokland:
 	open:
@@ -726,12 +931,16 @@ smokland:
 		Length: 72
 		Tick: 120
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: playersmoke.shp
 		Start: 72
 		Length: 20
 		Tick: 120
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 
 fire:
 	1:
@@ -739,6 +948,8 @@ fire:
 		Length: *
 		Offset: 0,-3
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	2:
 		Filename: fire2.shp
 		Length: *
@@ -760,92 +971,152 @@ rank:
 		Filename: rank.shp
 		Offset: 0, 3
 	rank-veteran-1:
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-2:
 		Start: 1
+		Palette: effect
+		IsPlayerPalette: False
 	rank-veteran-3:
 		Start: 2
+		Palette: effect
+		IsPlayerPalette: False
 	rank-elite:
 		Start: 3
 		Offset: 1, 3
+		Palette: effect
+		IsPlayerPalette: False
 
 iconchevrons:
 	veteran:
 		Filename: iconchevrons.shp
 		Offset: 2, 2
+		Palette: chrome
+		IsPlayerPalette: False
 
 atomic:
 	up:
 		Filename: atomicup.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 	down:
 		Filename: atomicdn.shp
 		Length: *
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 bubbles:
 	idle:
 		Filename: bubbles.shp
 		Length: *
 		Tick: 220
+		Palette: effect
+		IsPlayerPalette: False
 
 mpspawn:
 	idle:
 		Filename: mpspawn.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 waypoint:
 	idle:
 		Filename: waypoint.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 camera:
 	idle:
 		Filename: camera.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 
 gpsdot:
 	Defaults:
 		Filename: gpsdot.shp
 	Infantry:
+		Palette: player
+		IsPlayerPalette: True
 	Vehicle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	Ship:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 	Helicopter:
 		Start: 3
+		Palette: player
+		IsPlayerPalette: True
 	Plane:
 		Start: 4
+		Palette: player
+		IsPlayerPalette: True
 	Harvester:
 		Start: 5
+		Palette: player
+		IsPlayerPalette: True
 	Structure:
 		Start: 6
+		Palette: player
+		IsPlayerPalette: True
 	Oil:
 		Start: 7
+		Palette: player
+		IsPlayerPalette: True
 	Hospital:
 		Start: 8
+		Palette: player
+		IsPlayerPalette: True
 	Biohazard:
 		Start: 9
+		Palette: player
+		IsPlayerPalette: True
 	Communications:
 		Start: 10
+		Palette: player
+		IsPlayerPalette: True
 	Forward:
 		Start: 11
+		Palette: player
+		IsPlayerPalette: True
 
 icon:
 	abomb:
 		Filename: atomicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	invuln:
 		Filename: infxicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	chrono:
 		Filename: warpicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	spyplane:
 		Filename: smigicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	paratroopers:
 		Filename: pinficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	gps:
 		Filename: gpssicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	parabombs:
 		Filename: pbmbicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	sonar:
 		Filename: sonricon.shp
 
@@ -854,22 +1125,32 @@ quee:
 		Filename: quee.shp
 	idle:
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 
 lar1:
 	idle:
 		Filename: lar1.shp
+		Palette: terrain
+		IsPlayerPalette: False
 
 lar2:
 	idle:
 		Filename: lar2.shp
+		Palette: terrain
+		IsPlayerPalette: False
 
 minp:
 	idle:
 		Filename: minp.shp
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: jmin.shp
 
@@ -884,13 +1165,25 @@ overlay:
 	Defaults:
 		Filename: trans.icn
 	build-valid:
+		Palette: terrain
+		IsPlayerPalette: False
 	build-invalid:
 		Start: 2
+		Palette: terrain
+		IsPlayerPalette: False
 	target-valid:
+		Palette: chrome
+		IsPlayerPalette: False
 	target-select:
 		Start: 1
+		Palette: terrain
+		IsPlayerPalette: False
+		Palette: chrome
+		IsPlayerPalette: False
 	target-invalid:
 		Start: 2
+		Palette: chrome
+		IsPlayerPalette: False
 
 editor-overlay:
 	Defaults:
@@ -906,109 +1199,157 @@ resources:
 		Filename: gold01.tem
 		TilesetFilenames:
 			SNOW: gold01.sno
+		Palette: player
+		IsPlayerPalette: False
 	gold02:
 		Filename: gold02.tem
 		TilesetFilenames:
 			SNOW: gold02.sno
+		Palette: player
+		IsPlayerPalette: False
 	gold03:
 		Filename: gold03.tem
 		TilesetFilenames:
 			SNOW: gold03.sno
+		Palette: player
+		IsPlayerPalette: False
 	gold04:
 		Filename: gold04.tem
 		TilesetFilenames:
 			SNOW: gold04.sno
+		Palette: player
+		IsPlayerPalette: False
 	gem01:
 		Filename: gem01.tem
 		TilesetFilenames:
 			SNOW: gem01.sno
+		Palette: player
+		IsPlayerPalette: False
 	gem02:
 		Filename: gem02.tem
 		TilesetFilenames:
 			SNOW: gem02.sno
+		Palette: player
+		IsPlayerPalette: False
 	gem03:
 		Filename: gem03.tem
 		TilesetFilenames:
 			SNOW: gem03.sno
+		Palette: player
+		IsPlayerPalette: False
 	gem04:
 		Filename: gem04.tem
 		TilesetFilenames:
 			SNOW: gem04.sno
+		Palette: player
+		IsPlayerPalette: False
 
 shroud:
 	shroud:
 		Filename: shadow.shp
 		Length: *
+		Palette: shroud
+		IsPlayerPalette: False
+		Palette: fog
+		IsPlayerPalette: False
 
 # Note: The order of smudges and craters determines
 # the index that is mapped to them in maps
 scorches:
 	Defaults:
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	sc1:
 		Filename: sc1.tem
 		TilesetFilenames:
 			SNOW: sc1.sno
 			DESERT: sc1.des
+		Palette: terrain
+		IsPlayerPalette: False
 	sc2:
 		Filename: sc2.tem
 		TilesetFilenames:
 			SNOW: sc2.sno
 			DESERT: sc2.des
+		Palette: terrain
+		IsPlayerPalette: False
 	sc3:
 		Filename: sc3.tem
 		TilesetFilenames:
 			SNOW: sc3.sno
 			DESERT: sc3.des
+		Palette: terrain
+		IsPlayerPalette: False
 	sc4:
 		Filename: sc4.tem
 		TilesetFilenames:
 			SNOW: sc4.sno
 			DESERT: sc4.des
+		Palette: terrain
+		IsPlayerPalette: False
 	sc5:
 		Filename: sc5.tem
 		TilesetFilenames:
 			SNOW: sc5.sno
 			DESERT: sc5.des
+		Palette: terrain
+		IsPlayerPalette: False
 	sc6:
 		Filename: sc6.tem
 		TilesetFilenames:
 			SNOW: sc6.sno
 			DESERT: sc6.des
+		Palette: terrain
+		IsPlayerPalette: False
 
 craters:
 	Defaults:
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	cr1:
 		Filename: cr1.tem
 		TilesetFilenames:
 			SNOW: cr1.sno
 			DESERT: cr1.des
+		Palette: terrain
+		IsPlayerPalette: False
 	cr2:
 		Filename: cr2.tem
 		TilesetFilenames:
 			SNOW: cr2.sno
 			DESERT: cr2.des
+		Palette: terrain
+		IsPlayerPalette: False
 	cr3:
 		Filename: cr3.tem
 		TilesetFilenames:
 			SNOW: cr3.sno
 			DESERT: cr3.des
+		Palette: terrain
+		IsPlayerPalette: False
 	cr4:
 		Filename: cr4.tem
 		TilesetFilenames:
 			SNOW: cr4.sno
 			DESERT: cr4.des
+		Palette: terrain
+		IsPlayerPalette: False
 	cr5:
 		Filename: cr5.tem
 		TilesetFilenames:
 			SNOW: cr5.sno
 			DESERT: cr5.des
+		Palette: terrain
+		IsPlayerPalette: False
 	cr6:
 		Filename: cr6.tem
 		TilesetFilenames:
 			SNOW: cr6.sno
 			DESERT: cr6.des
+		Palette: terrain
+		IsPlayerPalette: False
 
 mine:
 	idle:
@@ -1018,6 +1359,8 @@ mine:
 			TEMPERAT: mine.tem
 			DESERT: mine.des
 		ZOffset: -2c512
+		Palette: terrain
+		IsPlayerPalette: False
 
 gmine:
 	idle:
@@ -1026,6 +1369,8 @@ gmine:
 			SNOW: gmine.sno
 			DESERT: gmine.des
 		ZOffset: -2c512
+		Palette: player
+		IsPlayerPalette: False
 
 railmine:
 	idle:
@@ -1034,6 +1379,8 @@ railmine:
 			SNOW: railmine.sno
 			DESERT: railmine.des
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: False
 
 ctflag:
 	idle:
@@ -1041,6 +1388,8 @@ ctflag:
 		Length: 9
 		Tick: 50
 		Offset: 0,-12
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbGAP.sno
@@ -1048,47 +1397,71 @@ ctflag:
 			TEMPERAT: mbGAP.tem
 			DESERT: mbGAP.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 
 paradirection:
 	arrow-t:
 		Filename: mouse.shp
 		Start: 1
 		Offset: 0, -19, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tr:
 		Filename: mouse.shp
 		Start: 2
 		Offset: 15, -15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-r:
 		Filename: mouse.shp
 		Start: 3
 		Offset: 19, 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-br:
 		Filename: mouse.shp
 		Start: 4
 		Offset: 15, 15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-b:
 		Filename: mouse.shp
 		Start: 5
 		Offset: 0, 19, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-bl:
 		Filename: mouse.shp
 		Start: 6
 		Offset: -15, 15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-l:
 		Filename: mouse.shp
 		Start: 7
 		Offset: -19, 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 	arrow-tl:
 		Filename: mouse.shp
 		Start: 8
 		Offset: -15, -15, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 twinkle:
 	Defaults:
 		Length: *
 	twinkle1:
 		Filename: twinkle1.shp
+		Palette: effect
+		IsPlayerPalette: False
 	twinkle2:
 		Filename: twinkle2.shp
+		Palette: effect
+		IsPlayerPalette: False
 	twinkle3:
 		Filename: twinkle3.shp
+		Palette: effect
+		IsPlayerPalette: False

--- a/mods/ra/sequences/ships.yaml
+++ b/mods/ra/sequences/ships.yaml
@@ -3,67 +3,107 @@ ss:
 		Filename: ss.shp
 		Facings: 16
 		InterpolatedFacings: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: ssicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 ca:
 	idle:
 		Filename: ca.shp
 		Facings: 16
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: turr.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: caicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 dd:
 	idle:
 		Filename: dd.shp
 		Facings: 16
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: ssam.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: ddicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 pt:
 	idle:
 		Filename: pt.shp
 		Facings: 16
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: mgun.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: pticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 lst:
 	Defaults:
 		Filename: lst.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Start: 1
 		Length: 4
 		Tick: 150
+		Palette: player
+		IsPlayerPalette: True
 	close:
 		Frames: 4, 3, 2, 1
 		Length: 4
 		Tick: 150
+		Palette: player
+		IsPlayerPalette: True
 	unload:
 		Start: 4
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: lsticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 msub:
 	idle:
 		Filename: msub.shp
 		Facings: 16
 		InterpolatedFacings: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: msubicon.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -2,8 +2,12 @@ fcom:
 	Defaults:
 		Filename: fcom.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: fcommake.shp
 		Length: *
@@ -13,18 +17,26 @@ fcom:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 
 hosp:
 	Defaults:
 		Filename: hosp.shp
 	idle:
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 4
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 8
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hospmake.shp
 		Length: *
@@ -36,6 +48,8 @@ hosp:
 			DESERT: mbHOSP.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: hospicon.shp
 
@@ -43,11 +57,17 @@ bio:
 	Defaults:
 		Filename: bio.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: biomake.shp
 		Length: *
@@ -57,9 +77,13 @@ oilb:
 		Filename: oilb.shp
 		Offset: 0,-6
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	make:
 	bib:
 		Filename: bib3.tem
@@ -73,60 +97,108 @@ fact:
 	Defaults:
 		Filename: fact.shp
 	idle:
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: factmake.shp
 		Length: *
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	build:
 		Start: 1
 		Length: 25
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 26
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build:
 		Start: 27
 		Length: 25
+		Palette: colorpicker
+		IsPlayerPalette: False
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Filename: factdead.shp
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib2.tem
 		TilesetFilenames:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: facticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: facficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 proc:
 	Defaults:
 		Filename: proc.shp
 	idle:
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
+		Palette: terrain
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
+		Palette: terrain
+		IsPlayerPalette: False
 	idle-top:
 		Filename: proctop.shp
 		ZOffset: 0
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-top:
 		Filename: proctop.shp
 		Start: 1
 		ZOffset: 0
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: procmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Filename: procdead.shp
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib2.tem
 		TilesetFilenames:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: procicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 silo:
 	idle:
@@ -140,15 +212,21 @@ silo:
 		Filename: silo2.shp
 		Length: 9
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		Filename: silo2.shp
 		Start: 9
 		Length: 9
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: silomake.shp
 		Length: *
 		Offset: 0,-1
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbSILO.sno
@@ -156,58 +234,90 @@ silo:
 			TEMPERAT: mbSILO.tem
 			DESERT: mbSILO.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: siloicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 powr:
 	Defaults:
 		Filename: powr.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: powrmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Filename: powrdead.shp
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: powricon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: fpwricon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 apwr:
 	Defaults:
 		Filename: apwr.shp
 	idle:
 		Offset: 0,-10
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Offset: 0,-10
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: apwrmake.shp
 		Length: *
 		Offset: 0,-10
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Filename: apwrdead.shp
 		Tick: 800
 		Offset: 0,-10
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib2.tem
 		TilesetFilenames:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: apwricon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: fapwicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 barr:
 	Defaults:
@@ -215,22 +325,32 @@ barr:
 	idle:
 		Length: 10
 		Offset: 0,-6
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
 		Offset: 0,-6
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: barrmake.shp
 		Length: *
 		Offset: 0,-6
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: barricon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 tent:
 	Defaults:
@@ -240,37 +360,55 @@ tent:
 			DESERT: tent.des
 	idle:
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: tentmake.tem
 		TilesetFilenames:
 			SNOW: tentmake.sno
 			DESERT: tentmake.des
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: tenticon.shp
 		TilesetFilenames:
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: tenficon.shp
 		TilesetFilenames:
+		Palette: chrome
+		IsPlayerPalette: False
 
 kenn:
 	Defaults:
 		Filename: kenn.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: kennmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbSILO.sno
@@ -278,133 +416,205 @@ kenn:
 			TEMPERAT: mbSILO.tem
 			DESERT: mbSILO.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: kennicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 dome:
 	Defaults:
 		Filename: dome.shp
 	idle:
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: domemake.shp
 		Length: *
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: domeicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: domficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 atek:
 	Defaults:
 		Filename: atek.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: atekmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Filename: sputdoor.shp
 		Length: *
 		Offset: -4,0
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: atekicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: ateficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 stek:
 	Defaults:
 		Filename: stek.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: stekmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib2.tem
 		TilesetFilenames:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: stekicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 weap:
 	Defaults:
 		Filename: weap.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	place:
 		Filename: weapmake.shp
 		Start: 14
+		Palette: terrain
+		IsPlayerPalette: False
 	make:
 		Filename: weapmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	build-top:
 		Filename: weap3.shp
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build-top:
 		Filename: weap2.shp
 		Start: 4
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib2.tem
 		TilesetFilenames:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: weapicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: weaficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 hpad:
 	Defaults:
 		Filename: hpad.shp
 	idle:
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Start: 1
 		Length: 6
 		Tick: 100
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 8
 		Length: 6
 		Tick: 100
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hpadmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		Filename: bib3.tem
 		TilesetFilenames:
 			SNOW: bib3.sno
 			DESERT: bib3.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: hpadicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 afld:
 	Defaults:
@@ -415,6 +625,8 @@ afld:
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: afldidle.shp
 		Start: 8
@@ -422,54 +634,84 @@ afld:
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 8
 		Length: 8
 		Tick: 160
 		ZOffset: -1023
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: afldmake.shp
 		Length: *
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: afldicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 spen:
 	Defaults:
 		Filename: spen.shp
 	idle:
 		Offset: 0,2
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Offset: 0,2
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: spenmake.shp
 		Length: *
 		Offset: 0,2
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: spenicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: speficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 syrd:
 	Defaults:
 		Filename: syrd.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: syrdmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: syrdicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: syrficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 fix:
 	Defaults:
@@ -477,24 +719,34 @@ fix:
 	idle:
 		Offset: 0,1
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		Offset: 0,1
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Start: 1
 		Length: 6
 		Offset: 0,1
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 8
 		Length: 6
 		Offset: 0,1
 		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: fixmake.shp
 		Length: *
 		Offset: 0,1
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbFIX.sno
@@ -504,22 +756,34 @@ fix:
 		Length: *
 		ZOffset: -1c511
 		Offset: 0,-4
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: fixicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: fixficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gun:
 	Defaults:
 		Filename: gun.shp
 	idle: # Empty first frame. We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
 		Filename: gunmake.shp
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: gunmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	recoil:
 		Start: 32
 		Facings: 32
@@ -528,6 +792,8 @@ gun:
 		Start: 64
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	damaged-recoil:
 		Start: 96
 		Facings: 32
@@ -535,6 +801,8 @@ gun:
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			SNOW: mbGUN.sno
@@ -543,22 +811,32 @@ gun:
 			DESERT: mbGUN.des
 		Length: *
 		Offset: -1,-1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: gunicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 agun:
 	Defaults:
 		Filename: agun.shp
 	idle: # Empty first frame (agunmake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
 		Filename: gunmake.shp
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: agunmake.shp
 		Length: *
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Facings: 32
 		UseClassicFacings: True
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	recoil:
 		Start: 32
 		Facings: 32
@@ -569,6 +847,8 @@ agun:
 		Facings: 32
 		UseClassicFacings: True
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	damaged-recoil:
 		Start: 96
 		Facings: 32
@@ -578,6 +858,8 @@ agun:
 		Filename: gunfire2.shp
 		Start: 1
 		Length: 4
+		Palette: effect
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			SNOW: mbAGUN.sno
@@ -585,32 +867,46 @@ agun:
 			TEMPERAT: mbAGUN.tem
 			DESERT: mbAGUN.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: agunicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 sam:
 	idle: # Empty first frame (sammake has no empty frames). We need WithSpriteBody for the make anim, and WSB needs at least a placeholder default sequence to work
 		Filename: gunmake.shp
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: sam2.shp
 		Facings: 32
 		UseClassicFacings: True
 		Offset: -1,-2
+		Palette: player
+		IsPlayerPalette: True
 	damaged-turret:
 		Filename: sam2.shp
 		Start: 34
 		Facings: 32
 		UseClassicFacings: True
 		Offset: -1,-2
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: sammake.shp
 		Length: *
 		Offset: -1,-2
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: samfire.shp
 		Length: 18
 		Facings: 8
 		Offset: -1,6
+		Palette: effect
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			SNOW: mbSAM.sno
@@ -619,21 +915,31 @@ sam:
 			DESERT: mbSAM.des
 		Length: *
 		Offset: 0,1
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: samicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 ftur:
 	Defaults:
 		Filename: ftur.shp
 	idle:
 		Offset: 0,-2
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		Offset: 0,-2
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: fturmake.shp
 		Length: *
 		Offset: 0,-2
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbFTUR.sno
@@ -641,31 +947,45 @@ ftur:
 			TEMPERAT: mbFTUR.tem
 			DESERT: mbFTUR.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: fturicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 tsla:
 	Defaults:
 		Filename: tsla.shp
 	idle:
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: tslamake.shp
 		Length: *
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Start: 1
 		Length: 9
 		Tick: 100
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 11
 		Length: 9
 		Tick: 100
 		Offset: 0,-13
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbTSLA.sno
@@ -673,18 +993,28 @@ tsla:
 			TEMPERAT: mbTSLA.tem
 			DESERT: mbTSLA.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: tslaicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 pbox:
 	Defaults:
 		Filename: pbox.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: pboxmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
@@ -697,8 +1027,12 @@ pbox:
 			DESERT: mbPBOX.des
 		Length: *
 		Offset: 0,-2
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: pboxicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 hbox:
 	Defaults:
@@ -707,14 +1041,20 @@ hbox:
 			SNOW: hbox.sno
 			DESERT: hbox.des
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 2
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: hboxmake.tem
 		TilesetFilenames:
 			SNOW: hboxmake.sno
 			DESERT: hboxmake.des
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		TilesetFilenames:
@@ -723,6 +1063,8 @@ hbox:
 	icon:
 		Filename: hboxicon.shp
 		TilesetFilenames:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gap:
 	Defaults:
@@ -730,14 +1072,20 @@ gap:
 	idle:
 		Length: 32
 		Offset: 0,-14
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 32
 		Length: 32
 		Offset: 0,-14
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: gapmake.shp
 		Length: *
 		Offset: 0,-14
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbGAP.sno
@@ -745,28 +1093,42 @@ gap:
 			TEMPERAT: mbGAP.tem
 			DESERT: mbGAP.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: gapicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 iron:
 	Defaults:
 		Filename: iron.shp
 	idle:
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 11
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 11
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 11
 		Length: 11
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: ironmake.shp
 		Length: *
 		Offset: 0,-4
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbIRON.sno
@@ -775,15 +1137,23 @@ iron:
 			DESERT: mbIRON.des
 		Length: *
 		Offset: 0,-2
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: ironicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 pdox:
 	Defaults:
 		Filename: pdox.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 29
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Length: 29
 	damaged-active:
@@ -792,6 +1162,8 @@ pdox:
 	make:
 		Filename: pdoxmake.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	bib:
 		TilesetFilenames:
 			SNOW: mbPDOX.sno
@@ -800,10 +1172,16 @@ pdox:
 			DESERT: mbPDOX.des
 		Length: *
 		Offset: 0,-4
+		Palette: terrain
+		IsPlayerPalette: False
 	icon:
 		Filename: pdoxicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: pdoficon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mslo:
 	Defaults:
@@ -812,37 +1190,57 @@ mslo:
 			SNOW: mslo.sno
 			DESERT: mslo.des
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 8
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: mslomake.tem
 		TilesetFilenames:
 			SNOW: mslomake.sno
 			DESERT: mslomake.des
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		Start: 1
 		Length: 7
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	damaged-active:
 		Start: 9
 		Length: 7
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: msloicon2.shp
 		TilesetFilenames:
+		Palette: chrome
+		IsPlayerPalette: False
 	fake-icon:
 		Filename: mslficon.shp
 		TilesetFilenames:
+		Palette: chrome
+		IsPlayerPalette: False
 
 miss:
 	Defaults:
 		Filename: miss.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 800
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: missmake.shp
 		Length: *
@@ -852,40 +1250,62 @@ miss:
 			SNOW: bib2.sno
 			DESERT: bib2.des
 		Length: *
+		Palette: terrain
+		IsPlayerPalette: False
 
 brik:
 	Defaults:
 		Filename: brik.shp
 	idle:
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	scratched-idle:
 		Start: 16
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 32
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: brikicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 sbag:
 	idle:
 		Filename: sbag.shp
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sbagicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 fenc:
 	idle:
 		Filename: fenc.shp
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: fencicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 cycl:
 	Defaults:
 		Filename: cycl.shp
 	idle:
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 16
 		Length: 16
+		Palette: effect
+		IsPlayerPalette: False

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -97,35 +97,25 @@ fact:
 	Defaults:
 		Filename: fact.shp
 	idle:
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	make:
 		Filename: factmake.shp
 		Length: *
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	build:
 		Start: 1
 		Length: 25
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	damaged-idle:
 		Start: 26
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	damaged-build:
 		Start: 27
 		Length: 25
-		Palette: colorpicker
-		IsPlayerPalette: False
 		Palette: player
 		IsPlayerPalette: True
 	dead:
@@ -150,6 +140,12 @@ fact:
 		Palette: chrome
 		IsPlayerPalette: False
 
+fact.colorpicker:
+	Inherits: fact
+	idle:
+		Palette: colorpicker
+		IsPlayerPalette: False
+
 proc:
 	Defaults:
 		Filename: proc.shp
@@ -157,15 +153,15 @@ proc:
 		ZOffset: -1c511
 		Palette: player
 		IsPlayerPalette: True
-		Palette: terrain
-		IsPlayerPalette: False
+	place:
+		ZOffset: -1c511
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ZOffset: -1c511
 		Palette: player
 		IsPlayerPalette: True
-		Palette: terrain
-		IsPlayerPalette: False
 	idle-top:
 		Filename: proctop.shp
 		ZOffset: 0

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -3,8 +3,12 @@ mcv:
 		Filename: mcv.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mcvicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mcvhusk:
 	idle:
@@ -12,14 +16,20 @@ mcvhusk:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 
 truk:
 	idle:
 		Filename: truk.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: trukicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 harv:
 	Defaults:
@@ -27,31 +37,47 @@ harv:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	harvest:
 		Start: 32
 		Length: 8
 		Facings: 8
+		Palette: player
+		IsPlayerPalette: True
 	dock:
 		Filename: harv.shp
 		Start: 96
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	dock-loop:
 		Filename: harv.shp
 		Start: 104
 		Length: 7
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: harvicon.shp
 		Start: 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 harvempty:
 	Inherits: harv
 	Defaults:
 		Filename: harvempty.shp
+	idle:
+		Palette: player
+		IsPlayerPalette: True
 
 harvhalf:
 	Inherits: harv
 	Defaults:
 		Filename: harvhalf.shp
+	idle:
+		Palette: player
+		IsPlayerPalette: True
 
 hhusk:
 	idle:
@@ -59,6 +85,8 @@ hhusk:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 
 hhusk2:
 	idle:
@@ -66,6 +94,8 @@ hhusk2:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -1023
+		Palette: player
+		IsPlayerPalette: True
 
 1tnk:
 	Defaults:
@@ -73,15 +103,23 @@ hhusk2:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 2
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: 1tnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 1tnk.destroyed:
 	idle:
@@ -102,15 +140,23 @@ hhusk2:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: 2tnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 2tnk.destroyed:
 	idle:
@@ -118,12 +164,16 @@ hhusk2:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: 2tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 3tnk:
 	Defaults:
@@ -131,15 +181,23 @@ hhusk2:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: 3tnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 3tnk.destroyed:
 	idle:
@@ -147,12 +205,16 @@ hhusk2:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: 3tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 4tnk:
 	Defaults:
@@ -160,15 +222,23 @@ hhusk2:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: 4tnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 4tnk.destroyed:
 	idle:
@@ -176,12 +246,16 @@ hhusk2:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Filename: 4tnk.shp
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 
 v2rl:
 	Defaults:
@@ -189,23 +263,35 @@ v2rl:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	empty-idle:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: v2rlicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 arty:
 	idle:
 		Filename: arty.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: artyicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 jeep:
 	Defaults:
@@ -213,16 +299,24 @@ jeep:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: jeepicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 apc:
 	Defaults:
@@ -230,10 +324,14 @@ apc:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: minigun.shp
 		Length: 6
 		Facings: 8
+		Palette: effect
+		IsPlayerPalette: False
 	open:
 		Start: 32
 		Length: 3
@@ -241,14 +339,20 @@ apc:
 		Start: 32
 	icon:
 		Filename: apcicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mnly:
 	idle:
 		Filename: mnly.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mnlyicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mrj:
 	Defaults:
@@ -256,11 +360,17 @@ mrj:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	spinner:
 		Start: 32
 		Length: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: mrjicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mgg:
 	Defaults:
@@ -268,14 +378,20 @@ mgg:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	spinner:
 		Start: 32
 		Length: 8
+		Palette: player
+		IsPlayerPalette: True
 	spinner-idle:
 		Start: 32
 		Length: 1
 	icon:
 		Filename: mggicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 mgg.destroyed:
 	idle:
@@ -283,6 +399,8 @@ mgg.destroyed:
 		Facings: 32
 		UseClassicFacings: True
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	spinner:
 		Filename: mgg.shp
 		Start: 32
@@ -291,6 +409,8 @@ mgg.destroyed:
 	spinner-idle:
 		Filename: mgg.shp
 		Start: 32
+		Palette: player
+		IsPlayerPalette: True
 
 ttnk:
 	Defaults:
@@ -298,11 +418,17 @@ ttnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	spinner:
 		Start: 32
 		Length: 32
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: ttnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 ftrk:
 	Defaults:
@@ -310,34 +436,50 @@ ftrk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 32
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 2
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: ftrkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 dtrk:
 	idle:
 		Filename: dtrk.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: dtrkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 ctnk:
 	idle:
 		Filename: ctnk.shp
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire2.shp
 		Length: 5
 	icon:
 		Filename: ctnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 qtnk:
 	Defaults:
@@ -345,12 +487,16 @@ qtnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	piston:
 		Start: 32
 		Facings: 8
 		Length: 8
 	icon:
 		Filename: qtnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 stnk:
 	Defaults:
@@ -358,9 +504,15 @@ stnk:
 	idle:
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		Start: 38
 		Facings: 32
 		UseClassicFacings: True
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: stnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -238,7 +238,6 @@ TorpTube:
 		HorizontalRateOfTurn: 4
 		RangeLimit: 10c819
 		BoundToTerrainType: Water
-		Palette: shadow
 		MaximumLaunchAngle: 0
 		CruiseAltitude: 0
 	Warhead@1Dam: SpreadDamage

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -30,7 +30,6 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: supportpowers-support-powers-palette.ready
 					HoldText: supportpowers-support-powers-palette.hold
-					ClockPalette: iconclock
 					HotkeyPrefix: SupportPower
 					HotkeyCount: 6
 		Image@COMMAND_BAR_BACKGROUND:
@@ -495,9 +494,7 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: productionpalette-sidebar-production-palette.ready
 					HoldText: productionpalette-sidebar-production-palette.hold
-					ClockPalette: iconclock
 					NotBuildableAnimation: darken
-					NotBuildablePalette: chromewithshadow
 					IconSize: 64, 48
 					IconMargin: 3, 4
 					IconSpriteOffset: 0, 0

--- a/mods/ts/maps/sunstroke/sequences.yaml
+++ b/mods/ts/maps/sunstroke/sequences.yaml
@@ -2,61 +2,8 @@ slav:
 	icon:
 		Filename: xxicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	run:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	idle1:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	idle2:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	stand:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	attack:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	attack-muzzle:
-		Palette: muzzle
-		IsPlayerPalette: False
-	prone-run:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	prone-stand:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	prone-attack:
-		Palette: player-nomuzzle
-		IsPlayerPalette: True
-	prone-attack-muzzle:
-		Palette: muzzle
-		IsPlayerPalette: False
-	die-twirling:
-		Palette: player
-		IsPlayerPalette: True
-	die-flying:
-		Palette: player
-		IsPlayerPalette: True
-	die-exploding:
-		Palette: effect
-		IsPlayerPalette: False
-	die-melting:
-		Palette: ra
-		IsPlayerPalette: False
-	die-crushed:
-		Palette: player
-		IsPlayerPalette: True
 
 4tnk:
 	icon:
 		Filename: xxicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
-	muzzle:
-		Palette: effect
-		IsPlayerPalette: False

--- a/mods/ts/maps/sunstroke/sequences.yaml
+++ b/mods/ts/maps/sunstroke/sequences.yaml
@@ -1,7 +1,62 @@
 slav:
 	icon:
 		Filename: xxicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 4tnk:
 	icon:
 		Filename: xxicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
+	muzzle:
+		Palette: effect
+		IsPlayerPalette: False

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -34,7 +34,6 @@ DPOD:
 		Margin: 4, 5
 		FullSequence: pip-ammo
 		EmptySequence: pip-ammoempty
-		Palette: pips
 
 DPOD2:
 	Inherits@2: ^ExistsInWorld
@@ -179,7 +178,6 @@ ORCA:
 		Margin: 4, 5
 		FullSequence: pip-ammo
 		EmptySequence: pip-ammoempty
-		Palette: pips
 
 ORCAB:
 	Inherits: ^EMPableAircraft
@@ -247,7 +245,6 @@ ORCAB:
 		PipCount: 2
 		FullSequence: pip-ammo
 		EmptySequence: pip-ammoempty
-		Palette: pips
 	AppearsOnRadar:
 		ValidRelationships: Ally
 	AppearsOnRadar@ENEMY:
@@ -408,7 +405,6 @@ SCRIN:
 		PipCount: 3
 		FullSequence: pip-ammo
 		EmptySequence: pip-ammoempty
-		Palette: pips
 	AppearsOnRadar:
 		ValidRelationships: Ally
 	AppearsOnRadar@ENEMY:
@@ -485,7 +481,6 @@ APACHE:
 		PipCount: 4
 		FullSequence: pip-ammo
 		EmptySequence: pip-ammoempty
-		Palette: pips
 	WithShadow:
 	WithVoxelBody:
 		ShowShadow: False

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -8,7 +8,6 @@ CABHUT:
 	BridgeHut:
 		NeighbourOffsets: -1,-1, -1,0, -1,1, 0,-1, 0,1, 1,-1, 1,0, 1,1
 	RenderSprites:
-		Palette: player
 	Targetable:
 		TargetTypes: C4
 	-IsometricSelectable:
@@ -24,7 +23,6 @@ CABHUT:
 
 ^LowBridgeRamp:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	AppearsOnRadar:
 	RadarColorFromTerrain:
@@ -171,7 +169,6 @@ LOBRDG_R_SW:
 
 ^ElevatedBridgePlaceholder:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	AppearsOnRadar:
 	RadarColorFromTerrain:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -78,7 +78,6 @@ CHAMSPY:
 		Margin: 6, 10
 		Image: pips
 		Sequence: pip-disguise
-		Palette: pips
 	Infiltrates:
 		Types: SpyInfiltrate
 		Notification: BuildingInfiltrated
@@ -168,9 +167,6 @@ MUTANT3:
 		FacingTolerance: 0
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
-		Palette: player-nobright
-		IsPlayerPalette: true
-		SplitAttackPalette: bright
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 
@@ -229,9 +225,6 @@ CIV1:
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
-		Palette: player-nomuzzle
-		IsPlayerPalette: true
-		SplitAttackPalette: muzzle
 	Armament:
 		Weapon: Pistola
 	AttackFrontal:
@@ -257,9 +250,6 @@ CTECH:
 		Image: civ3
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
-		Palette: player-nomuzzle
-		IsPlayerPalette: true
-		SplitAttackPalette: muzzle
 	Armament:
 		Weapon: Pistola
 	AttackFrontal:

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1509,7 +1509,7 @@ INGALITE:
 	Immobile:
 		OccupiesSpace: false
 	RenderSpritesEditorOnly:
-		Image: galite
+		Image: galite-editor
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -301,7 +301,6 @@ AMMOCRAT:
 	Health:
 		HP: 1
 	RenderSprites:
-		Palette: player
 
 BBOARD01:
 	Inherits: ^CivBillboard
@@ -745,7 +744,6 @@ CAARAY:
 	Health:
 		HP: 40000
 	RenderSprites:
-		Palette: player
 	WithIdleOverlay@SATELLITE:
 		Sequence: idle-satellite
 	WithIdleOverlay@RADAR:
@@ -754,7 +752,6 @@ CAARAY:
 		Sequence: idle-scanner
 	WithIdleOverlay@LIGHT-bright:
 		Sequence: idle-light-bright
-		Palette: bright
 	FireProjectilesOnDeath@SMALL:
 		Pieces: 5, 7
 	FireProjectilesOnDeath@LARGE:
@@ -775,7 +772,6 @@ CAARMR:
 	Health:
 		HP: 80000
 	RenderSprites:
-		Palette: player
 	ProvidesPrerequisite:
 		Prerequisite: barracks.upgraded
 	CaptureManager:
@@ -822,7 +818,6 @@ CAHOSP:
 	Health:
 		HP: 80000
 	RenderSprites:
-		Palette: player
 	CaptureManager:
 	Capturable:
 		Types: building
@@ -1323,7 +1318,6 @@ CTDAM:
 		ExcludeTilesets: SNOW
 	WithIdleOverlay@LIGHT-BRIGHT:
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@WATER-A:
 		Sequence: idle-water-a
 	WithIdleOverlay@WATER-B:
@@ -1369,28 +1363,18 @@ GAKODK:
 	Health:
 		HP: 150000
 	RenderSprites:
-		Palette: player
 	WithIdleOverlay@LARGELIGHTS:
 		Sequence: large-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHT-BRIGHT:
 		Sequence: large-lights-bright
-		Palette: bright
 	WithIdleOverlay@SMALLLIGHT:
 		Sequence: small-light
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@SMALLLIGHT-BRIGHT:
 		Sequence: small-light-bright
-		Palette: bright
 	WithIdleOverlay@SMALLLIGHTS:
 		Sequence: small-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@SMALLLIGHTS-BRIGHT:
 		Sequence: small-lights-bright
-		Palette: bright
 
 GAOLDCC1:
 	Inherits: ^OldBase
@@ -1478,7 +1462,6 @@ GASPOT:
 		MaxHeightDelta: 3
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		Sequence: idle-lights-bright
-		Palette: bright
 	MapEditorData:
 		Categories: Civilian building
 	IsometricSelectable:
@@ -1492,7 +1475,6 @@ GALITE:
 		Name: actor-galite-name
 	RenderSprites:
 		Image: galite
-		Palette: terraindecoration
 	-WithMakeAnimation:
 	-WithDeathAnimation:
 	Sellable:
@@ -1528,7 +1510,6 @@ INGALITE:
 		OccupiesSpace: false
 	RenderSpritesEditorOnly:
 		Image: galite
-		Palette: terrainalpha
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
@@ -1691,7 +1672,6 @@ TSTLAMP:
 	-TerrainLightSource:
 	WithIdleOverlay@LIGHTING:
 		Sequence: lighting
-		Palette: alpha
 
 GAICBM:
 	Inherits: ^Building
@@ -1732,14 +1712,10 @@ NAMNTK:
 	Health:
 		HP: 150000
 	RenderSprites:
-		Palette: player
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHT-BRIGHT:
 		Sequence: idle-lights-bright
-		Palette: bright
 	IsometricSelectable:
 		Height: 36
 
@@ -1758,7 +1734,6 @@ NTPYRA:
 	Health:
 		HP: 150000
 	RenderSprites:
-		Palette: player
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	FireProjectilesOnDeath@SMALL:
@@ -1775,7 +1750,6 @@ UFO:
 		Dimensions: 6, 4
 		Footprint: xxxxxx xxxxxx xxxxxx xxxxxx
 	RenderSprites:
-		Palette: terraindecoration
 	Tooltip:
 		Name: actor-ufo-name
 	Health:

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -49,7 +49,6 @@ DOGGIE:
 		ArmamentNames: primary
 		Condition: attacking
 	RenderSprites:
-		Palette: greentiberium
 	WithSpriteBody:
 		RequiresCondition: hidingplace && !moving && !attacking
 		StartSequence: laydown
@@ -138,10 +137,8 @@ JFISH:
 		Sequence: attack
 	WithAttackOverlay@muzzle:
 		Sequence: attack-shock
-		Palette: bright
 	RenderSprites:
 		Image: floater
-		Palette: player-nobright
 	Selectable:
 		Bounds: 965, 1930, 0, -301
 	AmbientSound:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -64,7 +64,6 @@
 		Margin: 3, 4
 		Image: rank
 		Sequence: veteran
-		Palette: ra
 		ValidRelationships: Ally, Enemy, Neutral
 	WithDecoration@ELITE:
 		RequiresCondition: rank-elite
@@ -72,7 +71,6 @@
 		Margin: 3, 4
 		Image: rank
 		Sequence: elite
-		Palette: ra
 		ValidRelationships: Ally, Enemy, Neutral
 
 ^InfantryExperienceHospitalOverrides:
@@ -107,7 +105,6 @@
 		Color: 000000B4
 	WithIdleOverlay@EMPDISABLE:
 		Sequence: emp-overlay
-		Palette: effect
 
 ^EmpDisable:
 	Inherits: ^EmpVisualEffects
@@ -327,7 +324,6 @@
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
 		UndeploySounds: cashturn.aud
 	ActorPreviewPlaceBuildingPreview:
-		Palette: ra
 		FootprintAlpha: 0.7
 		LineBuildFootprintAlpha: 0.5
 		PreviewAlpha: 0.55
@@ -408,7 +404,6 @@
 		Image: allyrepair
 		Sequence: repair
 		Position: Center
-		Palette: mouse
 
 ^CivBuilding:
 	Inherits: ^BasicBuilding
@@ -421,7 +416,6 @@
 		Range: 4c0
 		MaxHeightDelta: 3
 	RenderSprites:
-		Palette: terraindecoration
 	MapEditorData:
 		Categories: Civilian building
 
@@ -436,7 +430,6 @@
 	Health:
 		HP: 40000
 	RenderSprites:
-		-Palette:
 	-Cloak@EXTERNALCLOAK:
 	-ExternalCondition@CLOAKGENERATOR:
 	-ExternalCondition@CRATE-CLOAK:
@@ -467,7 +460,6 @@
 		Duration: 4500
 		TerrainTypes: Clear, Rough, Sand, Road, DirtRoad, Tiberium, BlueTiberium, Veins, Green, Pavement
 	RenderSprites:
-		Palette: terraindecoration
 	WithCrateBody:
 	MapEditorData:
 		Categories: System
@@ -490,7 +482,6 @@
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
 		UndeploySounds: cashturn.aud
 	FootprintPlaceBuildingPreview:
-		Palette: ra
 		FootprintAlpha: 0.7
 		LineBuildFootprintAlpha: 0.5
 	RequiresBuildableArea:
@@ -540,7 +531,6 @@
 		UndeploySounds: cashturn.aud
 	SequencePlaceBuildingPreview:
 		Sequence: place
-		Palette: ra
 		FootprintAlpha: 0.7
 		SequenceAlpha: 0.55
 	KillsSelf:
@@ -629,7 +619,6 @@
 		Margin: 3, 4
 		Image: pips
 		Sequence: medic
-		Palette: pips
 		BlinkInterval: 32
 		BlinkPattern: Off, On
 	RevealOnFire:
@@ -647,8 +636,6 @@
 		Position: Center
 		Image: typeglyphs
 		Sequence: infantry
-		Palette: player
-		IsPlayerPalette: true
 
 ^RegularInfantryDeath:
 	WithDeathAnimation@normal:
@@ -658,20 +645,14 @@
 			SmallExplosionDeath: flying
 	WithDeathAnimation@explosion:
 		DeathSequence: die-
-		DeathSequencePalette: effect
-		DeathPaletteIsPlayerPalette: False
 		DeathTypes:
 			ExplosionDeath: exploding
 	WithDeathAnimation@energy:
 		DeathSequence: die-
-		DeathSequencePalette: ra
-		DeathPaletteIsPlayerPalette: False
 		DeathTypes:
 			EnergyDeath: melting
 	WithDeathAnimation:
 		CrushedSequence: die-crushed
-		CrushedSequencePalette: player
-		CrushedPaletteIsPlayerPalette: true
 	DeathSounds@NORMAL:
 		DeathTypes: BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@EXPLOSION:
@@ -713,9 +694,6 @@
 		ProneOffset: 300,0,0
 	WithSplitAttackPaletteInfantryBody:
 		IdleSequences: idle1, idle2
-		Palette: player-nomuzzle
-		IsPlayerPalette: true
-		SplitAttackPalette: muzzle
 
 ^Cyborg:
 	Inherits@1: ^Infantry
@@ -746,9 +724,6 @@
 	WithSplitAttackPaletteInfantryBody:
 		DefaultAttackSequence: attack
 		IdleSequences: idle1, idle2
-		Palette: player-nomuzzle
-		IsPlayerPalette: true
-		SplitAttackPalette: muzzle
 	GrantConditionOnDamageState@CRITICAL:
 		Condition: critical
 		ValidDamageStates: Critical
@@ -858,8 +833,6 @@
 		Position: Center
 		Image: typeglyphs
 		Sequence: vehicle
-		Palette: player
-		IsPlayerPalette: true
 	Sellable:
 		SellSounds: cashturn.aud
 		Cursor: sell2
@@ -1041,7 +1014,6 @@
 	Tooltip:
 		Name: meta-blossomtree-name
 	RenderSprites:
-		Palette: player
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -1066,7 +1038,6 @@
 	Interactable:
 	FrozenUnderFog:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -1092,11 +1063,9 @@
 		ValidDamageStates: Heavy, Critical
 	WithIdleOverlay@SmallFire:
 		Image: fire2
-		Palette: effect
 		RequiresCondition: small-fire
 	WithIdleOverlay@LargeFire:
 		Image: fire1
-		Palette: effect
 		RequiresCondition: large-fire
 	SpreadsCondition@Fire:
 		RequiresCondition: small-fire || large-fire
@@ -1111,7 +1080,6 @@
 	Interactable:
 	HiddenUnderShroud:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -1128,7 +1096,6 @@
 	Interactable:
 	HiddenUnderShroud:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	Building:
 		Footprint: x
@@ -1228,7 +1195,6 @@
 	Immobile:
 		OccupiesSpace: False
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	BodyOrientation:
 		UseClassicPerspectiveFudge: False
@@ -1246,7 +1212,6 @@
 
 ^Tunnel:
 	RenderSprites:
-		Palette: terraindecoration
 	WithSpriteBody:
 	BodyOrientation:
 		UseClassicPerspectiveFudge: False
@@ -1339,7 +1304,6 @@
 		RequiresCondition: !inside-tunnel
 	LeavesTrails@VEINS:
 		Image: veins
-		Palette: player
 		TerrainTypes: Veins
 		TrailWhileStationary: true
 		StationaryInterval: 16
@@ -1374,7 +1338,6 @@
 	WithDecoration@POWERDOWN:
 		Image: poweroff
 		Sequence: offline
-		Palette: mouse
 		RequiresCondition: powerdown
 		Position: Center
 		Offsets:
@@ -1426,7 +1389,6 @@
 	WithCargoPipsDecoration:
 		Position: BottomLeft
 		RequiresSelection: true
-		Palette: pips
 		Margin: 5, 2
 		CustomPipSequences:
 			red: pip-red

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -130,14 +130,11 @@ JUMPJET:
 		DefaultAttackSequence: flying-attack
 		StandSequences: flying
 		MoveSequence: flying
-		Palette: player-nomuzzle
-		IsPlayerPalette: true
 	WithInfantryBody@flying-muzzle:
 		RequiresCondition: airborne
 		DefaultAttackSequence: flying-attack-muzzle
 		StandSequences: flying-muzzle
 		MoveSequence: flying-muzzle
-		Palette: muzzle
 	AppearsOnRadar:
 		ValidRelationships: Ally
 	AppearsOnRadar@ENEMY:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -25,19 +25,15 @@ GAPOWR:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@PLUG:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
 		Sequence: idle-plug
 	WithMakeOverlay@MAKE-BRIGHT:
 		Sequence: make-bright
-		Palette: bright
 	Power:
 		Amount: 100
 		RequiresCondition: !empdisable
@@ -129,8 +125,6 @@ GAPILE:
 		Range: 5c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Infantry
 		CirclesSequence:
@@ -183,16 +177,12 @@ GAPILE:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@LIGHT-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-light-bright
-		Palette: bright
 	WithIdleOverlay@FLAG:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-flag
@@ -226,8 +216,6 @@ GAWEAP:
 	Armor:
 		Type: Heavy
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Vehicle
 		CirclesSequence:
@@ -251,27 +239,20 @@ GAWEAP:
 	WithIdleOverlay@WHITELIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-white
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@WHITELIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-white-bright
-		Palette: bright
 	WithIdleOverlay@REDLIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-red
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@REDLIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-red-bright
-		Palette: bright
 	WithIdleOverlay@TURBINES:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-turbines
 	WithMakeOverlay@MAKE-BRIGHT:
 		Sequence: make-bright
-		Palette: bright
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
@@ -304,8 +285,6 @@ GAHPAD:
 		Facing: 896
 	ExitsDebugOverlay:
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Air
 		CirclesSequence:
@@ -331,12 +310,9 @@ GAHPAD:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithDeathAnimation@BIB:
 		DeathSequence: dead-platform
 		UseDeathTypeSuffix: false
@@ -374,8 +350,6 @@ GADEPT:
 		FinishRepairingNotification: UnitRepaired
 		FinishRepairingTextNotification: notification-unit-repaired
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		CirclesSequence:
 	CommandBarBlacklist:
@@ -383,39 +357,30 @@ GADEPT:
 	WithIdleOverlay@LIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-light
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHT-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-light-bright
-		Palette: bright
 	WithIdleOverlay@GROUND:
 		RequiresCondition: !build-incomplete
 		Sequence: ground
 	WithIdleOverlay@CIRCUITS:
 		RequiresCondition: !build-incomplete
 		Sequence: circuits
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@CIRCUITS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: circuits-bright
-		Palette: bright
 	WithRepairOverlay@CRANE:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
 		StartSequence: crane-start
 		Sequence: crane-loop
 		EndSequence: crane-end
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithRepairOverlay@CRANE-BRIGHT:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
 		StartSequence: crane-start
 		Sequence: crane-loop-bright
 		EndSequence: crane-end
-		Palette: bright
 	WithRepairOverlay@PLATFORM:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: platform
@@ -508,12 +473,9 @@ GATECH:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@buildingname:
@@ -543,7 +505,6 @@ GAPLUG:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@STRIP:
 		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-strip
@@ -632,24 +593,18 @@ GAPLUG:
 		RequiresCondition: !build-incomplete && plug.hunterseekera
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekera
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@hunterseekera-bright:
 		RequiresCondition: !build-incomplete && plug.hunterseekera
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekera-bright
-		Palette: bright
 	WithIdleOverlay@droppoda:
 		RequiresCondition: !build-incomplete && plug.droppoda
 		PauseOnCondition: disabled
 		Sequence: idle-droppoda
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@droppoda-bright:
 		RequiresCondition: !build-incomplete && plug.droppoda
 		PauseOnCondition: disabled
 		Sequence: idle-droppoda-bright
-		Palette: bright
 	Pluggable@plugb:
 		Offset: 1,2
 		Conditions:
@@ -672,24 +627,18 @@ GAPLUG:
 		RequiresCondition: !build-incomplete && plug.hunterseekerb
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekerb
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@hunterseekerb-bright:
 		RequiresCondition: !build-incomplete && plug.hunterseekerb
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekerb-bright
-		Palette: bright
 	WithIdleOverlay@droppodb:
 		RequiresCondition: plug.droppodb
 		PauseOnCondition: disabled
 		Sequence: idle-droppodb
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@droppodb-bright:
 		RequiresCondition: plug.droppodb
 		PauseOnCondition: disabled
 		Sequence: idle-droppodb-bright
-		Palette: bright
 	ProvidesPrerequisite@buildingname:
 	ProvidesPrerequisite@pluggableion:
 		RequiresCondition: !plug.ioncannona && !plug.ioncannonb
@@ -782,27 +731,21 @@ GAFIRE:
 	WithIdleOverlay@lights:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: true
 	WithIdleOverlay@lights-bright:
 		RequiresCondition: !build-incomplete && !empdisable && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithSwitchableOverlay@active-nobright:
 		RequiresCondition: !build-incomplete
 		EnabledSequence: active
 		SwitchingSequence: switching
 		DisabledSequence: disabled
 		PauseOnCondition: empdisable || disabled
-		Palette: player-nobright
-		IsPlayerPalette: true
 		SwitchingLevel: 20
 		SwitchingLevelOnSpawn: 20
 	WithSwitchableOverlay@active-bright:
 		RequiresCondition: !build-incomplete
 		EnabledSequence: active-bright
 		PauseOnCondition: empdisable || disabled
-		Palette: bright
 		IsDecoration: true
 		SwitchingLevel: 20
 		SwitchingLevelOnSpawn: 20

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -378,9 +378,9 @@ GADEPT:
 	WithRepairOverlay@CRANE-BRIGHT:
 		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
-		StartSequence: crane-start
+		StartSequence: crane-start-bright
 		Sequence: crane-loop-bright
-		EndSequence: crane-end
+		EndSequence: crane-end-bright
 	WithRepairOverlay@PLATFORM:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: platform

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -109,15 +109,11 @@ GACTWR:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithMakeOverlay@MAKE-BRIGHT:
 		Sequence: make-bright
-		Palette: bright
 	LineBuildNode:
 		Types: turret
 	Power@base:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -43,7 +43,6 @@ APC:
 	LeavesTrails:
 		RequiresCondition: !inside-tunnel && inwater
 		Image: wake
-		Palette: effect
 		TerrainTypes: Water
 		StationaryInterval: 18
 		MovingInterval: 6
@@ -97,7 +96,6 @@ HVR:
 	LeavesTrails:
 		RequiresCondition: !inside-tunnel
 		Image: wake
-		Palette: effect
 		TerrainTypes: Water
 		TrailWhileStationary: True
 		StationaryInterval: 18
@@ -150,7 +148,6 @@ SMECH:
 		CameraPitch: 250
 	WithAttackOverlay@muzzle:
 		Sequence: shoot-muzzle
-		Palette: muzzle
 		IsDecoration: true
 	Selectable:
 		Bounds: 603, 1930, 0, -482

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -25,12 +25,9 @@ NAPOWR:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: 100
 		RequiresCondition: !empdisable
@@ -68,12 +65,9 @@ NAAPWR:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: 200
 		RequiresCondition: !empdisable
@@ -156,8 +150,6 @@ NAHAND:
 		ExitCell: 0,2
 	ExitsDebugOverlay:
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Infantry
 		CirclesSequence:
@@ -171,11 +163,9 @@ NAHAND:
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@LIGHT-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-light-bright
-		Palette: bright
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
@@ -206,8 +196,6 @@ NAWEAP:
 		Range: 4c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Vehicle
 		CirclesSequence:
@@ -231,12 +219,9 @@ NAWEAP:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
@@ -269,8 +254,6 @@ NAHPAD:
 		Facing: 896
 	ExitsDebugOverlay:
 	RallyPoint:
-		Palette: mouse
-		IsPlayerPalette: false
 		LineWidth: 2
 		ForceSetType: Air
 		CirclesSequence:
@@ -296,12 +279,9 @@ NAHPAD:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithDeathAnimation@BIB:
 		DeathSequence: dead-platform
 		UseDeathTypeSuffix: false
@@ -383,12 +363,9 @@ NATECH:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@buildingname:
@@ -468,12 +445,9 @@ NATMPL:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 	ProduceActorPower:
 		PauseOnCondition: empdisable || disabled
 		Name: actor-natmpl.produceactorpower-name
@@ -519,12 +493,9 @@ NAMISL:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 	Power:
 		Amount: -50
 	ProvidesPrerequisite@buildingname:
@@ -558,12 +529,9 @@ NAMISL:
 		TrailInterval: 0
 		TrailSequences: idle
 	WithSupportPowerActivationOverlay:
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithSupportPowerActivationOverlay@BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights-bright
-		Palette: bright
 
 NAWAST:
 	Inherits: ^Building
@@ -608,7 +576,6 @@ NAWAST:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@BIB:
 		RequiresCondition: !build-incomplete
 		Sequence: bib
@@ -621,4 +588,3 @@ NAWAST:
 		EmptySequence: pip-empty-building
 		PipStride: 4, 2
 		PipCount: 15
-		Palette: pips

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -75,16 +75,12 @@ NAPOST:
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: lights-bright
-		Palette: bright
 	WithIdleOverlay@CHAINOFLIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: chainoflights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@CHAINOFLIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: chainoflights-bright
-		Palette: bright
 	LineBuildSegmentExternalCondition:
 		RequiresCondition: !build-incomplete && !disabled
 		Condition: active-posts
@@ -123,27 +119,21 @@ NAFNCE:
 		Type: laserfence
 		Sequence: enabled-x
 		Name: x-enabled
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithWallSpriteBody@XENABLED-BRIGHT:
 		RequiresCondition: laserfence-direction-x && active-posts == 2
 		Type: laserfence
 		Sequence: enabled-x-bright
 		Name: x-enabled-bright
-		Palette: bright
 	WithWallSpriteBody@YENABLED:
 		RequiresCondition: laserfence-direction-y && active-posts == 2
 		Type: laserfence
 		Sequence: enabled-y
 		Name: y-enabled
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithWallSpriteBody@YENABLED-BRIGHT:
 		RequiresCondition: laserfence-direction-y && active-posts == 2
 		Type: laserfence
 		Sequence: enabled-y-bright
 		Name: y-enabled-bright
-		Palette: bright
 	WithSpriteBody@XDISABLED:
 		RequiresCondition: laserfence-direction-x && active-posts < 2
 		Sequence: disabled-x
@@ -242,8 +232,6 @@ NAOBEL:
 		Interval: 30, 40
 	WithChargeOverlay:
 		RequiresCondition: !build-incomplete
-		Palette: player
-		IsPlayerPalette: true
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -390,7 +390,6 @@ WEED:
 		RequiresSelection: true
 		Margin: 5, 2
 		FullSequence: pip-red
-		Palette: pips
 		PipCount: 7
 
 SAPC:
@@ -595,7 +594,6 @@ SGEN:
 		Condition: real-actor
 	RenderSprites:
 		Image: mstl
-		PlayerPalette: playertem
 	GrantConditionOnDeploy:
 		PauseOnCondition: empdisable || being-captured
 		DeployedCondition: deployed
@@ -621,8 +619,6 @@ SGEN:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: deployed && real-actor && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	RenderVoxels:
 		Scale: 11.5
 	ProximityExternalCondition:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -125,8 +125,6 @@ Player:
 		TextNotification: notification-harvester-under-attack
 	PlayerStatistics:
 	PlaceBeacon:
-		Palette: effect
-		IsPlayerPalette: false
 		BeaconSequence: idle
 		ArrowSequence:
 		CircleSequence:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -65,27 +65,20 @@ GACNST:
 	WithIdleOverlay@TOP:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-top
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@TOP-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-top-bright
-		Palette: bright
 	WithIdleOverlay@SIDE:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-side
 	WithIdleOverlay@FRONT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-front
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@FRONT-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-front-bright
-		Palette: bright
 	WithMakeOverlay@MAKE-BRIGHT:
 		Sequence: make-bright
-		Palette: bright
 	WithBuildingPlacedOverlay:
 		RequiresCondition: !build-incomplete
 	Power:
@@ -136,19 +129,15 @@ PROC:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-bright
-		Palette: bright
 	WithIdleOverlay@BIB:
 		RequiresCondition: !build-incomplete
 		Sequence: bib
 	WithDockedOverlay@FLAME:
 		RequiresCondition: !build-incomplete
 		Sequence: flame
-		Palette: effect
 	WithDockingOverlay@UNLOAD:
 		RequiresCondition: !build-incomplete
 	Power:
@@ -172,7 +161,6 @@ PROC:
 		EmptySequence: pip-empty-building
 		PipStride: 4, 2
 		PipCount: 25
-		Palette: pips
 
 GASILO:
 	Inherits: ^Building
@@ -210,7 +198,6 @@ GASILO:
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-bright
-		Palette: bright
 	StoresPlayerResources:
 		Capacity: 1500
 	Power:
@@ -228,7 +215,6 @@ GASILO:
 		EmptySequence: pip-empty-building
 		PipStride: 4, 2
 		PipCount: 12
-		Palette: pips
 
 ANYPOWER:
 	Interactable:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -94,7 +94,6 @@ HARV:
 		Weapon: TiberiumExplosion
 	WithHarvestOverlay:
 		LocalOffset: 543,0,0
-		Palette: effect
 	RenderSprites:
 		Image: harv.gdi
 		FactionImages:
@@ -107,7 +106,6 @@ HARV:
 		RequiresSelection: true
 		Margin: 5, 2
 		PipCount: 7
-		Palette: pips
 		ResourceSequences:
 			Tiberium: pip-green
 			BlueTiberium: pip-blue
@@ -154,7 +152,6 @@ LPST:
 		Condition: real-actor
 	RenderSprites:
 		Image: lpst.gdi
-		PlayerPalette: playertem
 		FactionImages:
 			gdi: lpst.gdi
 			nod: lpst.nod
@@ -183,12 +180,9 @@ LPST:
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: deployed && real-actor && !empdisable
 		Sequence: idle-lights
-		Palette: player-nobright
-		IsPlayerPalette: True
 	WithIdleOverlay@LIGHTS-BRIGHT:
 		RequiresCondition: deployed && real-actor && !empdisable
 		Sequence: idle-lights-bright
-		Palette: bright
 	DetectCloaked:
 		RequiresCondition: !empdisable && deployed
 		Range: 18c0

--- a/mods/ts/rules/trees.yaml
+++ b/mods/ts/rules/trees.yaml
@@ -12,7 +12,6 @@ BIGBLUE:
 	Tooltip:
 		Name: actor-bigblue-name
 	RenderSprites:
-		Palette: bluetiberium
 	RadarColorFromTerrain:
 		Terrain: BlueTiberium
 	AppearsOnMapPreview:
@@ -114,7 +113,6 @@ VEINHOLE:
 	Tooltip:
 		Name: actor-veinhole-name
 	RenderSprites:
-		Palette: player
 	WithSpriteBody:
 	MapEditorData:
 		Categories: Resource spawn

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -14,8 +14,6 @@
 	ShroudRenderer:
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
 		UseExtendedIndex: true
-		ShroudPalette: shroud
-		FogPalette: shroud
 	Locomotor@FOOT:
 		Name: foot
 		Crushes: crate
@@ -207,11 +205,9 @@
 		ResourceTypes:
 			Tiberium:
 				Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
-				Palette: greentiberium
 				Name: resource-tiberium
 			BlueTiberium:
 				Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
-				Palette: bluetiberium
 				Name: resource-tiberium
 		Ramp1Sequences:
 			Tiberium: tib13, tib14
@@ -228,7 +224,6 @@
 	TSVeinsRenderer:
 		ResourceType: Veins
 		Name: resource-veins
-		Palette: player
 		VeinholeActors: veinhole
 
 World:
@@ -398,7 +393,6 @@ World:
 	OrderEffects:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
-		TerrainFlashPalette: moveflash
 		ActorFlashType: Tint
 
 EditorWorld:
@@ -427,7 +421,6 @@ EditorWorld:
 	EditorActionManager:
 	BuildableTerrainOverlay:
 		AllowedTerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
-		Palette: ra
 		Alpha: 0.35
 	MarkerLayerOverlay:
 	TilingPathTool:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -204,23 +204,23 @@
 	TSTiberiumRenderer:
 		ResourceTypes:
 			Tiberium:
-				Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+				Sequences: tib01g, tib02g, tib03g, tib04g, tib05g, tib06g, tib07g, tib08g, tib09g, tib10g, tib11g, tib12g
 				Name: resource-tiberium
 			BlueTiberium:
-				Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+				Sequences: tib01b, tib02b, tib03b, tib04b, tib05b, tib06b, tib07b, tib08b, tib09b, tib10b, tib11b, tib12b
 				Name: resource-tiberium
 		Ramp1Sequences:
-			Tiberium: tib13, tib14
-			BlueTiberium: tib13, tib14
+			Tiberium: tib13g, tib14g
+			BlueTiberium: tib13b, tib14b
 		Ramp2Sequences:
-			Tiberium: tib15, tib16
-			BlueTiberium: tib15, tib16
+			Tiberium: tib15g, tib16g
+			BlueTiberium: tib15b, tib16b
 		Ramp3Sequences:
-			Tiberium: tib17, tib18
-			BlueTiberium: tib17, tib18
+			Tiberium: tib17g, tib18g
+			BlueTiberium: tib17b, tib18b
 		Ramp4Sequences:
-			Tiberium: tib19, tib20
-			BlueTiberium: tib19, tib20
+			Tiberium: tib19g, tib20g
+			BlueTiberium: tib19b, tib20b
 	TSVeinsRenderer:
 		ResourceType: Veins
 		Name: resource-veins

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -3,47 +3,30 @@ orca:
 	icon:
 		Filename: orcaicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 orcab:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: obmbicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 trnsport:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: otrnicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 scrin:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: proicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 apache:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: apchicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	rotor:
 		Filename: harpyrotor.shp
 		Start: 32
@@ -61,19 +44,12 @@ apache:
 		Tick: 50
 		Palette: player
 		IsPlayerPalette: True
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 orcatran:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: crryicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 pod:
 	Inherits: ^VehicleOverlays

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -2,26 +2,48 @@ orca:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: orcaicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 orcab:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: obmbicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 trnsport:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: otrnicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 scrin:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: proicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 apache:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: apchicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	rotor:
 		Filename: harpyrotor.shp
 		Start: 32
@@ -29,17 +51,29 @@ apache:
 		Offset: 0, 0, 32
 		ZRamp: 1
 		Tick: 25
+		Palette: player
+		IsPlayerPalette: True
 	slow-rotor:
 		Filename: harpyrotor.shp
 		Length: 31
 		Offset: 0, 0, 32
 		ZRamp: 1
 		Tick: 50
+		Palette: player
+		IsPlayerPalette: True
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 orcatran:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: crryicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 pod:
 	Inherits: ^VehicleOverlays
@@ -47,3 +81,5 @@ pod:
 		Filename: pod.shp
 		Facings: 1
 		Length: 1
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/ts/sequences/bridges.yaml
+++ b/mods/ts/sequences/bridges.yaml
@@ -54,10 +54,6 @@ lobrdg_a_d:
 		TilesetFilenames:
 			TEMPERATE: lobrdg28.tem
 			SNOW: lobrdg28.sno
-	editor:
-		TilesetFilenames:
-			TEMPERATE: lobrdg10.tem
-			SNOW: lobrdg10.sno
 
 lobrdg_b:
 	Inherits: ^bridge
@@ -108,10 +104,6 @@ lobrdg_b_d:
 		TilesetFilenames:
 			TEMPERATE: lobrdg27.tem
 			SNOW: lobrdg27.sno
-	editor:
-		TilesetFilenames:
-			TEMPERATE: lobrdg01.tem
-			SNOW: lobrdg01.sno
 
 lobrdg_r_se:
 	Inherits: ^bridge

--- a/mods/ts/sequences/bridges.yaml
+++ b/mods/ts/sequences/bridges.yaml
@@ -12,43 +12,36 @@ lobrdg_a:
 			TEMPERATE: lobrdg10.tem
 			SNOW: lobrdg10.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle2:
 		TilesetFilenames:
 			TEMPERATE: lobrdg11.tem
 			SNOW: lobrdg11.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle3:
 		TilesetFilenames:
 			TEMPERATE: lobrdg12.tem
 			SNOW: lobrdg12.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle4:
 		TilesetFilenames:
 			TEMPERATE: lobrdg13.tem
 			SNOW: lobrdg13.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	adead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg15.tem
 			SNOW: lobrdg15.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	bdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg14.tem
 			SNOW: lobrdg14.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	abdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg16.tem
 			SNOW: lobrdg16.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 lobrdg_a_d:
 	Inherits: ^bridge
@@ -57,7 +50,6 @@ lobrdg_a_d:
 			TEMPERATE: lobrdg28.tem
 			SNOW: lobrdg28.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	aramp:
 		TilesetFilenames:
 			TEMPERATE: lobrdg17.tem
@@ -78,43 +70,36 @@ lobrdg_b:
 			TEMPERATE: lobrdg01.tem
 			SNOW: lobrdg01.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle2:
 		TilesetFilenames:
 			TEMPERATE: lobrdg02.tem
 			SNOW: lobrdg02.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle3:
 		TilesetFilenames:
 			TEMPERATE: lobrdg03.tem
 			SNOW: lobrdg03.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle4:
 		TilesetFilenames:
 			TEMPERATE: lobrdg04.tem
 			SNOW: lobrdg04.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	adead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg05.tem
 			SNOW: lobrdg05.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	bdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg06.tem
 			SNOW: lobrdg06.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	abdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg07.tem
 			SNOW: lobrdg07.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 lobrdg_b_d:
 	Inherits: ^bridge
@@ -123,7 +108,6 @@ lobrdg_b_d:
 			TEMPERATE: lobrdg27.tem
 			SNOW: lobrdg27.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	aramp:
 		TilesetFilenames:
 			TEMPERATE: lobrdg08.tem
@@ -144,13 +128,11 @@ lobrdg_r_se:
 			TEMPERATE: lobrdg19.tem
 			SNOW: lobrdg19.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg20.tem
 			SNOW: lobrdg20.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 lobrdg_r_nw:
 	Inherits: ^bridge
@@ -159,13 +141,11 @@ lobrdg_r_nw:
 			TEMPERATE: lobrdg21.tem
 			SNOW: lobrdg21.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg22.tem
 			SNOW: lobrdg22.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 lobrdg_r_ne:
 	Inherits: ^bridge
@@ -174,13 +154,11 @@ lobrdg_r_ne:
 			TEMPERATE: lobrdg23.tem
 			SNOW: lobrdg23.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg24.tem
 			SNOW: lobrdg24.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 lobrdg_r_sw:
 	Inherits: ^bridge
@@ -189,13 +167,11 @@ lobrdg_r_sw:
 			TEMPERATE: lobrdg25.tem
 			SNOW: lobrdg25.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg26.tem
 			SNOW: lobrdg26.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bridge1:
 	idle:
@@ -207,7 +183,6 @@ bridge1:
 		ZRamp: 1
 		Offset: 0, -13, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bridge2:
 	idle:
@@ -220,7 +195,6 @@ bridge2:
 		ZRamp: 1
 		Offset: 0, -25, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 railbrdg1:
 	idle:
@@ -232,7 +206,6 @@ railbrdg1:
 		ZRamp: 1
 		Offset: 0, -13, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 railbrdg2:
 	idle:
@@ -245,4 +218,3 @@ railbrdg2:
 		ZRamp: 1
 		Offset: 0, -25, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False

--- a/mods/ts/sequences/bridges.yaml
+++ b/mods/ts/sequences/bridges.yaml
@@ -11,30 +11,44 @@ lobrdg_a:
 		TilesetFilenames:
 			TEMPERATE: lobrdg10.tem
 			SNOW: lobrdg10.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle2:
 		TilesetFilenames:
 			TEMPERATE: lobrdg11.tem
 			SNOW: lobrdg11.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle3:
 		TilesetFilenames:
 			TEMPERATE: lobrdg12.tem
 			SNOW: lobrdg12.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle4:
 		TilesetFilenames:
 			TEMPERATE: lobrdg13.tem
 			SNOW: lobrdg13.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	adead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg15.tem
 			SNOW: lobrdg15.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	bdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg14.tem
 			SNOW: lobrdg14.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	abdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg16.tem
 			SNOW: lobrdg16.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 lobrdg_a_d:
 	Inherits: ^bridge
@@ -42,6 +56,8 @@ lobrdg_a_d:
 		TilesetFilenames:
 			TEMPERATE: lobrdg28.tem
 			SNOW: lobrdg28.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	aramp:
 		TilesetFilenames:
 			TEMPERATE: lobrdg17.tem
@@ -61,30 +77,44 @@ lobrdg_b:
 		TilesetFilenames:
 			TEMPERATE: lobrdg01.tem
 			SNOW: lobrdg01.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle2:
 		TilesetFilenames:
 			TEMPERATE: lobrdg02.tem
 			SNOW: lobrdg02.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle3:
 		TilesetFilenames:
 			TEMPERATE: lobrdg03.tem
 			SNOW: lobrdg03.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle4:
 		TilesetFilenames:
 			TEMPERATE: lobrdg04.tem
 			SNOW: lobrdg04.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	adead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg05.tem
 			SNOW: lobrdg05.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	bdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg06.tem
 			SNOW: lobrdg06.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	abdead:
 		TilesetFilenames:
 			TEMPERATE: lobrdg07.tem
 			SNOW: lobrdg07.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 lobrdg_b_d:
 	Inherits: ^bridge
@@ -92,6 +122,8 @@ lobrdg_b_d:
 		TilesetFilenames:
 			TEMPERATE: lobrdg27.tem
 			SNOW: lobrdg27.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	aramp:
 		TilesetFilenames:
 			TEMPERATE: lobrdg08.tem
@@ -111,10 +143,14 @@ lobrdg_r_se:
 		TilesetFilenames:
 			TEMPERATE: lobrdg19.tem
 			SNOW: lobrdg19.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg20.tem
 			SNOW: lobrdg20.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 lobrdg_r_nw:
 	Inherits: ^bridge
@@ -122,10 +158,14 @@ lobrdg_r_nw:
 		TilesetFilenames:
 			TEMPERATE: lobrdg21.tem
 			SNOW: lobrdg21.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg22.tem
 			SNOW: lobrdg22.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 lobrdg_r_ne:
 	Inherits: ^bridge
@@ -133,10 +173,14 @@ lobrdg_r_ne:
 		TilesetFilenames:
 			TEMPERATE: lobrdg23.tem
 			SNOW: lobrdg23.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg24.tem
 			SNOW: lobrdg24.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 lobrdg_r_sw:
 	Inherits: ^bridge
@@ -144,10 +188,14 @@ lobrdg_r_sw:
 		TilesetFilenames:
 			TEMPERATE: lobrdg25.tem
 			SNOW: lobrdg25.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: lobrdg26.tem
 			SNOW: lobrdg26.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bridge1:
 	idle:
@@ -158,6 +206,8 @@ bridge1:
 		# ShadowStart: 18
 		ZRamp: 1
 		Offset: 0, -13, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bridge2:
 	idle:
@@ -169,6 +219,8 @@ bridge2:
 		# ShadowStart: 27
 		ZRamp: 1
 		Offset: 0, -25, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 railbrdg1:
 	idle:
@@ -179,6 +231,8 @@ railbrdg1:
 		# ShadowStart: 18
 		ZRamp: 1
 		Offset: 0, -13, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 railbrdg2:
 	idle:
@@ -190,3 +244,5 @@ railbrdg2:
 		# ShadowStart: 27
 		ZRamp: 1
 		Offset: 0, -25, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -5,7 +5,6 @@ ammocrat:
 		ShadowStart: 2
 		Offset: 0, -12, 12
 		Palette: player
-		IsPlayerPalette: False
 
 ^abanbase:
 	Defaults:
@@ -62,10 +61,8 @@ aban01:
 		Filename: aban01.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban02:
 	Inherits: ^aban5x3
@@ -73,10 +70,8 @@ aban02:
 		Filename: aban02.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban03:
 	Inherits: ^aban2x5
@@ -84,10 +79,8 @@ aban03:
 		Filename: aban03.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban04:
 	Inherits: ^aban4x2
@@ -95,10 +88,8 @@ aban04:
 		Filename: aban04.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban05:
 	Inherits: ^aban3x2
@@ -106,10 +97,8 @@ aban05:
 		Filename: aban05.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban06:
 	Inherits: ^aban2x2
@@ -117,10 +106,8 @@ aban06:
 		Filename: aban06.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban07:
 	Inherits: ^aban2x2
@@ -128,10 +115,8 @@ aban07:
 		Filename: aban07.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban08:
 	Inherits: ^aban2x2
@@ -139,10 +124,8 @@ aban08:
 		Filename: aban08.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban09:
 	Inherits: ^aban2x2
@@ -151,10 +134,8 @@ aban09:
 		Offset: 2, -20, 24
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban10:
 	Inherits: ^aban2x2
@@ -162,10 +143,8 @@ aban10:
 		Filename: aban10.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban11:
 	Inherits: ^aban2x2
@@ -174,10 +153,8 @@ aban11:
 		Offset: 0, -20, 24
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban12:
 	Inherits: ^aban2x2
@@ -186,10 +163,8 @@ aban12:
 		Offset: 2, -22, 24
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban13:
 	Inherits: ^aban1x1
@@ -198,10 +173,8 @@ aban13:
 		Offset: 0, -10, 12
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban14:
 	Inherits: ^aban1x1
@@ -209,10 +182,8 @@ aban14:
 		Filename: aban14.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban15:
 	Inherits: ^aban1x1
@@ -221,10 +192,8 @@ aban15:
 		Offset: 0, -10, 12
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban16:
 	Inherits: ^aban2x2
@@ -232,10 +201,8 @@ aban16:
 		Filename: aban16.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban17:
 	Inherits: ^aban1x1
@@ -243,10 +210,8 @@ aban17:
 		Filename: aban17.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 aban18:
 	Inherits: ^aban1x1
@@ -254,10 +219,8 @@ aban18:
 		Filename: aban18.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^bboard1x1:
 	Defaults:
@@ -292,10 +255,8 @@ bboard01:
 		Filename: bboard01.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard02:
 	Inherits: ^bboard1x1
@@ -303,10 +264,8 @@ bboard02:
 		Filename: bboard02.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard03:
 	Inherits: ^bboard1x1
@@ -314,10 +273,8 @@ bboard03:
 		Filename: bboard03.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard04:
 	Inherits: ^bboard1x1
@@ -325,10 +282,8 @@ bboard04:
 		Filename: bboard04.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard05:
 	Inherits: ^bboard1x1
@@ -336,10 +291,8 @@ bboard05:
 		Filename: bboard05.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard06:
 	Inherits: ^bboard1x2
@@ -347,10 +300,8 @@ bboard06:
 		Filename: bboard06.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard07:
 	Inherits: ^bboard1x2
@@ -358,10 +309,8 @@ bboard07:
 		Filename: bboard07.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard08:
 	Inherits: ^bboard1x2
@@ -369,10 +318,8 @@ bboard08:
 		Filename: bboard08.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard09:
 	Inherits: ^bboard1x1
@@ -380,10 +327,8 @@ bboard09:
 		Filename: bboard09.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard10:
 	Inherits: ^bboard1x1
@@ -391,10 +336,8 @@ bboard10:
 		Filename: bboard10.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard11:
 	Inherits: ^bboard1x1
@@ -402,10 +345,8 @@ bboard11:
 		Filename: bboard11.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard12:
 	Inherits: ^bboard1x1
@@ -413,10 +354,8 @@ bboard12:
 		Filename: bboard12.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard13:
 	Inherits: ^bboard1x1
@@ -424,10 +363,8 @@ bboard13:
 		Filename: bboard13.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard14:
 	Inherits: ^bboard2x1
@@ -435,10 +372,8 @@ bboard14:
 		Filename: bboard14.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard15:
 	Inherits: ^bboard2x1
@@ -446,10 +381,8 @@ bboard15:
 		Filename: bboard15.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 bboard16:
 	Inherits: ^bboard2x1
@@ -457,10 +390,8 @@ bboard16:
 		Filename: bboard16.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^cabase:
 	Defaults:
@@ -512,10 +443,8 @@ ca0001:
 			SNOW: ca0001.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0002:
 	Inherits: ^ca3x3
@@ -525,10 +454,8 @@ ca0002:
 			SNOW: ca0002.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0003:
 	Inherits: ^ca2x2
@@ -538,10 +465,8 @@ ca0003:
 			SNOW: ca0003.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0004:
 	Inherits: ^ca2x2
@@ -551,10 +476,8 @@ ca0004:
 			SNOW: ca0004.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0005:
 	Inherits: ^ca1x2
@@ -564,10 +487,8 @@ ca0005:
 			SNOW: ca0005.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0006:
 	Inherits: ^ca1x2
@@ -577,10 +498,8 @@ ca0006:
 			SNOW: ca0006.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0007:
 	Inherits: ^ca1x2
@@ -590,10 +509,8 @@ ca0007:
 			SNOW: ca0007.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0008:
 	Inherits: ^ca2x3
@@ -603,10 +520,8 @@ ca0008:
 			SNOW: ca0008.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0009:
 	Inherits: ^ca2x3
@@ -616,10 +531,8 @@ ca0009:
 			SNOW: ca0009.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0010:
 	Inherits: ^ca2x2
@@ -629,10 +542,8 @@ ca0010:
 			SNOW: ca0010.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0011:
 	Inherits: ^ca1x2
@@ -642,10 +553,8 @@ ca0011:
 			SNOW: ca0011.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0012:
 	Inherits: ^ca1x2
@@ -655,10 +564,8 @@ ca0012:
 			SNOW: ca0012.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0013:
 	Inherits: ^ca2x1
@@ -668,10 +575,8 @@ ca0013:
 			SNOW: ca0013.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0014:
 	Inherits: ^ca1x1
@@ -681,10 +586,8 @@ ca0014:
 			SNOW: ca0014.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0015:
 	Inherits: ^ca1x1
@@ -694,10 +597,8 @@ ca0015:
 			SNOW: ca0015.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0016:
 	Inherits: ^ca1x1
@@ -707,10 +608,8 @@ ca0016:
 			SNOW: ca0016.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0017:
 	Inherits: ^ca1x1
@@ -720,10 +619,8 @@ ca0017:
 			SNOW: ca0017.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0018:
 	Inherits: ^ca1x2
@@ -733,10 +630,8 @@ ca0018:
 			SNOW: ca0018.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0019:
 	Inherits: ^ca1x2
@@ -746,10 +641,8 @@ ca0019:
 			SNOW: ca0019.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0020:
 	Inherits: ^ca1x2
@@ -759,10 +652,8 @@ ca0020:
 			SNOW: ca0020.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ca0021:
 	Inherits: ^ca1x2
@@ -772,10 +663,8 @@ ca0021:
 			SNOW: ca0021.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 caarmr:
 	Defaults:
@@ -785,19 +674,16 @@ caarmr:
 		Filename: ctarmr.shp
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Filename: ctarmr.shp
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Filename: ctarmr.shp
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 
 caaray:
 	Defaults:
@@ -807,51 +693,43 @@ caaray:
 		Filename: ctaray.shp
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Filename: ctaray.shp
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Filename: ctaray.shp
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 	idle-satellite:
 		Filename: ctaray_a.shp
 		Length: 16
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: False
 	idle-radar:
 		Filename: ctaray_b.shp
 		Length: 16
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: False
 	idle-scanner:
 		Filename: ctaray_c.shp
 		Length: 16
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle-scanner:
 		Filename: ctaray_c.shp
 		Start: 16
 		Length: 16
 		Tick: 100
 		Palette: player
-		IsPlayerPalette: False
 	idle-light-bright:
 		Filename: ctaray_d.shp
 		Length: 12
 		Tick: 100
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-light-bright:
 		Filename: ctaray_d.shp
 		Start: 12
@@ -859,7 +737,6 @@ caaray:
 		Tick: 100
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 
 cabhut:
 	idle:
@@ -870,7 +747,6 @@ cabhut:
 		Offset: 0, -12, 12
 		ShadowStart: 1
 		Palette: player
-		IsPlayerPalette: False
 
 ^cacrsh:
 	idle:
@@ -883,7 +759,6 @@ cacrsh01:
 			TEMPERATE: ctcrsh01.shp
 			SNOW: cacrsh01.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 cacrsh02:
 	Inherits: ^cacrsh
@@ -892,7 +767,6 @@ cacrsh02:
 			TEMPERATE: ctcrsh02.shp
 			SNOW: cacrsh02.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 cacrsh03:
 	Inherits: ^cacrsh
@@ -901,7 +775,6 @@ cacrsh03:
 			TEMPERATE: ctcrsh03.shp
 			SNOW: cacrsh03.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 cacrsh04:
 	Inherits: ^cacrsh
@@ -910,7 +783,6 @@ cacrsh04:
 			TEMPERATE: ctcrsh04.shp
 			SNOW: cacrsh04.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 cacrsh05:
 	Inherits: ^cacrsh
@@ -919,7 +791,6 @@ cacrsh05:
 			TEMPERATE: ctcrsh05.shp
 			SNOW: cacrsh05.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 cahosp:
 	Defaults:
@@ -932,17 +803,14 @@ cahosp:
 	idle:
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 
 capyr01:
 	idle:
@@ -951,7 +819,6 @@ capyr01:
 		ShadowStart: 1
 		Offset: 0, -24, 24
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 capyr02:
 	idle:
@@ -960,7 +827,6 @@ capyr02:
 		ShadowStart: 1
 		Offset: 0, -48, 48
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 capyr03:
 	idle:
@@ -969,7 +835,6 @@ capyr03:
 		ShadowStart: 1
 		Offset: 0, -48, 48
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^city1x1:
 	Inherits: ^cabase
@@ -1018,10 +883,8 @@ city01:
 		Offset: -12, -30, 36
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city02:
 	Inherits: ^city2x3
@@ -1029,10 +892,8 @@ city02:
 		Filename: city02.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city03:
 	Inherits: ^city3x2
@@ -1040,10 +901,8 @@ city03:
 		Filename: city03.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city04:
 	Inherits: ^city3x2
@@ -1051,10 +910,8 @@ city04:
 		Filename: city04.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city05:
 	Inherits: ^city3x2
@@ -1062,10 +919,8 @@ city05:
 		Filename: city05.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city06:
 	Inherits: ^city4x2
@@ -1073,10 +928,8 @@ city06:
 		Filename: city06.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city07:
 	Inherits: ^city4x2
@@ -1085,10 +938,8 @@ city07:
 		Offset: -12, -30, 36
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city08:
 	Inherits: ^city2x2
@@ -1096,10 +947,8 @@ city08:
 		Filename: city08.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city09:
 	Inherits: ^city2x2
@@ -1107,10 +956,8 @@ city09:
 		Filename: city09.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city10:
 	Inherits: ^city2x2
@@ -1118,10 +965,8 @@ city10:
 		Filename: city10.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city11:
 	Inherits: ^city2x2
@@ -1129,10 +974,8 @@ city11:
 		Filename: city11.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city12:
 	Inherits: ^city2x2
@@ -1140,10 +983,8 @@ city12:
 		Filename: city12.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city13:
 	Inherits: ^city2x2
@@ -1151,10 +992,8 @@ city13:
 		Filename: city13.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city14:
 	Inherits: ^city1x1
@@ -1162,10 +1001,8 @@ city14:
 		Filename: city14.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city15:
 	Inherits: ^city4x2
@@ -1173,10 +1010,8 @@ city15:
 		Filename: city15.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city16:
 	Inherits: ^city4x2
@@ -1185,10 +1020,8 @@ city16:
 		Offset: -24, -30, 36
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city17:
 	Inherits: ^city4x3
@@ -1196,10 +1029,8 @@ city17:
 		Filename: city17.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city18:
 	Inherits: ^city3x5
@@ -1207,10 +1038,8 @@ city18:
 		Filename: city18.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city19:
 	Inherits: ^city2x2
@@ -1218,10 +1047,8 @@ city19:
 		Filename: city19.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city20:
 	Inherits: ^city1x1
@@ -1229,10 +1056,8 @@ city20:
 		Filename: city20.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city21:
 	Inherits: ^city1x1
@@ -1240,10 +1065,8 @@ city21:
 		Filename: city21.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 city22:
 	Inherits: ^city2x2
@@ -1251,10 +1074,8 @@ city22:
 		Filename: city22.shp
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ctdam:
 	Defaults:
@@ -1262,18 +1083,15 @@ ctdam:
 		Offset: 36,-42, 42
 	idle:
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle-lights-bright:
 		Filename: ctdam_a.shp
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		Filename: ctdam_a.shp
 		Start: 10
@@ -1281,34 +1099,29 @@ ctdam:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-water-a:
 		Filename: ctdam_b.shp
 		Length: 8
 		Tick: 200
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle-water-a:
 		Filename: ctdam_b.shp
 		Start: 8
 		Length: 8
 		Tick: 200
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	idle-water-b:
 		Filename: ctdam_b.shp
 		Start: 16
 		Length: 8
 		Tick: 200
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle-water-b:
 		Filename: ctdam_b.shp
 		Start: 24
 		Length: 8
 		Tick: 200
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ctvega:
 	Defaults:
@@ -1318,17 +1131,14 @@ ctvega:
 	idle:
 		ShadowStart: 3
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Palette: terraindecoration
-		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^gaoldcc:
 	idle:
@@ -1401,17 +1211,14 @@ gakodk:
 	idle:
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 	large-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
@@ -1428,7 +1235,6 @@ gakodk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-large-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
@@ -1447,7 +1253,6 @@ gakodk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	small-light:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_b.shp
@@ -1464,7 +1269,6 @@ gakodk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	small-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
@@ -1481,7 +1285,6 @@ gakodk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-small-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
@@ -1500,7 +1303,6 @@ gakodk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 
 gaspot:
 	Defaults:
@@ -1532,7 +1334,6 @@ gaspot:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtspot_a.shp
@@ -1542,7 +1343,6 @@ gaspot:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtspotmk.shp
@@ -1561,7 +1361,6 @@ gaspot:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: spoticon.shp
 		TilesetFilenames:
@@ -1578,9 +1377,6 @@ galite:
 			SNOW: galite.shp
 		ShadowStart: 2
 		Palette: terraindecoration
-		IsPlayerPalette: False
-		Palette: terrainalpha
-		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: gtlite.shp
@@ -1588,9 +1384,6 @@ galite:
 		Start: 1
 		ShadowStart: 3
 		Palette: terraindecoration
-		IsPlayerPalette: False
-		Palette: terrainalpha
-		IsPlayerPalette: False
 	lighting:
 		Filename: alphatst.shp
 		BlendMode: DoubleMultiplicative
@@ -1600,7 +1393,6 @@ galite:
 		ZRamp: 1
 		ZOffset: 10240
 		Palette: alpha
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -1610,11 +1402,17 @@ galite:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: liteicon.shp
 		Offset: 0, 0
 		DepthSprite:
+
+galite-editor:
+	Inherits: galite
+	idle:
+		Palette: terrainalpha
+	damaged-idle:
+		Palette: terrainalpha
 
 namntk:
 	Defaults:
@@ -1627,17 +1425,14 @@ namntk:
 	idle:
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntmntk_a.shp
@@ -1654,7 +1449,6 @@ namntk:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 
 ntpyra:
 	Defaults:
@@ -1664,30 +1458,25 @@ ntpyra:
 	idle:
 		ShadowStart: 3
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Palette: player
-		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
 		Palette: player
-		IsPlayerPalette: False
 	idle-lights:
 		Filename: ntpyra_a.shp
 		Length: 16
 		Tick: 200
 		Palette: player
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		Filename: ntpyra_a.shp
 		Start: 16
 		Length: 16
 		Tick: 200
 		Palette: player
-		IsPlayerPalette: False
 
 ufo:
 	idle:
@@ -1695,4 +1484,3 @@ ufo:
 		DepthSprite: isodepth.shp
 		Offset: -24, -60, 60
 		Palette: terraindecoration
-		IsPlayerPalette: False

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -4,6 +4,8 @@ ammocrat:
 		DepthSprite: isodepth.shp
 		ShadowStart: 2
 		Offset: 0, -12, 12
+		Palette: player
+		IsPlayerPalette: False
 
 ^abanbase:
 	Defaults:
@@ -58,96 +60,204 @@ aban01:
 	Inherits: ^aban2x6
 	Defaults:
 		Filename: aban01.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban02:
 	Inherits: ^aban5x3
 	Defaults:
 		Filename: aban02.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban03:
 	Inherits: ^aban2x5
 	Defaults:
 		Filename: aban03.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban04:
 	Inherits: ^aban4x2
 	Defaults:
 		Filename: aban04.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban05:
 	Inherits: ^aban3x2
 	Defaults:
 		Filename: aban05.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban06:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban06.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban07:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban07.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban08:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban08.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban09:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban09.shp
 		Offset: 2, -20, 24
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban10:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban10.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban11:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban11.shp
 		Offset: 0, -20, 24
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban12:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban12.shp
 		Offset: 2, -22, 24
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban13:
 	Inherits: ^aban1x1
 	Defaults:
 		Filename: aban13.shp
 		Offset: 0, -10, 12
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban14:
 	Inherits: ^aban1x1
 	Defaults:
 		Filename: aban14.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban15:
 	Inherits: ^aban1x1
 	Defaults:
 		Filename: aban15.shp
 		Offset: 0, -10, 12
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban16:
 	Inherits: ^aban2x2
 	Defaults:
 		Filename: aban16.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban17:
 	Inherits: ^aban1x1
 	Defaults:
 		Filename: aban17.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 aban18:
 	Inherits: ^aban1x1
 	Defaults:
 		Filename: aban18.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	critical-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^bboard1x1:
 	Defaults:
@@ -180,81 +290,177 @@ bboard01:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard01.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard02:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard02.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard03:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard03.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard04:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard04.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard05:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard05.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard06:
 	Inherits: ^bboard1x2
 	Defaults:
 		Filename: bboard06.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard07:
 	Inherits: ^bboard1x2
 	Defaults:
 		Filename: bboard07.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard08:
 	Inherits: ^bboard1x2
 	Defaults:
 		Filename: bboard08.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard09:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard09.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard10:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard10.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard11:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard11.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard12:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard12.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard13:
 	Inherits: ^bboard1x1
 	Defaults:
 		Filename: bboard13.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard14:
 	Inherits: ^bboard2x1
 	Defaults:
 		Filename: bboard14.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard15:
 	Inherits: ^bboard2x1
 	Defaults:
 		Filename: bboard15.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 bboard16:
 	Inherits: ^bboard2x1
 	Defaults:
 		Filename: bboard16.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^cabase:
 	Defaults:
@@ -304,6 +510,12 @@ ca0001:
 		TilesetFilenames:
 			TEMPERATE: ct0001.shp
 			SNOW: ca0001.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0002:
 	Inherits: ^ca3x3
@@ -311,6 +523,12 @@ ca0002:
 		TilesetFilenames:
 			TEMPERATE: ct0002.shp
 			SNOW: ca0002.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0003:
 	Inherits: ^ca2x2
@@ -318,6 +536,12 @@ ca0003:
 		TilesetFilenames:
 			TEMPERATE: ct0003.shp
 			SNOW: ca0003.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0004:
 	Inherits: ^ca2x2
@@ -325,6 +549,12 @@ ca0004:
 		TilesetFilenames:
 			TEMPERATE: ct0004.shp
 			SNOW: ca0004.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0005:
 	Inherits: ^ca1x2
@@ -332,6 +562,12 @@ ca0005:
 		TilesetFilenames:
 			TEMPERATE: ct0005.shp
 			SNOW: ca0005.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0006:
 	Inherits: ^ca1x2
@@ -339,6 +575,12 @@ ca0006:
 		TilesetFilenames:
 			TEMPERATE: ct0006.shp
 			SNOW: ca0006.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0007:
 	Inherits: ^ca1x2
@@ -346,6 +588,12 @@ ca0007:
 		TilesetFilenames:
 			TEMPERATE: ct0007.shp
 			SNOW: ca0007.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0008:
 	Inherits: ^ca2x3
@@ -353,6 +601,12 @@ ca0008:
 		TilesetFilenames:
 			TEMPERATE: ct0008.shp
 			SNOW: ca0008.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0009:
 	Inherits: ^ca2x3
@@ -360,6 +614,12 @@ ca0009:
 		TilesetFilenames:
 			TEMPERATE: ct0009.shp
 			SNOW: ca0009.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0010:
 	Inherits: ^ca2x2
@@ -367,6 +627,12 @@ ca0010:
 		TilesetFilenames:
 			TEMPERATE: ct0010.shp
 			SNOW: ca0010.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0011:
 	Inherits: ^ca1x2
@@ -374,6 +640,12 @@ ca0011:
 		TilesetFilenames:
 			TEMPERATE: ct0011.shp
 			SNOW: ca0011.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0012:
 	Inherits: ^ca1x2
@@ -381,6 +653,12 @@ ca0012:
 		TilesetFilenames:
 			TEMPERATE: ct0012.shp
 			SNOW: ca0012.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0013:
 	Inherits: ^ca2x1
@@ -388,6 +666,12 @@ ca0013:
 		TilesetFilenames:
 			TEMPERATE: ct0013.shp
 			SNOW: ca0013.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0014:
 	Inherits: ^ca1x1
@@ -395,6 +679,12 @@ ca0014:
 		TilesetFilenames:
 			TEMPERATE: ct0014.shp
 			SNOW: ca0014.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0015:
 	Inherits: ^ca1x1
@@ -402,6 +692,12 @@ ca0015:
 		TilesetFilenames:
 			TEMPERATE: ct0015.shp
 			SNOW: ca0015.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0016:
 	Inherits: ^ca1x1
@@ -409,6 +705,12 @@ ca0016:
 		TilesetFilenames:
 			TEMPERATE: ct0016.shp
 			SNOW: ca0016.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0017:
 	Inherits: ^ca1x1
@@ -416,6 +718,12 @@ ca0017:
 		TilesetFilenames:
 			TEMPERATE: ct0017.shp
 			SNOW: ca0017.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0018:
 	Inherits: ^ca1x2
@@ -423,6 +731,12 @@ ca0018:
 		TilesetFilenames:
 			TEMPERATE: ct0018.shp
 			SNOW: ca0018.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0019:
 	Inherits: ^ca1x2
@@ -430,6 +744,12 @@ ca0019:
 		TilesetFilenames:
 			TEMPERATE: ct0019.shp
 			SNOW: ca0019.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0020:
 	Inherits: ^ca1x2
@@ -437,6 +757,12 @@ ca0020:
 		TilesetFilenames:
 			TEMPERATE: ct0020.shp
 			SNOW: ca0020.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ca0021:
 	Inherits: ^ca1x2
@@ -444,6 +770,12 @@ ca0021:
 		TilesetFilenames:
 			TEMPERATE: ct0021.shp
 			SNOW: ca0021.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 caarmr:
 	Defaults:
@@ -452,14 +784,20 @@ caarmr:
 	idle:
 		Filename: ctarmr.shp
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: ctarmr.shp
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Filename: ctarmr.shp
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 
 caaray:
 	Defaults:
@@ -468,42 +806,60 @@ caaray:
 	idle:
 		Filename: ctaray.shp
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Filename: ctaray.shp
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Filename: ctaray.shp
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 	idle-satellite:
 		Filename: ctaray_a.shp
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: False
 	idle-radar:
 		Filename: ctaray_b.shp
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: False
 	idle-scanner:
 		Filename: ctaray_c.shp
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle-scanner:
 		Filename: ctaray_c.shp
 		Start: 16
 		Length: 16
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: False
 	idle-light-bright:
 		Filename: ctaray_d.shp
 		Length: 12
 		Tick: 100
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-light-bright:
 		Filename: ctaray_d.shp
 		Start: 12
 		Length: 12
 		Tick: 100
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 
 cabhut:
 	idle:
@@ -513,6 +869,8 @@ cabhut:
 		DepthSprite: isodepth.shp
 		Offset: 0, -12, 12
 		ShadowStart: 1
+		Palette: player
+		IsPlayerPalette: False
 
 ^cacrsh:
 	idle:
@@ -524,6 +882,8 @@ cacrsh01:
 		TilesetFilenames:
 			TEMPERATE: ctcrsh01.shp
 			SNOW: cacrsh01.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 cacrsh02:
 	Inherits: ^cacrsh
@@ -531,6 +891,8 @@ cacrsh02:
 		TilesetFilenames:
 			TEMPERATE: ctcrsh02.shp
 			SNOW: cacrsh02.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 cacrsh03:
 	Inherits: ^cacrsh
@@ -538,6 +900,8 @@ cacrsh03:
 		TilesetFilenames:
 			TEMPERATE: ctcrsh03.shp
 			SNOW: cacrsh03.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 cacrsh04:
 	Inherits: ^cacrsh
@@ -545,6 +909,8 @@ cacrsh04:
 		TilesetFilenames:
 			TEMPERATE: ctcrsh04.shp
 			SNOW: cacrsh04.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 cacrsh05:
 	Inherits: ^cacrsh
@@ -552,6 +918,8 @@ cacrsh05:
 		TilesetFilenames:
 			TEMPERATE: ctcrsh05.shp
 			SNOW: cacrsh05.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 cahosp:
 	Defaults:
@@ -563,12 +931,18 @@ cahosp:
 		Offset: 15, -36, 36
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 
 capyr01:
 	idle:
@@ -576,6 +950,8 @@ capyr01:
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -24, 24
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 capyr02:
 	idle:
@@ -583,6 +959,8 @@ capyr02:
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -48, 48
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 capyr03:
 	idle:
@@ -590,6 +968,8 @@ capyr03:
 		DepthSprite: isodepth.shp
 		ShadowStart: 1
 		Offset: 0, -48, 48
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^city1x1:
 	Inherits: ^cabase
@@ -636,151 +1016,299 @@ city01:
 	Defaults:
 		Filename: city01.shp
 		Offset: -12, -30, 36
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city02:
 	Inherits: ^city2x3
 	Defaults:
 		Filename: city02.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city03:
 	Inherits: ^city3x2
 	Defaults:
 		Filename: city03.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city04:
 	Inherits: ^city3x2
 	Defaults:
 		Filename: city04.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city05:
 	Inherits: ^city3x2
 	Defaults:
 		Filename: city05.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city06:
 	Inherits: ^city4x2
 	Defaults:
 		Filename: city06.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city07:
 	Inherits: ^city4x2
 	Defaults:
 		Filename: city07.shp
 		Offset: -12, -30, 36
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city08:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city08.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city09:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city09.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city10:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city10.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city11:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city11.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city12:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city12.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city13:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city13.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city14:
 	Inherits: ^city1x1
 	Defaults:
 		Filename: city14.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city15:
 	Inherits: ^city4x2
 	Defaults:
 		Filename: city15.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city16:
 	Inherits: ^city4x2
 	Defaults:
 		Filename: city16.shp
 		Offset: -24, -30, 36
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city17:
 	Inherits: ^city4x3
 	Defaults:
 		Filename: city17.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city18:
 	Inherits: ^city3x5
 	Defaults:
 		Filename: city18.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city19:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city19.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city20:
 	Inherits: ^city1x1
 	Defaults:
 		Filename: city20.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city21:
 	Inherits: ^city1x1
 	Defaults:
 		Filename: city21.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 city22:
 	Inherits: ^city2x2
 	Defaults:
 		Filename: city22.shp
+	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
+	damaged-idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ctdam:
 	Defaults:
 		Filename: ctdam.shp
 		Offset: 36,-42, 42
 	idle:
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle-lights-bright:
 		Filename: ctdam_a.shp
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		Filename: ctdam_a.shp
 		Start: 10
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-water-a:
 		Filename: ctdam_b.shp
 		Length: 8
 		Tick: 200
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle-water-a:
 		Filename: ctdam_b.shp
 		Start: 8
 		Length: 8
 		Tick: 200
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	idle-water-b:
 		Filename: ctdam_b.shp
 		Start: 16
 		Length: 8
 		Tick: 200
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle-water-b:
 		Filename: ctdam_b.shp
 		Start: 24
 		Length: 8
 		Tick: 200
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ctvega:
 	Defaults:
@@ -789,12 +1317,18 @@ ctvega:
 		Offset: 0, -48, 48
 	idle:
 		ShadowStart: 3
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: terraindecoration
+		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^gaoldcc:
 	idle:
@@ -808,6 +1342,8 @@ gaoldcc1:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc1.shp
 			SNOW: gaoldcc1.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gaoldcc2:
 	Inherits: ^gaoldcc
@@ -815,6 +1351,8 @@ gaoldcc2:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc2.shp
 			SNOW: gaoldcc2.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gaoldcc3:
 	Inherits: ^gaoldcc
@@ -822,6 +1360,8 @@ gaoldcc3:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc3.shp
 			SNOW: gaoldcc3.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gaoldcc4:
 	Inherits: ^gaoldcc
@@ -829,6 +1369,8 @@ gaoldcc4:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc4.shp
 			SNOW: gaoldcc4.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gaoldcc5:
 	Inherits: ^gaoldcc
@@ -836,6 +1378,8 @@ gaoldcc5:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc5.shp
 			SNOW: gaoldcc5.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gaoldcc6:
 	Inherits: ^gaoldcc
@@ -843,6 +1387,8 @@ gaoldcc6:
 		TilesetFilenames:
 			TEMPERATE: gtoldcc6.shp
 			SNOW: gaoldcc6.shp
+		Palette: player
+		IsPlayerPalette: True
 
 gakodk:
 	Defaults:
@@ -854,18 +1400,26 @@ gakodk:
 		Offset: -24, -36, 36
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 	large-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
 			SNOW: gakodk_a.shp
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	large-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
@@ -873,6 +1427,8 @@ gakodk:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-large-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
@@ -880,6 +1436,8 @@ gakodk:
 		Start: 12
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-large-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_a.shp
@@ -888,12 +1446,16 @@ gakodk:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	small-light:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_b.shp
 			SNOW: gakodk_b.shp
 		Length: 22
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	small-light-bright:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_b.shp
@@ -901,12 +1463,16 @@ gakodk:
 		Length: 22
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	small-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
 			SNOW: gakodk_c.shp
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	small-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
@@ -914,6 +1480,8 @@ gakodk:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-small-lights:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
@@ -921,6 +1489,8 @@ gakodk:
 		Start: 12
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-small-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtkodk_c.shp
@@ -929,6 +1499,8 @@ gakodk:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 
 gaspot:
 	Defaults:
@@ -939,13 +1511,19 @@ gaspot:
 		Offset: 0, -12, 12
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtspot_a.shp
@@ -953,6 +1531,8 @@ gaspot:
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtspot_a.shp
@@ -961,12 +1541,16 @@ gaspot:
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtspotmk.shp
 			SNOW: gaspotmk.shp
 		Length: 14
 		ShadowStart: 14
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -976,6 +1560,8 @@ gaspot:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: spoticon.shp
 		TilesetFilenames:
@@ -991,12 +1577,20 @@ galite:
 			TEMPERATE: gtlite.shp
 			SNOW: galite.shp
 		ShadowStart: 2
+		Palette: terraindecoration
+		IsPlayerPalette: False
+		Palette: terrainalpha
+		IsPlayerPalette: False
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: gtlite.shp
 			SNOW: galite.shp
 		Start: 1
 		ShadowStart: 3
+		Palette: terraindecoration
+		IsPlayerPalette: False
+		Palette: terrainalpha
+		IsPlayerPalette: False
 	lighting:
 		Filename: alphatst.shp
 		BlendMode: DoubleMultiplicative
@@ -1005,6 +1599,8 @@ galite:
 		Offset: 0, 0, 240
 		ZRamp: 1
 		ZOffset: 10240
+		Palette: alpha
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -1013,6 +1609,8 @@ galite:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: liteicon.shp
 		Offset: 0, 0
@@ -1028,18 +1626,26 @@ namntk:
 		Offset: 24, -24, 24
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntmntk_a.shp
 			SNOW: namntk_a.shp
 		Length: 8
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntmntk_a.shp
@@ -1047,6 +1653,8 @@ namntk:
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 
 ntpyra:
 	Defaults:
@@ -1055,24 +1663,36 @@ ntpyra:
 		Offset: 0, -42, 42
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: False
 	critical-idle:
 		Start: 2
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: False
 	idle-lights:
 		Filename: ntpyra_a.shp
 		Length: 16
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		Filename: ntpyra_a.shp
 		Start: 16
 		Length: 16
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: False
 
 ufo:
 	idle:
 		Filename: ufo.tem
 		DepthSprite: isodepth.shp
 		Offset: -24, -60, 60
+		Palette: terraindecoration
+		IsPlayerPalette: False

--- a/mods/ts/sequences/critters.yaml
+++ b/mods/ts/sequences/critters.yaml
@@ -7,14 +7,12 @@ doggie:
 		Facings: 8
 		ShadowStart: 119
 		Palette: greentiberium
-		IsPlayerPalette: False
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 127
 		Palette: greentiberium
-		IsPlayerPalette: False
 	attack:
 		Start: 56
 		Length: 4
@@ -25,12 +23,10 @@ doggie:
 		Length: 2
 		ShadowStart: 207
 		Palette: greentiberium
-		IsPlayerPalette: False
 	hide:
 		Start: 90
 		ShadowStart: 209
 		Palette: greentiberium
-		IsPlayerPalette: False
 	idle1:
 		Start: 91
 		Length: 8
@@ -51,7 +47,6 @@ doggie:
 		Filename: s_bang34.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	die-crushed:
 		Start: 105
 		Length: 4
@@ -72,7 +67,6 @@ doggie:
 		Length: 10
 		ShadowStart: 228
 		Palette: ra
-		IsPlayerPalette: False
 
 vissml:
 	idle:
@@ -120,7 +114,6 @@ floater:
 		Tick: 100
 		Offset: 0, 0, 16
 		Palette: player-nobright
-		IsPlayerPalette: False
 	attack:
 		Length: 16
 		Start: 16
@@ -128,7 +121,6 @@ floater:
 		Tick: 100
 		Offset: 0, 0, 16
 		Palette: player-nobright
-		IsPlayerPalette: False
 	attack-shock:
 		Length: 16
 		Start: 16
@@ -136,4 +128,3 @@ floater:
 		Offset: 0, 0, 16
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False

--- a/mods/ts/sequences/critters.yaml
+++ b/mods/ts/sequences/critters.yaml
@@ -6,11 +6,15 @@ doggie:
 	stand:
 		Facings: 8
 		ShadowStart: 119
+		Palette: greentiberium
+		IsPlayerPalette: False
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 127
+		Palette: greentiberium
+		IsPlayerPalette: False
 	attack:
 		Start: 56
 		Length: 4
@@ -20,9 +24,13 @@ doggie:
 		Start: 88
 		Length: 2
 		ShadowStart: 207
+		Palette: greentiberium
+		IsPlayerPalette: False
 	hide:
 		Start: 90
 		ShadowStart: 209
+		Palette: greentiberium
+		IsPlayerPalette: False
 	idle1:
 		Start: 91
 		Length: 8
@@ -31,28 +39,40 @@ doggie:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
+		Palette: player
+		IsPlayerPalette: True
 	die-flying:
 		Start: 99
 		Length: 10
 		ShadowStart: 218
+		Palette: player
+		IsPlayerPalette: True
 	die-exploding:
 		Filename: s_bang34.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	die-crushed:
 		Start: 105
 		Length: 4
 		ShadowStart: 224
 		Tick: 800
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	die-burning:
 		Start: 109
 		Length: 10
 		ShadowStart: 228
 		IgnoreWorldTint: True
+		Palette: player
+		IsPlayerPalette: True
 	die-melting:
 		Start: 109
 		Length: 10
 		ShadowStart: 228
+		Palette: ra
+		IsPlayerPalette: False
 
 vissml:
 	idle:
@@ -61,6 +81,8 @@ vissml:
 		ShadowStart: 90
 		Tick: 80
 		Offset: 0, 0, 16
+		Palette: player
+		IsPlayerPalette: True
 
 vislrg:
 	idle:
@@ -69,6 +91,8 @@ vislrg:
 		ShadowStart: 90
 		Tick: 80
 		Offset: 0, 0, 16
+		Palette: player
+		IsPlayerPalette: True
 	attack:
 		Combine:
 			0:
@@ -83,6 +107,8 @@ vislrg:
 		Length: 5
 		Tick: 80
 		Offset: 0, 0, 16
+		Palette: player
+		IsPlayerPalette: True
 #		ShadowStart: 40 # TODO: enable shadow frames
 
 floater:
@@ -93,15 +119,21 @@ floater:
 		ShadowStart: 32
 		Tick: 100
 		Offset: 0, 0, 16
+		Palette: player-nobright
+		IsPlayerPalette: False
 	attack:
 		Length: 16
 		Start: 16
 		ShadowStart: 48
 		Tick: 100
 		Offset: 0, 0, 16
+		Palette: player-nobright
+		IsPlayerPalette: False
 	attack-shock:
 		Length: 16
 		Start: 16
 		Tick: 100
 		Offset: 0, 0, 16
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -85,7 +85,6 @@ e1.gdi:
 	icon:
 		Filename: sidebar-gdi|e1icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -103,7 +102,6 @@ e1.gdi:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -115,7 +113,6 @@ e1.gdi:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -124,10 +121,8 @@ e1.gdi:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -140,7 +135,6 @@ e1.nod:
 	icon:
 		Filename: sidebar-nod|e1icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -158,7 +152,6 @@ e1.nod:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -170,7 +163,6 @@ e1.nod:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -179,10 +171,8 @@ e1.nod:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -195,7 +185,6 @@ e2:
 	icon:
 		Filename: e2icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -213,7 +202,6 @@ e2:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -225,7 +213,6 @@ e2:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -234,10 +221,8 @@ e2:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -250,7 +235,6 @@ e3:
 	icon:
 		Filename: e4icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -268,7 +252,6 @@ e3:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -280,7 +263,6 @@ e3:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -289,10 +271,8 @@ e3:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -304,7 +284,6 @@ engineer.gdi:
 	icon:
 		Filename: sidebar-gdi|engnicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -331,10 +310,8 @@ engineer.gdi:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -346,7 +323,6 @@ engineer.nod:
 	icon:
 		Filename: sidebar-nod|engnicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -373,10 +349,8 @@ engineer.nod:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -405,7 +379,6 @@ umagon:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -417,7 +390,6 @@ umagon:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -426,10 +398,8 @@ umagon:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -442,7 +412,6 @@ ghost:
 	icon:
 		Filename: gosticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -460,7 +429,6 @@ ghost:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -472,7 +440,6 @@ ghost:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -481,10 +448,8 @@ ghost:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -496,7 +461,6 @@ mhijack:
 	icon:
 		Filename: chamicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -523,10 +487,8 @@ mhijack:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -563,10 +525,8 @@ chamspy:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -595,7 +555,6 @@ mutant:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -607,7 +566,6 @@ mutant:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -616,10 +574,8 @@ mutant:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -648,7 +604,6 @@ mwmn:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -660,7 +615,6 @@ mwmn:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -669,10 +623,8 @@ mwmn:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -701,7 +653,6 @@ mutant3:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: bright
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nobright
 		IsPlayerPalette: True
@@ -713,7 +664,6 @@ mutant3:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: bright
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -722,10 +672,8 @@ mutant3:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -762,10 +710,8 @@ tratos:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -792,7 +738,6 @@ oxanna:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -804,7 +749,6 @@ oxanna:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -813,10 +757,8 @@ oxanna:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -843,7 +785,6 @@ slav:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-run:
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
@@ -855,7 +796,6 @@ slav:
 		IsPlayerPalette: True
 	prone-attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling:
 		Palette: player
 		IsPlayerPalette: True
@@ -864,10 +804,8 @@ slav:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -890,7 +828,6 @@ civ1:
 		ShadowStart: 456
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	panic-run:
 		Start: 86
 		Length: 6
@@ -917,10 +854,8 @@ civ1:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -955,10 +890,8 @@ civ2:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -968,23 +901,15 @@ civ3:
 	Defaults:
 		Filename: civ3.shp
 	run:
-		Palette: player
-		IsPlayerPalette: True
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
 	stand:
-		Palette: player
-		IsPlayerPalette: True
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
 	panic-run:
-		Palette: player
-		IsPlayerPalette: True
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
 	panic-stand:
-		Palette: player
-		IsPlayerPalette: True
 		Palette: player-nomuzzle
 		IsPlayerPalette: True
 	die-twirling:
@@ -995,10 +920,8 @@ civ3:
 		IsPlayerPalette: True
 	die-exploding:
 		Palette: effect
-		IsPlayerPalette: False
 	die-melting:
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Palette: player
 		IsPlayerPalette: True
@@ -1007,7 +930,6 @@ civ3:
 		IsPlayerPalette: True
 	attack-muzzle:
 		Palette: muzzle
-		IsPlayerPalette: False
 
 cyborg:
 	Defaults:
@@ -1065,7 +987,6 @@ cyborg:
 		Facings: 8
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	crippled-attack:
 		Start: 212
 		Length: 6
@@ -1079,7 +1000,6 @@ cyborg:
 		Facings: 8
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -1087,11 +1007,9 @@ cyborg:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: cybiicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 cyc2:
 	Defaults:
@@ -1150,7 +1068,6 @@ cyc2:
 		ShadowStart: 520
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	crippled-attack:
 		Start: 260
 		Length: 6
@@ -1165,7 +1082,6 @@ cyc2:
 		ShadowStart: 568
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -1173,11 +1089,9 @@ cyc2:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: cybcicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 medic:
 	Defaults:
@@ -1238,7 +1152,6 @@ medic:
 		Filename: s_bang34.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	die-crushed:
 		Start: 159
 		Length: 5
@@ -1263,11 +1176,9 @@ medic:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: mediicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 jumpjet:
 	Defaults:
@@ -1319,7 +1230,6 @@ jumpjet:
 		Start: 292
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	die-twirling: # TODO: animation for falling from sky starts at 436
 		Start: 445
 		Length: 6
@@ -1346,7 +1256,6 @@ jumpjet:
 		Filename: s_bang34.shp
 		Length: *
 		Palette: effect
-		IsPlayerPalette: False
 	die-crushed:
 		Start: 450
 		ShadowStart: 901
@@ -1367,7 +1276,6 @@ jumpjet:
 		Facings: 8
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	flying-attack:
 		Start: 388
 		Facings: 8
@@ -1381,7 +1289,6 @@ jumpjet:
 		Length: 6
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	prone-attack:
 		Start: 212
 		Length: 6
@@ -1402,11 +1309,9 @@ jumpjet:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: jjeticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 weedguy:
 	Defaults:
@@ -1482,7 +1387,6 @@ weedguy:
 		Length: 11
 		ShadowStart: 368
 		Palette: effect
-		IsPlayerPalette: False
 	die-burning:
 		Start: 177
 		Length: 20
@@ -1494,7 +1398,6 @@ weedguy:
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
 		Palette: ra
-		IsPlayerPalette: False
 	die-crushed:
 		Start: 174
 		Length: 3

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -84,6 +84,53 @@ e1.gdi:
 		Filename: e1.shp
 	icon:
 		Filename: sidebar-gdi|e1icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 e1.nod:
 	Inherits: ^BasicInfantry
@@ -92,6 +139,53 @@ e1.nod:
 		Filename: e1.shp
 	icon:
 		Filename: sidebar-nod|e1icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 e2:
 	Inherits: ^BasicInfantry
@@ -100,6 +194,53 @@ e2:
 		Filename: e2.shp
 	icon:
 		Filename: e2icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 e3:
 	Inherits: ^BasicInfantry
@@ -108,6 +249,53 @@ e3:
 		Filename: e3.shp
 	icon:
 		Filename: e4icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 engineer.gdi:
 	Inherits: ^BasicInfantry
@@ -115,6 +303,41 @@ engineer.gdi:
 		Filename: engineer.shp
 	icon:
 		Filename: sidebar-gdi|engnicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 engineer.nod:
 	Inherits: ^BasicInfantry
@@ -122,6 +345,41 @@ engineer.nod:
 		Filename: engineer.shp
 	icon:
 		Filename: sidebar-nod|engnicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 umagon:
 	Inherits: ^BasicInfantry
@@ -130,6 +388,51 @@ umagon:
 		Filename: umagon.shp
 	icon:
 		Filename: umagicon.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 ghost:
 	Inherits: ^BasicInfantry
@@ -138,6 +441,53 @@ ghost:
 		Filename: ghost.shp
 	icon:
 		Filename: gosticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 mhijack:
 	Inherits: ^BasicInfantry
@@ -145,6 +495,41 @@ mhijack:
 		Filename: mhijack.shp
 	icon:
 		Filename: chamicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 chamspy:
 	Inherits: ^BasicInfantry
@@ -152,6 +537,39 @@ chamspy:
 		Filename: chamspy.shp
 	icon:
 		Filename: chamicon.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	idle1:
+		Palette: player
+		IsPlayerPalette: True
+	idle2:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	prone-run:
+		Palette: player
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 mutant:
 	Inherits: ^BasicInfantry
@@ -160,6 +578,51 @@ mutant:
 		Filename: mutant.shp
 	icon:
 		Filename: mutcicon.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 mwmn:
 	Inherits: ^BasicInfantry
@@ -168,6 +631,51 @@ mwmn:
 		Filename: mwmn.shp
 	icon:
 		Filename: mutcicon.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 mutant3:
 	Inherits: ^BasicInfantry
@@ -176,6 +684,51 @@ mutant3:
 		Filename: mutant3.shp
 	icon:
 		Filename: mutcicon.shp
+	run:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: bright
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: bright
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 tratos:
 	Inherits: ^BasicInfantry
@@ -183,18 +736,141 @@ tratos:
 		Filename: tratos.shp
 	icon:
 		Filename: mutcicon.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 oxanna:
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
 	Defaults:
 		Filename: oxanna.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 slav:
 	Inherits: ^BasicInfantry
 	Inherits@attack: ^BasicInfantryAttack
 	Defaults:
 		Filename: slav.shp
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle1:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	idle2:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	prone-run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	prone-attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 civ1:
 	Inherits: ^BasicInfantry
@@ -205,20 +881,49 @@ civ1:
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack-muzzle:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	panic-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
 		ShadowStart: 292
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	run:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 civ2:
 	Inherits: ^BasicInfantry
@@ -229,14 +934,80 @@ civ2:
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Palette: player
+		IsPlayerPalette: True
 	panic-stand:
 		Facings: 8
 		ShadowStart: 292
+		Palette: player
+		IsPlayerPalette: True
+	run:
+		Palette: player
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
 
 civ3:
 	Inherits: civ1
 	Defaults:
 		Filename: civ3.shp
+	run:
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	stand:
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	panic-run:
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	panic-stand:
+		Palette: player
+		IsPlayerPalette: True
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	die-twirling:
+		Palette: player
+		IsPlayerPalette: True
+	die-flying:
+		Palette: player
+		IsPlayerPalette: True
+	die-exploding:
+		Palette: effect
+		IsPlayerPalette: False
+	die-melting:
+		Palette: ra
+		IsPlayerPalette: False
+	die-crushed:
+		Palette: player
+		IsPlayerPalette: True
+	attack:
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
+	attack-muzzle:
+		Palette: muzzle
+		IsPlayerPalette: False
 
 cyborg:
 	Defaults:
@@ -246,57 +1017,81 @@ cyborg:
 	stand:
 		Facings: 8
 		ShadowStart: 370
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 378
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle1:
 		Start: 56
 		Length: 15
 		ShadowStart: 426
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle2:
 		Start: 71
 		Length: 15
 		ShadowStart: 441
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 456
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 456
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 534
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack-muzzle:
 		Start: 164
 		Length: 6
 		Facings: 8
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	crippled-attack:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 582
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-attack-muzzle:
 		Start: 212
 		Length: 6
 		Facings: 8
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: cybiicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 cyc2:
 	Defaults:
@@ -306,59 +1101,83 @@ cyc2:
 		Facings: 8
 		ShadowStart: 308
 		Offset: 0, 0, 16
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 9
 		Facings: 8
 		ShadowStart: 316
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle1:
 		Start: 80
 		Length: 15
 		ShadowStart: 388
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle2:
 		Start: 95
 		Length: 15
 		ShadowStart: 403
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-run:
 		Start: 110
 		Length: 9
 		Facings: 8
 		ShadowStart: 418
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-stand:
 		Start: 110
 		Facings: 8
 		Stride: 9
 		ShadowStart: 418
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 520
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack-muzzle:
 		Start: 212
 		Length: 6
 		Facings: 8
 		ShadowStart: 520
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	crippled-attack:
 		Start: 260
 		Length: 6
 		Facings: 8
 		ShadowStart: 568
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	crippled-attack-muzzle:
 		Start: 260
 		Length: 6
 		Facings: 8
 		ShadowStart: 568
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: cybcicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 medic:
 	Defaults:
@@ -368,46 +1187,66 @@ medic:
 	stand:
 		Facings: 8
 		ShadowStart: 307
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 315
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle1:
 		Start: 56
 		Length: 15
 		ShadowStart: 363
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle2:
 		Start: 71
 		Length: 15
 		ShadowStart: 378
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	prone-run:
 		Start: 86
 		Length: 6
 		Facings: 8
 		ShadowStart: 393
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 86
 		Facings: 8
 		Stride: 6
 		ShadowStart: 393
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	die-twirling:
 		Start: 134
 		Length: 15
 		ShadowStart: 441
+		Palette: player
+		IsPlayerPalette: True
 	die-flying:
 		Start: 149
 		Length: 15
 		ShadowStart: 455
+		Palette: player
+		IsPlayerPalette: True
 	die-exploding:
 		Filename: s_bang34.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	die-crushed:
 		Start: 159
 		Length: 5
 		ShadowStart: 451
 		Tick: 800
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	standup:
 		Start: 260
 		Length: 2
@@ -417,12 +1256,18 @@ medic:
 		Start: 292
 		Length: 14
 		ShadowStart: 599
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	die-melting:
 		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: mediicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 jumpjet:
 	Defaults:
@@ -432,19 +1277,27 @@ jumpjet:
 	stand:
 		Facings: 8
 		ShadowStart: 451
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 459
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle1:
 		Start: 56
 		Length: 15
 		ShadowStart: 507
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle2:
 		Start: 71
 		Length: 15
 		ShadowStart: 522
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	prone-run:
 		Start: 86
 		Length: 6
@@ -458,53 +1311,77 @@ jumpjet:
 		Length: 6
 		Start: 292
 		ShadowStart: 743
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	flying-muzzle:
 		Facings: 8
 		Length: 6
 		Start: 292
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	die-twirling: # TODO: animation for falling from sky starts at 436
 		Start: 445
 		Length: 6
 		ShadowStart: 896
+		Palette: player
+		IsPlayerPalette: True
 	die-falling:
 		Start: 436
 		Length: 9
+		Palette: player
+		IsPlayerPalette: True
 	die-flying: # TODO: animation for falling from sky starts at 436
 		Start: 445
 		Length: 6
 		ShadowStart: 896
+		Palette: player
+		IsPlayerPalette: True
 	die-splash:
 		Filename: h2o_exp2.shp
 		Length: *
+		Palette: player
+		IsPlayerPalette: True
 	die-exploding:
 		Filename: s_bang34.shp
 		Length: *
+		Palette: effect
+		IsPlayerPalette: False
 	die-crushed:
 		Start: 450
 		ShadowStart: 901
 		Tick: 800
 		ZOffset: -511
+		Palette: player
+		IsPlayerPalette: True
 	attack:
 		Start: 164
 		Length: 6
 		Facings: 8
 		ShadowStart: 615
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack-muzzle:
 		Start: 164
 		Length: 6
 		Facings: 8
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	flying-attack:
 		Start: 388
 		Facings: 8
 		Length: 6
 		ShadowStart: 839
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	flying-attack-muzzle:
 		Start: 388
 		Facings: 8
 		Length: 6
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	prone-attack:
 		Start: 212
 		Length: 6
@@ -524,8 +1401,12 @@ jumpjet:
 		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: jjeticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 weedguy:
 	Defaults:
@@ -535,11 +1416,15 @@ weedguy:
 	stand:
 		Facings: 8
 		ShadowStart: 202
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	run:
 		Start: 8
 		Length: 6
 		Facings: 8
 		ShadowStart: 210
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	attack:
 		Start: 56
 		Facings: 8
@@ -559,44 +1444,64 @@ weedguy:
 		Length: 6
 		Facings: 8
 		ShadowStart: 288
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	prone-stand:
 		Start: 64
 		Facings: 8
 		Stride: 6
 		ShadowStart: 288
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle1:
 		Start: 128
 		Length: 8
 		ShadowStart: 330
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	idle2:
 		Start: 136
 		Length: 16
 		ShadowStart: 338
+		Palette: player-nomuzzle
+		IsPlayerPalette: True
 	die-twirling:
 		Start: 152
 		Length: 8
 		ShadowStart: 354
+		Palette: player
+		IsPlayerPalette: True
 	die-flying:
 		Start: 160
 		Length: 6
 		ShadowStart: 362
+		Palette: player
+		IsPlayerPalette: True
 	die-exploding:
 		Start: 166
 		Length: 11
 		ShadowStart: 368
+		Palette: effect
+		IsPlayerPalette: False
 	die-burning:
 		Start: 177
 		Length: 20
 		ShadowStart: 379
+		Palette: player
+		IsPlayerPalette: True
 	die-melting:
 		Filename: electro.shp
 		Frames: 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
 		Length: *
+		Palette: ra
+		IsPlayerPalette: False
 	die-crushed:
 		Start: 174
 		Length: 3
 		ShadowStart: 376
 		Tick: 1000
+		Palette: player
+		IsPlayerPalette: True
 
 flameguy:
 	Defaults:
@@ -608,11 +1513,17 @@ flameguy:
 		IgnoreWorldTint: True
 	idle:
 	stand:
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Length: 6
+		Palette: player
+		IsPlayerPalette: True
 	die:
 		Start: 44
 		Facings: 1
 		Length: 104
 		ShadowStart: 192
 		AlphaFade: True
+		Palette: player
+		IsPlayerPalette: True

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -8,7 +8,6 @@ overlay:
 	build-invalid:
 		Start: 1
 		Palette: ra
-		IsPlayerPalette: False
 	target-select:
 
 editor-overlay:
@@ -27,7 +26,6 @@ poweroff:
 		Tick: 160
 		ZOffset: 2047
 		Palette: mouse
-		IsPlayerPalette: False
 
 allyrepair:
 	repair:
@@ -36,7 +34,6 @@ allyrepair:
 		Tick: 160
 		ZOffset: 2047
 		Palette: mouse
-		IsPlayerPalette: False
 
 rallypoint:
 	flag:
@@ -45,7 +42,6 @@ rallypoint:
 		Length: 8
 		ZOffset: 3072
 		Palette: mouse
-		IsPlayerPalette: False
 
 beacon:
 	idle:
@@ -54,7 +50,6 @@ beacon:
 		Tick: 200
 		ZOffset: 2047
 		Palette: effect
-		IsPlayerPalette: False
 
 crate:
 	idle:
@@ -64,7 +59,6 @@ crate:
 		ShadowStart: 1
 		Offset: 0, -10, 10
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -73,50 +67,40 @@ crate-effects:
 	dollar:
 		Filename: money.shp
 		Palette: effect
-		IsPlayerPalette: False
 	reveal-map:
 		Filename: reveal.shp
 		Palette: effect
-		IsPlayerPalette: False
 	hide-map:
 		Filename: shroudx.shp
 		Palette: effect
-		IsPlayerPalette: False
 	firepower:
 		Filename: firepowr.shp
 		Palette: effect
-		IsPlayerPalette: False
 	armor:
 		Filename: armor.shp
 		Palette: effect
-		IsPlayerPalette: False
 	stealth:
 		Filename: cloak.shp
 		Palette: effect
-		IsPlayerPalette: False
 	heal:
 		Filename: healall.shp
 		Palette: effect
-		IsPlayerPalette: False
 	nuke:
 		Filename: mltimisl.shp
 	levelup:
 		Filename: veteran.shp
 		Palette: effect
-		IsPlayerPalette: False
 
 rank:
 	veteran:
 		Filename: pips.shp
 		Start: 7
 		Palette: ra
-		IsPlayerPalette: False
 	elite:
 		Filename: pips.shp
 		Start: 8
 		Offset: 3, 3
 		Palette: ra
-		IsPlayerPalette: False
 
 mpspawn:
 	idle:
@@ -150,14 +134,12 @@ clock:
 		Filename: gclock2.shp
 		Length: *
 		Palette: iconclock
-		IsPlayerPalette: False
 
 darken:
 	idle:
 		Filename: gclock2.shp
 		Length: 1
 		Palette: chromewithshadow
-		IsPlayerPalette: False
 
 pips:
 	Defaults:
@@ -165,21 +147,17 @@ pips:
 	medic:
 		Start: 6
 		Palette: pips
-		IsPlayerPalette: False
 	pip-empty:
 		Filename: pips2.shp
 		Palette: pips
-		IsPlayerPalette: False
 	pip-green:
 		Filename: pips2.shp
 		Start: 1
 		Palette: pips
-		IsPlayerPalette: False
 	pip-yellow:
 		Filename: pips2.shp
 		Start: 2
 		Palette: pips
-		IsPlayerPalette: False
 	pip-gray:
 		Filename: pips2.shp
 		Start: 3
@@ -187,36 +165,29 @@ pips:
 		Filename: pips2.shp
 		Start: 4
 		Palette: pips
-		IsPlayerPalette: False
 	pip-blue:
 		Filename: pips2.shp
 		Start: 5
 		Palette: pips
-		IsPlayerPalette: False
 	pip-ammo:
 		Filename: ammopips.shp
 		Palette: pips
-		IsPlayerPalette: False
 	pip-ammoempty:
 		Filename: ammopips.shp
 		Start: 1
 		Palette: pips
-		IsPlayerPalette: False
 	pip-disguise:
 		Filename: pip-disguise.shp
 		Length: *
 		Tick: 300
 		Offset: 0, -6
 		Palette: pips
-		IsPlayerPalette: False
 	# TODO:
 	pip-empty-building:
 		Palette: pips
-		IsPlayerPalette: False
 	pip-green-building:
 		Start: 1
 		Palette: pips
-		IsPlayerPalette: False
 	pip-yellow-building:
 		Start: 2
 	pip-gray-building:
@@ -224,7 +195,6 @@ pips:
 	pip-red-building:
 		Start: 4
 		Palette: pips
-		IsPlayerPalette: False
 	pip-blue-building:
 		Start: 5
 
@@ -239,77 +209,66 @@ explosion:
 		Filename: twlt070.shp
 		Offset: 0, 0, 36
 		Palette: effect
-		IsPlayerPalette: False
 	ionring:
 		Filename: ring1.shp
 		ZRamp: 1
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam:
 		Filename: ionbeam.shp
 		Offset: 0, -60, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam2:
 		Filename: ionbeam.shp
 		Offset: 0, -180, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam3:
 		Filename: ionbeam.shp
 		Offset: 0, -300, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam4:
 		Filename: ionbeam.shp
 		Offset: 0, -420, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam5:
 		Filename: ionbeam.shp
 		Offset: 0, -540, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	ionbeam6:
 		Filename: ionbeam.shp
 		Offset: 0, -660, 60
 		Tick: 100
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	pulse_explosion:
 		Filename: pulsefx2.shp
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 80
 		Palette: effect
-		IsPlayerPalette: False
 	pulse_explosion_small:
 		Filename: mempfx.shp
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 11
 		Palette: effect
-		IsPlayerPalette: False
 	small_watersplash:
 		Filename: h2o_exp2.shp
 		IgnoreWorldTint: False
 		AlphaFade: False
 		Alpha: 0.5
 		Palette: player
-		IsPlayerPalette: False
 	large_watersplash:
 		Filename: h2o_exp1.shp
 		Offset: 0, 0, 39
@@ -320,26 +279,21 @@ explosion:
 		Filename: w_piff.shp
 		IgnoreWorldTint: False
 		Palette: ra
-		IsPlayerPalette: False
 	water_piffs:
 		Filename: w_piffs.shp
 		IgnoreWorldTint: False
 		Palette: ra
-		IsPlayerPalette: False
 	piff:
 		Filename: piff.shp
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	piffs:
 		Filename: piffpiff.shp
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	small_explosion:
 		Filename: explosml.shp
 		Palette: effect
-		IsPlayerPalette: False
 	medium_explosion:
 		Filename: explomed.shp
 		Offset: 0, 0, 27
@@ -347,21 +301,17 @@ explosion:
 		Filename: explolrg.shp
 		Offset: 0, 0, 31
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_bang:
 		Filename: s_bang16.shp
 	small_bang:
 		Filename: s_bang24.shp
 		Palette: effect
-		IsPlayerPalette: False
 	medium_bang:
 		Filename: s_bang34.shp
 		Palette: effect
-		IsPlayerPalette: False
 	large_bang:
 		Filename: s_bang48.shp
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_brnl:
 		Filename: s_brnl20.shp
 	small_brnl:
@@ -369,12 +319,10 @@ explosion:
 	medium_brnl:
 		Filename: s_brnl40.shp
 		Palette: effect
-		IsPlayerPalette: False
 	large_brnl:
 		Filename: s_brnl58.shp
 		Offset: 0, 0, 30
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_tumu:
 		Filename: s_tumu22.shp
 	small_tumu:
@@ -385,44 +333,35 @@ explosion:
 		Filename: s_tumu60.shp
 		Offset: 0, 0, 31
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_clsn:
 		Filename: s_clsn16.shp
 	small_clsn:
 		Filename: s_clsn22.shp
 		Palette: effect
-		IsPlayerPalette: False
 	medium_clsn:
 		Filename: s_clsn30.shp
 		Palette: effect
-		IsPlayerPalette: False
 	large_clsn:
 		Filename: s_clsn42.shp
 		Palette: effect
-		IsPlayerPalette: False
 	verylarge_clsn:
 		Filename: s_clsn58.shp
 		Offset: 0, 0, 30
 		Palette: effect
-		IsPlayerPalette: False
 	tiny_twlt:
 		Filename: twlt026.shp
 		Palette: effect
-		IsPlayerPalette: False
 	small_twlt:
 		Filename: twlt036.shp
 		Palette: effect
-		IsPlayerPalette: False
 	medium_twlt:
 		Filename: twlt050.shp
 		Offset: 0, 0, 26
 		Palette: effect
-		IsPlayerPalette: False
 	large_twlt:
 		Filename: twlt070.shp
 		Offset: 0, 0, 36
 		Palette: effect
-		IsPlayerPalette: False
 	verylarge_twlt:
 		Filename: twlt100.shp
 		Offset: 0, 0, 51
@@ -433,7 +372,6 @@ explosion:
 		Filename: xgrysml2.shp
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	medium_grey_explosion:
 		Filename: xgrymed1.shp
 		IgnoreWorldTint: False
@@ -441,35 +379,30 @@ explosion:
 		Filename: xgrymed2.shp
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	droppod_explosion:
 		Filename: droppod.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	droppod2_explosion:
 		Filename: droppod2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	droppody_explosion:
 		Filename: droppody.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 	droppody2_explosion:
 		Filename: droppody2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
 		Palette: effect
-		IsPlayerPalette: False
 
 discus:
 	idle:
@@ -478,7 +411,6 @@ discus:
 		ZOffset: 1023
 		Offset: 0, 0, 12
 		Palette: effect
-		IsPlayerPalette: False
 
 canister:
 	idle:
@@ -487,7 +419,6 @@ canister:
 		ZOffset: 1023
 		Offset: 0, 0, 12
 		Palette: player
-		IsPlayerPalette: False
 
 pulsball:
 	idle:
@@ -497,7 +428,6 @@ pulsball:
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		Palette: effect
-		IsPlayerPalette: False
 
 dragon:
 	idle:
@@ -506,7 +436,6 @@ dragon:
 		ZOffset: 1023
 		Offset: 0, 0, 6
 		Palette: ra
-		IsPlayerPalette: False
 
 crystal4:
 	idle:
@@ -518,7 +447,6 @@ crystal4:
 		ZOffset: 1023
 		Offset: 0, 0, 6
 		Palette: greentiberium
-		IsPlayerPalette: False
 
 120mm:
 	idle:
@@ -526,7 +454,6 @@ crystal4:
 		ZOffset: 1023
 		Offset: 0, 0, 4
 		Palette: ra
-		IsPlayerPalette: False
 
 torpedo:
 	idle:
@@ -536,7 +463,6 @@ torpedo:
 		Offset: 0, 0, 8
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 
 flameall:
 	idle:
@@ -549,7 +475,6 @@ flameall:
 		IgnoreWorldTint: True
 		Alpha: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
 		Palette: effect
-		IsPlayerPalette: False
 
 largesmoke:
 	idle:
@@ -559,7 +484,6 @@ largesmoke:
 		Offset: 0, 0, 24
 		AlphaFade: True
 		Palette: effect
-		IsPlayerPalette: False
 
 smallsmoke:
 	idle:
@@ -585,7 +509,6 @@ small_smoke_trail:
 		Offset: 0, 0, 24
 		AlphaFade: True
 		Palette: effect
-		IsPlayerPalette: False
 
 largefire:
 	idle:
@@ -595,7 +518,6 @@ largefire:
 		Alpha: 0.5
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 
 mediumfire:
 	idle:
@@ -605,7 +527,6 @@ mediumfire:
 		Alpha: 0.5
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 
 smallfire:
 	idle:
@@ -615,7 +536,6 @@ smallfire:
 		Alpha: 0.5
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 
 tinyfire:
 	idle:
@@ -634,7 +554,6 @@ moveflsh:
 		ZRamp: 1
 		AlphaFade: True
 		Palette: moveflash
-		IsPlayerPalette: False
 
 wake:
 	idle:
@@ -646,7 +565,6 @@ wake:
 		Offset: 0, 0, 1
 		AlphaFade: True
 		Palette: effect
-		IsPlayerPalette: False
 
 resources:
 	Defaults:
@@ -655,166 +573,206 @@ resources:
 		Offset: 0, -12, 1
 		ZRamp: 1
 		IgnoreWorldTint: true
-	tib01:
+	tib01g:
 		TilesetFilenames:
 			TEMPERATE: tib01.tem
 			SNOW: tib01.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib01b:
+		TilesetFilenames:
+			TEMPERATE: tib01.tem
+			SNOW: tib01.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib02:
+	tib02g:
 		TilesetFilenames:
 			TEMPERATE: tib02.tem
 			SNOW: tib02.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib02b:
+		TilesetFilenames:
+			TEMPERATE: tib02.tem
+			SNOW: tib02.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib03:
+	tib03g:
 		TilesetFilenames:
 			TEMPERATE: tib03.tem
 			SNOW: tib03.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib03b:
+		TilesetFilenames:
+			TEMPERATE: tib03.tem
+			SNOW: tib03.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib04:
+	tib04g:
 		TilesetFilenames:
 			TEMPERATE: tib04.tem
 			SNOW: tib04.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib04b:
+		TilesetFilenames:
+			TEMPERATE: tib04.tem
+			SNOW: tib04.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib05:
+	tib05g:
 		TilesetFilenames:
 			TEMPERATE: tib05.tem
 			SNOW: tib05.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib05b:
+		TilesetFilenames:
+			TEMPERATE: tib05.tem
+			SNOW: tib05.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib06:
+	tib06g:
 		TilesetFilenames:
 			TEMPERATE: tib06.tem
 			SNOW: tib06.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib06b:
+		TilesetFilenames:
+			TEMPERATE: tib06.tem
+			SNOW: tib06.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib07:
+	tib07g:
 		TilesetFilenames:
 			TEMPERATE: tib07.tem
 			SNOW: tib07.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib07b:
+		TilesetFilenames:
+			TEMPERATE: tib07.tem
+			SNOW: tib07.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib08:
+	tib08g:
 		TilesetFilenames:
 			TEMPERATE: tib08.tem
 			SNOW: tib08.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib08b:
+		TilesetFilenames:
+			TEMPERATE: tib08.tem
+			SNOW: tib08.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib09:
+	tib09g:
 		TilesetFilenames:
 			TEMPERATE: tib09.tem
 			SNOW: tib09.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib09b:
+		TilesetFilenames:
+			TEMPERATE: tib09.tem
+			SNOW: tib09.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib10:
+	tib10g:
 		TilesetFilenames:
 			TEMPERATE: tib10.tem
 			SNOW: tib10.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib10b:
+		TilesetFilenames:
+			TEMPERATE: tib10.tem
+			SNOW: tib10.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib11:
+	tib11g:
 		TilesetFilenames:
 			TEMPERATE: tib11.tem
 			SNOW: tib11.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib11b:
+		TilesetFilenames:
+			TEMPERATE: tib11.tem
+			SNOW: tib11.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib12:
+	tib12g:
 		TilesetFilenames:
 			TEMPERATE: tib12.tem
 			SNOW: tib12.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib12b:
+		TilesetFilenames:
+			TEMPERATE: tib12.tem
+			SNOW: tib12.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib13:
+	tib13g:
 		TilesetFilenames:
 			TEMPERATE: tib13.tem
 			SNOW: tib13.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib13b:
+		TilesetFilenames:
+			TEMPERATE: tib13.tem
+			SNOW: tib13.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib14:
+	tib14g:
 		TilesetFilenames:
 			TEMPERATE: tib14.tem
 			SNOW: tib14.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib14b:
+		TilesetFilenames:
+			TEMPERATE: tib14.tem
+			SNOW: tib14.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib15:
+	tib15g:
 		TilesetFilenames:
 			TEMPERATE: tib15.tem
 			SNOW: tib15.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib15b:
+		TilesetFilenames:
+			TEMPERATE: tib15.tem
+			SNOW: tib15.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib16:
+	tib16g:
 		TilesetFilenames:
 			TEMPERATE: tib16.tem
 			SNOW: tib16.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib16b:
+		TilesetFilenames:
+			TEMPERATE: tib16.tem
+			SNOW: tib16.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib17:
+	tib17g:
 		TilesetFilenames:
 			TEMPERATE: tib17.tem
 			SNOW: tib17.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib17b:
+		TilesetFilenames:
+			TEMPERATE: tib17.tem
+			SNOW: tib17.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib18:
+	tib18g:
 		TilesetFilenames:
 			TEMPERATE: tib18.tem
 			SNOW: tib18.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib18b:
+		TilesetFilenames:
+			TEMPERATE: tib18.tem
+			SNOW: tib18.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib19:
+	tib19g:
 		TilesetFilenames:
 			TEMPERATE: tib19.tem
 			SNOW: tib19.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib19b:
+		TilesetFilenames:
+			TEMPERATE: tib19.tem
+			SNOW: tib19.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
-	tib20:
+	tib20g:
 		TilesetFilenames:
 			TEMPERATE: tib20.tem
 			SNOW: tib20.sno
 		Palette: greentiberium
-		IsPlayerPalette: False
+	tib20b:
+		TilesetFilenames:
+			TEMPERATE: tib20.tem
+			SNOW: tib20.sno
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	veins:
 		TilesetFilenames:
 			TEMPERATE: veins.tem
@@ -823,7 +781,6 @@ resources:
 		ShadowStart: -1
 		IgnoreWorldTint: false
 		Palette: player
-		IsPlayerPalette: False
 
 veins:
 	idle:
@@ -834,7 +791,6 @@ veins:
 		ZOffset: 1023
 		Offset: 0, -12, 24
 		Palette: player
-		IsPlayerPalette: False
 
 shroud:
 	Defaults:
@@ -844,220 +800,183 @@ shroud:
 	shroud:
 		Length: *
 		Palette: shroud
-		IsPlayerPalette: False
 	fog:
 		Filename: fog.shp
 		Length: *
 		Palette: shroud
-		IsPlayerPalette: False
 
 smallscorches:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	sc1:
 		TilesetFilenames:
 			TEMPERATE: burnt01.tem
 			SNOW: burnt01.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc2:
 		TilesetFilenames:
 			TEMPERATE: burnt02.tem
 			SNOW: burnt02.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc3:
 		TilesetFilenames:
 			TEMPERATE: burnt03.tem
 			SNOW: burnt03.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc4:
 		TilesetFilenames:
 			TEMPERATE: burnt04.tem
 			SNOW: burnt04.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc5:
 		TilesetFilenames:
 			TEMPERATE: burnt05.tem
 			SNOW: burnt05.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc6:
 		TilesetFilenames:
 			TEMPERATE: burnt06.tem
 			SNOW: burnt06.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 mediumscorches:
 	Defaults:
 		Offset: 0, -18, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	sc7:
 		TilesetFilenames:
 			TEMPERATE: burnt07.tem
 			SNOW: burnt07.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc8:
 		TilesetFilenames:
 			TEMPERATE: burnt08.tem
 			SNOW: burnt08.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc9:
 		TilesetFilenames:
 			TEMPERATE: burnt09.tem
 			SNOW: burnt09.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc10:
 		TilesetFilenames:
 			TEMPERATE: burnt10.tem
 			SNOW: burnt10.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 largescorches:
 	Defaults:
 		Offset: 0, -24, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	sc11:
 		TilesetFilenames:
 			TEMPERATE: burnt11.tem
 			SNOW: burnt11.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	sc12:
 		TilesetFilenames:
 			TEMPERATE: burnt12.tem
 			SNOW: burnt12.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 smallcraters:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	cr1:
 		TilesetFilenames:
 			TEMPERATE: crater01.tem
 			SNOW: crater01.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr2:
 		TilesetFilenames:
 			TEMPERATE: crater02.tem
 			SNOW: crater02.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr3:
 		TilesetFilenames:
 			TEMPERATE: crater03.tem
 			SNOW: crater03.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr4:
 		TilesetFilenames:
 			TEMPERATE: crater04.tem
 			SNOW: crater04.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr5:
 		TilesetFilenames:
 			TEMPERATE: crater05.tem
 			SNOW: crater05.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr6:
 		TilesetFilenames:
 			TEMPERATE: crater06.tem
 			SNOW: crater06.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 mediumcraters:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	cr7:
 		TilesetFilenames:
 			TEMPERATE: crater07.tem
 			SNOW: crater07.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr8:
 		TilesetFilenames:
 			TEMPERATE: crater08.tem
 			SNOW: crater08.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr9:
 		TilesetFilenames:
 			TEMPERATE: crater09.tem
 			SNOW: crater09.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr10:
 		TilesetFilenames:
 			TEMPERATE: crater10.tem
 			SNOW: crater10.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 largecraters:
 	Defaults:
 		Offset: 0, -24, 1
 		ZRamp: 1
 		Palette: terrain
-		IsPlayerPalette: False
 	cr11:
 		TilesetFilenames:
 			TEMPERATE: crater11.tem
 			SNOW: crater11.sno
 		Palette: terrain
-		IsPlayerPalette: False
 	cr12:
 		TilesetFilenames:
 			TEMPERATE: crater12.tem
 			SNOW: crater12.sno
 		Palette: terrain
-		IsPlayerPalette: False
 
 icon:
 	clustermissile:
 		Filename: mltiicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	ioncannon:
 		Filename: ioncicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	hunterseeker:
 		Filename: detnicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	emp:
 		Filename: pulsicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	droppods:
 		Filename: podsicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 clustermissile:
 	up: # TODO: use voxel
@@ -1065,20 +984,17 @@ clustermissile:
 		Frames: 0
 		Length: 1
 		Palette: effect
-		IsPlayerPalette: False
 	down: # TODO: use voxel
 		Filename: mltimisl-placeholder.shp
 		Frames: 1
 		Length: 1
 		Palette: effect
-		IsPlayerPalette: False
 
 ^rock:
 	idle:
 		ShadowStart: 1
 		Offset: 0, -12
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 trock01:
 	Inherits: ^rock
@@ -1087,7 +1003,6 @@ trock01:
 			TEMPERATE: trock01.tem
 			SNOW: trock01.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 trock02:
 	Inherits: ^rock
@@ -1096,7 +1011,6 @@ trock02:
 			TEMPERATE: trock02.tem
 			SNOW: trock02.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 trock03:
 	Inherits: ^rock
@@ -1105,7 +1019,6 @@ trock03:
 			TEMPERATE: trock03.tem
 			SNOW: trock03.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 trock04:
 	Inherits: ^rock
@@ -1114,7 +1027,6 @@ trock04:
 			TEMPERATE: trock04.tem
 			SNOW: trock04.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 trock05:
 	Inherits: ^rock
@@ -1123,7 +1035,6 @@ trock05:
 			TEMPERATE: trock05.tem
 			SNOW: trock05.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 srock01:
 	Inherits: ^rock
@@ -1132,7 +1043,6 @@ srock01:
 			TEMPERATE: srock01.tem
 			SNOW: srock01.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 srock02:
 	Inherits: ^rock
@@ -1141,7 +1051,6 @@ srock02:
 			TEMPERATE: srock02.tem
 			SNOW: srock02.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 srock03:
 	Inherits: ^rock
@@ -1150,7 +1059,6 @@ srock03:
 			TEMPERATE: srock03.tem
 			SNOW: srock03.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 srock04:
 	Inherits: ^rock
@@ -1159,7 +1067,6 @@ srock04:
 			TEMPERATE: srock04.tem
 			SNOW: srock04.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 srock05:
 	Inherits: ^rock
@@ -1168,7 +1075,6 @@ srock05:
 			TEMPERATE: srock05.tem
 			SNOW: srock05.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 dbrissm:
 	Defaults:
@@ -1177,43 +1083,33 @@ dbrissm:
 	1:
 		Filename: dbris1sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	2:
 		Filename: dbris2sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	3:
 		Filename: dbris3sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	4:
 		Filename: dbris4sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	5:
 		Filename: dbris5sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	6:
 		Filename: dbris6sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	7:
 		Filename: dbris7sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	8:
 		Filename: dbris8sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	9:
 		Filename: dbris9sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 	10:
 		Filename: dbrs10sm.shp
 		Palette: effect
-		IsPlayerPalette: False
 
 dbrislg:
 	Defaults:
@@ -1222,141 +1118,117 @@ dbrislg:
 	1:
 		Filename: dbris1lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	2:
 		Filename: dbris2lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	3:
 		Filename: dbris3lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	4:
 		Filename: dbris4lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	5:
 		Filename: dbris5lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	6:
 		Filename: dbris6lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	7:
 		Filename: dbris7lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	8:
 		Filename: dbris8lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	9:
 		Filename: dbris9lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 	10:
 		Filename: dbrs10lg.shp
 		Palette: effect
-		IsPlayerPalette: False
 
 ^crate:
 	idle:
 		Offset: 0, 0, 12
 		DepthSprite: isodepth.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat01:
 	Inherits: ^crate
 	idle:
 		Filename: crat01.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat02:
 	Inherits: ^crate
 	idle:
 		Filename: crat02.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat03:
 	Inherits: ^crate
 	idle:
 		Filename: crat03.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat04:
 	Inherits: ^crate
 	idle:
 		Filename: crat04.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat0a:
 	Inherits: ^crate
 	idle:
 		Filename: crat0a.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat0b:
 	Inherits: ^crate
 	idle:
 		Filename: crat0b.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 crat0c:
 	Inherits: ^crate
 	idle:
 		Filename: crat0c.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 drum01:
 	Inherits: ^crate
 	idle:
 		Filename: drum01.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 drum02:
 	Inherits: ^crate
 	idle:
 		Filename: drum02.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 palet01:
 	Inherits: ^crate
 	idle:
 		Filename: palet01.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 palet02:
 	Inherits: ^crate
 	idle:
 		Filename: palet02.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 palet03:
 	Inherits: ^crate
 	idle:
 		Filename: palet03.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 palet04:
 	Inherits: ^crate
 	idle:
 		Filename: palet04.shp
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^tracks:
 	idle:
@@ -1371,7 +1243,6 @@ tracks01:
 			TEMPERATE: tracks01.tem
 			SNOW: tracks01.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks02:
 	Inherits: ^tracks
@@ -1380,7 +1251,6 @@ tracks02:
 			TEMPERATE: tracks02.tem
 			SNOW: tracks02.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks03:
 	Inherits: ^tracks
@@ -1389,7 +1259,6 @@ tracks03:
 			TEMPERATE: tracks03.tem
 			SNOW: tracks03.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks04:
 	Inherits: ^tracks
@@ -1398,7 +1267,6 @@ tracks04:
 			TEMPERATE: tracks04.tem
 			SNOW: tracks04.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks05:
 	Inherits: ^tracks
@@ -1407,7 +1275,6 @@ tracks05:
 			TEMPERATE: tracks05.tem
 			SNOW: tracks05.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks06:
 	Inherits: ^tracks
@@ -1416,7 +1283,6 @@ tracks06:
 			TEMPERATE: tracks06.tem
 			SNOW: tracks06.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks07:
 	Inherits: ^tracks
@@ -1425,7 +1291,6 @@ tracks07:
 			TEMPERATE: tracks07.tem
 			SNOW: tracks07.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks08:
 	Inherits: ^tracks
@@ -1434,7 +1299,6 @@ tracks08:
 			TEMPERATE: tracks08.tem
 			SNOW: tracks08.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks09:
 	Inherits: ^tracks
@@ -1443,7 +1307,6 @@ tracks09:
 			TEMPERATE: tracks09.tem
 			SNOW: tracks09.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks10:
 	Inherits: ^tracks
@@ -1452,7 +1315,6 @@ tracks10:
 			TEMPERATE: tracks10.tem
 			SNOW: tracks10.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks11:
 	Inherits: ^tracks
@@ -1461,7 +1323,6 @@ tracks11:
 			TEMPERATE: tracks11.tem
 			SNOW: tracks11.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks12:
 	Inherits: ^tracks
@@ -1470,7 +1331,6 @@ tracks12:
 			TEMPERATE: tracks12.tem
 			SNOW: tracks12.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks13:
 	Inherits: ^tracks
@@ -1479,7 +1339,6 @@ tracks13:
 			TEMPERATE: tracks13.tem
 			SNOW: tracks13.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks14:
 	Inherits: ^tracks
@@ -1488,7 +1347,6 @@ tracks14:
 			TEMPERATE: tracks14.tem
 			SNOW: tracks14.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks15:
 	Inherits: ^tracks
@@ -1497,7 +1355,6 @@ tracks15:
 			TEMPERATE: tracks15.tem
 			SNOW: tracks15.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tracks16:
 	Inherits: ^tracks
@@ -1506,7 +1363,6 @@ tracks16:
 			TEMPERATE: tracks16.tem
 			SNOW: tracks16.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 ^tuntop:
 	idle:
@@ -1520,7 +1376,6 @@ tuntop01:
 			SNOW: tuntop01.sno
 		Offset: 24, -49, 48
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tuntop02:
 	Inherits: ^tuntop
@@ -1530,7 +1385,6 @@ tuntop02:
 			SNOW: tuntop02.sno
 		Offset: -24, -49, 48
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tuntop03:
 	Inherits: ^tuntop
@@ -1540,7 +1394,6 @@ tuntop03:
 			SNOW: tuntop03.sno
 		Offset: 24, -49, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tuntop04:
 	Inherits: ^tuntop
@@ -1550,7 +1403,6 @@ tuntop04:
 			SNOW: tuntop04.sno
 		Offset: -24, -49, 49
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 dig:
 	idle:
@@ -1559,7 +1411,6 @@ dig:
 		ZOffset: 511
 		Offset: 0, 0, 24
 		Palette: effect
-		IsPlayerPalette: False
 
 typeglyphs:
 	Defaults:
@@ -1587,7 +1438,6 @@ podring:
 		Length: *
 		AlphaFade: True
 		Palette: effect
-		IsPlayerPalette: False
 
 fire1:
 	idle-overlay:
@@ -1597,7 +1447,6 @@ fire1:
 		Offset: 0, -24, 24
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 fire2:
 	idle-overlay:
@@ -1607,7 +1456,6 @@ fire2:
 		Offset: 0, -18, 18
 		ZOffset: 1023
 		Palette: effect
-		IsPlayerPalette: False
 
 caryland:
 	idle:
@@ -1619,7 +1467,6 @@ caryland:
 		Offset: 0, 0, 1
 		BlendMode: Translucent
 		Palette: effect
-		IsPlayerPalette: False
 
 dropland:
 	idle:
@@ -1631,4 +1478,3 @@ dropland:
 		Offset: 0, 0, 1
 		BlendMode: Translucent
 		Palette: effect
-		IsPlayerPalette: False

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -7,6 +7,8 @@ overlay:
 	build-valid-temperate:
 	build-invalid:
 		Start: 1
+		Palette: ra
+		IsPlayerPalette: False
 	target-select:
 
 editor-overlay:
@@ -24,6 +26,8 @@ poweroff:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: mouse
+		IsPlayerPalette: False
 
 allyrepair:
 	repair:
@@ -31,6 +35,8 @@ allyrepair:
 		Length: *
 		Tick: 160
 		ZOffset: 2047
+		Palette: mouse
+		IsPlayerPalette: False
 
 rallypoint:
 	flag:
@@ -38,6 +44,8 @@ rallypoint:
 		Start: 221
 		Length: 8
 		ZOffset: 3072
+		Palette: mouse
+		IsPlayerPalette: False
 
 beacon:
 	idle:
@@ -45,6 +53,8 @@ beacon:
 		Length: 5
 		Tick: 200
 		ZOffset: 2047
+		Palette: effect
+		IsPlayerPalette: False
 
 crate:
 	idle:
@@ -53,6 +63,8 @@ crate:
 			SNOW: crate.sno
 		ShadowStart: 1
 		Offset: 0, -10, 10
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crate-effects:
 	Defaults:
@@ -60,31 +72,51 @@ crate-effects:
 		Offset: 0, 0, 96
 	dollar:
 		Filename: money.shp
+		Palette: effect
+		IsPlayerPalette: False
 	reveal-map:
 		Filename: reveal.shp
+		Palette: effect
+		IsPlayerPalette: False
 	hide-map:
 		Filename: shroudx.shp
+		Palette: effect
+		IsPlayerPalette: False
 	firepower:
 		Filename: firepowr.shp
+		Palette: effect
+		IsPlayerPalette: False
 	armor:
 		Filename: armor.shp
+		Palette: effect
+		IsPlayerPalette: False
 	stealth:
 		Filename: cloak.shp
+		Palette: effect
+		IsPlayerPalette: False
 	heal:
 		Filename: healall.shp
+		Palette: effect
+		IsPlayerPalette: False
 	nuke:
 		Filename: mltimisl.shp
 	levelup:
 		Filename: veteran.shp
+		Palette: effect
+		IsPlayerPalette: False
 
 rank:
 	veteran:
 		Filename: pips.shp
 		Start: 7
+		Palette: ra
+		IsPlayerPalette: False
 	elite:
 		Filename: pips.shp
 		Start: 8
 		Offset: 3, 3
+		Palette: ra
+		IsPlayerPalette: False
 
 mpspawn:
 	idle:
@@ -92,6 +124,8 @@ mpspawn:
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
+		Palette: player
+		IsPlayerPalette: True
 
 waypoint:
 	idle:
@@ -99,6 +133,8 @@ waypoint:
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
+		Palette: player
+		IsPlayerPalette: True
 
 camera:
 	idle:
@@ -106,59 +142,89 @@ camera:
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
+		Palette: player
+		IsPlayerPalette: True
 
 clock:
 	idle:
 		Filename: gclock2.shp
 		Length: *
+		Palette: iconclock
+		IsPlayerPalette: False
 
 darken:
 	idle:
 		Filename: gclock2.shp
 		Length: 1
+		Palette: chromewithshadow
+		IsPlayerPalette: False
 
 pips:
 	Defaults:
 		Filename: pips.shp
 	medic:
 		Start: 6
+		Palette: pips
+		IsPlayerPalette: False
 	pip-empty:
 		Filename: pips2.shp
+		Palette: pips
+		IsPlayerPalette: False
 	pip-green:
 		Filename: pips2.shp
 		Start: 1
+		Palette: pips
+		IsPlayerPalette: False
 	pip-yellow:
 		Filename: pips2.shp
 		Start: 2
+		Palette: pips
+		IsPlayerPalette: False
 	pip-gray:
 		Filename: pips2.shp
 		Start: 3
 	pip-red:
 		Filename: pips2.shp
 		Start: 4
+		Palette: pips
+		IsPlayerPalette: False
 	pip-blue:
 		Filename: pips2.shp
 		Start: 5
+		Palette: pips
+		IsPlayerPalette: False
 	pip-ammo:
 		Filename: ammopips.shp
+		Palette: pips
+		IsPlayerPalette: False
 	pip-ammoempty:
 		Filename: ammopips.shp
 		Start: 1
+		Palette: pips
+		IsPlayerPalette: False
 	pip-disguise:
 		Filename: pip-disguise.shp
 		Length: *
 		Tick: 300
 		Offset: 0, -6
+		Palette: pips
+		IsPlayerPalette: False
 	# TODO:
 	pip-empty-building:
+		Palette: pips
+		IsPlayerPalette: False
 	pip-green-building:
 		Start: 1
+		Palette: pips
+		IsPlayerPalette: False
 	pip-yellow-building:
 		Start: 2
 	pip-gray-building:
 		Start: 3
 	pip-red-building:
 		Start: 4
+		Palette: pips
+		IsPlayerPalette: False
 	pip-blue-building:
 		Start: 5
 
@@ -172,56 +238,78 @@ explosion:
 	building:
 		Filename: twlt070.shp
 		Offset: 0, 0, 36
+		Palette: effect
+		IsPlayerPalette: False
 	ionring:
 		Filename: ring1.shp
 		ZRamp: 1
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam:
 		Filename: ionbeam.shp
 		Offset: 0, -60, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam2:
 		Filename: ionbeam.shp
 		Offset: 0, -180, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam3:
 		Filename: ionbeam.shp
 		Offset: 0, -300, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam4:
 		Filename: ionbeam.shp
 		Offset: 0, -420, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam5:
 		Filename: ionbeam.shp
 		Offset: 0, -540, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	ionbeam6:
 		Filename: ionbeam.shp
 		Offset: 0, -660, 60
 		Tick: 100
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	pulse_explosion:
 		Filename: pulsefx2.shp
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 80
+		Palette: effect
+		IsPlayerPalette: False
 	pulse_explosion_small:
 		Filename: mempfx.shp
 		BlendMode: Additive
 		ZRamp: 1
 		Tick: 11
+		Palette: effect
+		IsPlayerPalette: False
 	small_watersplash:
 		Filename: h2o_exp2.shp
 		IgnoreWorldTint: False
 		AlphaFade: False
 		Alpha: 0.5
+		Palette: player
+		IsPlayerPalette: False
 	large_watersplash:
 		Filename: h2o_exp1.shp
 		Offset: 0, 0, 39
@@ -231,40 +319,62 @@ explosion:
 	water_piff:
 		Filename: w_piff.shp
 		IgnoreWorldTint: False
+		Palette: ra
+		IsPlayerPalette: False
 	water_piffs:
 		Filename: w_piffs.shp
 		IgnoreWorldTint: False
+		Palette: ra
+		IsPlayerPalette: False
 	piff:
 		Filename: piff.shp
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	piffs:
 		Filename: piffpiff.shp
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	small_explosion:
 		Filename: explosml.shp
+		Palette: effect
+		IsPlayerPalette: False
 	medium_explosion:
 		Filename: explomed.shp
 		Offset: 0, 0, 27
 	large_explosion:
 		Filename: explolrg.shp
 		Offset: 0, 0, 31
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_bang:
 		Filename: s_bang16.shp
 	small_bang:
 		Filename: s_bang24.shp
+		Palette: effect
+		IsPlayerPalette: False
 	medium_bang:
 		Filename: s_bang34.shp
+		Palette: effect
+		IsPlayerPalette: False
 	large_bang:
 		Filename: s_bang48.shp
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_brnl:
 		Filename: s_brnl20.shp
 	small_brnl:
 		Filename: s_brnl30.shp
 	medium_brnl:
 		Filename: s_brnl40.shp
+		Palette: effect
+		IsPlayerPalette: False
 	large_brnl:
 		Filename: s_brnl58.shp
 		Offset: 0, 0, 30
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_tumu:
 		Filename: s_tumu22.shp
 	small_tumu:
@@ -274,27 +384,45 @@ explosion:
 	large_tumu:
 		Filename: s_tumu60.shp
 		Offset: 0, 0, 31
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_clsn:
 		Filename: s_clsn16.shp
 	small_clsn:
 		Filename: s_clsn22.shp
+		Palette: effect
+		IsPlayerPalette: False
 	medium_clsn:
 		Filename: s_clsn30.shp
+		Palette: effect
+		IsPlayerPalette: False
 	large_clsn:
 		Filename: s_clsn42.shp
+		Palette: effect
+		IsPlayerPalette: False
 	verylarge_clsn:
 		Filename: s_clsn58.shp
 		Offset: 0, 0, 30
+		Palette: effect
+		IsPlayerPalette: False
 	tiny_twlt:
 		Filename: twlt026.shp
+		Palette: effect
+		IsPlayerPalette: False
 	small_twlt:
 		Filename: twlt036.shp
+		Palette: effect
+		IsPlayerPalette: False
 	medium_twlt:
 		Filename: twlt050.shp
 		Offset: 0, 0, 26
+		Palette: effect
+		IsPlayerPalette: False
 	large_twlt:
 		Filename: twlt070.shp
 		Offset: 0, 0, 36
+		Palette: effect
+		IsPlayerPalette: False
 	verylarge_twlt:
 		Filename: twlt100.shp
 		Offset: 0, 0, 51
@@ -304,32 +432,44 @@ explosion:
 	small_grey_explosion:
 		Filename: xgrysml2.shp
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	medium_grey_explosion:
 		Filename: xgrymed1.shp
 		IgnoreWorldTint: False
 	large_grey_explosion:
 		Filename: xgrymed2.shp
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	droppod_explosion:
 		Filename: droppod.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	droppod2_explosion:
 		Filename: droppod2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	droppody_explosion:
 		Filename: droppody.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 	droppody2_explosion:
 		Filename: droppody2.shp
 		Length: 8
 		Tick: 360
 		IgnoreWorldTint: False
+		Palette: effect
+		IsPlayerPalette: False
 
 discus:
 	idle:
@@ -337,6 +477,8 @@ discus:
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 12
+		Palette: effect
+		IsPlayerPalette: False
 
 canister:
 	idle:
@@ -344,6 +486,8 @@ canister:
 		Length: *
 		ZOffset: 1023
 		Offset: 0, 0, 12
+		Palette: player
+		IsPlayerPalette: False
 
 pulsball:
 	idle:
@@ -352,6 +496,8 @@ pulsball:
 		BlendMode: Additive
 		ZOffset: 1023
 		Offset: 0, 0, 24
+		Palette: effect
+		IsPlayerPalette: False
 
 dragon:
 	idle:
@@ -359,6 +505,8 @@ dragon:
 		Facings: 32
 		ZOffset: 1023
 		Offset: 0, 0, 6
+		Palette: ra
+		IsPlayerPalette: False
 
 crystal4:
 	idle:
@@ -369,12 +517,16 @@ crystal4:
 		ShadowStart: 15
 		ZOffset: 1023
 		Offset: 0, 0, 6
+		Palette: greentiberium
+		IsPlayerPalette: False
 
 120mm:
 	idle:
 		Filename: 120mm.shp
 		ZOffset: 1023
 		Offset: 0, 0, 4
+		Palette: ra
+		IsPlayerPalette: False
 
 torpedo:
 	idle:
@@ -383,6 +535,8 @@ torpedo:
 		ZOffset: 1023
 		Offset: 0, 0, 8
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 
 flameall:
 	idle:
@@ -394,6 +548,8 @@ flameall:
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
 		Alpha: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1
+		Palette: effect
+		IsPlayerPalette: False
 
 largesmoke:
 	idle:
@@ -402,6 +558,8 @@ largesmoke:
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
+		Palette: effect
+		IsPlayerPalette: False
 
 smallsmoke:
 	idle:
@@ -426,6 +584,8 @@ small_smoke_trail:
 		ZOffset: 1023
 		Offset: 0, 0, 24
 		AlphaFade: True
+		Palette: effect
+		IsPlayerPalette: False
 
 largefire:
 	idle:
@@ -434,6 +594,8 @@ largefire:
 		Offset: 0, 0, 36
 		Alpha: 0.5
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 
 mediumfire:
 	idle:
@@ -442,6 +604,8 @@ mediumfire:
 		Offset: 0, 0, 24
 		Alpha: 0.5
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 
 smallfire:
 	idle:
@@ -450,6 +614,8 @@ smallfire:
 		Offset: 0, 0, 24
 		Alpha: 0.5
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 
 tinyfire:
 	idle:
@@ -467,6 +633,8 @@ moveflsh:
 		ZOffset: 2047
 		ZRamp: 1
 		AlphaFade: True
+		Palette: moveflash
+		IsPlayerPalette: False
 
 wake:
 	idle:
@@ -477,6 +645,8 @@ wake:
 		ZRamp: 1
 		Offset: 0, 0, 1
 		AlphaFade: True
+		Palette: effect
+		IsPlayerPalette: False
 
 resources:
 	Defaults:
@@ -489,82 +659,162 @@ resources:
 		TilesetFilenames:
 			TEMPERATE: tib01.tem
 			SNOW: tib01.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib02:
 		TilesetFilenames:
 			TEMPERATE: tib02.tem
 			SNOW: tib02.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib03:
 		TilesetFilenames:
 			TEMPERATE: tib03.tem
 			SNOW: tib03.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib04:
 		TilesetFilenames:
 			TEMPERATE: tib04.tem
 			SNOW: tib04.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib05:
 		TilesetFilenames:
 			TEMPERATE: tib05.tem
 			SNOW: tib05.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib06:
 		TilesetFilenames:
 			TEMPERATE: tib06.tem
 			SNOW: tib06.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib07:
 		TilesetFilenames:
 			TEMPERATE: tib07.tem
 			SNOW: tib07.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib08:
 		TilesetFilenames:
 			TEMPERATE: tib08.tem
 			SNOW: tib08.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib09:
 		TilesetFilenames:
 			TEMPERATE: tib09.tem
 			SNOW: tib09.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib10:
 		TilesetFilenames:
 			TEMPERATE: tib10.tem
 			SNOW: tib10.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib11:
 		TilesetFilenames:
 			TEMPERATE: tib11.tem
 			SNOW: tib11.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib12:
 		TilesetFilenames:
 			TEMPERATE: tib12.tem
 			SNOW: tib12.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib13:
 		TilesetFilenames:
 			TEMPERATE: tib13.tem
 			SNOW: tib13.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib14:
 		TilesetFilenames:
 			TEMPERATE: tib14.tem
 			SNOW: tib14.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib15:
 		TilesetFilenames:
 			TEMPERATE: tib15.tem
 			SNOW: tib15.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib16:
 		TilesetFilenames:
 			TEMPERATE: tib16.tem
 			SNOW: tib16.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib17:
 		TilesetFilenames:
 			TEMPERATE: tib17.tem
 			SNOW: tib17.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib18:
 		TilesetFilenames:
 			TEMPERATE: tib18.tem
 			SNOW: tib18.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib19:
 		TilesetFilenames:
 			TEMPERATE: tib19.tem
 			SNOW: tib19.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	tib20:
 		TilesetFilenames:
 			TEMPERATE: tib20.tem
 			SNOW: tib20.sno
+		Palette: greentiberium
+		IsPlayerPalette: False
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	veins:
 		TilesetFilenames:
 			TEMPERATE: veins.tem
@@ -572,6 +822,8 @@ resources:
 		Length: *
 		ShadowStart: -1
 		IgnoreWorldTint: false
+		Palette: player
+		IsPlayerPalette: False
 
 veins:
 	idle:
@@ -581,6 +833,8 @@ veins:
 		Length: 12
 		ZOffset: 1023
 		Offset: 0, -12, 24
+		Palette: player
+		IsPlayerPalette: False
 
 shroud:
 	Defaults:
@@ -589,162 +843,242 @@ shroud:
 		ZRamp: 1
 	shroud:
 		Length: *
+		Palette: shroud
+		IsPlayerPalette: False
 	fog:
 		Filename: fog.shp
 		Length: *
+		Palette: shroud
+		IsPlayerPalette: False
 
 smallscorches:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	sc1:
 		TilesetFilenames:
 			TEMPERATE: burnt01.tem
 			SNOW: burnt01.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc2:
 		TilesetFilenames:
 			TEMPERATE: burnt02.tem
 			SNOW: burnt02.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc3:
 		TilesetFilenames:
 			TEMPERATE: burnt03.tem
 			SNOW: burnt03.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc4:
 		TilesetFilenames:
 			TEMPERATE: burnt04.tem
 			SNOW: burnt04.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc5:
 		TilesetFilenames:
 			TEMPERATE: burnt05.tem
 			SNOW: burnt05.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc6:
 		TilesetFilenames:
 			TEMPERATE: burnt06.tem
 			SNOW: burnt06.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 mediumscorches:
 	Defaults:
 		Offset: 0, -18, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	sc7:
 		TilesetFilenames:
 			TEMPERATE: burnt07.tem
 			SNOW: burnt07.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc8:
 		TilesetFilenames:
 			TEMPERATE: burnt08.tem
 			SNOW: burnt08.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc9:
 		TilesetFilenames:
 			TEMPERATE: burnt09.tem
 			SNOW: burnt09.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc10:
 		TilesetFilenames:
 			TEMPERATE: burnt10.tem
 			SNOW: burnt10.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 largescorches:
 	Defaults:
 		Offset: 0, -24, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	sc11:
 		TilesetFilenames:
 			TEMPERATE: burnt11.tem
 			SNOW: burnt11.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	sc12:
 		TilesetFilenames:
 			TEMPERATE: burnt12.tem
 			SNOW: burnt12.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 smallcraters:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	cr1:
 		TilesetFilenames:
 			TEMPERATE: crater01.tem
 			SNOW: crater01.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr2:
 		TilesetFilenames:
 			TEMPERATE: crater02.tem
 			SNOW: crater02.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr3:
 		TilesetFilenames:
 			TEMPERATE: crater03.tem
 			SNOW: crater03.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr4:
 		TilesetFilenames:
 			TEMPERATE: crater04.tem
 			SNOW: crater04.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr5:
 		TilesetFilenames:
 			TEMPERATE: crater05.tem
 			SNOW: crater05.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr6:
 		TilesetFilenames:
 			TEMPERATE: crater06.tem
 			SNOW: crater06.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 mediumcraters:
 	Defaults:
 		Offset: 0, -12, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	cr7:
 		TilesetFilenames:
 			TEMPERATE: crater07.tem
 			SNOW: crater07.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr8:
 		TilesetFilenames:
 			TEMPERATE: crater08.tem
 			SNOW: crater08.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr9:
 		TilesetFilenames:
 			TEMPERATE: crater09.tem
 			SNOW: crater09.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr10:
 		TilesetFilenames:
 			TEMPERATE: crater10.tem
 			SNOW: crater10.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 largecraters:
 	Defaults:
 		Offset: 0, -24, 1
 		ZRamp: 1
+		Palette: terrain
+		IsPlayerPalette: False
 	cr11:
 		TilesetFilenames:
 			TEMPERATE: crater11.tem
 			SNOW: crater11.sno
+		Palette: terrain
+		IsPlayerPalette: False
 	cr12:
 		TilesetFilenames:
 			TEMPERATE: crater12.tem
 			SNOW: crater12.sno
+		Palette: terrain
+		IsPlayerPalette: False
 
 icon:
 	clustermissile:
 		Filename: mltiicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	ioncannon:
 		Filename: ioncicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	hunterseeker:
 		Filename: detnicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	emp:
 		Filename: pulsicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	droppods:
 		Filename: podsicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 clustermissile:
 	up: # TODO: use voxel
 		Filename: mltimisl-placeholder.shp
 		Frames: 0
 		Length: 1
+		Palette: effect
+		IsPlayerPalette: False
 	down: # TODO: use voxel
 		Filename: mltimisl-placeholder.shp
 		Frames: 1
 		Length: 1
+		Palette: effect
+		IsPlayerPalette: False
 
 ^rock:
 	idle:
 		ShadowStart: 1
 		Offset: 0, -12
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 trock01:
 	Inherits: ^rock
@@ -752,6 +1086,8 @@ trock01:
 		TilesetFilenames:
 			TEMPERATE: trock01.tem
 			SNOW: trock01.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 trock02:
 	Inherits: ^rock
@@ -759,6 +1095,8 @@ trock02:
 		TilesetFilenames:
 			TEMPERATE: trock02.tem
 			SNOW: trock02.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 trock03:
 	Inherits: ^rock
@@ -766,6 +1104,8 @@ trock03:
 		TilesetFilenames:
 			TEMPERATE: trock03.tem
 			SNOW: trock03.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 trock04:
 	Inherits: ^rock
@@ -773,6 +1113,8 @@ trock04:
 		TilesetFilenames:
 			TEMPERATE: trock04.tem
 			SNOW: trock04.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 trock05:
 	Inherits: ^rock
@@ -780,6 +1122,8 @@ trock05:
 		TilesetFilenames:
 			TEMPERATE: trock05.tem
 			SNOW: trock05.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 srock01:
 	Inherits: ^rock
@@ -787,6 +1131,8 @@ srock01:
 		TilesetFilenames:
 			TEMPERATE: srock01.tem
 			SNOW: srock01.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 srock02:
 	Inherits: ^rock
@@ -794,6 +1140,8 @@ srock02:
 		TilesetFilenames:
 			TEMPERATE: srock02.tem
 			SNOW: srock02.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 srock03:
 	Inherits: ^rock
@@ -801,6 +1149,8 @@ srock03:
 		TilesetFilenames:
 			TEMPERATE: srock03.tem
 			SNOW: srock03.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 srock04:
 	Inherits: ^rock
@@ -808,6 +1158,8 @@ srock04:
 		TilesetFilenames:
 			TEMPERATE: srock04.tem
 			SNOW: srock04.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 srock05:
 	Inherits: ^rock
@@ -815,6 +1167,8 @@ srock05:
 		TilesetFilenames:
 			TEMPERATE: srock05.tem
 			SNOW: srock05.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 dbrissm:
 	Defaults:
@@ -822,24 +1176,44 @@ dbrissm:
 		Length: *
 	1:
 		Filename: dbris1sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	2:
 		Filename: dbris2sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	3:
 		Filename: dbris3sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	4:
 		Filename: dbris4sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	5:
 		Filename: dbris5sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	6:
 		Filename: dbris6sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	7:
 		Filename: dbris7sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	8:
 		Filename: dbris8sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	9:
 		Filename: dbris9sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 	10:
 		Filename: dbrs10sm.shp
+		Palette: effect
+		IsPlayerPalette: False
 
 dbrislg:
 	Defaults:
@@ -847,94 +1221,142 @@ dbrislg:
 		Length: *
 	1:
 		Filename: dbris1lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	2:
 		Filename: dbris2lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	3:
 		Filename: dbris3lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	4:
 		Filename: dbris4lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	5:
 		Filename: dbris5lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	6:
 		Filename: dbris6lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	7:
 		Filename: dbris7lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	8:
 		Filename: dbris8lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	9:
 		Filename: dbris9lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 	10:
 		Filename: dbrs10lg.shp
+		Palette: effect
+		IsPlayerPalette: False
 
 ^crate:
 	idle:
 		Offset: 0, 0, 12
 		DepthSprite: isodepth.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat01:
 	Inherits: ^crate
 	idle:
 		Filename: crat01.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat02:
 	Inherits: ^crate
 	idle:
 		Filename: crat02.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat03:
 	Inherits: ^crate
 	idle:
 		Filename: crat03.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat04:
 	Inherits: ^crate
 	idle:
 		Filename: crat04.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat0a:
 	Inherits: ^crate
 	idle:
 		Filename: crat0a.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat0b:
 	Inherits: ^crate
 	idle:
 		Filename: crat0b.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 crat0c:
 	Inherits: ^crate
 	idle:
 		Filename: crat0c.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 drum01:
 	Inherits: ^crate
 	idle:
 		Filename: drum01.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 drum02:
 	Inherits: ^crate
 	idle:
 		Filename: drum02.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 palet01:
 	Inherits: ^crate
 	idle:
 		Filename: palet01.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 palet02:
 	Inherits: ^crate
 	idle:
 		Filename: palet02.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 palet03:
 	Inherits: ^crate
 	idle:
 		Filename: palet03.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 palet04:
 	Inherits: ^crate
 	idle:
 		Filename: palet04.shp
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^tracks:
 	idle:
@@ -948,6 +1370,8 @@ tracks01:
 		TilesetFilenames:
 			TEMPERATE: tracks01.tem
 			SNOW: tracks01.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks02:
 	Inherits: ^tracks
@@ -955,6 +1379,8 @@ tracks02:
 		TilesetFilenames:
 			TEMPERATE: tracks02.tem
 			SNOW: tracks02.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks03:
 	Inherits: ^tracks
@@ -962,6 +1388,8 @@ tracks03:
 		TilesetFilenames:
 			TEMPERATE: tracks03.tem
 			SNOW: tracks03.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks04:
 	Inherits: ^tracks
@@ -969,6 +1397,8 @@ tracks04:
 		TilesetFilenames:
 			TEMPERATE: tracks04.tem
 			SNOW: tracks04.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks05:
 	Inherits: ^tracks
@@ -976,6 +1406,8 @@ tracks05:
 		TilesetFilenames:
 			TEMPERATE: tracks05.tem
 			SNOW: tracks05.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks06:
 	Inherits: ^tracks
@@ -983,6 +1415,8 @@ tracks06:
 		TilesetFilenames:
 			TEMPERATE: tracks06.tem
 			SNOW: tracks06.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks07:
 	Inherits: ^tracks
@@ -990,6 +1424,8 @@ tracks07:
 		TilesetFilenames:
 			TEMPERATE: tracks07.tem
 			SNOW: tracks07.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks08:
 	Inherits: ^tracks
@@ -997,6 +1433,8 @@ tracks08:
 		TilesetFilenames:
 			TEMPERATE: tracks08.tem
 			SNOW: tracks08.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks09:
 	Inherits: ^tracks
@@ -1004,6 +1442,8 @@ tracks09:
 		TilesetFilenames:
 			TEMPERATE: tracks09.tem
 			SNOW: tracks09.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks10:
 	Inherits: ^tracks
@@ -1011,6 +1451,8 @@ tracks10:
 		TilesetFilenames:
 			TEMPERATE: tracks10.tem
 			SNOW: tracks10.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks11:
 	Inherits: ^tracks
@@ -1018,6 +1460,8 @@ tracks11:
 		TilesetFilenames:
 			TEMPERATE: tracks11.tem
 			SNOW: tracks11.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks12:
 	Inherits: ^tracks
@@ -1025,6 +1469,8 @@ tracks12:
 		TilesetFilenames:
 			TEMPERATE: tracks12.tem
 			SNOW: tracks12.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks13:
 	Inherits: ^tracks
@@ -1032,6 +1478,8 @@ tracks13:
 		TilesetFilenames:
 			TEMPERATE: tracks13.tem
 			SNOW: tracks13.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks14:
 	Inherits: ^tracks
@@ -1039,6 +1487,8 @@ tracks14:
 		TilesetFilenames:
 			TEMPERATE: tracks14.tem
 			SNOW: tracks14.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks15:
 	Inherits: ^tracks
@@ -1046,6 +1496,8 @@ tracks15:
 		TilesetFilenames:
 			TEMPERATE: tracks15.tem
 			SNOW: tracks15.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tracks16:
 	Inherits: ^tracks
@@ -1053,6 +1505,8 @@ tracks16:
 		TilesetFilenames:
 			TEMPERATE: tracks16.tem
 			SNOW: tracks16.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 ^tuntop:
 	idle:
@@ -1065,6 +1519,8 @@ tuntop01:
 			TEMPERATE: tuntop01.tem
 			SNOW: tuntop01.sno
 		Offset: 24, -49, 48
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tuntop02:
 	Inherits: ^tuntop
@@ -1073,6 +1529,8 @@ tuntop02:
 			TEMPERATE: tuntop02.tem
 			SNOW: tuntop02.sno
 		Offset: -24, -49, 48
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tuntop03:
 	Inherits: ^tuntop
@@ -1081,6 +1539,8 @@ tuntop03:
 			TEMPERATE: tuntop03.tem
 			SNOW: tuntop03.sno
 		Offset: 24, -49, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tuntop04:
 	Inherits: ^tuntop
@@ -1089,6 +1549,8 @@ tuntop04:
 			TEMPERATE: tuntop04.tem
 			SNOW: tuntop04.sno
 		Offset: -24, -49, 49
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 dig:
 	idle:
@@ -1096,17 +1558,25 @@ dig:
 		Length: *
 		ZOffset: 511
 		Offset: 0, 0, 24
+		Palette: effect
+		IsPlayerPalette: False
 
 typeglyphs:
 	Defaults:
 		Filename: typeglyphs.shp
 	infantry:
+		Palette: player
+		IsPlayerPalette: True
 	vehicle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	helicopter:
 		Start: 2
 	harvester:
 		Start: 3
+		Palette: player
+		IsPlayerPalette: True
 	structure:
 		Start: 4
 
@@ -1116,6 +1586,8 @@ podring:
 		Frames: 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
 		Length: *
 		AlphaFade: True
+		Palette: effect
+		IsPlayerPalette: False
 
 fire1:
 	idle-overlay:
@@ -1124,6 +1596,8 @@ fire1:
 		BlendMode: Translucent
 		Offset: 0, -24, 24
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 fire2:
 	idle-overlay:
@@ -1132,6 +1606,8 @@ fire2:
 		BlendMode: Translucent
 		Offset: 0, -18, 18
 		ZOffset: 1023
+		Palette: effect
+		IsPlayerPalette: False
 
 caryland:
 	idle:
@@ -1142,6 +1618,8 @@ caryland:
 		ZRamp: 1
 		Offset: 0, 0, 1
 		BlendMode: Translucent
+		Palette: effect
+		IsPlayerPalette: False
 
 dropland:
 	idle:
@@ -1152,3 +1630,5 @@ dropland:
 		ZRamp: 1
 		Offset: 0, 0, 1
 		BlendMode: Translucent
+		Palette: effect
+		IsPlayerPalette: False

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -7,19 +7,27 @@ gacnst:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtcnstmk.shp
 			SNOW: gacnstmk.shp
 		Length: 24
 		ShadowStart: 24
+		Palette: player
+		IsPlayerPalette: True
 	make-bright:
 		TilesetFilenames:
 			TEMPERATE: gtcnstmk.shp
@@ -27,18 +35,24 @@ gacnst:
 		Length: 24
 		IgnoreWorldTint: True
 		ZOffset: 1023
+		Palette: bright
+		IsPlayerPalette: False
 	crane-overlay:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_d.shp
 			SNOW: gacnst_d.shp
 		Length: 20
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	damaged-crane-overlay:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_d.shp
 			SNOW: gacnst_d.shp
 		Length: 20
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	critical-crane-overlay:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_d.shp
@@ -46,12 +60,16 @@ gacnst:
 		Start: 20
 		Length: 20
 		ZOffset: 1023
+		Palette: player
+		IsPlayerPalette: True
 	idle-top:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_c.shp
 			SNOW: gacnst_c.shp
 		Length: 15
 		Tick: 80
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-top-bright:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_c.shp
@@ -59,6 +77,8 @@ gacnst:
 		Length: 15
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-top:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_c.shp
@@ -66,6 +86,8 @@ gacnst:
 		Start: 15
 		Length: 15
 		Tick: 80
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-top-bright:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_c.shp
@@ -74,28 +96,38 @@ gacnst:
 		Length: 15
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-side:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_a.shp
 			SNOW: gacnst_a.shp
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-side:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_a.shp
 			SNOW: gacnst_a.shp
 		Start: 10
 		Length: 10
+		Palette: player
+		IsPlayerPalette: True
 	idle-front:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_b.shp
 			SNOW: gacnst_b.shp
 		Length: 10
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-front-bright:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_b.shp
 			SNOW: gacnst_b.shp
 		Length: 10
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -105,11 +137,15 @@ gacnst:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: facticon.shp
 		TilesetFilenames:
 		Offset: 0,0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gapowr:
 	Defaults:
@@ -120,19 +156,27 @@ gapowr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_a.shp
 			SNOW: gapowr_a.shp
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_a.shp
@@ -140,6 +184,8 @@ gapowr:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_a.shp
@@ -147,6 +193,8 @@ gapowr:
 		Start: 12
 		Length: 12
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_a.shp
@@ -155,18 +203,24 @@ gapowr:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-plug:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
 			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-plug:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
 			SNOW: gapowr_b.shp
 		Length: 12
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	idle-powrupa:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
@@ -174,6 +228,8 @@ gapowr:
 		Length: 12
 		Tick: 200
 		Offset: -48, -24, 36
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-powrupa:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
@@ -181,6 +237,8 @@ gapowr:
 		Length: 12
 		Tick: 200
 		Offset: -48, -24, 36
+		Palette: player
+		IsPlayerPalette: True
 	idle-powrupb:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
@@ -188,6 +246,8 @@ gapowr:
 		Length: 12
 		Tick: 200
 		Offset: -24, -12, 40
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-powrupb:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
@@ -195,12 +255,16 @@ gapowr:
 		Length: 12
 		Tick: 200
 		Offset: -24, -12, 40
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtpowrmk.shp
 			SNOW: gapowrmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	make-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpowrmk.shp
@@ -208,6 +272,8 @@ gapowr:
 		Length: 20
 		ShadowStart: 20
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -217,11 +283,15 @@ gapowr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: powricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gapowrup:
 	place:
@@ -230,8 +300,12 @@ gapowrup:
 		Start: 0
 		Length: 11
 		Tick: 200
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: turbicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gapile:
 	Defaults:
@@ -242,13 +316,19 @@ gapile:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtpile_a.shp
@@ -256,6 +336,8 @@ gapile:
 		Length: 8
 		Tick: 200
 		ZOffset: 1023
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpile_a.shp
@@ -264,6 +346,8 @@ gapile:
 		Tick: 200
 		ZOffset: 1023
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-light-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpile_b.shp
@@ -271,12 +355,16 @@ gapile:
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-flag:
 		TilesetFilenames:
 			TEMPERATE: gtpile_c.shp
 			SNOW: gapile_c.shp
 		Length: 7
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-flag:
 		TilesetFilenames:
 			TEMPERATE: gtpile_c.shp
@@ -284,12 +372,16 @@ gapile:
 		Start: 7
 		Length: 7
 		Tick: 100
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtpilemk.shp
 			SNOW: gapilemk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -299,11 +391,15 @@ gapile:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: brrkicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaweap:
 	Defaults:
@@ -319,6 +415,8 @@ gaweap:
 		ZOffset: -1024
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: gtweap_1.shp
@@ -329,17 +427,23 @@ gaweap:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	idle-roof:
 		TilesetFilenames:
 			TEMPERATE: gtweap_2.shp
 			SNOW: gaweap_2.shp
 		ShadowStart: 2
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-roof:
 		TilesetFilenames:
 			TEMPERATE: gtweap_2.shp
 			SNOW: gaweap_2.shp
 		Start: 1
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		TilesetFilenames:
 			TEMPERATE: gtweap.shp
@@ -347,6 +451,8 @@ gaweap:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-white:
 		TilesetFilenames:
 			TEMPERATE: gtweap_a.shp
@@ -354,6 +460,8 @@ gaweap:
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-white-bright:
 		TilesetFilenames:
 			TEMPERATE: gtweap_a.shp
@@ -362,6 +470,8 @@ gaweap:
 		Tick: 100
 		ZOffset: 2048
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-lights-red:
 		TilesetFilenames:
 			TEMPERATE: gtweap_b.shp
@@ -369,6 +479,8 @@ gaweap:
 		Length: 8
 		Tick: 120
 		ZOffset: 2048
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-red-bright:
 		TilesetFilenames:
 			TEMPERATE: gtweap_b.shp
@@ -377,6 +489,8 @@ gaweap:
 		Tick: 120
 		ZOffset: 2048
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-turbines:
 		TilesetFilenames:
 			TEMPERATE: gtweap_c.shp
@@ -384,6 +498,8 @@ gaweap:
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-turbines:
 		TilesetFilenames:
 			TEMPERATE: gtweap_c.shp
@@ -391,18 +507,24 @@ gaweap:
 		Length: 4
 		Tick: 80
 		ZOffset: 2048
+		Palette: player
+		IsPlayerPalette: True
 	build-door:
 		TilesetFilenames:
 			TEMPERATE: gtweap_d.shp
 			SNOW: gaweap_d.shp
 		Length: 9
 		ShadowStart: 9
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build-door:
 		TilesetFilenames:
 			TEMPERATE: gtweap_d.shp
 			SNOW: gaweap_d.shp
 		Length: 9
 		ShadowStart: 9
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtweapmk.shp
@@ -412,6 +534,8 @@ gaweap:
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
+		Palette: player
+		IsPlayerPalette: True
 	make-bright:
 		TilesetFilenames:
 			TEMPERATE: gtweapmk.shp
@@ -421,6 +545,8 @@ gaweap:
 		Offset: -12, -42, 44
 		DepthSpriteOffset: -12, 0
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -429,10 +555,14 @@ gaweap:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: weapicon.shp
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 napowr:
 	Defaults:
@@ -443,19 +573,27 @@ napowr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntpowr_a.shp
 			SNOW: napowr_a.shp
 		Length: 9
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpowr_a.shp
@@ -463,6 +601,8 @@ napowr:
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntpowr_a.shp
@@ -470,6 +610,8 @@ napowr:
 		Start: 9
 		Length: 9
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpowr_a.shp
@@ -478,12 +620,16 @@ napowr:
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntpowrmk.shp
 			SNOW: napowrmk.shp
 		Length: 19
 		ShadowStart: 19
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -493,11 +639,15 @@ napowr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: npwricon.shp
 		TilesetFilenames:
 		Offset: 0, 0, 25
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 naapwr:
 	Defaults:
@@ -509,19 +659,27 @@ naapwr:
 		DepthSpriteOffset: 12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntapwr_a.shp
 			SNOW: naapwr_a.shp
 		Length: 9
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntapwr_a.shp
@@ -529,6 +687,8 @@ naapwr:
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntapwr_a.shp
@@ -536,6 +696,8 @@ naapwr:
 		Start: 9
 		Length: 9
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntapwr_a.shp
@@ -544,12 +706,16 @@ naapwr:
 		Length: 9
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntapwrmk.shp
 			SNOW: naapwrmk.shp
 		Length: 19
 		ShadowStart: 19
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -559,11 +725,15 @@ naapwr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: apwricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nahand:
 	Defaults:
@@ -575,13 +745,19 @@ nahand:
 		DepthSpriteOffset: -12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-light-bright:
 		TilesetFilenames:
 			TEMPERATE: nthand_a.shp
@@ -590,6 +766,8 @@ nahand:
 		Tick: 100
 		ZOffset: 1023
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthand_b.shp
@@ -597,6 +775,8 @@ nahand:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthand_b.shp
@@ -605,12 +785,16 @@ nahand:
 		Length: 12
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nthandmk.shp
 			SNOW: nahandmk.shp
 		Length: 15
 		ShadowStart: 15
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -620,11 +804,15 @@ nahand:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: handicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 naweap:
 	Defaults:
@@ -640,6 +828,8 @@ naweap:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: ntweap_1.shp
@@ -650,12 +840,16 @@ naweap:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	idle-roof:
 		TilesetFilenames:
 			TEMPERATE: ntweap_2.shp
 			SNOW: naweap_2.shp
 		ShadowStart: 2
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-roof:
 		TilesetFilenames:
 			TEMPERATE: ntweap_2.shp
@@ -663,6 +857,8 @@ naweap:
 		Start: 1
 		ShadowStart: 3
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		TilesetFilenames:
 			TEMPERATE: ntweap.shp
@@ -670,6 +866,8 @@ naweap:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntweap_a.shp
@@ -677,6 +875,8 @@ naweap:
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntweap_a.shp
@@ -685,6 +885,8 @@ naweap:
 		Tick: 100
 		ZOffset: 2048
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntweap_a.shp
@@ -693,6 +895,8 @@ naweap:
 		Length: 16
 		Tick: 100
 		ZOffset: 2048
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntweap_a.shp
@@ -702,6 +906,8 @@ naweap:
 		Tick: 100
 		ZOffset: 2048
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	build-door:
 		TilesetFilenames:
 			TEMPERATE: ntweap_b.shp
@@ -709,6 +915,8 @@ naweap:
 		Length: 10
 		ShadowStart: 10
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 	damaged-build-door:
 		TilesetFilenames:
 			TEMPERATE: ntweap_b.shp
@@ -717,6 +925,8 @@ naweap:
 		Length: 10
 		ShadowStart: 20
 		ZOffset: 512
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntweapmk.shp
@@ -726,6 +936,8 @@ naweap:
 		ShadowStart: 22
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -734,10 +946,14 @@ naweap:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: nwepicon.shp
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 naradr:
 	Defaults:
@@ -748,19 +964,27 @@ naradr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		TilesetFilenames:
 			TEMPERATE: ntradr_a.shp
 			SNOW: naradr_a.shp
 		Length: 24
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-dish:
 		TilesetFilenames:
 			TEMPERATE: ntradr_a.shp
@@ -768,12 +992,16 @@ naradr:
 		Start: 24
 		Length: 24
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntradrmk.shp
 			SNOW: naradrmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -783,11 +1011,15 @@ naradr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: nradicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 natech:
 	Defaults:
@@ -798,19 +1030,27 @@ natech:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nttech_a.shp
 			SNOW: natech_a.shp
 		Length: 10
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nttech_a.shp
@@ -818,6 +1058,8 @@ natech:
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nttech_a.shp
@@ -825,6 +1067,8 @@ natech:
 		Start: 10
 		Length: 10
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nttech_a.shp
@@ -833,12 +1077,16 @@ natech:
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nttechmk.shp
 			SNOW: natechmk.shp
 		Length: 18
 		ShadowStart: 18
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -848,11 +1096,15 @@ natech:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: ntchicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 natmpl:
 	Defaults:
@@ -864,19 +1116,27 @@ natmpl:
 		DepthSpriteOffset: -12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nttmpl_a.shp
 			SNOW: natmpl_a.shp
 		Length: 16
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nttmpl_a.shp
@@ -884,12 +1144,16 @@ natmpl:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nttmplmk.shp
 			SNOW: natmplmk.shp
 		Length: 17
 		ShadowStart: 17
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -899,11 +1163,15 @@ natmpl:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: tmplicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 garadr:
 	Defaults:
@@ -914,13 +1182,19 @@ garadr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		TilesetFilenames:
 			TEMPERATE: gtradr_a.shp
@@ -928,6 +1202,8 @@ garadr:
 		Length: 15
 		Reverses: True
 		Tick: 200
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-dish:
 		TilesetFilenames:
 			TEMPERATE: gtradr_a.shp
@@ -936,12 +1212,16 @@ garadr:
 		Length: 15
 		Reverses: True
 		Tick: 240
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtradrmk.shp
 			SNOW: garadrmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -951,11 +1231,15 @@ garadr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: radricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gatech:
 	Defaults:
@@ -967,19 +1251,27 @@ gatech:
 		DepthSpriteOffset: -12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gttech_a.shp
 			SNOW: gatech_a.shp
 		Length: 8
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gttech_a.shp
@@ -987,6 +1279,8 @@ gatech:
 		Length: 8
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gttech_a.shp
@@ -994,6 +1288,8 @@ gatech:
 		Start: 8
 		Length: 8
 		Tick: 240
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gttech_a.shp
@@ -1002,12 +1298,16 @@ gatech:
 		Length: 8
 		Tick: 240
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gttechmk.shp
 			SNOW: gatechmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1017,11 +1317,15 @@ gatech:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: techicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gasand:
 	Defaults:
@@ -1033,15 +1337,21 @@ gasand:
 	idle:
 		Length: 16
 		ShadowStart: 32
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Length: 16
 		ShadowStart: 48
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: sbagicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gawall:
 	Defaults:
@@ -1053,19 +1363,27 @@ gawall:
 	idle:
 		Length: 16
 		ShadowStart: 48
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Length: 16
 		ShadowStart: 64
+		Palette: player
+		IsPlayerPalette: True
 	critical-idle:
 		Start: 32
 		Length: 16
 		ShadowStart: 80
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: wallicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gagate_a:
 	Defaults:
@@ -1078,6 +1396,8 @@ gagate_a:
 	idle:
 		Length: 10
 		ShadowStart: 21
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Start: 9
 		ShadowStart: 30
@@ -1085,10 +1405,14 @@ gagate_a:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
 		ShadowStart: 31
+		Palette: player
+		IsPlayerPalette: True
 	damaged-open:
 		Start: 19
 		ShadowStart: 40
@@ -1096,10 +1420,14 @@ gagate_a:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1109,11 +1437,15 @@ gagate_a:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: gateicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gagate_b:
 	Defaults:
@@ -1126,6 +1458,8 @@ gagate_b:
 	idle:
 		Length: 10
 		ShadowStart: 21
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Start: 9
 		ShadowStart: 30
@@ -1133,10 +1467,14 @@ gagate_b:
 		ZOffset: -1024
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 10
 		Length: 10
 		ShadowStart: 31
+		Palette: player
+		IsPlayerPalette: True
 	damaged-open:
 		Start: 19
 		ShadowStart: 40
@@ -1144,10 +1482,14 @@ gagate_b:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1157,11 +1499,15 @@ gagate_b:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: gat2icon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nagate_a:
 	Defaults:
@@ -1175,6 +1521,8 @@ nagate_a:
 	idle:
 		Length: 7
 		ShadowStart: 15
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		Length: 7
@@ -1186,10 +1534,14 @@ nagate_a:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		Length: 7
 		ShadowStart: 22
+		Palette: player
+		IsPlayerPalette: True
 	damaged-open:
 		Start: 13
 		ShadowStart: 28
@@ -1197,10 +1549,14 @@ nagate_a:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1210,11 +1566,15 @@ nagate_a:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: ngaticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nagate_b:
 	Defaults:
@@ -1228,6 +1588,8 @@ nagate_b:
 	idle:
 		Length: 7
 		ShadowStart: 15
+		Palette: player
+		IsPlayerPalette: True
 	open:
 		Start: 6
 		ShadowStart: 21
@@ -1235,10 +1597,14 @@ nagate_b:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 7
 		Length: 7
 		ShadowStart: 22
+		Palette: player
+		IsPlayerPalette: True
 	damaged-open:
 		Start: 13
 		ShadowStart: 28
@@ -1246,10 +1612,14 @@ nagate_b:
 		ZRamp: 1
 		ZOffset: -1024
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1259,11 +1629,15 @@ nagate_b:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: nga2icon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 napost:
 	Defaults:
@@ -1275,9 +1649,13 @@ napost:
 	idle:
 		Start: 0
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpost_b.shp
@@ -1287,6 +1665,8 @@ napost:
 		ShadowStart: 14
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpost_b.shp
@@ -1296,6 +1676,8 @@ napost:
 		ShadowStart: 21
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	chainoflights:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1304,6 +1686,8 @@ napost:
 		Length: 12
 		ShadowStart: 24
 		Tick: 80
+		Palette: player-nobright
+		IsPlayerPalette: True
 	chainoflights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1313,6 +1697,8 @@ napost:
 		ShadowStart: 24
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-chainoflights:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1321,6 +1707,8 @@ napost:
 		Length: 12
 		ShadowStart: 36
 		Tick: 80
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-chainoflights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1330,10 +1718,14 @@ napost:
 		ShadowStart: 36
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Tick: 400
 		ShadowStart: 5
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntpostmk.shp
@@ -1341,6 +1733,8 @@ napost:
 		Start: 0
 		Length: 12
 		ShadowStart: 12
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1350,11 +1744,15 @@ napost:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: lasricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nafnce:
 	Defaults:
@@ -1371,30 +1769,42 @@ nafnce:
 		Offset: 0, -12, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	disabled-y:
 		Start: 12
 		Length: 1
 		Offset: 0, -12, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	enabled-x:
 		Frames: 3,3,1,1,3,3,1,1,2,2,0,0,2,2,0,0
 		Length: 16
 		DepthSpriteOffset: -12, 0
+		Palette: player-nobright
+		IsPlayerPalette: True
 	enabled-x-bright:
 		Frames: 3,3,1,1,3,3,1,1,2,2,0,0,2,2,0,0
 		Length: 16
 		DepthSpriteOffset: -12, 0
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	enabled-y:
 		Frames: 7,5,7,5,6,4,6,4,7,5,7,5,6,4,6,4
 		Length: 16
 		DepthSpriteOffset: 12, 0
+		Palette: player-nobright
+		IsPlayerPalette: True
 	enabled-y-bright:
 		Frames: 7,5,7,5,6,4,6,4,7,5,7,5,6,4,6,4
 		Length: 16
 		DepthSpriteOffset: 12, 0
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1415,19 +1825,27 @@ nawall:
 	idle:
 		Length: 16
 		ShadowStart: 48
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 16
 		Length: 16
 		ShadowStart: 64
+		Palette: player
+		IsPlayerPalette: True
 	critical-idle:
 		Start: 32
 		Length: 16
 		ShadowStart: 80
+		Palette: player
+		IsPlayerPalette: True
 	icon:
 		Filename: nwalicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaicbm:
 	Defaults:
@@ -1439,9 +1857,13 @@ gaicbm:
 		DepthSpriteOffset: -12, 6
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1451,12 +1873,16 @@ gaicbm:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gticbmmk.shp
 			SNOW: gaicbmmk.shp
 		Length: 30
 		ShadowStart: 30
+		Palette: player
+		IsPlayerPalette: True
 
 naobel:
 	Defaults:
@@ -1467,13 +1893,19 @@ naobel:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		TilesetFilenames:
 			TEMPERATE: ntobel_b.shp
@@ -1481,18 +1913,24 @@ naobel:
 		Length: 12
 		Tick: 200
 		ZOffset: 2
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntobel_a.shp
 			SNOW: naobel_a.shp
 		Length: 12
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntobelmk.shp
 			SNOW: naobelmk.shp
 		Length: 19
 		ShadowStart: 19
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1502,11 +1940,15 @@ naobel:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: obliicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nalasr:
 	Defaults:
@@ -1517,19 +1959,27 @@ nalasr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntlasrmk.shp
 			SNOW: nalasrmk.shp
 		Length: 21
 		ShadowStart: 21
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1539,11 +1989,15 @@ nalasr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: plticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nasam:
 	Defaults:
@@ -1554,15 +2008,21 @@ nasam:
 	idle:
 		ShadowStart: 3
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_d.shp
@@ -1570,6 +2030,8 @@ nasam:
 		Facings: 32
 		DepthSprite: isodepth.shp
 		Offset: 0, 0, 12
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntsammk.shp
@@ -1578,6 +2040,8 @@ nasam:
 		ShadowStart: 8
 		DepthSprite: isodepth.shp
 		Offset: 0, -12, 12
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1586,10 +2050,14 @@ nasam:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: samicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 napuls.gdi:
 	Defaults:
@@ -1600,24 +2068,34 @@ napuls.gdi:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		TilesetFilenames:
 			TEMPERATE: ntpuls_a.shp
 			SNOW: napuls_a.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntpulsmk.shp
 			SNOW: napulsmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1626,11 +2104,15 @@ napuls.gdi:
 		ZOffset: 512
 		BlendMode: Additive
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|empicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 napuls.nod:
 	Defaults:
@@ -1641,24 +2123,34 @@ napuls.nod:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	turret:
 		TilesetFilenames:
 			TEMPERATE: ntpuls_a.shp
 			SNOW: napuls_a.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntpulsmk.shp
 			SNOW: napulsmk.shp
 		Length: 20
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1668,11 +2160,15 @@ napuls.nod:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|empicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nastlh:
 	Defaults:
@@ -1684,19 +2180,27 @@ nastlh:
 		DepthSpriteOffset: -12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	pulse:
 		TilesetFilenames:
 			TEMPERATE: ntstlh_a.shp
 			SNOW: nastlh_a.shp
 		Length: 4
 		Tick: 480
+		Palette: player
+		IsPlayerPalette: True
 	damaged-pulse:
 		TilesetFilenames:
 			TEMPERATE: ntstlh_a.shp
@@ -1704,12 +2208,16 @@ nastlh:
 		Start: 4
 		Length: 4
 		Tick: 480
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntstlhmk.shp
 			SNOW: nastlhmk.shp
 		Length: 18
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1719,11 +2227,15 @@ nastlh:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: clckicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gactwr:
 	Defaults:
@@ -1734,22 +2246,32 @@ gactwr:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	invisible:
 		Filename: null.shp
 		TilesetFilenames:
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_a.shp
 			SNOW: gactwr_a.shp
 		Length: 6
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_a.shp
@@ -1757,12 +2279,16 @@ gactwr:
 		Length: 6
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtctwrmk.shp
 			SNOW: gactwrmk.shp
 		Length: 11
 		ShadowStart: 11
+		Palette: player
+		IsPlayerPalette: True
 	make-bright:
 		TilesetFilenames:
 			TEMPERATE: gtctwrmk.shp
@@ -1770,20 +2296,28 @@ gactwr:
 		Length: 11
 		ZOffset: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	turret-vulcan:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_b.shp
 			SNOW: gactwr_b.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	turret-rocket:
 		Filename: gtctwr_c.shp
 		TilesetFilenames:
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	turret-sam:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_d.shp
 			SNOW: gactwr_d.shp
 		Facings: 32
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		TilesetFilenames:
 		Combine:
@@ -1815,6 +2349,8 @@ gactwr:
 		Length: 6
 		Offset: 0, 0, 12
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1824,11 +2360,15 @@ gactwr:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: towricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gavulc:
 	place:
@@ -1837,8 +2377,12 @@ gavulc:
 			SNOW: gactwr_b.shp
 		Offset: 0, -12, 12
 		Start: 28
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: twr1icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 garock:
 	place:
@@ -1847,8 +2391,12 @@ garock:
 			SNOW: gactwr_c.shp
 		Offset: 0, -12, 12
 		Start: 28
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: twr2icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gacsam:
 	place:
@@ -1857,8 +2405,12 @@ gacsam:
 			SNOW: gactwr_d.shp
 		Offset: 0, -12, 12
 		Start: 28
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: twr3icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gahpad:
 	Defaults:
@@ -1872,12 +2424,16 @@ gahpad:
 		ZOffset: -1c511
 		Offset: 0, -24, 8
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c511
 		Offset: 0, -24, 8
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
@@ -1885,6 +2441,8 @@ gahpad:
 		Tick: 400
 		Offset: 0, -24, 8
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	idle-platform:
 		TilesetFilenames:
 			TEMPERATE: gthpadbb.shp
@@ -1892,6 +2450,8 @@ gahpad:
 		ShadowStart: 3
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-platform:
 		TilesetFilenames:
 			TEMPERATE: gthpadbb.shp
@@ -1900,6 +2460,8 @@ gahpad:
 		ShadowStart: 4
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead-platform:
 		TilesetFilenames:
 			TEMPERATE: gthpadbb.shp
@@ -1909,6 +2471,8 @@ gahpad:
 		ZOffset: -1c511
 		Tick: 400
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gthpad_a.shp
@@ -1918,6 +2482,8 @@ gahpad:
 		Offset: 0, -36
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gthpad_a.shp
@@ -1928,6 +2494,8 @@ gahpad:
 		ZOffset: -1c511
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gthpad_a.shp
@@ -1938,6 +2506,8 @@ gahpad:
 		Offset: 0, -36
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gthpad_a.shp
@@ -1949,6 +2519,8 @@ gahpad:
 		ZOffset: -1c511
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gthpadmk.shp
@@ -1959,6 +2531,8 @@ gahpad:
 		Offset: 0, -24, 24
 		DepthSpriteOffset: 0, 0
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1967,10 +2541,14 @@ gahpad:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: heliicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 nahpad:
 	Defaults:
@@ -1984,12 +2562,16 @@ nahpad:
 		ZOffset: -1c511
 		Offset: 0, -24, 3
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -1c511
 		Offset: 0, -24, 3
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
@@ -1997,6 +2579,8 @@ nahpad:
 		Tick: 400
 		Offset: 0, -24, 3
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	idle-platform:
 		TilesetFilenames:
 			TEMPERATE: nthpadbb.shp
@@ -2004,6 +2588,8 @@ nahpad:
 		ShadowStart: 3
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-platform:
 		TilesetFilenames:
 			TEMPERATE: nthpadbb.shp
@@ -2012,6 +2598,8 @@ nahpad:
 		ShadowStart: 4
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead-platform:
 		TilesetFilenames:
 			TEMPERATE: nthpadbb.shp
@@ -2021,6 +2609,8 @@ nahpad:
 		ZOffset: -1c511
 		Tick: 400
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nthpad_a.shp
@@ -2029,6 +2619,8 @@ nahpad:
 		ZOffset: -1c511
 		Tick: 100
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthpad_a.shp
@@ -2038,6 +2630,8 @@ nahpad:
 		Tick: 100
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nthpad_a.shp
@@ -2047,6 +2641,8 @@ nahpad:
 		Tick: 100
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthpad_a.shp
@@ -2057,6 +2653,8 @@ nahpad:
 		ZOffset: -1c511
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nthpadmk.shp
@@ -2066,6 +2664,8 @@ nahpad:
 		Offset: 0, -24, 24
 		DepthSpriteOffset: 0, 0
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2074,10 +2674,14 @@ nahpad:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: nhpdicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 proc.gdi:
 	Defaults:
@@ -2089,13 +2693,19 @@ proc.gdi:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntrefnmk.shp
@@ -2104,24 +2714,32 @@ proc.gdi:
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
+		Palette: player
+		IsPlayerPalette: True
 	flame:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_b.shp
 			SNOW: narefn_b.shp
 		Length: *
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	unload-overlay:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_a.shp
 			SNOW: narefn_a.shp
 		Length: *
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_c.shp
 			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_c.shp
@@ -2129,6 +2747,8 @@ proc.gdi:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2138,6 +2758,8 @@ proc.gdi:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2147,6 +2769,8 @@ proc.gdi:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead-bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2165,11 +2789,15 @@ proc.gdi:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|reficon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 proc.nod:
 	Defaults:
@@ -2181,13 +2809,19 @@ proc.nod:
 		DepthSprite: isodepth.shp
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntrefnmk.shp
@@ -2196,24 +2830,32 @@ proc.nod:
 		ShadowStart: 20
 		Offset: -12, -42, 43
 		DepthSpriteOffset: -12, 0
+		Palette: player
+		IsPlayerPalette: True
 	flame:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_b.shp
 			SNOW: narefn_b.shp
 		Length: *
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	unload-overlay:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_a.shp
 			SNOW: narefn_a.shp
 		Length: *
 		ZOffset: 1024
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_c.shp
 			SNOW: narefn_c.shp
 		Length: 16
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_c.shp
@@ -2221,6 +2863,8 @@ proc.nod:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2230,6 +2874,8 @@ proc.nod:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2239,6 +2885,8 @@ proc.nod:
 		Offset: -12, -42, 1
 		ZRamp: 1
 		DepthSprite:
+		Palette: player
+		IsPlayerPalette: True
 	dead-bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2257,11 +2905,15 @@ proc.nod:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|reficon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 nawast:
 	Defaults:
@@ -2273,13 +2925,19 @@ nawast:
 		DepthSpriteOffset: 16, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntwastmk.shp
@@ -2288,6 +2946,8 @@ nawast:
 		ShadowStart: 19
 		Offset: 0, -36, 36
 		DepthSpriteOffset: 0, 0
+		Palette: player
+		IsPlayerPalette: True
 	idle-glow:
 		TilesetFilenames:
 			TEMPERATE: ntwast_a.shp
@@ -2295,6 +2955,8 @@ nawast:
 		Length: 20
 		ShadowStart: 40
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-glow:
 		TilesetFilenames:
 			TEMPERATE: ntwast_a.shp
@@ -2303,6 +2965,8 @@ nawast:
 		Length: 20
 		ShadowStart: 60
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntwast_b.shp
@@ -2310,6 +2974,8 @@ nawast:
 		Length: 8
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntwast_b.shp
@@ -2318,6 +2984,8 @@ nawast:
 		Length: 8
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntwastbb.shp
@@ -2326,6 +2994,8 @@ nawast:
 		ZRamp: 1
 		DepthSprite:
 		Offset: 0, -36, 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-bib:
 		TilesetFilenames:
 			TEMPERATE: ntwastbb.shp
@@ -2335,6 +3005,8 @@ nawast:
 		ZRamp: 1
 		DepthSprite:
 		Offset: 0, -36, 1
+		Palette: player
+		IsPlayerPalette: True
 	dead-bib:
 		TilesetFilenames:
 			TEMPERATE: ntwastbb.shp
@@ -2353,11 +3025,15 @@ nawast:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: wasticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gasilo.gdi:
 	Defaults:
@@ -2380,24 +3056,34 @@ gasilo.gdi:
 			TEMPERATE: gtsilo_a.shp
 			SNOW: gasilo_a.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_a.shp
 			SNOW: gasilo_a.shp
 		Start: 4
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	idle-underlay:
 		ShadowStart: 3
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-underlay:
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -512
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -2405,6 +3091,8 @@ gasilo.gdi:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -2413,12 +3101,16 @@ gasilo.gdi:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtsilomk.shp
 			SNOW: gasilomk.shp
 		Length: 18
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2428,11 +3120,15 @@ gasilo.gdi:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|siloicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gasilo.nod:
 	Defaults:
@@ -2455,24 +3151,34 @@ gasilo.nod:
 			TEMPERATE: gtsilo_a.shp
 			SNOW: gasilo_a.shp
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	damaged-stages:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_a.shp
 			SNOW: gasilo_a.shp
 		Start: 4
 		Length: 4
+		Palette: player
+		IsPlayerPalette: True
 	idle-underlay:
 		ShadowStart: 3
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-underlay:
 		Start: 1
 		ShadowStart: 4
 		ZOffset: -512
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		ZOffset: -512
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -2480,6 +3186,8 @@ gasilo.nod:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -2488,12 +3196,16 @@ gasilo.nod:
 		Length: 16
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtsilomk.shp
 			SNOW: gasilomk.shp
 		Length: 18
 		ShadowStart: 20
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2503,11 +3215,15 @@ gasilo.nod:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|siloicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gadept.gdi:
 	Defaults:
@@ -2520,17 +3236,23 @@ gadept.gdi:
 		ShadowStart: 3
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2538,6 +3260,8 @@ gadept.gdi:
 		ShadowStart: 3
 		ZOffset: -1c611
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2546,6 +3270,8 @@ gadept.gdi:
 		ShadowStart: 4
 		ZOffset: -1c611
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead-ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2555,6 +3281,8 @@ gadept.gdi:
 		ZOffset: -1c611
 		Tick: 400
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	idle-light:
 		TilesetFilenames:
 			TEMPERATE: gtdept_b.shp
@@ -2563,6 +3291,8 @@ gadept.gdi:
 		Length: 7
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-light-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_b.shp
@@ -2572,6 +3302,8 @@ gadept.gdi:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2580,6 +3312,8 @@ gadept.gdi:
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	circuits-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2589,6 +3323,8 @@ gadept.gdi:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2598,6 +3334,8 @@ gadept.gdi:
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-circuits-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2608,6 +3346,8 @@ gadept.gdi:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-start:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2616,6 +3356,10 @@ gadept.gdi:
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
+		Palette: player-nobright
+		IsPlayerPalette: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-loop:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2625,6 +3369,8 @@ gadept.gdi:
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
+		Palette: player-nobright
+		IsPlayerPalette: True
 	crane-loop-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2635,6 +3381,8 @@ gadept.gdi:
 		Tick: 60
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-end:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2644,6 +3392,10 @@ gadept.gdi:
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
+		Palette: player-nobright
+		IsPlayerPalette: True
+		Palette: bright
+		IsPlayerPalette: False
 	platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -2651,6 +3403,8 @@ gadept.gdi:
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -2659,6 +3413,8 @@ gadept.gdi:
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtdeptmk.shp
@@ -2668,6 +3424,8 @@ gadept.gdi:
 		ShadowStart: 10
 		Offset: 0, -36, 36
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2676,10 +3434,14 @@ gadept.gdi:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|fixicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
 
 gadept.nod:
 	Defaults:
@@ -2692,17 +3454,23 @@ gadept.nod:
 		ShadowStart: 3
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2710,6 +3478,8 @@ gadept.nod:
 		ShadowStart: 3
 		ZOffset: -1c611
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2718,6 +3488,8 @@ gadept.nod:
 		ShadowStart: 4
 		ZOffset: -1c611
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead-ground:
 		TilesetFilenames:
 			TEMPERATE: gtdeptbb.shp
@@ -2727,6 +3499,8 @@ gadept.nod:
 		ZOffset: -1c611
 		Tick: 400
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	idle-light:
 		TilesetFilenames:
 			TEMPERATE: gtdept_b.shp
@@ -2735,6 +3509,8 @@ gadept.nod:
 		Length: 7
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-light-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_b.shp
@@ -2744,6 +3520,8 @@ gadept.nod:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2752,6 +3530,8 @@ gadept.nod:
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	circuits-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2761,6 +3541,8 @@ gadept.nod:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2770,6 +3552,8 @@ gadept.nod:
 		ZOffset: -1c511
 		Tick: 120
 		ZRamp: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-circuits-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -2780,6 +3564,8 @@ gadept.nod:
 		Tick: 120
 		ZRamp: 1
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-start:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2788,6 +3574,10 @@ gadept.nod:
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
+		Palette: player-nobright
+		IsPlayerPalette: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-loop:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2797,6 +3587,8 @@ gadept.nod:
 		Offset: 0, -36, 12
 		Tick: 60
 		DepthSprite: isodepth.shp
+		Palette: player-nobright
+		IsPlayerPalette: True
 	crane-loop-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2807,6 +3599,8 @@ gadept.nod:
 		Tick: 60
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	crane-end:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -2816,6 +3610,10 @@ gadept.nod:
 		Offset: 0, -36, 12
 		DepthSprite: isodepth.shp
 		Tick: 60
+		Palette: player-nobright
+		IsPlayerPalette: True
+		Palette: bright
+		IsPlayerPalette: False
 	platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -2823,6 +3621,8 @@ gadept.nod:
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	damaged-platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -2831,6 +3631,8 @@ gadept.nod:
 		Length: 7
 		ZOffset: -1c511
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtdeptmk.shp
@@ -2840,6 +3642,8 @@ gadept.nod:
 		ShadowStart: 10
 		Offset: 0, -36, 36
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2848,10 +3652,14 @@ gadept.nod:
 		ZOffset: 512
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|fixicon.shp
 		TilesetFilenames:
 		Offset: 76, 66
+		Palette: chrome
+		IsPlayerPalette: False
 
 namisl:
 	Defaults:
@@ -2861,17 +3669,25 @@ namisl:
 		Offset: 0, -24, 24
 		DepthSprite: isodepth.shp
 	idle:
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_b.shp
 			SNOW: namisl_b.shp
 		Length: 10
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_b.shp
@@ -2879,6 +3695,8 @@ namisl:
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_b.shp
@@ -2886,6 +3704,8 @@ namisl:
 		Start: 10
 		Length: 10
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_b.shp
@@ -2894,12 +3714,16 @@ namisl:
 		Length: 10
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntmislmk.shp
 			SNOW: namislmk.shp
 		Length: 18
 		ShadowStart: 18
+		Palette: player
+		IsPlayerPalette: True
 	active:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_a.shp
@@ -2908,6 +3732,8 @@ namisl:
 		Length: 25
 		Tick: 80
 		ZOffset: 2
+		Palette: player-nobright
+		IsPlayerPalette: True
 	active-bright:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_a.shp
@@ -2925,6 +3751,8 @@ namisl:
 		Length: 10
 		Tick: 80
 		ZOffset: 1
+		Palette: player-nobright
+		IsPlayerPalette: True
 	damaged-active-bright:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_a.shp
@@ -2943,11 +3771,15 @@ namisl:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: msslicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaplug:
 	Defaults:
@@ -2959,19 +3791,27 @@ gaplug:
 		DepthSpriteOffset: 12, 0
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	idle-dish:
 		TilesetFilenames:
 			TEMPERATE: gtplug_a.shp
 			SNOW: gaplug_a.shp
 		Length: 20
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-dish:
 		TilesetFilenames:
 			TEMPERATE: gtplug_a.shp
@@ -2979,6 +3819,8 @@ gaplug:
 		Start: 20
 		Length: 20
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_b.shp
@@ -2986,6 +3828,8 @@ gaplug:
 		Length: 20
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_b.shp
@@ -2994,12 +3838,16 @@ gaplug:
 		Length: 20
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-strip:
 		TilesetFilenames:
 			TEMPERATE: gtplug_c.shp
 			SNOW: gaplug_c.shp
 		Length: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle-strip-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_c.shp
@@ -3014,6 +3862,8 @@ gaplug:
 		Start: 8
 		Length: 8
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle-strip-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_c.shp
@@ -3030,6 +3880,8 @@ gaplug:
 		Tick: 120
 		Reverses: true
 		Offset: -12, -42, 30
+		Palette: player
+		IsPlayerPalette: True
 	idle-ioncannonb:
 		TilesetFilenames:
 			TEMPERATE: gtplug_f.shp
@@ -3037,6 +3889,8 @@ gaplug:
 		Length: 15
 		Reverses: true
 		Tick: 120
+		Palette: player
+		IsPlayerPalette: True
 	idle-hunterseekera:
 		TilesetFilenames:
 			TEMPERATE: gtplug_e.shp
@@ -3044,6 +3898,8 @@ gaplug:
 		Length: 15
 		Tick: 120
 		Offset: -12, -42, 30
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-hunterseekera-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_e.shp
@@ -3052,12 +3908,16 @@ gaplug:
 		Tick: 120
 		Offset: -12, -42, 30
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-hunterseekerb:
 		TilesetFilenames:
 			TEMPERATE: gtplug_e.shp
 			SNOW: gaplug_e.shp
 		Length: 15
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-hunterseekerb-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_e.shp
@@ -3065,6 +3925,8 @@ gaplug:
 		Length: 15
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-droppoda:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
@@ -3072,6 +3934,8 @@ gaplug:
 		Length: 15
 		Tick: 120
 		Offset: -12, -42, 30
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-droppoda-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
@@ -3080,12 +3944,16 @@ gaplug:
 		Tick: 120
 		Offset: -12, -42, 30
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	idle-droppodb:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
 			SNOW: gaplug_d.shp
 		Length: 15
 		Tick: 120
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-droppodb-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
@@ -3093,12 +3961,16 @@ gaplug:
 		Length: 15
 		Tick: 120
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtplugmk.shp
 			SNOW: gaplugmk.shp
 		Length: 17
 		ShadowStart: 17
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -3108,11 +3980,15 @@ gaplug:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		DepthSprite:
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: plugicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaplug2:
 	place:
@@ -3123,8 +3999,12 @@ gaplug2:
 		Reverses: true
 		Length: 14
 		Tick: 120
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: rad2icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaplug3:
 	place:
@@ -3135,8 +4015,12 @@ gaplug3:
 		Reverses: true
 		Length: 14
 		Tick: 120
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: rad3icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gaplug4:
 	place:
@@ -3147,8 +4031,12 @@ gaplug4:
 		Reverses: true
 		Length: 14
 		Tick: 120
+		Palette: ra
+		IsPlayerPalette: False
 	icon:
 		Filename: rad1icon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 
 gafire:
 	Defaults:
@@ -3158,40 +4046,56 @@ gafire:
 		Offset: -12, -30, 30
 	idle:
 		ShadowStart: 3
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Start: 1
 		ShadowStart: 4
+		Palette: player
+		IsPlayerPalette: True
 	dead:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+		Palette: player
+		IsPlayerPalette: True
 	active-bright:
 		TilesetFilenames:
 			TEMPERATE: gtfire_b.shp
 			SNOW: gafire_b.shp
 		Length: 16
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	active:
 		TilesetFilenames:
 			TEMPERATE: gtfire_a.shp
 			SNOW: gafire_a.shp
 		Start: 19
+		Palette: player-nobright
+		IsPlayerPalette: True
 	disabled:
 		TilesetFilenames:
 			TEMPERATE: gtfire_a.shp
 			SNOW: gafire_a.shp
 		Start: 0
+		Palette: player-nobright
+		IsPlayerPalette: True
 	switching:
 		TilesetFilenames:
 			TEMPERATE: gtfire_a.shp
 			SNOW: gafire_a.shp
 		Length: 20
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtfire_c.shp
 			SNOW: gafire_c.shp
 		Length: 6
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtfire_c.shp
@@ -3199,12 +4103,16 @@ gafire:
 		Length: 6
 		Tick: 240
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtfiremk.shp
 			SNOW: gafiremk.shp
 		Length: 15
 		ShadowStart: 17
+		Palette: player
+		IsPlayerPalette: True
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -3212,7 +4120,11 @@ gafire:
 		Offset: 0, 0
 		ZOffset: 512
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: fsdicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -36,7 +36,6 @@ gacnst:
 		IgnoreWorldTint: True
 		ZOffset: 1023
 		Palette: bright
-		IsPlayerPalette: False
 	crane-overlay:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_d.shp
@@ -78,7 +77,6 @@ gacnst:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-top:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_c.shp
@@ -97,7 +95,6 @@ gacnst:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-side:
 		TilesetFilenames:
 			TEMPERATE: gtcnst_a.shp
@@ -127,7 +124,6 @@ gacnst:
 		Length: 10
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -138,14 +134,12 @@ gacnst:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: facticon.shp
 		TilesetFilenames:
 		Offset: 0,0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gapowr:
 	Defaults:
@@ -185,7 +179,6 @@ gapowr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_a.shp
@@ -204,7 +197,6 @@ gapowr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-plug:
 		TilesetFilenames:
 			TEMPERATE: gtpowr_b.shp
@@ -273,7 +265,6 @@ gapowr:
 		ShadowStart: 20
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -284,14 +275,12 @@ gapowr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: powricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gapowrup:
 	place:
@@ -301,11 +290,9 @@ gapowrup:
 		Length: 11
 		Tick: 200
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: turbicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gapile:
 	Defaults:
@@ -347,7 +334,6 @@ gapile:
 		ZOffset: 1023
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-light-bright:
 		TilesetFilenames:
 			TEMPERATE: gtpile_b.shp
@@ -356,7 +342,6 @@ gapile:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-flag:
 		TilesetFilenames:
 			TEMPERATE: gtpile_c.shp
@@ -392,14 +377,12 @@ gapile:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: brrkicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaweap:
 	Defaults:
@@ -471,7 +454,6 @@ gaweap:
 		ZOffset: 2048
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-lights-red:
 		TilesetFilenames:
 			TEMPERATE: gtweap_b.shp
@@ -490,7 +472,6 @@ gaweap:
 		ZOffset: 2048
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-turbines:
 		TilesetFilenames:
 			TEMPERATE: gtweap_c.shp
@@ -546,7 +527,6 @@ gaweap:
 		DepthSpriteOffset: -12, 0
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		Length: *
@@ -556,13 +536,11 @@ gaweap:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: weapicon.shp
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 napowr:
 	Defaults:
@@ -602,7 +580,6 @@ napowr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntpowr_a.shp
@@ -621,7 +598,6 @@ napowr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntpowrmk.shp
@@ -640,14 +616,12 @@ napowr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: npwricon.shp
 		TilesetFilenames:
 		Offset: 0, 0, 25
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 naapwr:
 	Defaults:
@@ -688,7 +662,6 @@ naapwr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntapwr_a.shp
@@ -707,7 +680,6 @@ naapwr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntapwrmk.shp
@@ -726,14 +698,12 @@ naapwr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: apwricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nahand:
 	Defaults:
@@ -767,7 +737,6 @@ nahand:
 		ZOffset: 1023
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthand_b.shp
@@ -776,7 +745,6 @@ nahand:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: nthand_b.shp
@@ -786,7 +754,6 @@ nahand:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nthandmk.shp
@@ -805,14 +772,12 @@ nahand:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: handicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 naweap:
 	Defaults:
@@ -886,7 +851,6 @@ naweap:
 		ZOffset: 2048
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntweap_a.shp
@@ -907,7 +871,6 @@ naweap:
 		ZOffset: 2048
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	build-door:
 		TilesetFilenames:
 			TEMPERATE: ntweap_b.shp
@@ -947,13 +910,11 @@ naweap:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: nwepicon.shp
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 naradr:
 	Defaults:
@@ -1012,14 +973,12 @@ naradr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: nradicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 natech:
 	Defaults:
@@ -1059,7 +1018,6 @@ natech:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nttech_a.shp
@@ -1078,7 +1036,6 @@ natech:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nttechmk.shp
@@ -1097,14 +1054,12 @@ natech:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: ntchicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 natmpl:
 	Defaults:
@@ -1145,7 +1100,6 @@ natmpl:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nttmplmk.shp
@@ -1164,14 +1118,12 @@ natmpl:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: tmplicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 garadr:
 	Defaults:
@@ -1232,14 +1184,12 @@ garadr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: radricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gatech:
 	Defaults:
@@ -1280,7 +1230,6 @@ gatech:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gttech_a.shp
@@ -1299,7 +1248,6 @@ gatech:
 		Tick: 240
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gttechmk.shp
@@ -1318,14 +1266,12 @@ gatech:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: techicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gasand:
 	Defaults:
@@ -1351,7 +1297,6 @@ gasand:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gawall:
 	Defaults:
@@ -1383,7 +1328,6 @@ gawall:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gagate_a:
 	Defaults:
@@ -1438,14 +1382,12 @@ gagate_a:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: gateicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gagate_b:
 	Defaults:
@@ -1500,14 +1442,12 @@ gagate_b:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: gat2icon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nagate_a:
 	Defaults:
@@ -1567,14 +1507,12 @@ nagate_a:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: ngaticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nagate_b:
 	Defaults:
@@ -1630,14 +1568,12 @@ nagate_b:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: nga2icon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 napost:
 	Defaults:
@@ -1666,7 +1602,6 @@ napost:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntpost_b.shp
@@ -1677,7 +1612,6 @@ napost:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	chainoflights:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1698,7 +1632,6 @@ napost:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-chainoflights:
 		TilesetFilenames:
 			TEMPERATE: ntpost_a.shp
@@ -1719,7 +1652,6 @@ napost:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	dead:
 		Start: 2
 		Tick: 400
@@ -1745,14 +1677,12 @@ napost:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: lasricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nafnce:
 	Defaults:
@@ -1791,7 +1721,6 @@ nafnce:
 		DepthSpriteOffset: -12, 0
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	enabled-y:
 		Frames: 7,5,7,5,6,4,6,4,7,5,7,5,6,4,6,4
 		Length: 16
@@ -1804,7 +1733,6 @@ nafnce:
 		DepthSpriteOffset: 12, 0
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -1845,7 +1773,6 @@ nawall:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaicbm:
 	Defaults:
@@ -1874,7 +1801,6 @@ gaicbm:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gticbmmk.shp
@@ -1941,14 +1867,12 @@ naobel:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: obliicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nalasr:
 	Defaults:
@@ -1990,14 +1914,12 @@ nalasr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: plticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nasam:
 	Defaults:
@@ -2051,13 +1973,11 @@ nasam:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: samicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 napuls.gdi:
 	Defaults:
@@ -2105,14 +2025,12 @@ napuls.gdi:
 		BlendMode: Additive
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|empicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 napuls.nod:
 	Defaults:
@@ -2161,14 +2079,12 @@ napuls.nod:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|empicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nastlh:
 	Defaults:
@@ -2228,14 +2144,12 @@ nastlh:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: clckicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gactwr:
 	Defaults:
@@ -2280,7 +2194,6 @@ gactwr:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtctwrmk.shp
@@ -2297,7 +2210,6 @@ gactwr:
 		ZOffset: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	turret-vulcan:
 		TilesetFilenames:
 			TEMPERATE: gtctwr_b.shp
@@ -2350,7 +2262,6 @@ gactwr:
 		Offset: 0, 0, 12
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	emp-overlay:
 		Filename: emp_fx01.shp
 		TilesetFilenames:
@@ -2361,14 +2272,12 @@ gactwr:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: towricon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gavulc:
 	place:
@@ -2378,11 +2287,9 @@ gavulc:
 		Offset: 0, -12, 12
 		Start: 28
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: twr1icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 garock:
 	place:
@@ -2392,11 +2299,9 @@ garock:
 		Offset: 0, -12, 12
 		Start: 28
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: twr2icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gacsam:
 	place:
@@ -2406,11 +2311,9 @@ gacsam:
 		Offset: 0, -12, 12
 		Start: 28
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: twr3icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gahpad:
 	Defaults:
@@ -2495,7 +2398,6 @@ gahpad:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gthpad_a.shp
@@ -2520,7 +2422,6 @@ gahpad:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gthpadmk.shp
@@ -2542,13 +2443,11 @@ gahpad:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: heliicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 nahpad:
 	Defaults:
@@ -2631,7 +2530,6 @@ nahpad:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: nthpad_a.shp
@@ -2654,7 +2552,6 @@ nahpad:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: nthpadmk.shp
@@ -2675,13 +2572,11 @@ nahpad:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: nhpdicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 proc.gdi:
 	Defaults:
@@ -2723,7 +2618,6 @@ proc.gdi:
 		Length: *
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	unload-overlay:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_a.shp
@@ -2748,7 +2642,6 @@ proc.gdi:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2790,14 +2683,12 @@ proc.gdi:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|reficon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 proc.nod:
 	Defaults:
@@ -2839,7 +2730,6 @@ proc.nod:
 		Length: *
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	unload-overlay:
 		TilesetFilenames:
 			TEMPERATE: ntrefn_a.shp
@@ -2864,7 +2754,6 @@ proc.nod:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntrefnbb.shp
@@ -2906,14 +2795,12 @@ proc.nod:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|reficon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 nawast:
 	Defaults:
@@ -2975,7 +2862,6 @@ nawast:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: ntwast_b.shp
@@ -2985,7 +2871,6 @@ nawast:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	bib:
 		TilesetFilenames:
 			TEMPERATE: ntwastbb.shp
@@ -3026,14 +2911,12 @@ nawast:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: wasticon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gasilo.gdi:
 	Defaults:
@@ -3092,7 +2975,6 @@ gasilo.gdi:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -3102,7 +2984,6 @@ gasilo.gdi:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtsilomk.shp
@@ -3121,14 +3002,12 @@ gasilo.gdi:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|siloicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gasilo.nod:
 	Defaults:
@@ -3187,7 +3066,6 @@ gasilo.nod:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtsilo_b.shp
@@ -3197,7 +3075,6 @@ gasilo.nod:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtsilomk.shp
@@ -3216,14 +3093,12 @@ gasilo.nod:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|siloicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gadept.gdi:
 	Defaults:
@@ -3303,7 +3178,6 @@ gadept.gdi:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -3324,7 +3198,6 @@ gadept.gdi:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -3347,7 +3220,6 @@ gadept.gdi:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	crane-start:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -3358,8 +3230,15 @@ gadept.gdi:
 		DepthSprite: isodepth.shp
 		Palette: player-nobright
 		IsPlayerPalette: True
+	crane-start-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
+		Length: 6
+		Offset: 0, -36, 12
+		Tick: 60
+		DepthSprite: isodepth.shp
 		Palette: bright
-		IsPlayerPalette: False
 	crane-loop:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -3382,8 +3261,17 @@ gadept.gdi:
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	crane-end:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
+		Start: 10
+		Length: 6
+		Offset: 0, -36, 12
+		Tick: 60
+		DepthSprite: isodepth.shp
+		Palette: bright
+	crane-end-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
 			SNOW: gadept_c.shp
@@ -3394,8 +3282,6 @@ gadept.gdi:
 		DepthSprite: isodepth.shp
 		Palette: player-nobright
 		IsPlayerPalette: True
-		Palette: bright
-		IsPlayerPalette: False
 	platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -3435,13 +3321,11 @@ gadept.gdi:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|fixicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
 
 gadept.nod:
 	Defaults:
@@ -3521,7 +3405,6 @@ gadept.nod:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -3542,7 +3425,6 @@ gadept.nod:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-circuits:
 		TilesetFilenames:
 			TEMPERATE: gtdept_a.shp
@@ -3565,7 +3447,6 @@ gadept.nod:
 		ZRamp: 1
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	crane-start:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -3576,8 +3457,15 @@ gadept.nod:
 		DepthSprite: isodepth.shp
 		Palette: player-nobright
 		IsPlayerPalette: True
+	crane-start-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
+		Length: 6
+		Offset: 0, -36, 12
+		Tick: 60
+		DepthSprite: isodepth.shp
 		Palette: bright
-		IsPlayerPalette: False
 	crane-loop:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -3600,7 +3488,6 @@ gadept.nod:
 		DepthSprite: isodepth.shp
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	crane-end:
 		TilesetFilenames:
 			TEMPERATE: gtdept_c.shp
@@ -3612,8 +3499,16 @@ gadept.nod:
 		Tick: 60
 		Palette: player-nobright
 		IsPlayerPalette: True
+	crane-end-bright:
+		TilesetFilenames:
+			TEMPERATE: gtdept_c.shp
+			SNOW: gadept_c.shp
+		Start: 10
+		Length: 6
+		Offset: 0, -36, 12
+		DepthSprite: isodepth.shp
+		Tick: 60
 		Palette: bright
-		IsPlayerPalette: False
 	platform:
 		TilesetFilenames:
 			TEMPERATE: gtdept_d.shp
@@ -3653,13 +3548,11 @@ gadept.nod:
 		BlendMode: Additive
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|fixicon.shp
 		TilesetFilenames:
 		Offset: 76, 66
 		Palette: chrome
-		IsPlayerPalette: False
 
 namisl:
 	Defaults:
@@ -3696,7 +3589,6 @@ namisl:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights:
 		TilesetFilenames:
 			TEMPERATE: ntmisl_b.shp
@@ -3715,7 +3607,6 @@ namisl:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: ntmislmk.shp
@@ -3772,14 +3663,12 @@ namisl:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: msslicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaplug:
 	Defaults:
@@ -3829,7 +3718,6 @@ gaplug:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	damaged-idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtplug_b.shp
@@ -3839,7 +3727,6 @@ gaplug:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-strip:
 		TilesetFilenames:
 			TEMPERATE: gtplug_c.shp
@@ -3909,7 +3796,6 @@ gaplug:
 		Offset: -12, -42, 30
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-hunterseekerb:
 		TilesetFilenames:
 			TEMPERATE: gtplug_e.shp
@@ -3926,7 +3812,6 @@ gaplug:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-droppoda:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
@@ -3945,7 +3830,6 @@ gaplug:
 		Offset: -12, -42, 30
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	idle-droppodb:
 		TilesetFilenames:
 			TEMPERATE: gtplug_d.shp
@@ -3962,7 +3846,6 @@ gaplug:
 		Tick: 120
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtplugmk.shp
@@ -3981,14 +3864,12 @@ gaplug:
 		IgnoreWorldTint: True
 		DepthSprite:
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: plugicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		DepthSprite:
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaplug2:
 	place:
@@ -4000,11 +3881,9 @@ gaplug2:
 		Length: 14
 		Tick: 120
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: rad2icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaplug3:
 	place:
@@ -4016,11 +3895,9 @@ gaplug3:
 		Length: 14
 		Tick: 120
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: rad3icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gaplug4:
 	place:
@@ -4032,11 +3909,9 @@ gaplug4:
 		Length: 14
 		Tick: 120
 		Palette: ra
-		IsPlayerPalette: False
 	icon:
 		Filename: rad1icon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 
 gafire:
 	Defaults:
@@ -4066,7 +3941,6 @@ gafire:
 		Length: 16
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	active:
 		TilesetFilenames:
 			TEMPERATE: gtfire_a.shp
@@ -4104,7 +3978,6 @@ gafire:
 		Tick: 240
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtfiremk.shp
@@ -4121,10 +3994,8 @@ gafire:
 		ZOffset: 512
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: fsdicon.shp
 		TilesetFilenames:
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -15,6 +15,12 @@ tibtre01:
 		TilesetFilenames:
 			TEMPERATE: tibtre01.tem
 			SNOW: tibtre01.sno
+	idle:
+		Palette: player
+		IsPlayerPalette: False
+	active:
+		Palette: player
+		IsPlayerPalette: False
 
 tibtre02:
 	Inherits: ^tibtree
@@ -22,6 +28,12 @@ tibtre02:
 		TilesetFilenames:
 			TEMPERATE: tibtre02.tem
 			SNOW: tibtre02.sno
+	idle:
+		Palette: player
+		IsPlayerPalette: False
+	active:
+		Palette: player
+		IsPlayerPalette: False
 
 tibtre03:
 	Inherits: ^tibtree
@@ -29,6 +41,12 @@ tibtre03:
 		TilesetFilenames:
 			TEMPERATE: tibtre03.tem
 			SNOW: tibtre03.sno
+	idle:
+		Palette: player
+		IsPlayerPalette: False
+	active:
+		Palette: player
+		IsPlayerPalette: False
 
 bigblue:
 	Defaults:
@@ -36,12 +54,16 @@ bigblue:
 	idle:
 		Filename: bigblue2.shp
 		ShadowStart: 10
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	active:
 		Filename: bigblue2.shp
 		Start: 1
 		Length: 9
 		ShadowStart: 11
 		Tick: 160
+		Palette: bluetiberium
+		IsPlayerPalette: False
 
 bigblue3:
 	Defaults:
@@ -49,16 +71,22 @@ bigblue3:
 		Offset: 0, -12, 12
 	idle:
 		ShadowStart: 10
+		Palette: bluetiberium
+		IsPlayerPalette: False
 	active:
 		Start: 1
 		Length: 9
 		ShadowStart: 11
 		Tick: 160
+		Palette: bluetiberium
+		IsPlayerPalette: False
 
 ^tree:
 	idle:
 		ShadowStart: 1
 		Offset: 0, -12, 12
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree01:
 	Inherits: ^tree
@@ -66,6 +94,8 @@ tree01:
 		TilesetFilenames:
 			TEMPERATE: tree01.tem
 			SNOW: tree01.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree02:
 	Inherits: ^tree
@@ -73,6 +103,8 @@ tree02:
 		TilesetFilenames:
 			TEMPERATE: tree02.tem
 			SNOW: tree02.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree03:
 	Inherits: ^tree
@@ -80,6 +112,8 @@ tree03:
 		TilesetFilenames:
 			TEMPERATE: tree03.tem
 			SNOW: tree03.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree04:
 	Inherits: ^tree
@@ -87,6 +121,8 @@ tree04:
 		TilesetFilenames:
 			TEMPERATE: tree04.tem
 			SNOW: tree04.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree05:
 	Inherits: ^tree
@@ -94,6 +130,8 @@ tree05:
 		TilesetFilenames:
 			TEMPERATE: tree05.tem
 			SNOW: tree05.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree06:
 	Inherits: ^tree
@@ -101,6 +139,8 @@ tree06:
 		TilesetFilenames:
 			TEMPERATE: tree06.tem
 			SNOW: tree06.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree07:
 	Inherits: ^tree
@@ -108,6 +148,8 @@ tree07:
 		TilesetFilenames:
 			TEMPERATE: tree07.tem
 			SNOW: tree07.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree08:
 	Inherits: ^tree
@@ -115,6 +157,8 @@ tree08:
 		TilesetFilenames:
 			TEMPERATE: tree08.tem
 			SNOW: tree08.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree09:
 	Inherits: ^tree
@@ -122,6 +166,8 @@ tree09:
 		TilesetFilenames:
 			TEMPERATE: tree09.tem
 			SNOW: tree09.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree10:
 	Inherits: ^tree
@@ -129,6 +175,8 @@ tree10:
 		TilesetFilenames:
 			TEMPERATE: tree10.tem
 			SNOW: tree10.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree11:
 	Inherits: ^tree
@@ -136,6 +184,8 @@ tree11:
 		TilesetFilenames:
 			TEMPERATE: tree11.tem
 			SNOW: tree11.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree12:
 	Inherits: ^tree
@@ -143,6 +193,8 @@ tree12:
 		TilesetFilenames:
 			TEMPERATE: tree12.tem
 			SNOW: tree12.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree13:
 	Inherits: ^tree
@@ -150,6 +202,8 @@ tree13:
 		TilesetFilenames:
 			TEMPERATE: tree13.tem
 			SNOW: tree13.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree14:
 	Inherits: ^tree
@@ -157,6 +211,8 @@ tree14:
 		TilesetFilenames:
 			TEMPERATE: tree14.tem
 			SNOW: tree14.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree15:
 	Inherits: ^tree
@@ -164,6 +220,8 @@ tree15:
 		TilesetFilenames:
 			TEMPERATE: tree15.tem
 			SNOW: tree15.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree16:
 	Inherits: ^tree
@@ -171,6 +229,8 @@ tree16:
 		TilesetFilenames:
 			TEMPERATE: tree16.tem
 			SNOW: tree16.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree17:
 	Inherits: ^tree
@@ -178,6 +238,8 @@ tree17:
 		TilesetFilenames:
 			TEMPERATE: tree17.tem
 			SNOW: tree17.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree18:
 	Inherits: ^tree
@@ -185,6 +247,8 @@ tree18:
 		TilesetFilenames:
 			TEMPERATE: tree18.tem
 			SNOW: tree18.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree19:
 	Inherits: ^tree
@@ -192,6 +256,8 @@ tree19:
 		TilesetFilenames:
 			TEMPERATE: tree19.tem
 			SNOW: tree19.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree20:
 	Inherits: ^tree
@@ -199,6 +265,8 @@ tree20:
 		TilesetFilenames:
 			TEMPERATE: tree20.tem
 			SNOW: tree20.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree21:
 	Inherits: ^tree
@@ -206,6 +274,8 @@ tree21:
 		TilesetFilenames:
 			TEMPERATE: tree21.tem
 			SNOW: tree21.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree22:
 	Inherits: ^tree
@@ -213,6 +283,8 @@ tree22:
 		TilesetFilenames:
 			TEMPERATE: tree22.tem
 			SNOW: tree22.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree23:
 	Inherits: ^tree
@@ -220,6 +292,8 @@ tree23:
 		TilesetFilenames:
 			TEMPERATE: tree23.tem
 			SNOW: tree23.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree24:
 	Inherits: ^tree
@@ -227,6 +301,8 @@ tree24:
 		TilesetFilenames:
 			TEMPERATE: tree24.tem
 			SNOW: tree24.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 tree25:
 	Inherits: ^tree
@@ -234,81 +310,113 @@ tree25:
 		TilesetFilenames:
 			TEMPERATE: tree25.tem
 			SNOW: tree25.sno
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona01:
 	Inherits: ^tree
 	idle:
 		Filename: fona01.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona02:
 	Inherits: ^tree
 	idle:
 		Filename: fona02.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona03:
 	Inherits: ^tree
 	idle:
 		Filename: fona03.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona04:
 	Inherits: ^tree
 	idle:
 		Filename: fona04.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona05:
 	Inherits: ^tree
 	idle:
 		Filename: fona05.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona06:
 	Inherits: ^tree
 	idle:
 		Filename: fona06.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona07:
 	Inherits: ^tree
 	idle:
 		Filename: fona07.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona08:
 	Inherits: ^tree
 	idle:
 		Filename: fona08.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona09:
 	Inherits: ^tree
 	idle:
 		Filename: fona09.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona10:
 	Inherits: ^tree
 	idle:
 		Filename: fona10.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona11:
 	Inherits: ^tree
 	idle:
 		Filename: fona11.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona12:
 	Inherits: ^tree
 	idle:
 		Filename: fona12.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona13:
 	Inherits: ^tree
 	idle:
 		Filename: fona13.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona14:
 	Inherits: ^tree
 	idle:
 		Filename: fona14.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 fona15:
 	Inherits: ^tree
 	idle:
 		Filename: fona15.tem
+		Palette: terraindecoration
+		IsPlayerPalette: False
 
 veinhole:
 	idle:
@@ -318,3 +426,5 @@ veinhole:
 		ShadowStart: 1
 		Offset: 0, -36, 1
 		ZRamp: 1
+		Palette: player
+		IsPlayerPalette: False

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -17,10 +17,8 @@ tibtre01:
 			SNOW: tibtre01.sno
 	idle:
 		Palette: player
-		IsPlayerPalette: False
 	active:
 		Palette: player
-		IsPlayerPalette: False
 
 tibtre02:
 	Inherits: ^tibtree
@@ -30,10 +28,8 @@ tibtre02:
 			SNOW: tibtre02.sno
 	idle:
 		Palette: player
-		IsPlayerPalette: False
 	active:
 		Palette: player
-		IsPlayerPalette: False
 
 tibtre03:
 	Inherits: ^tibtree
@@ -43,10 +39,8 @@ tibtre03:
 			SNOW: tibtre03.sno
 	idle:
 		Palette: player
-		IsPlayerPalette: False
 	active:
 		Palette: player
-		IsPlayerPalette: False
 
 bigblue:
 	Defaults:
@@ -55,7 +49,6 @@ bigblue:
 		Filename: bigblue2.shp
 		ShadowStart: 10
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	active:
 		Filename: bigblue2.shp
 		Start: 1
@@ -63,7 +56,6 @@ bigblue:
 		ShadowStart: 11
 		Tick: 160
 		Palette: bluetiberium
-		IsPlayerPalette: False
 
 bigblue3:
 	Defaults:
@@ -72,21 +64,18 @@ bigblue3:
 	idle:
 		ShadowStart: 10
 		Palette: bluetiberium
-		IsPlayerPalette: False
 	active:
 		Start: 1
 		Length: 9
 		ShadowStart: 11
 		Tick: 160
 		Palette: bluetiberium
-		IsPlayerPalette: False
 
 ^tree:
 	idle:
 		ShadowStart: 1
 		Offset: 0, -12, 12
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree01:
 	Inherits: ^tree
@@ -95,7 +84,6 @@ tree01:
 			TEMPERATE: tree01.tem
 			SNOW: tree01.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree02:
 	Inherits: ^tree
@@ -104,7 +92,6 @@ tree02:
 			TEMPERATE: tree02.tem
 			SNOW: tree02.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree03:
 	Inherits: ^tree
@@ -113,7 +100,6 @@ tree03:
 			TEMPERATE: tree03.tem
 			SNOW: tree03.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree04:
 	Inherits: ^tree
@@ -122,7 +108,6 @@ tree04:
 			TEMPERATE: tree04.tem
 			SNOW: tree04.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree05:
 	Inherits: ^tree
@@ -131,7 +116,6 @@ tree05:
 			TEMPERATE: tree05.tem
 			SNOW: tree05.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree06:
 	Inherits: ^tree
@@ -140,7 +124,6 @@ tree06:
 			TEMPERATE: tree06.tem
 			SNOW: tree06.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree07:
 	Inherits: ^tree
@@ -149,7 +132,6 @@ tree07:
 			TEMPERATE: tree07.tem
 			SNOW: tree07.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree08:
 	Inherits: ^tree
@@ -158,7 +140,6 @@ tree08:
 			TEMPERATE: tree08.tem
 			SNOW: tree08.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree09:
 	Inherits: ^tree
@@ -167,7 +148,6 @@ tree09:
 			TEMPERATE: tree09.tem
 			SNOW: tree09.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree10:
 	Inherits: ^tree
@@ -176,7 +156,6 @@ tree10:
 			TEMPERATE: tree10.tem
 			SNOW: tree10.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree11:
 	Inherits: ^tree
@@ -185,7 +164,6 @@ tree11:
 			TEMPERATE: tree11.tem
 			SNOW: tree11.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree12:
 	Inherits: ^tree
@@ -194,7 +172,6 @@ tree12:
 			TEMPERATE: tree12.tem
 			SNOW: tree12.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree13:
 	Inherits: ^tree
@@ -203,7 +180,6 @@ tree13:
 			TEMPERATE: tree13.tem
 			SNOW: tree13.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree14:
 	Inherits: ^tree
@@ -212,7 +188,6 @@ tree14:
 			TEMPERATE: tree14.tem
 			SNOW: tree14.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree15:
 	Inherits: ^tree
@@ -221,7 +196,6 @@ tree15:
 			TEMPERATE: tree15.tem
 			SNOW: tree15.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree16:
 	Inherits: ^tree
@@ -230,7 +204,6 @@ tree16:
 			TEMPERATE: tree16.tem
 			SNOW: tree16.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree17:
 	Inherits: ^tree
@@ -239,7 +212,6 @@ tree17:
 			TEMPERATE: tree17.tem
 			SNOW: tree17.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree18:
 	Inherits: ^tree
@@ -248,7 +220,6 @@ tree18:
 			TEMPERATE: tree18.tem
 			SNOW: tree18.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree19:
 	Inherits: ^tree
@@ -257,7 +228,6 @@ tree19:
 			TEMPERATE: tree19.tem
 			SNOW: tree19.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree20:
 	Inherits: ^tree
@@ -266,7 +236,6 @@ tree20:
 			TEMPERATE: tree20.tem
 			SNOW: tree20.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree21:
 	Inherits: ^tree
@@ -275,7 +244,6 @@ tree21:
 			TEMPERATE: tree21.tem
 			SNOW: tree21.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree22:
 	Inherits: ^tree
@@ -284,7 +252,6 @@ tree22:
 			TEMPERATE: tree22.tem
 			SNOW: tree22.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree23:
 	Inherits: ^tree
@@ -293,7 +260,6 @@ tree23:
 			TEMPERATE: tree23.tem
 			SNOW: tree23.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree24:
 	Inherits: ^tree
@@ -302,7 +268,6 @@ tree24:
 			TEMPERATE: tree24.tem
 			SNOW: tree24.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 tree25:
 	Inherits: ^tree
@@ -311,112 +276,96 @@ tree25:
 			TEMPERATE: tree25.tem
 			SNOW: tree25.sno
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona01:
 	Inherits: ^tree
 	idle:
 		Filename: fona01.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona02:
 	Inherits: ^tree
 	idle:
 		Filename: fona02.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona03:
 	Inherits: ^tree
 	idle:
 		Filename: fona03.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona04:
 	Inherits: ^tree
 	idle:
 		Filename: fona04.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona05:
 	Inherits: ^tree
 	idle:
 		Filename: fona05.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona06:
 	Inherits: ^tree
 	idle:
 		Filename: fona06.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona07:
 	Inherits: ^tree
 	idle:
 		Filename: fona07.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona08:
 	Inherits: ^tree
 	idle:
 		Filename: fona08.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona09:
 	Inherits: ^tree
 	idle:
 		Filename: fona09.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona10:
 	Inherits: ^tree
 	idle:
 		Filename: fona10.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona11:
 	Inherits: ^tree
 	idle:
 		Filename: fona11.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona12:
 	Inherits: ^tree
 	idle:
 		Filename: fona12.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona13:
 	Inherits: ^tree
 	idle:
 		Filename: fona13.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona14:
 	Inherits: ^tree
 	idle:
 		Filename: fona14.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 fona15:
 	Inherits: ^tree
 	idle:
 		Filename: fona15.tem
 		Palette: terraindecoration
-		IsPlayerPalette: False
 
 veinhole:
 	idle:
@@ -427,4 +376,3 @@ veinhole:
 		Offset: 0, -36, 1
 		ZRamp: 1
 		Palette: player
-		IsPlayerPalette: False

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -5,36 +5,25 @@
 		Length: *
 		BlendMode: Additive
 		IgnoreWorldTint: True
+		Palette: effect
 
 mcv.gdi:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sidebar-gdi|mcvicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 mcv.nod:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sidebar-nod|mcvicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 apc:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: apcicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 harv.gdi:
 	Inherits: ^VehicleOverlays
@@ -44,14 +33,9 @@ harv.gdi:
 		ZRamp: 1
 		Offset: 0, 0, 1
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|harvicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 harv.nod:
 	Inherits: ^VehicleOverlays
@@ -61,24 +45,15 @@ harv.nod:
 		ZRamp: 1
 		Offset: 0, 0, 1
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|harvicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 hvr:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: hovricon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 4tnk:
 	Inherits: ^VehicleOverlays
@@ -87,10 +62,6 @@ hvr:
 		Length: *
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 lpst.gdi:
 	Inherits: ^VehicleOverlays
@@ -137,27 +108,20 @@ lpst.gdi:
 		Tick: 200
 		IgnoreWorldTint: True
 		Palette: bright
-		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|lpsticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 lpst.nod:
 	Inherits: lpst.gdi
 	icon:
 		Filename: sidebar-nod|lpsticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	idle:
 		Palette: playertem
 		IsPlayerPalette: True
 	emp-overlay:
 		Palette: effect
-		IsPlayerPalette: False
 	make:
 		Palette: playertem
 		IsPlayerPalette: True
@@ -166,24 +130,18 @@ lpst.nod:
 		IsPlayerPalette: True
 	idle-lights-bright:
 		Palette: bright
-		IsPlayerPalette: False
 
 repair:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: rboticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 art2:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: artyicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	idle:
 		TilesetFilenames:
 			TEMPERATE: gtarty.shp
@@ -219,40 +177,24 @@ art2:
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 weed:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: weedicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 hmec:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: hmecicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 bike:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: cyclicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 bggy:
 	Inherits: ^VehicleOverlays
@@ -288,45 +230,28 @@ bggy:
 		Length: 6
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: bggyicon.shp
 		Offset: 0, 0
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 sapc:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sapcicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 subtank:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: subticon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 sonic:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: soniicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 ttnk:
 	Inherits: ^VehicleOverlays
@@ -356,24 +281,15 @@ ttnk:
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: tickicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 stnk:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: stnkicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 mmch:
 	Defaults:
@@ -404,21 +320,15 @@ mmch:
 		Offset: 0, 0, 12
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
 	icon:
 		Filename: mmchicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 jugg:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: juggicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	stand:
 		Filename: jugger.shp
 		Facings: -8
@@ -466,10 +376,6 @@ jugg:
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
 		Palette: effect
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 gghunt:
 	Inherits: ^VehicleOverlays
@@ -514,91 +420,51 @@ smech:
 		Tick: 80
 		IgnoreWorldTint: True
 		Palette: muzzle
-		IsPlayerPalette: False
 	icon:
 		Filename: smchicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 mobilemp:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: mempicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 trucka:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 truckb:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 icbm:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 bus:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 pick:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 car:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 wini:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 locomotive:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 traincar:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 cargocar:
 	Inherits: ^VehicleOverlays
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False
 
 mstl:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: mstlicon.shp
 		Palette: chrome
-		IsPlayerPalette: False
 	idle:
 		Filename: mstl.shp
 		ShadowStart: 3
@@ -619,6 +485,3 @@ mstl:
 		Offset: 0, -15, 15
 		Palette: playertem
 		IsPlayerPalette: True
-	emp-overlay:
-		Palette: effect
-		IsPlayerPalette: False

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -10,16 +10,31 @@ mcv.gdi:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sidebar-gdi|mcvicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 mcv.nod:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sidebar-nod|mcvicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 apc:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: apcicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 harv.gdi:
 	Inherits: ^VehicleOverlays
@@ -28,8 +43,15 @@ harv.gdi:
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|harvicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 harv.nod:
 	Inherits: ^VehicleOverlays
@@ -38,13 +60,25 @@ harv.nod:
 		Length: *
 		ZRamp: 1
 		Offset: 0, 0, 1
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-nod|harvicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 hvr:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: hovricon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 4tnk:
 	Inherits: ^VehicleOverlays
@@ -52,6 +86,11 @@ hvr:
 		Filename: gunfire.shp
 		Length: *
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 lpst.gdi:
 	Inherits: ^VehicleOverlays
@@ -63,6 +102,8 @@ lpst.gdi:
 		DepthSpriteOffset: -6, -6
 		Offset: 0, -13, 12
 		ShadowStart: 3
+		Palette: playertem
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtdpsamk.shp
@@ -72,6 +113,8 @@ lpst.gdi:
 		Offset: 0, -13, 12
 		Length: 36
 		ShadowStart: 36
+		Palette: playertem
+		IsPlayerPalette: True
 	idle-lights:
 		TilesetFilenames:
 			TEMPERATE: gtdpsa_a.shp
@@ -81,6 +124,8 @@ lpst.gdi:
 		Offset: 0, -13, 12
 		Length: 10
 		Tick: 200
+		Palette: player-nobright
+		IsPlayerPalette: True
 	idle-lights-bright:
 		TilesetFilenames:
 			TEMPERATE: gtdpsa_a.shp
@@ -91,23 +136,54 @@ lpst.gdi:
 		Length: 10
 		Tick: 200
 		IgnoreWorldTint: True
+		Palette: bright
+		IsPlayerPalette: False
 	icon:
 		Filename: sidebar-gdi|lpsticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 lpst.nod:
 	Inherits: lpst.gdi
 	icon:
 		Filename: sidebar-nod|lpsticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	idle:
+		Palette: playertem
+		IsPlayerPalette: True
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
+	make:
+		Palette: playertem
+		IsPlayerPalette: True
+	idle-lights:
+		Palette: player-nobright
+		IsPlayerPalette: True
+	idle-lights-bright:
+		Palette: bright
+		IsPlayerPalette: False
 
 repair:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: rboticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 art2:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: artyicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	idle:
 		TilesetFilenames:
 			TEMPERATE: gtarty.shp
@@ -115,6 +191,8 @@ art2:
 		ShadowStart: 3
 		Offset: 0, -12, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		TilesetFilenames:
 			TEMPERATE: gtarty.shp
@@ -123,6 +201,8 @@ art2:
 		ShadowStart: 4
 		Offset: 0, -12, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		TilesetFilenames:
 			TEMPERATE: gtartymk.shp
@@ -131,26 +211,48 @@ art2:
 		ShadowStart: 16
 		Offset: 0, -12, 12
 		DepthSprite: isodepth.shp
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 weed:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: weedicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 hmec:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: hmecicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 bike:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: cyclicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 bggy:
 	Inherits: ^VehicleOverlays
@@ -185,24 +287,46 @@ bggy:
 		Facings: 8
 		Length: 6
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: bggyicon.shp
 		Offset: 0, 0
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 sapc:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: sapcicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 subtank:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: subticon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 sonic:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: soniicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 ttnk:
 	Inherits: ^VehicleOverlays
@@ -210,28 +334,46 @@ ttnk:
 		Filename: gatick.shp
 		ShadowStart: 3
 		Offset: 0, -14, 14
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: gatick.shp
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -14, 14
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: gatickmk.shp
 		Length: 24
 		ShadowStart: 24
 		Offset: 0, -14, 14
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: tickicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 stnk:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: stnkicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 mmch:
 	Defaults:
@@ -242,6 +384,8 @@ mmch:
 		Stride: 15
 		ShadowStart: 152
 		Offset: 0, 0, 12
+		Palette: player
+		IsPlayerPalette: True
 	walk:
 		Length: 15
 		Facings: -8
@@ -252,24 +396,37 @@ mmch:
 		Start: 120
 		Facings: -32
 		Offset: 0, 0, 12
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 12
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
 	icon:
 		Filename: mmchicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 jugg:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: juggicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	stand:
 		Filename: jugger.shp
 		Facings: -8
 		Stride: 15
 		ShadowStart: 120
 		Offset: 0, 0, 12
+		Palette: player
+		IsPlayerPalette: True
 	walk:
 		Filename: jugger.shp
 		Length: 15
@@ -281,25 +438,38 @@ jugg:
 		Filename: djugg_a.shp
 		Facings: 32
 		Offset: -4, 0, 12
+		Palette: player
+		IsPlayerPalette: True
 	idle:
 		Filename: djugg.shp
 		ShadowStart: 3
 		Offset: 0, -12, 12
+		Palette: player
+		IsPlayerPalette: True
 	damaged-idle:
 		Filename: djugg.shp
 		Start: 1
 		ShadowStart: 4
 		Offset: 0, -12, 12
+		Palette: player
+		IsPlayerPalette: True
 	make:
 		Filename: djuggmk.shp
 		Length: 18
 		ShadowStart: 18
 		Offset: 0, -12, 12
+		Palette: player
+		IsPlayerPalette: True
 	muzzle:
 		Filename: gunfire.shp
 		Length: *
 		Offset: 0, 0, 24
 		IgnoreWorldTint: True
+		Palette: effect
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 gghunt:
 	Inherits: ^VehicleOverlays
@@ -308,6 +478,8 @@ gghunt:
 		Facings: 1
 		Length: 8
 		ShadowStart: 8
+		Palette: player
+		IsPlayerPalette: True
 
 smech:
 	Inherits: ^VehicleOverlays
@@ -318,76 +490,135 @@ smech:
 		Start: 96
 		Facings: -8
 		ShadowStart: 232
+		Palette: player
+		IsPlayerPalette: True
 	run:
 		Facings: -8
 		Length: 12
 		ShadowStart: 136
 		Tick: 48
+		Palette: player
+		IsPlayerPalette: True
 	shoot:
 		Start: 104
 		Length: 4
 		Facings: -8
 		ShadowStart: 240
 		Tick: 80
+		Palette: player
+		IsPlayerPalette: True
 	shoot-muzzle:
 		Start: 104
 		Length: 4
 		Facings: -8
 		Tick: 80
 		IgnoreWorldTint: True
+		Palette: muzzle
+		IsPlayerPalette: False
 	icon:
 		Filename: smchicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 mobilemp:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: mempicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 trucka:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 truckb:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 icbm:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 bus:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 pick:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 car:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 wini:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 locomotive:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 traincar:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 cargocar:
 	Inherits: ^VehicleOverlays
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False
 
 mstl:
 	Inherits: ^VehicleOverlays
 	icon:
 		Filename: mstlicon.shp
+		Palette: chrome
+		IsPlayerPalette: False
 	idle:
 		Filename: mstl.shp
 		ShadowStart: 3
 		Offset: 0, -15, 15
+		Palette: playertem
+		IsPlayerPalette: True
 	idle-lights:
 		Filename: mstl_a.shp
 		Length: 10
 		ShadowStart: 10
 		Offset: 0, -15, 15
+		Palette: player-nobright
+		IsPlayerPalette: True
 	make:
 		Filename: mstlmk.shp
 		Length: 20
 		ShadowStart: 20
 		Offset: 0, -15, 15
+		Palette: playertem
+		IsPlayerPalette: True
+	emp-overlay:
+		Palette: effect
+		IsPlayerPalette: False

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -7,7 +7,6 @@
 		Image: 120mm
 		Shadow: true
 		LaunchAngle: 75
-		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 108
 		Falloff: 100, 50, 25, 12, 6, 3, 0
@@ -25,7 +24,6 @@
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle
@@ -68,7 +66,6 @@ RPGTower:
 		Speed: 384
 		Blockable: false
 		Image: canister
-		Palette: player
 	Warhead@1Dam: SpreadDamage
 		Damage: 11000
 		Versus:
@@ -142,7 +139,6 @@ Grenade:
 		LaunchAngle: 60
 		Inaccuracy: 0
 		Image: DISCUS
-		Palette: effect
 		BounceCount: 2
 	Warhead@1Dam: SpreadDamage
 		Spread: 154

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -106,7 +106,6 @@ SonicZap:
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -12,7 +12,6 @@
 		TrailImage: small_smoke_trail
 		HorizontalRateOfTurn: 100
 		RangeLimit: 15c0
-		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 216
 		Acceleration: 96
@@ -40,7 +39,6 @@
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -37,7 +37,6 @@ Bomb:
 		Acceleration: 0, 0, -8
 		Image: 120mm
 		Shadow: true
-		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 512
 		Falloff: 100, 50, 25, 12, 6, 3, 0
@@ -56,7 +55,6 @@ Bomb:
 		ValidTargets: Ground, Trees, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle
@@ -77,7 +75,6 @@ FiendShard:
 		Inaccuracy: 512
 		Shadow: true
 		LaunchAngle: 60
-		Palette: greentiberium
 	Warhead@1Dam: SpreadDamage
 		Damage: 3500
 		Versus:
@@ -87,7 +84,6 @@ FiendShard:
 		DamageTypes: Prone100Percent, TriggerProne, BulletDeath
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle
@@ -131,7 +127,6 @@ Veins:
 		DamageTypes: BulletDeath
 	Warhead@Effect: CreateEffect
 		Explosions: veins
-		ExplosionPalette: player
 
 ^Debris:
 	Range: 5c0
@@ -158,7 +153,6 @@ Veins:
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
-		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
 		InvalidTargets: Vehicle

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -18,7 +18,6 @@
 		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
-		ExplosionPalette: ra
 		ValidTargets: Water
 		InvalidTargets: Vehicle
 


### PR DESCRIPTION
Closes #3692

Most of the effort has gone into moving the definitions themselves. The way code dereferences can and should be improved.

The update rule is quite crazy, it shows how inconsistent our artwork definitions are. It may prove a bit difficult to use by third partty mods. It also has run into a limitation of update rules not being able to create new sequence definitions / sequence files (so TD campaign is broken)