### PR TITLE
Implement modular and mod-specific settings backend.

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -213,6 +213,11 @@ namespace OpenRA
 			return modules.GetOrDefault<T>();
 		}
 
+		public T GetSettings<T>() where T : SettingsModule
+		{
+			return Game.Settings.GetOrCreate<T>(ObjectCreator, Manifest.Id);
+		}
+
 		public void Dispose()
 		{
 			LoadScreen?.Dispose();

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -107,7 +107,7 @@ namespace OpenRA
 			SpriteLoaders = ObjectCreator.GetLoaders<ISpriteLoader>(Manifest.SpriteFormats, "sprite");
 			VideoLoaders = ObjectCreator.GetLoaders<IVideoLoader>(Manifest.VideoFormats, "video");
 			SpriteSequenceLoader = ObjectCreator.GetLoader<ISpriteSequenceLoader>(Manifest.SpriteSequenceFormat, "sequence");
-			Hotkeys = new HotkeyManager(ModFiles, Game.Settings.Keys, Manifest);
+			Hotkeys = new HotkeyManager(ModFiles, ObjectCreator, Manifest);
 			Cursors = ParseCursors(Manifest, DefaultFileSystem);
 
 			defaultRules = Exts.Lazy(() => Ruleset.LoadDefaults(this));

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -383,7 +383,6 @@ namespace OpenRA
 		public readonly ServerSettings Server;
 		public readonly DebugSettings Debug;
 		public readonly SinglePlayerGameSettings SinglePlayerSettings;
-		internal readonly Dictionary<string, Hotkey> Keys = [];
 
 		readonly Arguments args;
 		readonly TypeDictionary modules = [];
@@ -409,12 +408,6 @@ namespace OpenRA
 			Server = GetOrCreate<ServerSettings>(null);
 			Debug = GetOrCreate<DebugSettings>(null);
 			SinglePlayerSettings = GetOrCreate<SinglePlayerGameSettings>(null);
-
-			var keysNode = yaml.FirstOrDefault(n => n.Key == "Keys");
-			if (keysNode != null)
-				foreach (var node in keysNode.Value.Nodes)
-					if (node.Key != null)
-						Keys[node.Key] = FieldLoader.GetValue<Hotkey>(node.Key, node.Value.Value);
 		}
 
 		public T GetOrCreate<T>(ObjectCreator objectCreator, string mod = null) where T : SettingsModule
@@ -487,17 +480,6 @@ namespace OpenRA
 			if (commitModules)
 				foreach (var m in modules)
 					((SettingsModule)m).Commit();
-
-			var keysNode = yaml.FirstOrDefault(n => n.Key == "Keys");
-			if (keysNode == null)
-			{
-				keysNode = new MiniYamlNodeBuilder("Keys", "");
-				yaml.Add(keysNode);
-			}
-
-			keysNode.Value.Nodes.Clear();
-			foreach (var kv in Keys)
-				keysNode.Value.Nodes.Add(new MiniYamlNodeBuilder(kv.Key, FieldSaver.FormatValue(kv.Value)));
 
 			// Filter out modules with no fields and force a newline between each module
 			var container = new[] { null, new MiniYamlNodeBuilder("", "") };

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -271,6 +271,11 @@ namespace OpenRA
 			"Legacy: OpenGL 2.1 with framebuffer_object extension (requires DisableLegacyGL: False)",
 			"Automatic: Use the first supported profile.")]
 		public GLProfile GLProfile = GLProfile.Automatic;
+
+		public GraphicSettings Clone()
+		{
+			return (GraphicSettings)MemberwiseClone();
+		}
 	}
 
 	[YamlNode("Sound", shared: true)]
@@ -288,6 +293,11 @@ namespace OpenRA
 		public bool CashTicks = true;
 		public bool Mute = false;
 		public bool MuteBackgroundMusic = false;
+
+		public SoundSettings Clone()
+		{
+			return (SoundSettings)MemberwiseClone();
+		}
 	}
 
 	[YamlNode("Player", shared: true)]

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -300,15 +300,6 @@ namespace OpenRA
 		public ImmutableArray<Color> CustomColors = [];
 	}
 
-	[YamlNode("SinglePlayerSettings", shared: true)]
-	public class SinglePlayerGameSettings : SettingsModule
-	{
-		[Desc("Sets the Auto-save frequency, in seconds")]
-		public int AutoSaveInterval = 0;
-		[Desc("Sets the AutoSave number of max files to bes saved on the file-system")]
-		public int AutoSaveMaxFileCount = 10;
-	}
-
 	[YamlNode("Game", shared: true)]
 	public class GameSettings : SettingsModule
 	{
@@ -382,7 +373,6 @@ namespace OpenRA
 		public readonly GraphicSettings Graphics;
 		public readonly ServerSettings Server;
 		public readonly DebugSettings Debug;
-		public readonly SinglePlayerGameSettings SinglePlayerSettings;
 
 		readonly Arguments args;
 		readonly TypeDictionary modules = [];
@@ -407,7 +397,6 @@ namespace OpenRA
 			Graphics = GetOrCreate<GraphicSettings>(null);
 			Server = GetOrCreate<ServerSettings>(null);
 			Debug = GetOrCreate<DebugSettings>(null);
-			SinglePlayerSettings = GetOrCreate<SinglePlayerGameSettings>(null);
 		}
 
 		public T GetOrCreate<T>(ObjectCreator objectCreator, string mod = null) where T : SettingsModule

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -34,6 +34,7 @@ namespace OpenRA
 		readonly List<IEffect> effects = [];
 		readonly List<IEffect> unpartitionedEffects = [];
 		readonly List<ISync> syncedEffects = [];
+		readonly ModData modData;
 		readonly GameSettings gameSettings;
 
 		readonly Queue<Action<World>> frameEndActions = [];
@@ -178,6 +179,7 @@ namespace OpenRA
 		{
 			Type = type;
 			OrderManager = orderManager;
+			this.modData = modData;
 			Map = map;
 
 			if (string.IsNullOrEmpty(modData.Manifest.DefaultOrderGenerator))
@@ -229,7 +231,7 @@ namespace OpenRA
 				gameInfo.MapData = preview.ToBase64String();
 
 			RulesContainTemporaryBlocker = Map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
-			gameSettings = Game.Settings.Game;
+			gameSettings = GetSettings<GameSettings>();
 		}
 
 		public void AddToMaps(Actor self, IOccupySpace ios)
@@ -621,6 +623,11 @@ namespace OpenRA
 
 			// In the event the replay goes out of sync, it becomes no longer usable. For polish we permanently pause the world.
 			ReplayTimestep = 0;
+		}
+
+		public T GetSettings<T>() where T : SettingsModule
+		{
+			return modData.GetSettings<T>();
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -39,9 +39,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public IntroductionPromptLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, Action onComplete)
 		{
-			var ps = Game.Settings.Player;
-			var ds = Game.Settings.Graphics;
-			var gs = Game.Settings.Game;
+			var playerSettings = modData.GetSettings<PlayerSettings>();
+			var graphicSettings = modData.GetSettings<GraphicSettings>();
+			var gameSettings = modData.GetSettings<GameSettings>();
 
 			classic = FluentProvider.GetMessage(Classic);
 			modern = FluentProvider.GetMessage(Modern);
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var escPressed = false;
 			var nameTextfield = widget.Get<TextFieldWidget>("PLAYERNAME");
 			nameTextfield.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
-			nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+			nameTextfield.Text = Settings.SanitizedPlayerName(playerSettings.Name);
 
 			var itchIntegration = modData.GetOrCreate<ItchIntegration>();
 			itchIntegration.GetPlayerName(name => nameTextfield.Text = Settings.SanitizedPlayerName(name));
@@ -64,93 +64,94 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				nameTextfield.Text = nameTextfield.Text.Trim();
 				if (nameTextfield.Text.Length == 0)
-					nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+					nameTextfield.Text = Settings.SanitizedPlayerName(playerSettings.Name);
 				else
 				{
 					nameTextfield.Text = Settings.SanitizedPlayerName(nameTextfield.Text);
-					ps.Name = nameTextfield.Text;
+					playerSettings.Name = nameTextfield.Text;
 				}
 			};
 
 			nameTextfield.OnEnterKey = _ => { nameTextfield.YieldKeyboardFocus(); return true; };
 			nameTextfield.OnEscKey = _ =>
 			{
-				nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+				nameTextfield.Text = Settings.SanitizedPlayerName(playerSettings.Name);
 				escPressed = true;
 				nameTextfield.YieldKeyboardFocus();
 				return true;
 			};
 
 			var mouseControlDescClassic = widget.Get("MOUSE_CONTROL_DESC_CLASSIC");
-			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
+			mouseControlDescClassic.IsVisible = () => gameSettings.UseClassicMouseStyle;
 
 			var mouseControlDescModern = widget.Get("MOUSE_CONTROL_DESC_MODERN");
-			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
+			mouseControlDescModern.IsVisible = () => !gameSettings.UseClassicMouseStyle;
 
 			var mouseControlDropdown = widget.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
-			mouseControlDropdown.OnMouseDown = _ => InputSettingsLogic.ShowMouseControlDropdown(mouseControlDropdown, gs);
-			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? classic : modern;
+			mouseControlDropdown.OnMouseDown = _ => InputSettingsLogic.ShowMouseControlDropdown(mouseControlDropdown, gameSettings);
+			mouseControlDropdown.GetText = () => gameSettings.UseClassicMouseStyle ? classic : modern;
 
 			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })
 			{
 				var classicScrollRight = container.Get("DESC_SCROLL_RIGHT");
-				classicScrollRight.IsVisible = () => gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+				classicScrollRight.IsVisible = () => gameSettings.UseClassicMouseStyle ^ gameSettings.UseAlternateScrollButton;
 
 				var classicScrollMiddle = container.Get("DESC_SCROLL_MIDDLE");
-				classicScrollMiddle.IsVisible = () => !gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+				classicScrollMiddle.IsVisible = () => !gameSettings.UseClassicMouseStyle ^ gameSettings.UseAlternateScrollButton;
 
 				var zoomDesc = container.Get("DESC_ZOOM");
-				zoomDesc.IsVisible = () => gs.ZoomModifier == Modifiers.None;
+				zoomDesc.IsVisible = () => gameSettings.ZoomModifier == Modifiers.None;
 
 				var zoomDescModifier = container.Get<LabelWidget>("DESC_ZOOM_MODIFIER");
-				zoomDescModifier.IsVisible = () => gs.ZoomModifier != Modifiers.None;
+				zoomDescModifier.IsVisible = () => gameSettings.ZoomModifier != Modifiers.None;
 
 				var zoomDescModifierTemplate = zoomDescModifier.GetText();
 				var zoomDescModifierLabel = new CachedTransform<Modifiers, string>(
 					mod => zoomDescModifierTemplate.Replace("MODIFIER", mod.ToString()));
-				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gs.ZoomModifier);
+				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gameSettings.ZoomModifier);
 
 				var edgescrollDesc = container.Get<LabelWidget>("DESC_EDGESCROLL");
-				edgescrollDesc.IsVisible = () => gs.ViewportEdgeScroll;
+				edgescrollDesc.IsVisible = () => gameSettings.ViewportEdgeScroll;
 			}
 
-			SettingsUtils.BindCheckboxPref(widget, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
+			SettingsUtils.BindCheckboxPref(widget, "EDGESCROLL_CHECKBOX", gameSettings, "ViewportEdgeScroll");
 
 			var colorManager = modData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 
 			var colorDropdown = widget.Get<DropDownButtonWidget>("PLAYERCOLOR");
 			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
-			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, ps.Color, null, worldRenderer, color =>
+			colorDropdown.OnMouseDown = _ => colorManager.ShowColorDropDown(colorDropdown, playerSettings.Color, null, worldRenderer, color =>
 			{
-				ps.Color = color;
+				playerSettings.Color = color;
 				Game.Settings.Save();
 			});
-			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color;
+			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => playerSettings.Color;
 
 			var viewportSizes = modData.GetOrCreate<WorldViewportSizes>();
 			var battlefieldCameraDropDown = widget.Get<DropDownButtonWidget>("BATTLEFIELD_CAMERA_DROPDOWN");
 			var battlefieldCameraLabel = new CachedTransform<WorldViewport, string>(vs => DisplaySettingsLogic.GetViewportSizeName(modData, vs));
-			battlefieldCameraDropDown.OnMouseDown = _ => DisplaySettingsLogic.ShowBattlefieldCameraDropdown(modData, battlefieldCameraDropDown, viewportSizes, ds);
-			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
+			battlefieldCameraDropDown.OnMouseDown = _ => DisplaySettingsLogic.ShowBattlefieldCameraDropdown(
+				modData, battlefieldCameraDropDown, viewportSizes, graphicSettings);
+			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(graphicSettings.ViewportDistance);
 
 			var uiScaleDropdown = widget.Get<DropDownButtonWidget>("UI_SCALE_DROPDOWN");
 			var uiScaleLabel = new CachedTransform<float, string>(s => $"{(int)(100 * s)}%");
-			uiScaleDropdown.OnMouseDown = _ => DisplaySettingsLogic.ShowUIScaleDropdown(uiScaleDropdown, ds);
-			uiScaleDropdown.GetText = () => uiScaleLabel.Update(ds.UIScale);
+			uiScaleDropdown.OnMouseDown = _ => DisplaySettingsLogic.ShowUIScaleDropdown(uiScaleDropdown, graphicSettings);
+			uiScaleDropdown.GetText = () => uiScaleLabel.Update(graphicSettings.UIScale);
 
 			var minResolution = viewportSizes.MinEffectiveResolution;
 			var resolution = Game.Renderer.Resolution;
 			var disableUIScale = worldRenderer.World.Type != WorldType.Shellmap ||
-				resolution.Width * ds.UIScale < 1.25f * minResolution.Width ||
-				resolution.Height * ds.UIScale < 1.25f * minResolution.Height;
+				resolution.Width * graphicSettings.UIScale < 1.25f * minResolution.Width ||
+				resolution.Height * graphicSettings.UIScale < 1.25f * minResolution.Height;
 
 			uiScaleDropdown.IsDisabled = () => disableUIScale;
 
-			SettingsUtils.BindCheckboxPref(widget, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
+			SettingsUtils.BindCheckboxPref(widget, "CURSORDOUBLE_CHECKBOX", graphicSettings, "CursorDouble");
 
 			widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () =>
 			{
-				Game.Settings.Game.IntroductionPromptVersion = IntroductionVersion;
+				gameSettings.IntroductionPromptVersion = IntroductionVersion;
 				Game.Settings.Save();
 				Ui.CloseWindow();
 				onComplete();

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -31,10 +32,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly int[] autoSaveSeconds = [0, 10, 30, 45, 60, 120, 180, 300, 600];
 
 		readonly int[] autoSaveFileNumbers = [3, 5, 10, 20, 50, 100];
+		readonly AutoSaveSettings autoSaveSettings;
 
 		[ObjectCreator.UseCtor]
-		public GameplaySettingsLogic(Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel, string panelID, string label)
+		public GameplaySettingsLogic(ModData modData, Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
+			string panelID, string label)
 		{
+			autoSaveSettings = modData.GetSettings<AutoSaveSettings>();
 			registerPanel(panelID, label, InitPanel, ResetPanel);
 		}
 
@@ -49,17 +53,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			autoSaveIntervalDropDown.OnClick = () =>
 				ShowAutoSaveIntervalDropdown(autoSaveIntervalDropDown, autoSaveSeconds);
 
-			autoSaveIntervalDropDown.GetText = () => GetMessageForAutoSaveInterval(Game.Settings.SinglePlayerSettings.AutoSaveInterval);
+			autoSaveIntervalDropDown.GetText = () => GetMessageForAutoSaveInterval(autoSaveSettings.AutoSaveInterval);
 
 			// Setup dropdown for auto-save number.
 			var autoSaveNoDropDown = panel.Get<DropDownButtonWidget>("AUTO_SAVE_FILE_NUMBER_DROP_DOWN");
 
-			autoSaveNoDropDown.OnMouseDown = _ =>
-				ShowAutoSaveFileNumberDropdown(autoSaveNoDropDown, autoSaveFileNumbers);
-
-			autoSaveNoDropDown.GetText = () => FluentProvider.GetMessage(AutoSaveMaxFileNumber, "saves", Game.Settings.SinglePlayerSettings.AutoSaveMaxFileCount);
-
-			autoSaveNoDropDown.IsDisabled = () => Game.Settings.SinglePlayerSettings.AutoSaveInterval <= 0;
+			autoSaveNoDropDown.OnMouseDown = _ => ShowAutoSaveFileNumberDropdown(autoSaveNoDropDown, autoSaveFileNumbers);
+			autoSaveNoDropDown.GetText = () => FluentProvider.GetMessage(AutoSaveMaxFileNumber, "saves", autoSaveSettings.AutoSaveMaxFileCount);
+			autoSaveNoDropDown.IsDisabled = () => autoSaveSettings.AutoSaveInterval <= 0;
 
 			return () => false;
 		}
@@ -71,15 +72,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void ShowAutoSaveIntervalDropdown(DropDownButtonWidget dropdown, IEnumerable<int> options)
 		{
-			var gsp = Game.Settings.SinglePlayerSettings;
-
 			ScrollItemWidget SetupItem(int o, ScrollItemWidget itemTemplate)
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
-					() => gsp.AutoSaveInterval == o,
+					() => autoSaveSettings.AutoSaveInterval == o,
 					() =>
 					{
-						gsp.AutoSaveInterval = o;
+						autoSaveSettings.AutoSaveInterval = o;
 						Game.Settings.Save();
 					});
 
@@ -94,15 +93,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void ShowAutoSaveFileNumberDropdown(DropDownButtonWidget dropdown, IEnumerable<int> options)
 		{
-			var gsp = Game.Settings.SinglePlayerSettings;
-
 			ScrollItemWidget SetupItem(int o, ScrollItemWidget itemTemplate)
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
-					() => gsp.AutoSaveMaxFileCount == o,
+					() => autoSaveSettings.AutoSaveMaxFileCount == o,
 					() =>
 					{
-						gsp.AutoSaveMaxFileCount = o;
+						autoSaveSettings.AutoSaveMaxFileCount = o;
 						Game.Settings.Save();
 					});
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
@@ -35,11 +35,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly AutoSaveSettings autoSaveSettings;
 
 		[ObjectCreator.UseCtor]
-		public GameplaySettingsLogic(ModData modData, Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
-			string panelID, string label)
+		public GameplaySettingsLogic(ModData modData, SettingsLogic settingsLogic, string panelID, string label)
 		{
 			autoSaveSettings = modData.GetSettings<AutoSaveSettings>();
-			registerPanel(panelID, label, InitPanel, ResetPanel);
+			settingsLogic.RegisterSettingsPanel(panelID, label, InitPanel, ResetPanel);
 		}
 
 		Func<bool> InitPanel(Widget panel)
@@ -79,7 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() =>
 					{
 						autoSaveSettings.AutoSaveInterval = o;
-						Game.Settings.Save();
+						autoSaveSettings.Save();
 					});
 
 				var deviceLabel = item.Get<LabelWidget>("LABEL");
@@ -100,7 +99,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() =>
 					{
 						autoSaveSettings.AutoSaveMaxFileCount = o;
-						Game.Settings.Save();
+						autoSaveSettings.Save();
 					});
 
 				var deviceLabel = item.Get<LabelWidget>("LABEL");

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -60,17 +60,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Widget emptyListMessage;
 		Widget remapDialog;
 
-		static HotkeysSettingsLogic() { }
-
 		[ObjectCreator.UseCtor]
-		public HotkeysSettingsLogic(
-			Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>> registerPanel,
-			string panelID, string label, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+		public HotkeysSettingsLogic(ModData modData, SettingsLogic settingsLogic, string panelID, string label, Dictionary<string, MiniYaml> logicArgs)
 		{
 			this.modData = modData;
 			this.logicArgs = logicArgs;
 
-			registerPanel(panelID, label, InitPanel, ResetPanel);
+			settingsLogic.RegisterSettingsPanel(panelID, label, InitPanel, ResetPanel);
 		}
 
 		void BindHotkeyPref(HotkeyDefinition hd, Widget template)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -317,7 +317,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			WidgetUtils.TruncateButtonToTooltip(selectedHotkeyButton, hotkeyEntryWidget.Key.DisplayString());
 			modData.Hotkeys.Set(selectedHotkeyDefinition.Name, hotkeyEntryWidget.Key);
-			Game.Settings.Save();
+			modData.Hotkeys.Save();
 		}
 
 		void ResetHotkey()
@@ -338,7 +338,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (duplicateHotkeyButton != null)
 				WidgetUtils.TruncateButtonToTooltip(duplicateHotkeyButton, Hotkey.Invalid.DisplayString());
 			modData.Hotkeys.Set(duplicateHotkeyDefinition.Name, Hotkey.Invalid);
-			Game.Settings.Save();
+			modData.Hotkeys.Save();
 			hotkeyEntryWidget.YieldKeyboardFocus();
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -17,7 +17,12 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public class SettingsLogic : ChromeLogic
+	public interface ISettingsLogic
+	{
+		void RegisterSettingsPanel(string panelID, string label, Func<Widget, Func<bool>> init, Func<Widget, Action> reset);
+	}
+
+	public class SettingsLogic : ChromeLogic, ISettingsLogic
 	{
 		[FluentReference]
 		const string SettingsSaveTitle = "dialog-settings-save.title";
@@ -64,8 +69,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool needsRestart = false;
 
-		static SettingsLogic() { }
-
 		[ObjectCreator.UseCtor]
 		public SettingsLogic(Widget widget, Action onExit, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs, ModData modData)
 		{
@@ -92,7 +95,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					Game.LoadWidget(worldRenderer.World, panel.Key, container, new WidgetArgs()
 					{
-						{ "registerPanel", (Action<string, string, Func<Widget, Func<bool>>, Func<Widget, Action>>)RegisterSettingsPanel },
+						{ "settingsLogic", this },
 						{ "panelID", panel.Key },
 						{ "label", panel.Value }
 					});
@@ -102,8 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
 			{
 				needsRestart |= leavePanelActions[activePanel]();
-				var current = Game.Settings;
-				current.Save();
+				Game.Settings.Save();
 
 				void CloseAndExit() { Ui.CloseWindow(); onExit(); }
 				if (needsRestart)


### PR DESCRIPTION
#8276 and related issues require that the game settings become modular, which means that it won't be possible to statically load the full settings structure as the first step of game init.

~~There are a handful of particularly ugly cases (which will be dealt with individually), but most are straightforward to adapt for a modular system. This PR handles the boilerplate for these simple cases, such that a future PR simply needs to replace e.g. `gameSettings = Game.Settings.Game` with `gameSettings = modData.GetSettings<GameSettings>()`.~~ (see below)