### PR TITLE
Shorten trait requirement prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [ bleed, 'prep-*' ]
     paths-ignore:
       - '*.md'
+      - '*.py'
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)

--- a/packaging/format-docs.py
+++ b/packaging/format-docs.py
@@ -83,7 +83,7 @@ def format_docs(version, collectionName, types, relatedEnums):
 
             if "RequiresTraits" in currentType and currentType["RequiresTraits"]:
                 formattedRequiredTraits = [format_type_name(x, is_known_type(x, types)) for x in currentType["RequiresTraits"]]
-                print("\n> Requires trait(s): " + ", ".join(sorted(formattedRequiredTraits)) + '.')
+                print("\n> Requires: " + ", ".join(sorted(formattedRequiredTraits)) + '.')
 
             if currentType["Properties"] and len(currentType["Properties"]) > 0:
                 print()


### PR DESCRIPTION
This is a matter of taste edit. I find plural/singular and brackets hard to read. It seems needless in this case.

> Requires trait(s): [Mobile](https://docs.openra.net/en/release/traits/#mobile).

to

> Requires: [Mobile](https://docs.openra.net/en/release/traits/#mobile).

on the trait documentation page it should already be clear that this is also a trait.