### PR TITLE
Stopped syncing IsTraitPaused/Disabled

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Gate : PausableConditionalTrait<GateInfo>, ITick, ITemporaryBlocker, IBlocksProjectiles,
-		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
+		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, ISync
 	{
 		readonly Actor self;
 		readonly Building building;

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RepairableBuilding(init.Self, this); }
 	}
 
-	public class RepairableBuilding : ConditionalTrait<RepairableBuildingInfo>, ITick
+	public class RepairableBuilding : ConditionalTrait<RepairableBuildingInfo>, ITick, ISync
 	{
 		readonly IHealth health;
 		readonly Predicate<Player> isNotActiveAlly;

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class Cloak : PausableConditionalTrait<CloakInfo>,
 		IRenderModifier, INotifyDamage, INotifyUnloadCargo, INotifyLoadCargo, INotifyDemolition, INotifyInfiltration,
-		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyDockClient, INotifyDockHost, INotifySupportPower
+		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyDockClient, INotifyDockHost, INotifySupportPower, ISync
 	{
 		readonly float3 cloakedColor;
 		readonly float cloakedColorAlpha;

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 	/// Requires basing *Info on ConditionalTraitInfo and using base(info) constructor.
 	/// TraitEnabled will be called at creation if the trait starts enabled or does not use conditions.
 	/// </summary>
-	public abstract class ConditionalTrait<InfoType> : IObservesVariables, IDisabledTrait, INotifyCreated, ISync where InfoType : ConditionalTraitInfo
+	public abstract class ConditionalTrait<InfoType> : IObservesVariables, IDisabledTrait, INotifyCreated where InfoType : ConditionalTraitInfo
 	{
 		public readonly InfoType Info;
 
@@ -49,7 +49,6 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new VariableObserver(RequiredConditionsChanged, Info.RequiresCondition.Variables);
 		}
 
-		[Sync]
 		public bool IsTraitDisabled { get; private set; }
 
 		protected ConditionalTrait(InfoType info)

--- a/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
@@ -38,7 +38,6 @@ namespace OpenRA.Mods.Common.Traits
 	/// </summary>
 	public abstract class PausableConditionalTrait<InfoType> : ConditionalTrait<InfoType> where InfoType : PausableConditionalTraitInfo
 	{
-		[Sync]
 		public bool IsTraitPaused { get; private set; }
 
 		protected PausableConditionalTrait(InfoType info)

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ToggleConditionOnOrder(this); }
 	}
 
-	public class ToggleConditionOnOrder : PausableConditionalTrait<ToggleConditionOnOrderInfo>, IResolveOrder
+	public class ToggleConditionOnOrder : PausableConditionalTrait<ToggleConditionOnOrderInfo>, IResolveOrder, ISync
 	{
 		int conditionToken = Actor.InvalidConditionToken;
 

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new DamagedByTerrain(this); }
 	}
 
-	public class DamagedByTerrain : ConditionalTrait<DamagedByTerrainInfo>, ITick, ISync
+	public class DamagedByTerrain : ConditionalTrait<DamagedByTerrainInfo>, ITick
 	{
 		int damageTicks;
 

--- a/OpenRA.Mods.Common/Traits/FireWarheads.cs
+++ b/OpenRA.Mods.Common/Traits/FireWarheads.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class FireWarheads : PausableConditionalTrait<FireWarheadsInfo>, ITick
+	public class FireWarheads : PausableConditionalTrait<FireWarheadsInfo>, ITick, ISync
 	{
 		[Sync]
 		int cooldown = 0;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Mobile : PausableConditionalTrait<MobileInfo>, IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove, ITick, ICreationActivity,
-		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier, INotifyBecomingIdle
+		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier, INotifyBecomingIdle, ISync
 	{
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class Hovers : ConditionalTrait<HoversInfo>, IRenderModifier, ITick
+	public class Hovers : ConditionalTrait<HoversInfo>, IRenderModifier, ITick, ISync
 	{
 		readonly HoversInfo info;
 		readonly int stepPercentage;

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Turreted(init, this); }
 	}
 
-	public class Turreted : PausableConditionalTrait<TurretedInfo>, ITick, IDeathActorInitModifier, IActorPreviewInitModifier
+	public class Turreted : PausableConditionalTrait<TurretedInfo>, ITick, IDeathActorInitModifier, IActorPreviewInitModifier, ISync
 	{
 		AttackTurreted attack;
 		IFacing facing;


### PR DESCRIPTION
Split off from #21234 as suggested [in a comment](https://github.com/OpenRA/OpenRA/pull/21234/commits/9871ada71474412e3961ecfde4383038463530eb#r1421744031) so we can measure the performance impact of this in isolation.

A [discussion on Discord](https://discord.com/channels/153649279762694144/388282819371204608/1181890238759587881) decided we don't need to sync these.