### PR TITLE
ActorIndex: make constructor protected to allow defining custom actor indexes

### DIFF
--- a/OpenRA.Mods.Common/ActorIndex.cs
+++ b/OpenRA.Mods.Common/ActorIndex.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common
 
 		public IReadOnlyCollection<Actor> Actors => actors;
 
-		ActorIndex(World world, IEnumerable<Actor> initialActorsToIndex)
+		protected ActorIndex(World world, IEnumerable<Actor> initialActorsToIndex)
 		{
 			this.world = world;
 			world.ActorAdded += AddActor;


### PR DESCRIPTION
`ActorIndex` is a very interesting concept, but currently does not allow defining custom indexes, because its constructor is private.

This PR simply makes the constructor protected, so new indexes can be defined outside for the `ActorIndex` class.