### PR TITLE
Tweaks for map generator performance.

### DIFF
--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -54,13 +54,8 @@ namespace OpenRA
 		public ActorReference(string type, TypeDictionary inits)
 		{
 			Type = type;
-			initDict = new Lazy<TypeDictionary>(() =>
-			{
-				var dict = new TypeDictionary();
-				foreach (var i in inits)
-					dict.Add(i);
-				return dict;
-			});
+			var initsClone = new TypeDictionary(inits);
+			initDict = Exts.Lazy(() => initsClone);
 		}
 
 		static ActorInit LoadInit(string initName, MiniYaml initYaml)
@@ -110,11 +105,7 @@ namespace OpenRA
 
 		public ActorReference Clone()
 		{
-			var clone = new ActorReference(Type);
-			foreach (var init in initDict.Value)
-				clone.initDict.Value.Add(init);
-
-			return clone;
+			return new ActorReference(Type, initDict.Value);
 		}
 
 		public void Add(ActorInit init)

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -30,15 +30,15 @@ namespace OpenRA
 		internal TypeDictionary InitDict => initDict.Value;
 
 		public ActorReference(string type)
-			: this(type, new Dictionary<string, MiniYaml>()) { }
+			: this(type, new MiniYaml("")) { }
 
-		public ActorReference(string type, Dictionary<string, MiniYaml> inits)
+		public ActorReference(string type, MiniYaml inits)
 		{
 			Type = type;
 			initDict = Exts.Lazy(() =>
 			{
 				var dict = new TypeDictionary();
-				foreach (var i in inits)
+				foreach (var i in inits.Nodes)
 				{
 					var init = LoadInit(i.Key, i.Value);
 					if (init is ISingleInstanceInit && dict.Contains(init.GetType()))

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -756,7 +756,7 @@ namespace OpenRA
 			var positions = new List<(MPos Uv, Color Color)>();
 			foreach (var actor in actors)
 			{
-				var s = new ActorReference(actor.Value.Value, actor.Value.ToDictionary());
+				var s = new ActorReference(actor.Value.Value, actor.Value);
 
 				var ai = Rules.Actors[actor.Value.Value];
 				var impsis = ai.TraitInfos<IMapPreviewSignatureInfo>();

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -429,7 +429,7 @@ namespace OpenRA
 					var spawns = new List<CPos>();
 					foreach (var kv in actorDefinitions.Nodes.Where(d => d.Value.Value == "mpspawn"))
 					{
-						var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var s = new ActorReference(kv.Value.Value, kv.Value);
 						spawns.Add(s.Get<LocationInit>().Value);
 					}
 

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenRA.Primitives
 {
@@ -20,7 +21,17 @@ namespace OpenRA.Primitives
 		static readonly Func<Type, ITypeContainer> CreateTypeContainer = t =>
 			(ITypeContainer)typeof(TypeContainer<>).MakeGenericType(t).GetConstructor(Type.EmptyTypes).Invoke(null);
 
-		readonly Dictionary<Type, ITypeContainer> data = [];
+		readonly Dictionary<Type, ITypeContainer> data;
+
+		public TypeDictionary()
+		{
+			data = [];
+		}
+
+		public TypeDictionary(TypeDictionary cloneFrom)
+		{
+			data = cloneFrom.data.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
+		}
 
 		ITypeContainer InnerGet(Type t)
 		{
@@ -127,11 +138,12 @@ namespace OpenRA.Primitives
 			void Add(object value);
 			void Remove(object value);
 			void TrimExcess();
+			ITypeContainer Clone();
 		}
 
 		sealed class TypeContainer<T> : ITypeContainer
 		{
-			public List<T> Objects { get; } = [];
+			public List<T> Objects { get; private init; } = [];
 
 			public int Count => Objects.Count;
 
@@ -148,6 +160,11 @@ namespace OpenRA.Primitives
 			public void TrimExcess()
 			{
 				Objects.TrimExcess();
+			}
+
+			public ITypeContainer Clone()
+			{
+				return new TypeContainer<T>() { Objects = Objects.ToList() };
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (!VeinholeActors.Contains(type))
 					continue;
 
-				var actorReference = new ActorReference(type, kv.Value.ToDictionary());
+				var actorReference = new ActorReference(type, kv.Value);
 				var location = actorReference.Get<LocationInit>();
 				var veinholeInfo = map.Rules.Actors[actorReference.Type];
 				foreach (var cell in veinholeInfo.TraitInfo<IOccupySpaceInfo>().OccupiedCells(veinholeInfo, location.Value))

--- a/OpenRA.Mods.Common/Lint/CheckOwners.cs
+++ b/OpenRA.Mods.Common/Lint/CheckOwners.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var kv in map.ActorDefinitions)
 			{
-				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var actorReference = new ActorReference(kv.Value.Value, kv.Value);
 				var ownerInit = actorReference.GetOrDefault<OwnerInit>();
 				if (ownerInit == null)
 					emitError($"Actor `{kv.Key}` is not owned by any player.");

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 			var spawns = new List<CPos>();
 			foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
 			{
-				var s = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var s = new ActorReference(kv.Value.Value, kv.Value);
 				spawns.Add(s.Get<LocationInit>().Value);
 			}
 

--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -561,11 +561,12 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Func<CPos, P, P?> filler,
 			ImmutableArray<CVec> spread) where P : struct
 		{
+			var current = new List<(CPos CPos, P Prop)>();
 			var next = seeds.ToList();
 			while (next.Count != 0)
 			{
-				var current = next;
-				next = [];
+				(next, current) = (current, next);
+				next.Clear();
 				foreach (var (source, prop) in current)
 				{
 					var newProp = filler(source, prop);

--- a/OpenRA.Mods.Common/MapGenerator/Matrix.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Matrix.cs
@@ -57,9 +57,14 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public int Index(int x, int y)
 		{
 			if (!ContainsXY(x, y))
-				throw new IndexOutOfRangeException(
-					$"({x}, {y}) is out of bounds for a matrix of size ({Size.X}, {Size.Y})");
+				ThrowIndexOutOfRangeException(x, y);
 			return y * Size.X + x;
+		}
+
+		void ThrowIndexOutOfRangeException(int x, int y)
+		{
+			throw new IndexOutOfRangeException(
+				$"({x}, {y}) is out of bounds for a matrix of size ({Size.X}, {Size.Y})");
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MatrixUtils.cs
@@ -345,11 +345,12 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Func<int2, P, P?> filler,
 			ImmutableArray<int2> spread) where P : struct
 		{
+			var current = new List<(int2 XY, P Prop)>();
 			var next = seeds.ToList();
 			while (next.Count != 0)
 			{
-				var current = next;
-				next = [];
+				(next, current) = (current, next);
+				next.Clear();
 				foreach (var (source, prop) in current)
 				{
 					var newProp = filler(source, prop);

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -54,9 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			var exitLocations = new List<CPos>();
 
 			// Clone the initializer dictionary for the new actor
-			var td = new TypeDictionary();
-			foreach (var init in inits)
-				td.Add(init);
+			var td = new TypeDictionary(inits);
 
 			if (exitinfo != null && self.OccupiesSpace != null && producee.HasTraitInfo<IOccupySpaceInfo>())
 			{

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -82,13 +82,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				var td = new TypeDictionary();
-				foreach (var init in inits)
-					td.Add(init);
-
-				td.Add(new LocationInit(location.Value));
-				td.Add(new CenterPositionInit(pos));
-				td.Add(new FacingInit(initialFacing));
+				var td = new TypeDictionary(inits)
+				{
+					new LocationInit(location.Value),
+					new CenterPositionInit(pos),
+					new FacingInit(initialFacing)
+				};
 
 				var newUnit = self.World.CreateActor(producee.Name, td);
 

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -122,9 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 			var altitude = self.World.Map.Rules.Actors[actorType].TraitInfo<AircraftInfo>().CruiseAltitude;
 
 			// Clone the initializer dictionary for the new actor
-			var td = new TypeDictionary();
-			foreach (var init in inits)
-				td.Add(init);
+			var td = new TypeDictionary(inits);
 
 			if (self.OccupiesSpace != null)
 			{

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var kv = world.Map.ActorDefinitions.ElementAt(i);
 				names[i] = kv.Key;
-				references.Add(new ActorReference(kv.Value.Value, kv.Value.ToDictionary()));
+				references.Add(new ActorReference(kv.Value.Value, kv.Value));
 			}
 
 			AddRange(CollectionsMarshal.AsSpan(references), names);

--- a/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapStartingLocations.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 			var spawns = new List<CPos>();
 			foreach (var n in self.World.Map.ActorDefinitions)
 				if (n.Value.Value == "mpspawn")
-					spawns.Add(new ActorReference(n.Key, n.Value.ToDictionary()).GetValue<LocationInit, CPos>());
+					spawns.Add(new ActorReference(n.Key, n.Value).GetValue<LocationInit, CPos>());
 
 			spawnLocations = spawns.ToArray();
 

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var kv in world.Map.ActorDefinitions)
 			{
-				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var actorReference = new ActorReference(kv.Value.Value, kv.Value);
 
 				// If an actor's doesn't have a valid owner transfer ownership to neutral
 				var ownerInit = actorReference.Get<OwnerInit>();

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			foreach (var kv in map.ActorDefinitions)
 			{
-				var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var actor = new ActorReference(kv.Value.Value, kv.Value);
 				var locationInit = actor.GetOrDefault<LocationInit>();
 				if (locationInit == null)
 					continue;

--- a/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var spawnPoints = map.ActorDefinitions
 				.Where(d => d.Value.Value == "mpspawn")
-				.Select(kv => new ActorReference(kv.Value.Value, kv.Value.ToDictionary()).Get<LocationInit>().Value);
+				.Select(kv => new ActorReference(kv.Value.Value, kv.Value).Get<LocationInit>().Value);
 
 			Update(spawnPoints, map.Bounds, map.Grid.Type, new Png(map.Package.GetStream("map.png")));
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.ToDictionary(player => player.Name);
 			foreach (var kv in generatedMap.ActorDefinitions)
 			{
-				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+				var actorReference = new ActorReference(kv.Value.Value, kv.Value);
 				var ownerInit = actorReference.Get<OwnerInit>();
 				if (!players.TryGetValue(ownerInit.InternalName, out var owner))
 					throw new MapGenerationException("Generator produced mismatching player and actor definitions.");


### PR DESCRIPTION
The map generator is already performant, but we can remove a few rough edges from infrastructure it interacts with.

- Add TypeDictionary constructor to clone from an existing copy. The map editor infrastructure relies heavily on cloning ActorReferences and the underlying dictionaries. A dedicated clone method avoids reflection overhead for CreateTypeContainer on a fresh instance.
- Use ThrowIndexOutOfRangeException helper. This allows the Index method to be inlined.
- Reuse lists in FloodFill. This avoids allocating and resizing new lists on each loop when we can reuse the existing capacity.
- Manage CellEntryChanged at the layer rather than individual previews. We only need to attach/detach from the delegate once at the layer, rather than many times as previews are added and removed.