### PR TITLE
Fix usage of MapGeneratorMultiChoiceOption.Default

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorSettings.cs
@@ -127,7 +127,11 @@ namespace OpenRA.Mods.Common.MapGenerator
 			if (validChoices.Contains(value))
 				return Choices[value].Settings;
 
-			var fallback = Default != null ? Default.FirstOrDefault(validChoices.Contains) : validChoices.FirstOrDefault();
+			string fallback = null;
+			if (Default != null)
+				fallback = Default.FirstOrDefault(validChoices.Contains);
+			fallback ??= validChoices.FirstOrDefault();
+
 			return fallback != null ? Choices[fallback].Settings : [];
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -184,7 +184,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var validChoices = mo.ValidChoices(world.Map.Rules.TerrainInfo, playerCount);
 						if (!validChoices.Contains(mo.Value))
-							mo.Value = mo.Default != null ? mo.Default.FirstOrDefault(validChoices.Contains) : validChoices.FirstOrDefault();
+						{
+							if (mo.Default != null)
+								mo.Value = mo.Default.FirstOrDefault(validChoices.Contains);
+							mo.Value ??= validChoices.FirstOrDefault();
+						}
 
 						if (mo.Value != null && mo.Label != null && validChoices.Count > 0)
 						{

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -348,7 +348,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var validChoices = mo.ValidChoices(selectedTerrain, playerCount);
 						if (!validChoices.Contains(mo.Value))
-							mo.Value = mo.Default != null ? mo.Default.FirstOrDefault(validChoices.Contains) : validChoices.FirstOrDefault();
+						{
+							if (mo.Default != null)
+								mo.Value = mo.Default.FirstOrDefault(validChoices.Contains);
+							mo.Value ??= validChoices.FirstOrDefault();
+						}
 
 						if (mo.Label != null && validChoices.Count > 0)
 						{


### PR DESCRIPTION
When this switched to an ImmutableArray, this expression has to be updated as the struct is not nullable. It supports an overloaded equals (==) but not a null-conditional (?.) operator. This expression was rewritten incorrectly and failed to use the first valid choice as a fallback in all cases. Update the code to do this.

Fixes regression from #22168.

Fixes #22240.