### PR TITLE
Added check to cancel order state when releasing shift after queueing

### DIFF
--- a/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
@@ -29,8 +29,13 @@ namespace OpenRA.Mods.Common.Orders
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			mi.Modifiers |= Modifiers;
-			if ((cancelOnFirstUse && !mi.Modifiers.HasModifier(Modifiers.Shift)) || mi.Button == CancelButton)
-				world.CancelInputMode();
+			if (cancelOnFirstUse)
+			{
+				if (!mi.Modifiers.HasModifier(Modifiers.Shift) || mi.Button == CancelButton)
+					world.CancelInputMode();
+				else
+					HasIssuedQueuedCommand = true;
+			}
 
 			return base.OrderInner(world, cell, worldPixel, mi);
 		}

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -40,6 +40,8 @@ namespace OpenRA.Mods.Common.Orders
 			var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
 			if (!queued)
 				world.CancelInputMode();
+			else
+				HasIssuedQueuedCommand = true;
 
 			yield return new Order(orderName, null, Target.FromActor(target), queued, null, subjects.Where(s => s != target).ToArray());
 		}

--- a/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderGenerator.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Orders
 		public UnitOrderGenerator(World world)
 		{
 			gameSettings = Game.Settings.Game;
+			HasIssuedQueuedCommand = false;
 		}
 
 		protected static Target TargetForInput(World world, CPos cell, int2 worldPixel, MouseInput mi)
@@ -83,6 +84,7 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		public virtual void Tick(World world) { }
+
 		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public virtual IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 		public virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
@@ -220,5 +222,6 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		public virtual bool ClearSelectionOnLeftClick => true;
+		public virtual bool HasIssuedQueuedCommand { get; set; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -120,6 +120,8 @@ namespace OpenRA.Mods.Common.Traits
 			var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
 			if (!queued)
 				world.CancelInputMode();
+			else
+				HasIssuedQueuedCommand = true;
 
 			var orderName = mi.Modifiers.HasModifier(Modifiers.Ctrl) ? "AssaultMove" : "AttackMove";
 

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -231,5 +231,20 @@ namespace OpenRA.Mods.Common.Widgets
 				return World.OrderGenerator.GetCursor(World, cell, worldPixel, mi);
 			});
 		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (World.OrderGenerator is not UnitOrderGenerator uog)
+				return false;
+
+			if (uog.HasIssuedQueuedCommand && e.Event == KeyInputEvent.Up && (e.Key == Keycode.LSHIFT || e.Key == Keycode.RSHIFT))
+			{
+				World.CancelInputMode();
+				uog.HasIssuedQueuedCommand = false;
+				return true;
+			}
+
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
Changes behaviour when shift-queueing to reset to default OrderGenerator after issuing queued orders, rather than requiring the player to manually cancel (which often leads to accidentally ruining the whole queue, or at least issuing the wrong kind of order)