### PR TITLE
Fix force start crash

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Common.Server
 					return true;
 				}
 
-				if (server.LobbyInfo.Slots.All(sl => server.LobbyInfo.ClientInSlot(sl.Key) == null))
+				if (server.LobbyInfo.Slots.All(sl => server.LobbyInfo.ClientInSlot(sl.Key)?.State is null or Session.ClientState.Invalid))
 				{
 					server.SendFluentMessageTo(conn, NoStartWithoutPlayers);
 					return true;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -105,6 +105,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MapPreview map;
 		Session.MapStatus mapStatus;
 		MapGenerationArgs lastGeneratedMap;
+		bool gameStarting;
 
 		bool chatEnabled;
 		bool disableTeamChat;
@@ -232,7 +233,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var f in modRules.Actors[SystemActors.World].TraitInfos<FactionInfo>())
 				factions.Add(f.InternalName, new LobbyFaction { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
-			var gameStarting = false;
 			Func<bool> configurationDisabled = () => !Game.IsHost || gameStarting ||
 				panel == PanelType.Kick || panel == PanelType.ForceStart || !MapIsPlayable ||
 				orderManager.LocalClient == null || orderManager.LocalClient.IsReady;
@@ -966,6 +966,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void UpdateOptions()
 		{
+			gameStarting = false;
 			if (map == null || map.WorldActorInfo == null)
 				return;
 


### PR DESCRIPTION
Fixes #22248.

Testcase: Add `StartGame()` to https://github.com/OpenRA/OpenRA/blob/d69deba56f3cb8a8e555ad89b5fa776319259a98/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs#L248-L258 or have a fast natural double-click.