### PR TITLE
Save map generation args in replays/saves instead of full map.

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -158,16 +158,6 @@ namespace OpenRA.FileSystem
 				pkg.CommitUpdate();
 				Commit();
 			}
-
-			public static ReadWriteZipFile FromBase64String(string data)
-			{
-				return new ReadWriteZipFile(Convert.FromBase64String(data));
-			}
-
-			public string ToBase64String()
-			{
-				return Convert.ToBase64String(pkgStream.ToArray());
-			}
 		}
 
 		sealed class ZipFolder : IReadOnlyPackage

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -84,6 +84,7 @@ namespace OpenRA
 			public MapClassification Class;
 			public MapVisibility Visibility;
 			public DateTime ModifiedDate;
+			public MapGenerationArgs GenerationArgs;
 
 			public MiniYaml RuleDefinitions;
 			public MiniYaml WeaponDefinitions;
@@ -219,19 +220,6 @@ namespace OpenRA
 				return new Map(modData, package);
 		}
 
-		public string ToBase64String()
-		{
-			LoadPackage();
-			if (package is not ZipFileLoader.ReadWriteZipFile p)
-			{
-				var map = new Map(modData, package);
-				p = new ZipFileLoader.ReadWriteZipFile();
-				map.Save(p);
-			}
-
-			return p.ToBase64String();
-		}
-
 		IReadOnlyPackage parentPackage;
 
 		volatile InnerData innerData;
@@ -258,6 +246,8 @@ namespace OpenRA
 		public ActorInfo WorldActorInfo => innerData.WorldActorInfo;
 		public ActorInfo PlayerActorInfo => innerData.PlayerActorInfo;
 		public DateTime ModifiedDate => innerData.ModifiedDate;
+
+		public MapGenerationArgs GenerationArgs => innerData.GenerationArgs;
 
 		public long DownloadBytes { get; private set; }
 		public int DownloadPercentage { get; private set; }
@@ -482,6 +472,7 @@ namespace OpenRA
 				newData.Status = MapStatus.Generating;
 				newData.Title = args.Title;
 				newData.Author = args.Author;
+				newData.GenerationArgs = args;
 			}
 			else
 				newData.Status = MapStatus.Unavailable;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1356,7 +1356,7 @@ namespace OpenRA.Server
 				};
 
 				if (Map.Class == MapClassification.Generated)
-					gameInfo.MapData = Map.ToBase64String();
+					gameInfo.MapGenerationArgs = Map.GenerationArgs;
 
 				// Replay metadata should only include the playable players
 				foreach (var p in worldPlayers)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -228,7 +228,7 @@ namespace OpenRA
 
 			var preview = modData.MapCache[Map.Uid];
 			if (preview.Class == MapClassification.Generated)
-				gameInfo.MapData = preview.ToBase64String();
+				gameInfo.MapGenerationArgs = preview.GenerationArgs;
 
 			RulesContainTemporaryBlocker = Map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
 			gameSettings = GetSettings<GameSettings>();

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -163,6 +163,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var p = modData.MapCache[generatedMapArgs.Uid];
 					if (p.Status != MapStatus.Available && package is ZipFileLoader.ReadWriteZipFile zipPackage)
 					{
+						p.UpdateFromGenerationArgs(generatedMapArgs);
 						p.UpdateFromMap(zipPackage, MapClassification.Generated);
 
 						// UpdateFromMap took ownership of the package.

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -706,7 +706,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SelectReplay(ReplayMetadata replay)
 		{
 			selectedReplay = replay;
-			map = selectedReplay != null ? selectedReplay.GameInfo.MapPreview : MapCache.UnknownMap;
+			map = selectedReplay != null ? selectedReplay.GameInfo.GetMapPreview(modData) : MapCache.UnknownMap;
 
 			if (replay == null)
 				return;

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Mods[mod].Metadata.Version != version)
 				return IncompatibleReplayDialog(modData, onCancel, IncompatibleVersion, "version", version);
 
-			if (replayMeta.GameInfo.MapPreview.Status != MapStatus.Available)
+			if (replayMeta.GameInfo.GetMapPreview(modData).Status != MapStatus.Available)
 				return IncompatibleReplayDialog(modData, onCancel, UnvailableMap, "map", replayMeta.GameInfo.MapUid);
 
 			return true;


### PR DESCRIPTION
Closes #21952.

I attempted an additional change 132bc815de705696b9c1b164e0a2de46568805ff to save the generation args in the skirmish settings, but that introduces an unacceptable UI delay while the server generates the map. I can't think of a simple solution to that, so dropped the idea.