### PR TITLE
ActorIndex: allow forcing a refresh of the index externally

### DIFF
--- a/OpenRA.Mods.Common/ActorIndex.cs
+++ b/OpenRA.Mods.Common/ActorIndex.cs
@@ -48,6 +48,16 @@ namespace OpenRA.Mods.Common
 			actors.Remove(actor);
 		}
 
+		public virtual void Refresh()
+		{
+			actors.Clear();
+
+			foreach (var actor in world.Actors)
+			{
+				AddActor(actor);
+			}
+		}
+
 		public void Dispose()
 		{
 			Dispose(true);


### PR DESCRIPTION
Useful, if the consumer of the `ActorIndex` needs to work with the actors placed on the map in the map editor (or just created after the `ActorIndex` is set up).

The reason, the `Refresh()` is method virtual, is because the implementations might have more efficient way to refresh the index. But if it's not desired/necessary to allow this customization right now, I can remove it.