### PR TITLE
PerfDebugLogic: show world tick in addition to local tick

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -48,7 +48,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var wfbSize = Game.Renderer.WorldFrameBufferSize;
 				var viewportSize = worldRenderer.Viewport.ViewportSize;
-				return $"FPS: {fps:0}\nTick {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
+				return $"FPS: {fps:0}\n" +
+					$"Tick: {worldRenderer.World.WorldTick} / {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Batches: {PerfHistory.Items["batches"].LastValue}\n" +
 					$"Viewport Size: {viewportSize.Width} x {viewportSize.Height} / {Game.Renderer.WorldDownscaleFactor}\n" +


### PR DESCRIPTION
Useful for debugging stuff, which depends on happening in (or after) particular tick. The local tick is incremented even when the game is paused.

<img width="225" height="145" alt="image" src="https://github.com/user-attachments/assets/a73c6816-5c6d-4683-a9c4-876b7acda6ea" />
