### PR TITLE
Fix animations having wrong offsets

### DIFF
--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -110,19 +110,6 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 					}
 				}
 
-				// Keep a 1px empty border to work avoid rounding issues in the GPU shader.
-				if (left > 0)
-					left--;
-
-				if (top > 0)
-					top--;
-
-				if (right < origSize.Width - 1)
-					right++;
-
-				if (bottom < origSize.Height - 1)
-					bottom++;
-
 				var trimmedWidth = right - left + 1;
 				var trimmedHeight = bottom - top + 1;
 


### PR DESCRIPTION
Closes #21851

The logic is faulty incase some padding failed to add. We can just remove it as later on in the pipeline 1 px border gets added anyway