### PR TITLE
Docking: fix clients getting stuck, if they're too close to each other

### DIFF
--- a/OpenRA.Mods.Common/Activities/MoveToDock.cs
+++ b/OpenRA.Mods.Common/Activities/MoveToDock.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly bool ignoreOccupancy;
 
 		bool dockingCancelled;
+		int moveAttempt;
 
 		public MoveToDock(Actor self, Actor dockHostActor = null, IDockHost dockHost = null,
 			bool forceEnter = false, bool ignoreOccupancy = false, Color? dockLineColor = null)
@@ -79,14 +80,15 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			// Find the nearest DockHost if not explicitly ordered to a specific dock.
-			if (dockHost == null || !dockHost.IsEnabledAndInWorld)
+			// Find the nearest DockHost if not explicitly ordered to a specific dock (or the max number of move attempts has been reached).
+			if (dockHost == null || !dockHost.IsEnabledAndInWorld || moveAttempt >= 3)
 			{
-				var host = dockClient.ClosestDock(null);
+				var host = dockClient.ClosestDock(dockHost);
 				if (host.HasValue)
 				{
 					dockHost = host.Value.Trait;
 					dockHostActor = host.Value.Actor;
+					moveAttempt = 0;
 				}
 				else
 				{
@@ -106,6 +108,8 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					foreach (var ndcm in notifyDockClientMoving)
 						ndcm.MovingToDock(self, dockHostActor, dockHost);
+
+					moveAttempt++;
 
 					return false;
 				}

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -14,6 +14,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
@@ -402,25 +403,40 @@ namespace OpenRA.Mods.Common.Traits
 			if (mobile != null)
 			{
 				// Overlapping hosts can become hidden.
+				bool CanEnter(CPos location)
+				{
+					return mobile.Locomotor.MovementCostToEnterCell(
+						clientActor, location, BlockedByActor.All, clientActor, true) != PathGraph.MovementCostForUnreachableCell;
+				}
+
 				var lookup = docks
 					.GroupBy(dock => clientActor.World.Map.CellContaining(dock.Trait.DockPosition))
-					.ToDictionary(group => group.Key, group => group.First());
+					.ToDictionary(group => group.Key, group => (dock: group.First(), canEnter: CanEnter(group.Key)));
 
 				// Start a search from each docks position:
 				var path = mobile.PathFinder.FindPathToTargetCell(
 					clientActor, lookup.Keys, clientActor.Location, BlockedByActor.None,
 					location =>
 					{
-						if (!lookup.TryGetValue(location, out var dock))
+						if (!lookup.TryGetValue(location, out var tuple))
 							return 0;
+
+						var (dock, isBlocked) = tuple;
 
 						// Prefer docks with less occupancy (multiplier is to offset distance cost):
 						// TODO: add custom weights. E.g. owner vs allied.
-						return dock.Trait.ReservationCount * client.OccupancyCostModifier;
+						var expectedOccupancy = dock.Trait.ReservationCount;
+
+						// If the client is close to the dock location and the dock is currently occupied,
+						// increase the cost to avoid a possibility of getting stuck.
+						if (!isBlocked && (clientActor.Location - location).LengthSquared <= 3 * 3)
+							expectedOccupancy++;
+
+						return expectedOccupancy * client.OccupancyCostModifier;
 					});
 
 				if (path.Count > 0)
-					return lookup[path[^1]];
+					return lookup[path[^1]].dock;
 			}
 			else
 			{


### PR DESCRIPTION
In certain circumstances, the two or multiple dock clients can get stuck, if they're too close to the dock host(s).

Example in OpenE2140:

https://github.com/user-attachments/assets/2cb97564-dadd-44a9-b93e-3ab0d330cbc6

In our case the both Mine and Refinery buildings have three DockHosts to represent all three docking angles. There are two reasons this bug happens:
- the `ClosestDock()` extension method does not take into account that the chosen `IDockHost` could be occupied (even if there are no reservations for it)
- `MoveToDock` activity does not have logic for maximum number of retries and attempt to pick different `IDockHost`

This PR solves both issues and when applying the changes to OpenE2140, this is how it looks like:

https://github.com/user-attachments/assets/5c09e527-fbd1-4f66-9a3a-e535b43e2ad2

After a short while the trucks get into "equilibrium" and stop bumping into each other.

While there are certainly better ways to handle this, the suggested changes in the PR are small and as contained as possible.