### PR TITLE
Fix d2k crash when opening menu with spectators

### DIFF
--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -164,11 +164,13 @@ Container@SKIRMISH_STATS:
 							Visible: false
 							TooltipContainer: TOOLTIP_CONTAINER
 							Template: ANONYMOUS_PLAYER_TOOLTIP
-						Label@NAME:
+						LabelWithTooltip@NAME:
 							X: 29
 							Width: 191
 							Height: 25
 							Shadow: True
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Checkbox@MUTE:
 							X: 457
 							Width: 25


### PR DESCRIPTION
Closes #22266

Regression from #22118. Missed one label