### PR TITLE
Allow keyboard navigation (Up, Down, Home, End) on scrollable lists

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -593,7 +593,7 @@ namespace OpenRA
 
 			if (value == null)
 				return typeof(ImmutableArray<>).MakeGenericType(typeArgs)
-					.GetField(nameof(ImmutableArray<object>.Empty))
+					.GetField("Empty")
 					.GetValue(null);
 
 			object array;

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -30,8 +30,17 @@ namespace OpenRA.Mods.Common.Widgets
 		Widget panel;
 		MaskWidget fullscreenMask;
 		Widget panelRoot;
+		Widget previousKeyboardFocusWidget;
+		Widget ownerWindow;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getMarkerImage;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getSeparatorImage;
+
+		/// <summary>
+		/// Invoked after the dropdown panel has been removed.
+		/// </summary>
+		public Action DropDownClosed;
+
+		public bool IsDropDownOpen => panel != null;
 
 		[ObjectCreator.UseCtor]
 		public DropDownButtonWidget(ModData modData)
@@ -83,12 +92,41 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Hidden()
 		{
 			base.Hidden();
-			RemovePanel();
+			CloseDropdownUnlessInKeyboardNavigation();
 		}
 
 		public override void Removed()
 		{
 			base.Removed();
+			CloseDropdownUnlessInKeyboardNavigation();
+		}
+
+		static bool IsWidgetWithinPanel(Widget widget, Widget panel)
+		{
+			for (var w = widget; w != null; w = w.Parent)
+				if (ReferenceEquals(w, panel))
+					return true;
+
+			return false;
+		}
+
+		void CloseDropdownUnlessInKeyboardNavigation()
+		{
+			if (panel == null)
+				return;
+
+			// Always close if the dropdown belongs to a window that is no longer current.
+			if (ownerWindow != null && !ReferenceEquals(ownerWindow, Ui.CurrentWindow()))
+			{
+				RemovePanel();
+				return;
+			}
+
+			// Keep the panel open if the user is actively navigating it with the keyboard.
+			// This prevents dropdowns from closing when the source widget is replaced by a UI refresh (e.g. selecting bots in the lobby).
+			if (IsWidgetWithinPanel(Ui.KeyboardFocusWidget, panel))
+				return;
+
 			RemovePanel();
 		}
 
@@ -100,8 +138,15 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.RemoveChild(fullscreenMask);
 			panelRoot.RemoveChild(panel);
 			panel = fullscreenMask = null;
+			ownerWindow = null;
+
+			var focusToRestore = previousKeyboardFocusWidget;
+			previousKeyboardFocusWidget = null;
+			if (focusToRestore != null && focusToRestore.IsVisible())
+				focusToRestore.TakeKeyboardFocus();
 
 			Ui.ResetTooltips();
+			DropDownClosed?.Invoke();
 		}
 
 		public void AttachPanel(Widget p) { AttachPanel(p, null); }
@@ -110,6 +155,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (panel != null)
 				throw new InvalidOperationException("Attempted to attach a panel to an open dropdown");
 			panel = p;
+			previousKeyboardFocusWidget = Ui.KeyboardFocusWidget;
 
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget
@@ -118,10 +164,13 @@ namespace OpenRA.Mods.Common.Widgets
 			};
 
 			fullscreenMask.OnMouseDown += mi => { Game.Sound.PlayNotification(ModRules, null, "Sounds", ClickSound, null); RemovePanel(); };
+			fullscreenMask.OnEscapeKey = () => { RemovePanel(); onCancel?.Invoke(); return true; };
 			if (onCancel != null)
 				fullscreenMask.OnMouseDown += _ => onCancel();
 
 			panelRoot = PanelRoot == null ? Ui.Root : Ui.Root.Get(PanelRoot);
+
+			ownerWindow = Ui.CurrentWindow();
 
 			panelRoot.AddChild(fullscreenMask);
 
@@ -144,6 +193,18 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.AddChild(panel);
 
 			(panel as ScrollPanelWidget)?.ScrollToSelectedItem();
+
+			if (panel is ScrollPanelWidget scrollPanel)
+			{
+				scrollPanel.OnEscapeKey = () => { RemovePanel(); onCancel?.Invoke(); return true; };
+				scrollPanel.TakeKeyboardFocus();
+			}
+			else
+			{
+				// For non-scroll panels (like color picker), give focus to the mask
+				// so it can handle ESC to close the dropdown.
+				fullscreenMask.TakeKeyboardFocus();
+			}
 		}
 
 		public void ShowDropDown<T>(
@@ -184,7 +245,8 @@ namespace OpenRA.Mods.Common.Widgets
 				var group = kv.Key;
 				if (group.Length > 0 && headerTemplate != null)
 				{
-					var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+					// Headers are visual separators and should not be part of keyboard navigation.
+					var header = ScrollItemWidget.SetupHeader(headerTemplate);
 					header.Get<LabelWidget>("LABEL").GetText = () => group;
 					panel.AddChild(header);
 				}
@@ -209,11 +271,13 @@ namespace OpenRA.Mods.Common.Widgets
 	public class MaskWidget : Widget
 	{
 		public event Action<MouseInput> OnMouseDown = _ => { };
+		public Func<bool> OnEscapeKey;
 		public MaskWidget() { }
 		public MaskWidget(MaskWidget other)
 			: base(other)
 		{
 			OnMouseDown = other.OnMouseDown;
+			OnEscapeKey = other.OnEscapeKey;
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -225,6 +289,14 @@ namespace OpenRA.Mods.Common.Widgets
 				OnMouseDown(mi);
 
 			return true;
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (e.Event == KeyInputEvent.Down && e.Key == Keycode.ESCAPE && OnEscapeKey != null)
+				return OnEscapeKey();
+
+			return false;
 		}
 
 		public override string GetCursor(int2 pos) { return null; }

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -62,6 +62,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 
 			actorList = widget.Get<ScrollPanelWidget>("ACTOR_LIST");
+			actorList.OnEscapeKey = () =>
+			{
+				Game.Disconnect();
+				Ui.CloseWindow();
+				onExit();
+				return true;
+			};
 
 			headerTemplate = widget.Get<ScrollItemWidget>("HEADER");
 			template = widget.Get<ScrollItemWidget>("TEMPLATE");
@@ -134,7 +141,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void CreateActorGroup(string title, IEnumerable<ActorInfo> actors)
 		{
-			var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+			var header = ScrollItemWidget.SetupHeader(headerTemplate);
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			actorList.AddChild(header);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (teams.Count > 1)
 				{
-					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+					var teamHeader = ScrollItemWidget.SetupHeader(teamTemplate);
 					var team = t.Key > 0
 						? FluentProvider.GetMessage(TeamNumber, "team", t.Key)
 						: FluentProvider.GetMessage(NoTeam);
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var spectators = orderManager.LobbyInfo.Clients.Where(c => c.IsObserver).ToList();
 			if (spectators.Count > 0)
 			{
-				var spectatorHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+				var spectatorHeader = ScrollItemWidget.SetupHeader(teamTemplate);
 				var spectatorTeam = FluentProvider.GetMessage(Spectators);
 				spectatorHeader.Get<LabelWidget>("TEAM").GetText = () => spectatorTeam;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -282,7 +282,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (hasTeams)
 				{
-					var tt = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+					var tt = ScrollItemWidget.SetupHeader(teamTemplate);
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -284,9 +284,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				modData.MapCache.QueryRemoteMapDetails(services.MapRepository, remoteMapPool);
 			}
 
-			SetupMapPanel(MapClassification.User, "USER_MAPS_TAB");
-			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB");
-			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB");
+			SetupMapPanel(MapClassification.User, "USER_MAPS_TAB", approving, canceling);
+			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB", approving, canceling);
+			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB", approving, canceling);
 
 			var hasGenerator = modData.DefaultRules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorMapGeneratorInfo>();
 			if (onSelectGenerated != null && hasGenerator)
@@ -397,12 +397,26 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		void SetupMapPanel(MapClassification tab, string tabContainerName)
+		void SetupMapPanel(MapClassification tab, string tabContainerName, Action approving, Action canceling)
 		{
 			var tabContainer = widget.Get<ContainerWidget>(tabContainerName);
 			tabContainer.IsVisible = () => currentTab == tab;
 			var tabScrollpanel = tabContainer.Get<ScrollPanelWidget>("MAP_LIST");
 			tabScrollpanel.Layout = new GridLayout(tabScrollpanel);
+
+			tabScrollpanel.OnEnterKey = () =>
+			{
+				if (onSelect != null && !(currentTab == MapClassification.Generated && generatedMapArgs == null))
+				{
+					approving();
+					return true;
+				}
+
+				return false;
+			};
+
+			tabScrollpanel.OnEscapeKey = () => { canceling(); return true; };
+
 			scrollpanels.Add(tab, tabScrollpanel);
 
 			RefreshMaps(tab);
@@ -551,7 +565,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var item = ScrollItemWidget.Setup(preview.Uid, itemTemplate, () => selectedUid == preview.Uid,
 					() => selectedUid = preview.Uid, DblClick);
-				item.IsVisible = () => item.RenderBounds.IntersectsWith(scrollpanels[tab].RenderBounds);
+
+				// Use IsCulledForRendering instead of IsVisible for culling optimization.
+				// This allows keyboard navigation to items outside the visible area while
+				// still avoiding the rendering cost for off-screen items.
+				item.IsCulledForRendering = () => !item.RenderBounds.IntersectsWith(scrollpanels[tab].RenderBounds);
 
 				var titleLabel = item.Get<LabelWithTooltipWidget>("TITLE");
 				if (titleLabel != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -93,6 +93,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.BeforeGameStart += OnGameStart;
 
 			missionList = widget.Get<ScrollPanelWidget>("MISSION_LIST");
+			missionList.OnEnterKey = () =>
+			{
+				if (selectedMap != null)
+				{
+					StartMissionClicked(onExit);
+					return true;
+				}
+
+				return false;
+			};
+			missionList.OnEscapeKey = () =>
+			{
+				StopVideo(videoPlayer);
+				Ui.CloseWindow();
+				onExit();
+				return true;
+			};
 
 			headerTemplate = widget.Get<ScrollItemWidget>("HEADER");
 			template = widget.Get<ScrollItemWidget>("TEMPLATE");
@@ -260,7 +277,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void CreateMissionGroup(string title, IEnumerable<MapPreview> previews, Action onExit)
 		{
-			var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+			var header = ScrollItemWidget.SetupHeader(headerTemplate);
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			missionList.AddChild(header);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -138,9 +138,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
 			playerList.RemoveChildren();
 
-			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { cancelLoadingReplays = true; Ui.CloseWindow(); onExit(); };
+			var cancelAction = new Action(() => { cancelLoadingReplays = true; Ui.CloseWindow(); onExit(); });
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = cancelAction;
 
 			replayList = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
+			replayList.OnEnterKey = () =>
+			{
+				if (selectedReplay != null && map.Status == MapStatus.Available)
+				{
+					WatchReplay();
+					return true;
+				}
+
+				return false;
+			};
+			replayList.OnEscapeKey = () => { cancelAction(); return true; };
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			var mod = modData.Manifest;
@@ -739,7 +751,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var group = kv.Key;
 					if (group.Length > 0)
 					{
-						var header = ScrollItemWidget.Setup(playerHeader, () => false, () => { });
+						var header = ScrollItemWidget.SetupHeader(playerHeader);
 						header.Get<LabelWidget>("LABEL").GetText = () => group;
 						playerList.AddChild(header);
 					}
@@ -750,7 +762,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						var color = o.Color;
 
-						var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+						var item = ScrollItemWidget.SetupHeader(playerTemplate);
 
 						var label = item.Get<LabelWidget>("LABEL");
 						var font = Game.Renderer.Fonts[label.Font];

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly WebServices services;
 		readonly Probe lanGameProbe;
 
-		readonly Widget serverList;
+		readonly ScrollPanelWidget serverList;
 		readonly ScrollItemWidget serverTemplate;
 		readonly ScrollItemWidget headerTemplate;
 		readonly Widget noticeContainer;
@@ -190,6 +190,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			incompatibleGameStartedColor = ChromeMetrics.Get<Color>("IncompatibleGameStartedColor");
 
 			serverList = widget.Get<ScrollPanelWidget>("SERVER_LIST");
+			serverList.OnEnterKey = () =>
+			{
+				if (currentServer != null && currentServer.IsJoinable)
+				{
+					onJoin(currentServer);
+					return true;
+				}
+
+				return false;
+			};
+
 			headerTemplate = serverList.Get<ScrollItemWidget>("HEADER_TEMPLATE");
 			serverTemplate = serverList.Get<ScrollItemWidget>("SERVER_TEMPLATE");
 
@@ -600,7 +611,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var group = kv.Key;
 				if (group.Length > 0)
 				{
-					var header = ScrollItemWidget.Setup(clientHeader, () => false, () => { });
+					var header = ScrollItemWidget.SetupHeader(clientHeader);
 					header.Get<LabelWidget>("LABEL").GetText = () => group;
 					clientList.AddChild(header);
 				}
@@ -617,7 +628,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return WidgetUtils.TruncateText(name, s.Item2, s.Item3);
 					});
 
-					var item = ScrollItemWidget.Setup(clientTemplate, () => false, () => { });
+					var item = ScrollItemWidget.SetupHeader(clientTemplate);
 					if (!o.IsSpectator && server.Mod == modData.Manifest.Id)
 					{
 						var label = item.Get<LabelWidget>("LABEL");
@@ -699,7 +710,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (modGames.All(Filtered))
 					continue;
 
-				var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+				var header = ScrollItemWidget.SetupHeader(headerTemplate);
 
 				var headerTitle = modGames.First().ModLabel;
 				header.Get<LabelWidget>("LABEL").GetText = () => headerTitle;

--- a/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
@@ -22,6 +22,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly bool EnableChildMouseOver = false;
 		public string ItemKey;
 
+		/// <summary>
+		/// When true, this item is culled from rendering due to being outside the visible scroll area.
+		/// Unlike IsVisible, culled items should still be navigable via keyboard.
+		/// </summary>
+		public Func<bool> IsCulledForRendering = () => false;
+
 		readonly CachedTransform<(bool, bool, bool, bool, bool), Sprite[]> getPanelCache;
 
 		[ObjectCreator.UseCtor]
@@ -41,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Key = other.Key;
 			Background = other.Background;
 			EnableChildMouseOver = other.EnableChildMouseOver;
+			IsCulledForRendering = other.IsCulledForRendering;
 			getPanelCache = WidgetUtils.GetCachedStatefulPanelImages(Background);
 		}
 
@@ -54,6 +61,29 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		public Func<bool> IsSelected = () => false;
+		public Func<bool> IsKeyboardFocused = () => false;
+		public Action OnKeyboardSelect;
+		public bool IsSelectable = true;
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Event == MouseInputEvent.Down && mi.Button == MouseButton.Left && Parent is ScrollPanelWidget scrollPanel)
+			{
+				scrollPanel.ClearKeyboardFocusedItem();
+				scrollPanel.TakeKeyboardFocus();
+			}
+
+			return base.HandleMouseInput(mi);
+		}
+
+		public override void DrawOuter()
+		{
+			// Skip rendering if culled (outside visible scroll area) but keep IsVisible for logical filtering
+			if (IsCulledForRendering())
+				return;
+
+			base.DrawOuter();
+		}
 
 		public override void Draw()
 		{
@@ -65,7 +95,9 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!IgnoreChildMouseOver && !hover)
 				hover = Children.Contains(Ui.MouseOverWidget);
 
-			WidgetUtils.DrawPanel(RenderBounds, getPanelCache.Update((IsDisabled(), Depressed, hover, false, IsSelected() || IsHighlighted())));
+			var parentHasKeyboardFocus = Parent is ScrollPanelWidget sp && sp.HasKeyboardFocusedItem;
+			var highlighted = IsKeyboardFocused() || (!parentHasKeyboardFocus && (IsSelected() || IsHighlighted()));
+			WidgetUtils.DrawPanel(RenderBounds, getPanelCache.Update((IsDisabled(), Depressed, hover, false, highlighted)));
 		}
 
 		public override ScrollItemWidget Clone() { return new ScrollItemWidget(this); }
@@ -76,6 +108,7 @@ namespace OpenRA.Mods.Common.Widgets
 			w.IsVisible = () => true;
 			w.IsSelected = isSelected;
 			w.OnClick = onClick;
+			w.OnKeyboardSelect = onClick;
 			return w;
 		}
 
@@ -91,6 +124,15 @@ namespace OpenRA.Mods.Common.Widgets
 			var w = Setup(template, isSelected, onClick);
 			w.OnDoubleClick = onDoubleClick;
 			w.ItemKey = key;
+			return w;
+		}
+
+		public static ScrollItemWidget SetupHeader(ScrollItemWidget template)
+		{
+			var w = template.Clone();
+			w.IsVisible = () => true;
+			w.IsSelected = () => false;
+			w.IsSelectable = false;
 			return w;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
@@ -39,6 +40,16 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		readonly Ruleset modRules;
 		public int ScrollbarWidth = 24;
+
+		ScrollItemWidget keyboardFocusedItem;
+		public bool HasKeyboardFocusedItem => keyboardFocusedItem != null;
+
+		// Called when Enter or Space is pressed. Return true if the key was handled.
+		// If null or returns false, the focused item's OnClick will be invoked.
+		public Func<bool> OnEnterKey;
+
+		// Called when Escape is pressed. Return true if the key was handled.
+		public Func<bool> OnEscapeKey;
 		public int BorderWidth = 1;
 		public int TopBottomSpacing = 2;
 		public int ItemSpacing = 0;
@@ -389,6 +400,146 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			return upPressed || downPressed || thumbPressed;
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (e.Event != KeyInputEvent.Down)
+				return false;
+
+			switch (e.Key)
+			{
+				case Keycode.UP:
+					if (e.Modifiers.HasFlag(Modifiers.Meta) && Platform.CurrentPlatform == PlatformType.OSX)
+						return FocusFirstItem();
+					else
+						return FocusAdjacentItem(forward: false);
+
+				case Keycode.DOWN:
+					if (e.Modifiers.HasFlag(Modifiers.Meta) && Platform.CurrentPlatform == PlatformType.OSX)
+						return FocusLastItem();
+					else
+						return FocusAdjacentItem(forward: true);
+
+				case Keycode.HOME:
+					return FocusFirstItem();
+
+				case Keycode.END:
+					return FocusLastItem();
+
+				case Keycode.RETURN:
+				case Keycode.KP_ENTER:
+				case Keycode.SPACE:
+					if (OnEnterKey != null && OnEnterKey())
+						return true;
+					return ActivateFocusedItem();
+
+				case Keycode.ESCAPE:
+					if (OnEscapeKey != null)
+						return OnEscapeKey();
+					return false;
+
+				default:
+					return false;
+			}
+		}
+
+		bool ActivateFocusedItem()
+		{
+			if (keyboardFocusedItem == null)
+				return false;
+
+			keyboardFocusedItem.OnClick?.Invoke();
+			return true;
+		}
+
+		bool FocusAdjacentItem(bool forward)
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			var currentIndex = keyboardFocusedItem != null
+				? selectableItems.IndexOf(keyboardFocusedItem)
+				: selectableItems.FindIndex(item => item.IsSelected());
+
+			int newIndex;
+			if (currentIndex == -1)
+				newIndex = forward ? 0 : selectableItems.Count - 1;
+			else
+			{
+				newIndex = forward ? currentIndex + 1 : currentIndex - 1;
+
+				if (newIndex < 0 || newIndex >= selectableItems.Count)
+					return true;
+			}
+
+			SetKeyboardFocus(selectableItems[newIndex]);
+			ScrollToItem(selectableItems[newIndex]);
+
+			return true;
+		}
+
+		bool FocusFirstItem()
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			SetKeyboardFocus(selectableItems[0]);
+			ScrollToItem(selectableItems[0]);
+
+			return true;
+		}
+
+		bool FocusLastItem()
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			SetKeyboardFocus(selectableItems[^1]);
+			ScrollToItem(selectableItems[^1]);
+
+			return true;
+		}
+
+		void SetKeyboardFocus(ScrollItemWidget item)
+		{
+			if (keyboardFocusedItem != null)
+				keyboardFocusedItem.IsKeyboardFocused = () => false;
+
+			keyboardFocusedItem = item;
+
+			if (keyboardFocusedItem != null)
+			{
+				keyboardFocusedItem.IsKeyboardFocused = () => true;
+				keyboardFocusedItem.OnKeyboardSelect?.Invoke();
+			}
+		}
+
+		// Called when an item is clicked with the mouse to clear keyboard navigation state.
+		// This allows the visual highlight to fall back to the selected item.
+		public void ClearKeyboardFocusedItem()
+		{
+			SetKeyboardFocus(null);
+		}
+
+		List<ScrollItemWidget> GetSelectableItems()
+		{
+			var items = new List<ScrollItemWidget>();
+
+			foreach (var child in Children)
+			{
+				// Filter by IsVisible() for logical visibility (e.g. filtered items in AssetBrowser).
+				// Note: Items using IsCulledForRendering for geometric culling are still included
+				// because IsVisible() remains true for them - they are just not rendered when outside
+				// the visible scroll area but should still be navigable via keyboard.
+				if (child is ScrollItemWidget scrollItem && scrollItem.IsVisible() && scrollItem.IsSelectable)
+					items.Add(scrollItem);
+			}
+
+			return items;
 		}
 
 		IObservableCollection collection;


### PR DESCRIPTION
Adds keyboard navigation (Arrow Up/Down, Home/End) to all scrollable lists. Navigation stops at list boundaries, correctly skips non-selectable headers, and dropdowns remain open during keyboard navigation.

Fixes:
OpenRA#21004 - Allow to press Arrow Up and Arrow Down to browse files in the Asset Browser
OpenRA#10682 - Key-support for the replay-section
OpenRA#21649 - Select items in menu by using arrow keys
OpenRA#19715 - Allow us to use keyboard in map browser and server list

Changes:
- `ScrollPanelWidget`: Added keyboard navigation handling
- `ScrollItemWidget`: Added `OnKeyboardSelect` for keyboard-specific behavior, `IsSelectable` property, and `SetupHeader` factory method
- `DropDownButtonWidget`: Configured to keep dropdowns open during keyboard navigation
- Updated all Logic files to use `SetupHeader` for non-selectable header items

Applies to all lists using `ScrollPanelWidget` (Mission Browser, Multiplayer Server List, Replay Browser, Asset Browser, Encyclopedia, dropdowns, etc.).