### PR TITLE
Map Editor: Show where the map is saved

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
@@ -145,6 +146,27 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				directoryDropdown.OnClick = () =>
 					directoryDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, writableDirectories, SetupItem);
 			}
+
+			var mapFolderButton = widget.Get<ButtonWidget>("MAP_FOLDER_BUTTON");
+			mapFolderButton.OnClick = () =>
+			{
+				if (selectedDirectory != null && Directory.Exists(selectedDirectory.Folder.Name))
+				{
+					try
+					{
+						var folderPath = selectedDirectory.Folder.Name;
+						Process.Start(new ProcessStartInfo
+						{
+							FileName = folderPath,
+							UseShellExecute = true
+						});
+					}
+					catch (Exception e)
+					{
+						Log.Write("debug", $"Failed to open map folder: {e.Message}");
+					}
+				}
+			};
 
 			var mapIsUnpacked = map.Package != null && map.Package is Folder;
 

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -146,9 +146,16 @@ Container@SAVE_MAP_PANEL:
 				DropDownButton@DIRECTORY_DROPDOWN:
 					X: 110
 					Y: 120
-					Width: 220
+					Width: 155
 					Height: 25
 					Font: Regular
+				Button@MAP_FOLDER_BUTTON:
+					X: 270
+					Y: 120
+					Width: 60
+					Height: 25
+					Text: button-save-map-panel-map-folder
+					Font: Bold
 				Label@FILENAME_LABEL:
 					X: 10
 					Y: 155

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -54,6 +54,7 @@ dropdownbutton-save-map-background-visibility-dropdown = Map Visibility
 label-save-map-background-directory = Directory:
 label-save-map-background-filename = Filename:
 button-save-map-panel = Save
+button-save-map-panel-map-folder = Open
 label-actor-edit-panel-id = ID
 button-container-ok = OK
 button-editor-world-root-options-tooltip = Menu

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -136,8 +136,15 @@ Background@SAVE_MAP_PANEL:
 		DropDownButton@DIRECTORY_DROPDOWN:
 			X: 110
 			Y: 165
-			Width: 220
+			Width: 155
 			Height: 25
+		Button@MAP_FOLDER_BUTTON:
+			X: 270
+			Y: 165
+			Width: 60
+			Height: 25
+			Text: button-save-map-panel-map-folder
+			Font: Bold
 		Label@FILENAME_LABEL:
 			X: 10
 			Y: 200

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -51,6 +51,7 @@ dropdownbutton-save-map-panel-visibility-dropdown = Map Visibility
 label-save-map-panel-directory = Directory:
 label-save-map-panel-filename = Filename:
 button-save-map-panel = Save
+button-save-map-panel-map-folder = Open
 label-actor-edit-panel-id = ID
 button-container-ok = OK
 label-tiles-bg-search = Search:


### PR DESCRIPTION
- Adds an "Open Map Editor" button to the Map Editor menu 
- Modifies the "Saved current map" notification message by adding the path and filename of the map being saved

Fixes: 
#18694 - Add a button to the map editor taking you to the map(s) folder