### PR TITLE
Fix tileset templates to appear in the map editor in their order in YAML.

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -434,7 +434,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// <summary>Load a named MultiBrush collection from a map's tileset.</summary>
 		public static ImmutableArray<MultiBrush> LoadCollection(Map map, string name)
 		{
-			var templatedTerrainInfo = map.Rules.TerrainInfo as ITemplatedTerrainInfo;
+			var templatedTerrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 			return templatedTerrainInfo.MultiBrushCollections[name]
 				.Select(info => new MultiBrush(map, info))
 				.ToImmutableArray();

--- a/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
+++ b/OpenRA.Mods.Common/Terrain/TerrainInfo.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Terrain
 	{
 		ImmutableArray<string> EditorTemplateOrder { get; }
 		FrozenDictionary<ushort, TerrainTemplateInfo> Templates { get; }
+		ImmutableArray<TerrainTemplateInfo> TemplatesInDefinitionOrder { get; }
 		FrozenDictionary<string, ImmutableArray<MultiBrushInfo>> MultiBrushCollections { get; }
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -341,7 +341,7 @@ namespace OpenRA.Mods.Common.Traits
 			World = self.World;
 			TraitInfo = info;
 
-			var templatedTerrainInfo = World.Map.Rules.TerrainInfo as ITemplatedTerrainInfo;
+			var templatedTerrainInfo = (ITemplatedTerrainInfo)World.Map.Rules.TerrainInfo;
 			SegmentedBrushes =
 				templatedTerrainInfo.MultiBrushCollections.Keys
 					.Order()

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		readonly ITemplatedTerrainInfo terrainInfo;
-		readonly TileSelectorTemplate[] allTemplates;
+		readonly ImmutableArray<TileSelectorTemplate> allTemplates;
 
 		[ObjectCreator.UseCtor]
 		public TileSelectorLogic(Widget widget, ModData modData, World world, WorldRenderer worldRenderer)
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (terrainInfo == null)
 				throw new InvalidDataException("TileSelectorLogic requires a template-based tileset.");
 
-			allTemplates = terrainInfo.Templates.Values.Select(t => new TileSelectorTemplate(t)).ToArray();
+			allTemplates = terrainInfo.TemplatesInDefinitionOrder.Select(t => new TileSelectorTemplate(t)).ToImmutableArray();
 
 			allCategories = allTemplates.SelectMany(t => t.Categories)
 				.Distinct()


### PR DESCRIPTION
Fixes regression from #22168. When the Templates was changed from a Dictionary to a FrozenDictionary, this caused the items to be reordered. Some code was relying on the previous behaviour where the Dictionary ordering would happen to remain the same as the YAML input.

Fix this by creating a TemplatesInDefinitionOrder which can be used to iterate in the same ordering as given in YAML. Code that depends on the ordering can use this, and other code that does lookups can use the FrozenDictionary.

Fixes #22280.