### PR TITLE
Place map generator spawns more intuitively

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExperimentalMapGenerator.cs
@@ -947,6 +947,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Cosmetically repaint tiles
 			terraformer.RepaintTiles(repaintRandom, param.RepaintTiles);
 
+			terraformer.ReorderPlayerSpawns();
 			terraformer.BakeMap();
 
 			return map;

--- a/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
@@ -610,6 +610,7 @@ namespace OpenRA.Mods.D2k.Traits
 				}
 			}
 
+			terraformer.ReorderPlayerSpawns();
 			terraformer.BakeMap();
 
 			return map;


### PR DESCRIPTION
The map generators previously placed spawns in an order that was somewhat arbitrary and unintuitive to users, particularly for team games.

This change provides and makes use of a Terraformer utility to reorder spawns, based on their location, so that they typically make more sense to users selecting spawns from a lobby.

Added to ExperimentalMapGenerator (RA, CnC), and D2kMapGenerator.

Note that this changes the output of the map generator for a given selection of settings. (Replays using generated maps from older versions will lose compatibility and no longer load.)
