### PR TITLE
Cloak optimization

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -256,6 +256,7 @@ namespace OpenRA.Traits
 
 		WDist LargestActorRadius { get; }
 		WDist LargestBlockingActorRadius { get; }
+		WDist LargestDetectionRange { get; }
 
 		void UpdateOccupiedCells(IOccupySpace ios);
 		event Action<CPos> CellUpdated;

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -296,9 +296,32 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Cloaked || self.Owner.IsAlliedWith(viewer))
 				return true;
 
-			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.IsInWorld
-				&& a.Actor.Owner.IsAlliedWith(viewer) && Info.DetectionTypes.Overlaps(a.Trait.Info.DetectionTypes)
-				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Range.LengthSquared);
+			var searchRadius = self.World.ActorMap.LargestDetectionRange;
+			if (searchRadius == WDist.Zero)
+				return false;
+
+			var pos = self.CenterPosition;
+			var vec = new WVec(searchRadius.Length, searchRadius.Length, WDist.Zero.Length);
+
+			foreach (var actor in self.World.ActorMap.ActorsInBox(pos - vec, pos + vec))
+			{
+				if (!actor.IsInWorld || !actor.Owner.IsAlliedWith(viewer))
+					continue;
+
+				foreach (var detectCloaked in actor.TraitsImplementing<DetectCloaked>())
+				{
+					if (detectCloaked.IsTraitDisabled)
+						continue;
+
+					if (!Info.DetectionTypes.Overlaps(detectCloaked.Info.DetectionTypes))
+						continue;
+
+					if ((pos - actor.CenterPosition).LengthSquared <= detectCloaked.Range.LengthSquared)
+						return true;
+				}
+			}
+
+			return false;
 		}
 
 		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -187,6 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WDist LargestActorRadius { get; }
 		public WDist LargestBlockingActorRadius { get; }
+		public WDist LargestDetectionRange { get; }
 
 		public ActorMap(World world, ActorMapInfo info)
 		{
@@ -207,6 +208,8 @@ namespace OpenRA.Mods.Common.Traits
 			LargestActorRadius = map.Rules.Actors.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius);
 			var blockers = map.Rules.Actors.Where(a => a.Value.HasTraitInfo<IBlocksProjectilesInfo>()).ToList();
 			LargestBlockingActorRadius = blockers.Count != 0 ? blockers.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius) : WDist.Zero;
+			var detectors = map.Rules.Actors.SelectMany(a => a.Value.TraitInfos<DetectCloakedInfo>()).ToList();
+			LargestDetectionRange = detectors.Count != 0 ? detectors.Max(d => d.Range) : WDist.Zero;
 		}
 
 		void INotifyCreated.Created(Actor self)


### PR DESCRIPTION
Having lots of actors with the Cloak trait on the map causes significant performance degradation.

I tried a blob of 640 stealth tanks and a blob of 640 detectors (nothing else on the map) and it brought framerate down to ~10fps, despite the two blobs being nowhere near each other.

This is because the Cloak trait currently checks visibility by getting all detectors on the entire map and checking if they're in range.

Using the actor map we can check for detectors within a smaller radius, by adding a LargestDetectionRange similar to how there's a LargestActorRadius and LargestBlockingActorRadius.

The same test then gives me ~30fps as long as no detectors were within the maximum range of the cloaked units. The performance drops as cloaked units and detectors get within range of each other, but the performance is never worse than in the original example.