### PR TITLE
Rename "Experimental" map generator to "Classic"

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
@@ -23,7 +23,7 @@ using static OpenRA.Mods.Common.Traits.ResourceLayerInfo;
 namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.EditorWorld)]
-	public sealed class ExperimentalMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
+	public sealed class ClassicMapGeneratorInfo : TraitInfo, IEditorMapGeneratorInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Type = null;
@@ -955,18 +955,18 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override object Create(ActorInitializer init)
 		{
-			return new ExperimentalMapGenerator(init, this);
+			return new ClassicMapGenerator(init, this);
 		}
 	}
 
-	public class ExperimentalMapGenerator : IEditorTool
+	public class ClassicMapGenerator : IEditorTool
 	{
 		public string Label { get; }
 		public string PanelWidget { get; }
 		public TraitInfo TraitInfo { get; }
 		public bool IsEnabled { get; }
 
-		public ExperimentalMapGenerator(ActorInitializer init, ExperimentalMapGeneratorInfo info)
+		public ClassicMapGenerator(ActorInitializer init, ClassicMapGeneratorInfo info)
 		{
 			Label = info.Name;
 			PanelWidget = info.PanelWidget;

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -51,7 +51,7 @@ faction-nod =
      and the alien substance Tiberium. They use stealth technology
      and guerilla tactics to defeat those who oppose them.
 
-map-generator-experimental = Experimental RMG
+map-generator-classic = Map Generator
 map-generator-clear = Clear Terrain
 
 ## defaults.yaml

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -1,7 +1,7 @@
 ^MapGenerators:
-	ExperimentalMapGenerator@experimental:
-		Type: experimental
-		Name: map-generator-experimental
+	ClassicMapGenerator@classic:
+		Type: classic
+		Name: map-generator-classic
 		Tilesets: DESERT, SNOW, TEMPERAT, WINTER
 		Settings:
 			MultiChoiceOption@hidden_defaults:

--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -104,7 +104,7 @@ faction-smugglers =
 faction-fremen =
     .name = Fremen
 
-map-generator-d2k = D2K RMG
+map-generator-d2k = Map Generator
 map-generator-clear = Clear Terrain
 
 ## defaults.yaml

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -34,7 +34,7 @@ options-starting-units =
 
 resource-minerals = Valuable Minerals
 
-map-generator-experimental = Experimental RMG
+map-generator-classic = Map Generator
 map-generator-clear = Clear Terrain
 
 ## Faction

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -1,7 +1,7 @@
 ^MapGenerators:
-	ExperimentalMapGenerator@experimental:
-		Type: experimental
-		Name: map-generator-experimental
+	ClassicMapGenerator@classic:
+		Type: classic
+		Name: map-generator-classic
 		Tilesets: DESERT, SNOW, TEMPERAT
 		Settings:
 			MultiChoiceOption@hidden_defaults:


### PR DESCRIPTION
Renames the "Experimental" map generator to "Classic" in internal code, configuration, and user-facing text.

Additionally, replaces "RMG" with "Map Generator" in the user-facing map generator names, including D2K for consistency.
