### PR TITLE
Use Matrix4x4 and AABB structs to avoid allocations.

### DIFF
--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Numerics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -20,9 +21,9 @@ namespace OpenRA.Graphics
 		uint Frames { get; }
 		uint Sections { get; }
 
-		float[] TransformationMatrix(uint section, uint frame);
+		Matrix4x4 TransformationMatrix(uint section, uint frame);
 		float[] Size { get; }
-		float[] Bounds(uint frame);
+		AABB Bounds(uint frame);
 		ModelRenderData RenderData(uint section);
 
 		/// <summary>Returns the smallest rectangle that covers all rotations of all frames in a model.</summary>

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 
@@ -136,9 +137,10 @@ namespace OpenRA
 		void SetVec(string name, float x);
 		void SetVec(string name, float x, float y);
 		void SetVec(string name, float x, float y, float z);
-		void SetVec(string name, ReadOnlyMemory<float> vec, int length);
+		void SetVec(string name, Vector3 vec);
+		void SetVec(string name, Vector4 vec);
 		void SetTexture(string param, ITexture texture);
-		void SetMatrix(string param, float[] mtx);
+		void SetMatrix(string param, Matrix4x4 mtx);
 		void PrepareRender();
 		void Bind();
 	}

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -141,6 +141,7 @@ namespace OpenRA
 		void SetVec(string name, Vector4 vec);
 		void SetTexture(string param, ITexture texture);
 		void SetMatrix(string param, Matrix4x4 mtx);
+		void SetMatrixRowMajor(string param, Matrix4x4 mtx);
 		void PrepareRender();
 		void Bind();
 	}

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using OpenRA.Effects;
 using OpenRA.Primitives;
@@ -447,10 +448,10 @@ namespace OpenRA.Graphics
 		}
 
 		// For scaling vectors to pixel sizes in the model renderer
-		public float[] ScreenVector(in WVec vec)
+		public Vector4 ScreenVector(in WVec vec)
 		{
 			var xyz = ScreenVectorComponents(vec);
-			return [xyz.X, xyz.Y, xyz.Z, 1f];
+			return new Vector4(xyz.X, xyz.Y, xyz.Z, 1f);
 		}
 
 		public int2 ScreenPxOffset(in WVec vec)

--- a/OpenRA.Game/Primitives/AABB.cs
+++ b/OpenRA.Game/Primitives/AABB.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Numerics;
 
 namespace OpenRA.Primitives
@@ -28,5 +29,32 @@ namespace OpenRA.Primitives
 			(uint)index % 4 < 2 ? MinY : MaxY,
 			(uint)index % 2 < 1 ? MinZ : MaxZ,
 			1);
+
+		public static AABB Transform(AABB bounds, Matrix4x4 mtx)
+		{
+			// Vectors to opposing corner.
+			var minX = float.MaxValue;
+			var minY = float.MaxValue;
+			var minZ = float.MaxValue;
+			var maxX = float.MinValue;
+			var maxY = float.MinValue;
+			var maxZ = float.MinValue;
+
+			// Transform vectors and find new bounding box.
+			for (var i = 0; i < 8; i++)
+			{
+				var vec = bounds.Corner(i);
+				var tvec = Vector4.Transform(vec, mtx);
+
+				minX = Math.Min(minX, tvec[0] / tvec[3]);
+				minY = Math.Min(minY, tvec[1] / tvec[3]);
+				minZ = Math.Min(minZ, tvec[2] / tvec[3]);
+				maxX = Math.Max(maxX, tvec[0] / tvec[3]);
+				maxY = Math.Max(maxY, tvec[1] / tvec[3]);
+				maxZ = Math.Max(maxZ, tvec[2] / tvec[3]);
+			}
+
+			return new AABB(minX, minY, minZ, maxX, maxY, maxZ);
+		}
 	}
 }

--- a/OpenRA.Game/Primitives/AABB.cs
+++ b/OpenRA.Game/Primitives/AABB.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Numerics;
+
+namespace OpenRA.Primitives
+{
+	/// <summary>
+	/// Axis-aligned bounding box.
+	/// </summary>
+	public readonly record struct AABB(float MinX, float MinY, float MinZ, float MaxX, float MaxY, float MaxZ)
+	{
+		/// <summary>
+		/// Provides one of eight corners of the <see cref="AABB"/> at the given <paramref name="index"/>.
+		/// </summary>
+		/// <param name="index">Index into one of the eight possible corners (0 thru 7).</param>
+		/// <returns>A vector for this corner with a <see cref="Vector4.W"/> component of 1.</returns>
+		public readonly Vector4 Corner(int index) => new(
+			(uint)index % 8 < 4 ? MinX : MaxX,
+			(uint)index % 4 < 2 ? MinY : MaxY,
+			(uint)index % 2 < 1 ? MinZ : MaxZ,
+			1);
+	}
+}

--- a/OpenRA.Game/Primitives/Int32Matrix4x4.cs
+++ b/OpenRA.Game/Primitives/Int32Matrix4x4.cs
@@ -13,60 +13,26 @@ using System;
 
 namespace OpenRA
 {
-	public readonly struct Int32Matrix4x4 : IEquatable<Int32Matrix4x4>
+	public readonly record struct Int32Matrix4x4(
+			int M11, int M12, int M13, int M14,
+			int M21, int M22, int M23, int M24,
+			int M31, int M32, int M33, int M34,
+			int M41, int M42, int M43, int M44) : IEquatable<Int32Matrix4x4>
 	{
-		public readonly int M11, M12, M13, M14, M21, M22, M23, M24, M31, M32, M33, M34, M41, M42, M43, M44;
-
-		public Int32Matrix4x4(
-			int m11, int m12, int m13, int m14,
-			int m21, int m22, int m23, int m24,
-			int m31, int m32, int m33, int m34,
-			int m41, int m42, int m43, int m44)
-		{
-			M11 = m11;
-			M12 = m12;
-			M13 = m13;
-			M14 = m14;
-
-			M21 = m21;
-			M22 = m22;
-			M23 = m23;
-			M24 = m24;
-
-			M31 = m31;
-			M32 = m32;
-			M33 = m33;
-			M34 = m34;
-
-			M41 = m41;
-			M42 = m42;
-			M43 = m43;
-			M44 = m44;
-		}
-
-		public static bool operator ==(Int32Matrix4x4 me, Int32Matrix4x4 other)
-		{
-			return
-				me.M11 == other.M11 && me.M12 == other.M12 && me.M13 == other.M13 && me.M14 == other.M14 &&
-				me.M21 == other.M21 && me.M22 == other.M22 && me.M23 == other.M23 && me.M24 == other.M24 &&
-				me.M31 == other.M31 && me.M32 == other.M32 && me.M33 == other.M33 && me.M34 == other.M34 &&
-				me.M41 == other.M41 && me.M42 == other.M42 && me.M43 == other.M43 && me.M44 == other.M44;
-		}
-
-		public static bool operator !=(Int32Matrix4x4 me, Int32Matrix4x4 other) { return !(me == other); }
+		public bool Equals(Int32Matrix4x4 other) { return other == this; }
 
 		public override int GetHashCode() { return M11 ^ M22 ^ M33 ^ M44; }
 
-		public bool Equals(Int32Matrix4x4 other) { return other == this; }
-		public override bool Equals(object obj) { return obj is Int32Matrix4x4 matrix && Equals(matrix); }
-
+		/// <summary>Returns a string that represents this matrix.</summary>
 		public override string ToString()
 		{
 			return
-				"[" + M11 + " " + M12 + " " + M13 + " " + M14 + "],[" +
-				"[" + M21 + " " + M22 + " " + M23 + " " + M24 + "],[" +
-				"[" + M31 + " " + M32 + " " + M33 + " " + M34 + "],[" +
-				"[" + M41 + " " + M42 + " " + M43 + " " + M44 + "]";
+				"{{ " +
+				$"{{M11:{M11} M12:{M12} M13:{M13} M14:{M14}}} " +
+				$"{{M21:{M21} M22:{M22} M23:{M23} M24:{M24}}} " +
+				$"{{M31:{M31} M32:{M32} M33:{M33} M34:{M34}}} " +
+				$"{{M41:{M41} M42:{M42} M43:{M43} M44:{M44}}} " +
+				"}}";
 		}
 	}
 }

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using OpenRA.Primitives;
 
@@ -27,6 +28,7 @@ namespace OpenRA
 		public float2(int2 p) { X = p.X; Y = p.Y; }
 
 		public static implicit operator float2(int2 src) { return new float2(src.X, src.Y); }
+		public static implicit operator Vector2(float2 src) { return new Vector2(src.X, src.Y); }
 
 		public static float2 operator +(float2 a, float2 b) { return new float2(a.X + b.X, a.Y + b.Y); }
 		public static float2 operator -(float2 a, float2 b) { return new float2(a.X - b.X, a.Y - b.Y); }

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace OpenRA
@@ -27,6 +28,7 @@ namespace OpenRA
 
 		public static implicit operator float3(int2 src) { return new float3(src.X, src.Y, 0); }
 		public static implicit operator float3(float2 src) { return new float3(src.X, src.Y, 0); }
+		public static implicit operator Vector3(float3 src) { return new Vector3(src.X, src.Y, src.Z); }
 
 		public static float3 operator +(in float3 a, in float3 b) { return new float3(a.X + b.X, a.Y + b.Y, a.Z + b.Z); }
 		public static float3 operator -(in float3 a, in float3 b) { return new float3(a.X - b.X, a.Y - b.Y, a.Z - b.Z); }

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -160,17 +160,17 @@ namespace OpenRA
 			// Quaternion components use 10 bits, so there's no risk of overflow
 			mtx = new Int32Matrix4x4(
 				lsq - 2 * (y * y + z * z),
-				2 * (x * y + z * w),
-				2 * (x * z - y * w),
-				0,
-				/* row */
 				2 * (x * y - z * w),
-				lsq - 2 * (x * x + z * z),
-				2 * (y * z + x * w),
+				2 * (x * z + y * w),
 				0,
 				/* row */
-				2 * (x * z + y * w),
+				2 * (x * y + z * w),
+				lsq - 2 * (x * x + z * z),
 				2 * (y * z - x * w),
+				0,
+				/* row */
+				2 * (x * z - y * w),
+				2 * (y * z + x * w),
 				lsq - 2 * (x * x + y * y),
 				0,
 				/* row */

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Numerics;
 
 namespace OpenRA
 {
@@ -179,10 +180,32 @@ namespace OpenRA
 				lsq);
 		}
 
-		public Int32Matrix4x4 AsMatrix()
+		public Matrix4x4 ToFloatMatrix()
 		{
 			AsMatrix(out var mtx);
-			return mtx;
+			return MakeFloatMatrix(mtx);
+		}
+
+		static Matrix4x4 MakeFloatMatrix(Int32Matrix4x4 imtx)
+		{
+			var multipler = 1f / imtx.M44;
+			return new Matrix4x4(
+				imtx.M11 * multipler,
+				imtx.M12 * multipler,
+				imtx.M13 * multipler,
+				imtx.M14 * multipler,
+				imtx.M21 * multipler,
+				imtx.M22 * multipler,
+				imtx.M23 * multipler,
+				imtx.M24 * multipler,
+				imtx.M31 * multipler,
+				imtx.M32 * multipler,
+				imtx.M33 * multipler,
+				imtx.M34 * multipler,
+				imtx.M41 * multipler,
+				imtx.M42 * multipler,
+				imtx.M43 * multipler,
+				1f);
 		}
 
 		public override int GetHashCode() { return Roll.GetHashCode() ^ Pitch.GetHashCode() ^ Yaw.GetHashCode(); }

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -58,9 +58,9 @@ namespace OpenRA
 			var ly = (long)Y;
 			var lz = (long)Z;
 			return new WVec(
-				(int)((lx * mtx.M11 + ly * mtx.M21 + lz * mtx.M31) / mtx.M44),
-				(int)((lx * mtx.M12 + ly * mtx.M22 + lz * mtx.M32) / mtx.M44),
-				(int)((lx * mtx.M13 + ly * mtx.M23 + lz * mtx.M33) / mtx.M44));
+				(int)((lx * mtx.M11 + ly * mtx.M12 + lz * mtx.M13) / mtx.M44),
+				(int)((lx * mtx.M21 + ly * mtx.M22 + lz * mtx.M23) / mtx.M44),
+				(int)((lx * mtx.M31 + ly * mtx.M32 + lz * mtx.M33) / mtx.M44));
 		}
 
 		public WAngle Yaw

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -22,9 +22,6 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 		public HvaReader(Stream s, string fileName)
 		{
-			// Index swaps for transposing a matrix
-			var ids = new byte[] { 0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14 };
-
 			s.Seek(16, SeekOrigin.Begin);
 			FrameCount = s.ReadUInt32();
 			LimbCount = s.ReadUInt32();
@@ -38,13 +35,13 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				{
 					// Convert to column-major matrices and add the final matrix row
 					var c = LimbCount * j + i;
-					Transforms[c][0, 3] = 0;
-					Transforms[c][1, 3] = 0;
-					Transforms[c][2, 3] = 0;
+					Transforms[c][3, 0] = 0;
+					Transforms[c][3, 1] = 0;
+					Transforms[c][3, 2] = 0;
 					Transforms[c][3, 3] = 1;
 
 					for (var k = 0; k < 12; k++)
-						Transforms[c][ids[k] / 4, ids[k] % 4] = s.ReadSingle();
+						Transforms[c][k / 4, k % 4] = s.ReadSingle();
 
 					if (!Matrix4x4.Invert(Transforms[c], out var _))
 						throw new InvalidDataException(

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 					for (var k = 0; k < 12; k++)
 						Transforms[c][ids[k] / 4, ids[k] % 4] = s.ReadSingle();
 
-					if (Util.MatrixInverse(Transforms[c]) == null)
+					if (!Matrix4x4.Invert(Transforms[c], out var _))
 						throw new InvalidDataException(
 							$"The transformation matrix for HVA file `{fileName}` section {i} frame {j} is invalid because it is not invertible!");
 				}

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
-using System;
 using System.IO;
+using System.Numerics;
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 	{
 		public readonly uint FrameCount;
 		public readonly uint LimbCount;
-		public readonly float[] Transforms;
+		public readonly Matrix4x4[] Transforms;
 
 		public HvaReader(Stream s, string fileName)
 		{
@@ -31,24 +31,22 @@ namespace OpenRA.Mods.Cnc.FileFormats
 
 			// Skip limb names
 			s.Seek(16 * LimbCount, SeekOrigin.Current);
-			Transforms = new float[16 * FrameCount * LimbCount];
+			Transforms = new Matrix4x4[FrameCount * LimbCount];
 
-			var testMatrix = new float[16];
 			for (var j = 0; j < FrameCount; j++)
 				for (var i = 0; i < LimbCount; i++)
 				{
 					// Convert to column-major matrices and add the final matrix row
-					var c = 16 * (LimbCount * j + i);
-					Transforms[c + 3] = 0;
-					Transforms[c + 7] = 0;
-					Transforms[c + 11] = 0;
-					Transforms[c + 15] = 1;
+					var c = LimbCount * j + i;
+					Transforms[c][0, 3] = 0;
+					Transforms[c][1, 3] = 0;
+					Transforms[c][2, 3] = 0;
+					Transforms[c][3, 3] = 1;
 
 					for (var k = 0; k < 12; k++)
-						Transforms[c + ids[k]] = s.ReadSingle();
+						Transforms[c][ids[k] / 4, ids[k] % 4] = s.ReadSingle();
 
-					Array.Copy(Transforms, 16 * (LimbCount * j + i), testMatrix, 0, 16);
-					if (Util.MatrixInverse(testMatrix) == null)
+					if (Util.MatrixInverse(Transforms[c]) == null)
 						throw new InvalidDataException(
 							$"The transformation matrix for HVA file `{fileName}` section {i} frame {j} is invalid because it is not invertible!");
 				}

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.FileFormats
 {
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 	{
 		public string Name;
 		public float Scale;
-		public float[] Bounds;
+		public AABB Bounds;
 		public byte[] Size;
 		public NormalType Type;
 
@@ -135,9 +136,9 @@ namespace OpenRA.Mods.Cnc.FileFormats
 				Limbs[i].Scale = s.ReadSingle();
 				s.Seek(48, SeekOrigin.Current);
 
-				Limbs[i].Bounds = new float[6];
-				for (var j = 0; j < 6; j++)
-					Limbs[i].Bounds[j] = s.ReadSingle();
+				Limbs[i].Bounds = new AABB(
+					s.ReadSingle(), s.ReadSingle(), s.ReadSingle(),
+					s.ReadSingle(), s.ReadSingle(), s.ReadSingle());
 				Limbs[i].Size = s.ReadBytes(3);
 				Limbs[i].Type = (NormalType)s.ReadUInt8();
 			}

--- a/OpenRA.Mods.Cnc/Graphics/ModelActorPreview.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelActorPreview.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Mods.Common.Graphics;
@@ -23,8 +23,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly ModelRenderer renderer;
 		readonly ModelAnimation[] components;
 		readonly float scale;
-		readonly ImmutableArray<float> lightAmbientColor;
-		readonly ImmutableArray<float> lightDiffuseColor;
+		readonly Vector3 lightAmbientColor;
+		readonly Vector3 lightDiffuseColor;
 		readonly WRot lightSource;
 		readonly WRot camera;
 		readonly PaletteReference colorPalette;
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly int zOffset;
 
 		public ModelPreview(ModelRenderer renderer, ModelAnimation[] components, in WVec offset, int zOffset, float scale, WAngle lightPitch, WAngle lightYaw,
-			ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor, WAngle cameraPitch,
+			Vector3 lightAmbientColor, Vector3 lightDiffuseColor, WAngle cameraPitch,
 			PaletteReference colorPalette, PaletteReference normalsPalette, PaletteReference shadowPalette)
 		{
 			this.renderer = renderer;

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -211,10 +211,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(scaleTransform, rotation);
+					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(cameraTransform, worldTransform);
+					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
 					DrawBoundsBox(wr, pxPos, screenTransform, bounds, 1, Color.Yellow);
 				}
 			}
@@ -266,10 +266,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(scaleTransform, rotation);
+					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(cameraTransform, worldTransform);
+					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
 
 					for (var i = 0; i < 8; i++)
 					{

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -211,10 +211,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = v.RotationFunc().ToFloatMatrix();
-					var worldTransform = rotation * scaleTransform;
+					var worldTransform = scaleTransform * rotation;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = worldTransform * cameraTransform;
+					var screenTransform = cameraTransform * worldTransform;
 					DrawBoundsBox(wr, pxPos, screenTransform, bounds, 1, Color.Yellow);
 				}
 			}
@@ -266,10 +266,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = v.RotationFunc().ToFloatMatrix();
-					var worldTransform = rotation * scaleTransform;
+					var worldTransform = scaleTransform * rotation;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = worldTransform * cameraTransform;
+					var screenTransform = cameraTransform * worldTransform;
 
 					for (var i = 0; i < 8; i++)
 					{

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Primitives;
@@ -25,15 +25,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly IEnumerable<ModelAnimation> models;
 		readonly WRot camera;
 		readonly WRot lightSource;
-		readonly ImmutableArray<float> lightAmbientColor;
-		readonly ImmutableArray<float> lightDiffuseColor;
+		readonly Vector3 lightAmbientColor;
+		readonly Vector3 lightDiffuseColor;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
 
 		public ModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos pos, int zOffset, in WRot camera, float scale,
-			in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
+			in WRot lightSource, Vector3 lightAmbientColor, Vector3 lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow)
 			: this(renderer, models, pos, zOffset, camera, scale,
 				lightSource, lightAmbientColor, lightDiffuseColor,
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		public ModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos pos, int zOffset, in WRot camera, float scale,
-			in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
+			in WRot lightSource, Vector3 lightAmbientColor, Vector3 lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow,
 			float alpha, in float3 tint, TintModifiers tintModifiers)
 		{
@@ -219,16 +219,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 				}
 			}
 
-			static readonly uint[] CornerXIndex = [0, 0, 0, 0, 3, 3, 3, 3];
-			static readonly uint[] CornerYIndex = [1, 1, 4, 4, 1, 1, 4, 4];
-			static readonly uint[] CornerZIndex = [2, 5, 2, 5, 2, 5, 2, 5];
-			static void DrawBoundsBox(WorldRenderer wr, in float3 pxPos, float[] transform, float[] bounds, float width, Color c)
+			static void DrawBoundsBox(WorldRenderer wr, in float3 pxPos, Matrix4x4 transform, AABB bounds, float width, Color c)
 			{
 				var cr = Game.Renderer.RgbaColorRenderer;
 				var corners = new float2[8];
 				for (var i = 0; i < 8; i++)
 				{
-					var vec = new[] { bounds[CornerXIndex[i]], bounds[CornerYIndex[i]], bounds[CornerZIndex[i]], 1 };
+					var vec = bounds.Corner(i);
 					var screen = Util.MatrixVectorMultiply(transform, vec);
 					corners[i] = wr.Viewport.WorldToViewPx(pxPos + new float3(screen[0], screen[1], screen[2]));
 				}
@@ -276,7 +273,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 					for (var i = 0; i < 8; i++)
 					{
-						var vec = new float[] { bounds[CornerXIndex[i]], bounds[CornerYIndex[i]], bounds[CornerZIndex[i]], 1 };
+						var vec = bounds.Corner(i);
 						var screen = Util.MatrixVectorMultiply(screenTransform, vec);
 						minX = Math.Min(minX, pxPos.X + screen[0]);
 						minY = Math.Min(minY, pxPos.Y + screen[1]);

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -204,17 +204,17 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 				// Draw bounding box
 				var draw = model.models.Where(v => v.IsVisible);
-				var scaleTransform = Util.ScaleMatrix(model.scale, model.scale, model.scale);
-				var cameraTransform = Util.MakeFloatMatrix(model.camera.AsMatrix());
+				var scaleTransform = Matrix4x4.CreateScale(model.scale);
+				var cameraTransform = model.camera.ToFloatMatrix();
 
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
+					var rotation = v.RotationFunc().ToFloatMatrix();
+					var worldTransform = rotation * scaleTransform;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
+					var screenTransform = worldTransform * cameraTransform;
 					DrawBoundsBox(wr, pxPos, screenTransform, bounds, 1, Color.Yellow);
 				}
 			}
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 				for (var i = 0; i < 8; i++)
 				{
 					var vec = bounds.Corner(i);
-					var screen = Util.MatrixVectorMultiply(transform, vec);
+					var screen = Vector4.Transform(vec, transform);
 					corners[i] = wr.Viewport.WorldToViewPx(pxPos + new float3(screen[0], screen[1], screen[2]));
 				}
 
@@ -252,8 +252,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			{
 				var pxOrigin = wr.ScreenPosition(model.Pos);
 				var draw = model.models.Where(v => v.IsVisible);
-				var scaleTransform = Util.ScaleMatrix(model.scale, model.scale, model.scale);
-				var cameraTransform = Util.MakeFloatMatrix(model.camera.AsMatrix());
+				var scaleTransform = Matrix4x4.CreateScale(model.scale);
+				var cameraTransform = model.camera.ToFloatMatrix();
 
 				var minX = float.MaxValue;
 				var minY = float.MaxValue;
@@ -265,16 +265,16 @@ namespace OpenRA.Mods.Cnc.Graphics
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
+					var rotation = v.RotationFunc().ToFloatMatrix();
+					var worldTransform = rotation * scaleTransform;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
+					var screenTransform = worldTransform * cameraTransform;
 
 					for (var i = 0; i < 8; i++)
 					{
 						var vec = bounds.Corner(i);
-						var screen = Util.MatrixVectorMultiply(screenTransform, vec);
+						var screen = Vector4.Transform(vec, screenTransform);
 						minX = Math.Min(minX, pxPos.X + screen[0]);
 						minY = Math.Min(minY, pxPos.Y + screen[1]);
 						minZ = Math.Min(minZ, pxPos.Z + screen[2]);

--- a/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
@@ -127,10 +127,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = v.RotationFunc().ToFloatMatrix();
-					var worldTransform = rotation * scaleTransform;
+					var worldTransform = scaleTransform * rotation;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = worldTransform * cameraTransform;
+					var screenTransform = cameraTransform * worldTransform;
 
 					for (var i = 0; i < 8; i++)
 					{

--- a/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Primitives;
@@ -26,15 +26,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly int2 screenPos;
 		readonly WRot camera;
 		readonly WRot lightSource;
-		readonly ImmutableArray<float> lightAmbientColor;
-		readonly ImmutableArray<float> lightDiffuseColor;
+		readonly Vector3 lightAmbientColor;
+		readonly Vector3 lightDiffuseColor;
 		readonly PaletteReference normalsPalette;
 		readonly PaletteReference shadowPalette;
 		readonly float scale;
 
 		public UIModelRenderable(
 			ModelRenderer renderer, IEnumerable<ModelAnimation> models, WPos effectiveWorldPos, int2 screenPos, int zOffset,
-			in WRot camera, float scale, in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
+			in WRot camera, float scale, in WRot lightSource, Vector3 lightAmbientColor, Vector3 lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadow)
 		{
 			this.renderer = renderer;
@@ -109,9 +109,6 @@ namespace OpenRA.Mods.Cnc.Graphics
 				return Screen3DBounds(wr).Bounds;
 			}
 
-			static readonly uint[] CornerXIndex = [0, 0, 0, 0, 3, 3, 3, 3];
-			static readonly uint[] CornerYIndex = [1, 1, 4, 4, 1, 1, 4, 4];
-			static readonly uint[] CornerZIndex = [2, 5, 2, 5, 2, 5, 2, 5];
 			(Rectangle Bounds, float2 Z) Screen3DBounds(WorldRenderer wr)
 			{
 				var pxOrigin = model.screenPos;
@@ -137,7 +134,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 					for (var i = 0; i < 8; i++)
 					{
-						var vec = new float[] { bounds[CornerXIndex[i]], bounds[CornerYIndex[i]], bounds[CornerZIndex[i]], 1 };
+						var vec = bounds.Corner(i);
 						var screen = Util.MatrixVectorMultiply(screenTransform, vec);
 						minX = Math.Min(minX, pxPos.X + screen[0]);
 						minY = Math.Min(minY, pxPos.Y + screen[1]);

--- a/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
@@ -127,10 +127,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
 					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(scaleTransform, rotation);
+					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(cameraTransform, worldTransform);
+					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
 
 					for (var i = 0; i < 8; i++)
 					{

--- a/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/UIModelRenderable.cs
@@ -113,8 +113,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			{
 				var pxOrigin = model.screenPos;
 				var draw = model.models.Where(v => v.IsVisible);
-				var scaleTransform = Util.ScaleMatrix(model.scale, model.scale, model.scale);
-				var cameraTransform = Util.MakeFloatMatrix(model.camera.AsMatrix());
+				var scaleTransform = Matrix4x4.CreateScale(model.scale);
+				var cameraTransform = model.camera.ToFloatMatrix();
 
 				var minX = float.MaxValue;
 				var minY = float.MaxValue;
@@ -126,16 +126,16 @@ namespace OpenRA.Mods.Cnc.Graphics
 				foreach (var v in draw)
 				{
 					var bounds = v.Model.Bounds(v.FrameFunc());
-					var rotation = Util.MakeFloatMatrix(v.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(rotation, scaleTransform);
+					var rotation = v.RotationFunc().ToFloatMatrix();
+					var worldTransform = rotation * scaleTransform;
 
 					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
-					var screenTransform = Util.MatrixMultiply(worldTransform, cameraTransform);
+					var screenTransform = worldTransform * cameraTransform;
 
 					for (var i = 0; i < 8; i++)
 					{
 						var vec = bounds.Corner(i);
-						var screen = Util.MatrixVectorMultiply(screenTransform, vec);
+						var screen = Vector4.Transform(vec, screenTransform);
 						minX = Math.Min(minX, pxPos.X + screen[0]);
 						minY = Math.Min(minY, pxPos.Y + screen[1]);
 						minZ = Math.Min(minZ, pxPos.Z + screen[2]);

--- a/OpenRA.Mods.Cnc/Graphics/Voxel.cs
+++ b/OpenRA.Mods.Cnc/Graphics/Voxel.cs
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			t[3, 2] *= l.Scale * (l.Bounds.MaxZ - l.Bounds.MinZ) / l.Size[2];
 
 			// Center, flip and scale
-			t = Util.MatrixMultiply(Util.TranslationMatrix(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ), t);
-			t = Util.MatrixMultiply(t, Util.ScaleMatrix(l.Scale, -l.Scale, l.Scale));
+			t = Matrix4x4.CreateTranslation(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ) * t;
+			t *= Matrix4x4.CreateScale(l.Scale, -l.Scale, l.Scale);
 
 			return t;
 		}
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 					l.Bounds.MaxZ - l.Bounds.MinZ);
 
 				// Calculate limb bounding box
-				var bb = Util.MatrixAABBMultiply(TransformationMatrix(j, frame), b);
+				var bb = AABB.Transform(b, TransformationMatrix(j, frame));
 				minX = Math.Min(minX, bb.MinX);
 				minY = Math.Min(minY, bb.MinY);
 				minZ = Math.Min(minZ, bb.MinZ);

--- a/OpenRA.Mods.Cnc/Graphics/Voxel.cs
+++ b/OpenRA.Mods.Cnc/Graphics/Voxel.cs
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 			t[3, 2] *= l.Scale * (l.Bounds.MaxZ - l.Bounds.MinZ) / l.Size[2];
 
 			// Center, flip and scale
-			t = Util.MatrixMultiply(t, Util.TranslationMatrix(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ));
-			t = Util.MatrixMultiply(Util.ScaleMatrix(l.Scale, -l.Scale, l.Scale), t);
+			t = Util.MatrixMultiply(Util.TranslationMatrix(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ), t);
+			t = Util.MatrixMultiply(t, Util.ScaleMatrix(l.Scale, -l.Scale, l.Scale));
 
 			return t;
 		}

--- a/OpenRA.Mods.Cnc/Graphics/Voxel.cs
+++ b/OpenRA.Mods.Cnc/Graphics/Voxel.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Linq;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Primitives;
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 	struct Limb
 	{
 		public float Scale;
-		public float[] Bounds;
+		public AABB Bounds;
 		public byte[] Size;
 		public ModelRenderData RenderData;
 	}
@@ -28,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 	public class Voxel : IModel
 	{
 		readonly Limb[] limbData;
-		readonly float[] transforms;
+		readonly Matrix4x4[] transforms;
 		readonly uint frames;
 		readonly uint limbs;
 
@@ -50,14 +51,14 @@ namespace OpenRA.Mods.Cnc.Graphics
 				var vl = vxl.Limbs[i];
 				var l = default(Limb);
 				l.Scale = vl.Scale;
-				l.Bounds = (float[])vl.Bounds.Clone();
+				l.Bounds = vl.Bounds;
 				l.Size = (byte[])vl.Size.Clone();
 				l.RenderData = loader.GenerateRenderData(vxl.Limbs[i]);
 				limbData[i] = l;
 			}
 		}
 
-		public float[] TransformationMatrix(uint limb, uint frame)
+		public Matrix4x4 TransformationMatrix(uint limb, uint frame)
 		{
 			if (frame >= frames)
 				throw new ArgumentOutOfRangeException(nameof(frame), $"Only {frames} frames exist.");
@@ -65,16 +66,15 @@ namespace OpenRA.Mods.Cnc.Graphics
 				throw new ArgumentOutOfRangeException(nameof(limb), $"Only {limbs} limbs exist.");
 
 			var l = limbData[limb];
-			var t = new float[16];
-			Array.Copy(transforms, 16 * (limbs * frame + limb), t, 0, 16);
+			var t = transforms[limbs * frame + limb];
 
 			// Fix limb position
-			t[12] *= l.Scale * (l.Bounds[3] - l.Bounds[0]) / l.Size[0];
-			t[13] *= l.Scale * (l.Bounds[4] - l.Bounds[1]) / l.Size[1];
-			t[14] *= l.Scale * (l.Bounds[5] - l.Bounds[2]) / l.Size[2];
+			t[3, 0] *= l.Scale * (l.Bounds.MaxX - l.Bounds.MinX) / l.Size[0];
+			t[3, 1] *= l.Scale * (l.Bounds.MaxY - l.Bounds.MinY) / l.Size[1];
+			t[3, 2] *= l.Scale * (l.Bounds.MaxZ - l.Bounds.MinZ) / l.Size[2];
 
 			// Center, flip and scale
-			t = Util.MatrixMultiply(t, Util.TranslationMatrix(l.Bounds[0], l.Bounds[1], l.Bounds[2]));
+			t = Util.MatrixMultiply(t, Util.TranslationMatrix(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ));
 			t = Util.MatrixMultiply(Util.ScaleMatrix(l.Scale, -l.Scale, l.Scale), t);
 
 			return t;
@@ -99,46 +99,41 @@ namespace OpenRA.Mods.Cnc.Graphics
 			}
 		}
 
-		public float[] Bounds(uint frame)
+		public AABB Bounds(uint frame)
 		{
-			var ret = new[]
-			{
-				float.MaxValue, float.MaxValue, float.MaxValue,
-				float.MinValue, float.MinValue, float.MinValue
-			};
+			var minX = float.MaxValue;
+			var minY = float.MaxValue;
+			var minZ = float.MaxValue;
+			var maxX = float.MinValue;
+			var maxY = float.MinValue;
+			var maxZ = float.MinValue;
 
 			for (uint j = 0; j < limbs; j++)
 			{
 				var l = limbData[j];
-				var b = new[]
-				{
+				var b = new AABB(
 					0, 0, 0,
-					l.Bounds[3] - l.Bounds[0],
-					l.Bounds[4] - l.Bounds[1],
-					l.Bounds[5] - l.Bounds[2]
-				};
+					l.Bounds.MaxX - l.Bounds.MinX,
+					l.Bounds.MaxY - l.Bounds.MinY,
+					l.Bounds.MaxZ - l.Bounds.MinZ);
 
 				// Calculate limb bounding box
 				var bb = Util.MatrixAABBMultiply(TransformationMatrix(j, frame), b);
-				for (var i = 0; i < 3; i++)
-				{
-					ret[i] = Math.Min(ret[i], bb[i]);
-					ret[i + 3] = Math.Max(ret[i + 3], bb[i + 3]);
-				}
+				minX = Math.Min(minX, bb.MinX);
+				minY = Math.Min(minY, bb.MinY);
+				minZ = Math.Min(minZ, bb.MinZ);
+				maxX = Math.Max(maxX, bb.MaxX);
+				maxY = Math.Max(maxY, bb.MaxY);
+				maxZ = Math.Max(maxZ, bb.MaxZ);
 			}
 
-			return ret;
+			return new AABB(minX, minY, minZ, maxX, maxY, maxZ);
 		}
 
 		public Rectangle AggregateBounds
 		{
 			get
 			{
-				// Corner offsets
-				var ix = new uint[] { 0, 0, 0, 0, 3, 3, 3, 3 };
-				var iy = new uint[] { 1, 1, 4, 4, 1, 1, 4, 4 };
-				var iz = new uint[] { 2, 5, 2, 5, 2, 5, 2, 5 };
-
 				// Calculate the smallest sphere that covers the model limbs
 				var rSquared = 0f;
 				for (var f = 0U; f < frames; f++)
@@ -146,9 +141,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 					var bounds = Bounds(f);
 					for (var i = 0; i < 8; i++)
 					{
-						var x = bounds[ix[i]];
-						var y = bounds[iy[i]];
-						var z = bounds[iz[i]];
+						var corner = bounds.Corner(i);
+						var x = corner.X;
+						var y = corner.Y;
+						var z = corner.Z;
 						rSquared = Math.Max(rSquared, x * x + y * y + z * z);
 					}
 				}

--- a/OpenRA.Mods.Cnc/Graphics/Voxel.cs
+++ b/OpenRA.Mods.Cnc/Graphics/Voxel.cs
@@ -69,9 +69,9 @@ namespace OpenRA.Mods.Cnc.Graphics
 			var t = transforms[limbs * frame + limb];
 
 			// Fix limb position
-			t[3, 0] *= l.Scale * (l.Bounds.MaxX - l.Bounds.MinX) / l.Size[0];
-			t[3, 1] *= l.Scale * (l.Bounds.MaxY - l.Bounds.MinY) / l.Size[1];
-			t[3, 2] *= l.Scale * (l.Bounds.MaxZ - l.Bounds.MinZ) / l.Size[2];
+			t[0, 3] *= l.Scale * (l.Bounds.MaxX - l.Bounds.MinX) / l.Size[0];
+			t[1, 3] *= l.Scale * (l.Bounds.MaxY - l.Bounds.MinY) / l.Size[1];
+			t[2, 3] *= l.Scale * (l.Bounds.MaxZ - l.Bounds.MinZ) / l.Size[2];
 
 			// Center, flip and scale
 			t = Matrix4x4.CreateTranslation(l.Bounds.MinX, l.Bounds.MinY, l.Bounds.MinZ) * t;

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderVoxels.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Graphics;
@@ -53,8 +52,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public readonly WAngle LightPitch = WAngle.FromDegrees(50);
 		public readonly WAngle LightYaw = WAngle.FromDegrees(240);
-		public readonly ImmutableArray<float> LightAmbientColor = [0.6f, 0.6f, 0.6f];
-		public readonly ImmutableArray<float> LightDiffuseColor = [0.4f, 0.4f, 0.4f];
+		public readonly float3 LightAmbientColor = new(0.6f, 0.6f, 0.6f);
+		public readonly float3 LightDiffuseColor = new(0.4f, 0.4f, 0.4f);
 
 		public override object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
 

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var lightYaw = Util.MakeFloatMatrix(new WRot(WAngle.Zero, WAngle.Zero, -lightSource.Yaw).AsMatrix());
 			var lightPitch = Util.MakeFloatMatrix(new WRot(WAngle.Zero, -lightSource.Pitch, WAngle.Zero).AsMatrix());
 			var ground = Util.MakeFloatMatrix(groundOrientation.AsMatrix());
-			var shadowTransform = Util.MatrixMultiply(Util.MatrixMultiply(lightPitch, lightYaw), Util.MatrixInverse(ground).Value);
+			var shadowTransform = Util.MatrixMultiply(Util.MatrixInverse(ground).Value, Util.MatrixMultiply(lightYaw, lightPitch));
 
 			var groundNormal = Util.MatrixVectorMultiply(ground, GroundNormal);
 
@@ -133,8 +133,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
 				var worldTransform = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
-				worldTransform = Util.MatrixMultiply(scaleTransform, worldTransform);
-				worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
+				worldTransform = Util.MatrixMultiply(worldTransform, scaleTransform);
+				worldTransform = Util.MatrixMultiply(worldTransform, offsetTransform);
 
 				var bounds = m.Model.Bounds(m.FrameFunc());
 				var worldBounds = Util.MatrixAABBMultiply(worldTransform, bounds);
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				new(stl.X, sbr.Y, 0, 1),
 			};
 
-			var shadowScreenTransform = Util.MatrixMultiply(cameraTransform, invShadowTransform);
+			var shadowScreenTransform = Util.MatrixMultiply(invShadowTransform, cameraTransform);
 			var shadowGroundNormal = Util.MatrixVectorMultiply(shadowTransform, groundNormal);
 			var screenCorners = new float3[4];
 			for (var j = 0; j < 4; j++)
@@ -192,8 +192,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			var translateMtx = Util.TranslationMatrix(spriteCenter.X - spriteOffset.X, sheetSize - (spriteCenter.Y - spriteOffset.Y), 0);
 			var shadowTranslateMtx = Util.TranslationMatrix(shadowCenter.X - shadowSpriteOffset.X, sheetSize - (shadowCenter.Y - shadowSpriteOffset.Y), 0);
-			var correctionTransform = Util.MatrixMultiply(translateMtx, FlipMtx);
-			var shadowCorrectionTransform = Util.MatrixMultiply(shadowTranslateMtx, ShadowScaleFlipMtx);
+			var correctionTransform = Util.MatrixMultiply(FlipMtx, translateMtx);
+			var shadowCorrectionTransform = Util.MatrixMultiply(ShadowScaleFlipMtx, shadowTranslateMtx);
 
 			void RenderFunc()
 			{
@@ -204,16 +204,16 @@ namespace OpenRA.Mods.Cnc.Traits
 					var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
 
 					var rotations = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(scaleTransform, rotations);
-					worldTransform = Util.MatrixMultiply(offsetTransform, worldTransform);
+					var worldTransform = Util.MatrixMultiply(rotations, scaleTransform);
+					worldTransform = Util.MatrixMultiply(worldTransform, offsetTransform);
 
-					var transform = Util.MatrixMultiply(cameraTransform, worldTransform);
-					transform = Util.MatrixMultiply(correctionTransform, transform);
+					var transform = Util.MatrixMultiply(worldTransform, cameraTransform);
+					transform = Util.MatrixMultiply(transform, correctionTransform);
 
-					var shadow = Util.MatrixMultiply(shadowTransform, worldTransform);
-					shadow = Util.MatrixMultiply(shadowCorrectionTransform, shadow);
+					var shadow = Util.MatrixMultiply(worldTransform, shadowTransform);
+					shadow = Util.MatrixMultiply(shadow, shadowCorrectionTransform);
 
-					var lightTransform = Util.MatrixMultiply(Util.MatrixInverse(rotations).Value, invShadowTransform);
+					var lightTransform = Util.MatrixMultiply(invShadowTransform, Util.MatrixInverse(rotations).Value);
 
 					var frame = m.FrameFunc();
 					for (uint i = 0; i < m.Model.Sections; i++)
@@ -225,14 +225,14 @@ namespace OpenRA.Mods.Cnc.Traits
 							throw new InvalidOperationException($"Failed to invert the transformed matrix of frame {i} during RenderAsync.");
 
 						// Transform light vector from shadow -> world -> limb coords
-						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(it.Value, lightTransform));
+						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(lightTransform, it.Value));
 
-						Render(rd, ModelCache, Util.MatrixMultiply(transform, t), lightDirection,
+						Render(rd, ModelCache, Util.MatrixMultiply(t, transform), lightDirection,
 							lightAmbientColor, lightDiffuseColor, color.TextureIndex, normals.TextureIndex);
 
 						// Disable shadow normals by forcing zero diffuse and identity ambient light
 						if (m.ShowShadow)
-							Render(rd, ModelCache, Util.MatrixMultiply(shadow, t), lightDirection,
+							Render(rd, ModelCache, Util.MatrixMultiply(t, shadow), lightDirection,
 								ShadowAmbient, ShadowDiffuse, shadowPalette.TextureIndex, normals.TextureIndex);
 					}
 				}

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -11,8 +11,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -46,14 +46,14 @@ namespace OpenRA.Mods.Cnc.Traits
 	public sealed class ModelRenderer : IDisposable, IRenderer, INotifyActorDisposing
 	{
 		// Static constants
-		static readonly ImmutableArray<float> ShadowDiffuse = [0, 0, 0];
-		static readonly ImmutableArray<float> ShadowAmbient = [1, 1, 1];
+		static readonly Vector3 ShadowDiffuse = new(0, 0, 0);
+		static readonly Vector3 ShadowAmbient = new(1, 1, 1);
 		static readonly float2 SpritePadding = new(2, 2);
-		static readonly float[] ZeroVector = [0, 0, 0, 1];
-		static readonly float[] ZVector = [0, 0, 1, 1];
-		static readonly float[] FlipMtx = Util.ScaleMatrix(1, -1, 1);
-		static readonly float[] ShadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
-		static readonly float[] GroundNormal = [0, 0, 1, 1];
+		static readonly Vector4 ZeroVector = new(0, 0, 0, 1);
+		static readonly Vector4 ZVector = new(0, 0, 1, 1);
+		static readonly Matrix4x4 FlipMtx = Util.ScaleMatrix(1, -1, 1);
+		static readonly Matrix4x4 ShadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
+		static readonly Vector4 GroundNormal = new(0, 0, 1, 1);
 
 		readonly Renderer renderer;
 		readonly IShader shader;
@@ -83,20 +83,18 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			sheetSize = info.RenderBufferSize;
 			var a = 2f / sheetSize;
-			var view = new[]
-			{
+			var view = new Matrix4x4(
 				a, 0, 0, 0,
 				0, -a, 0, 0,
 				0, 0, -2 * a, 0,
-				-1, 1, 0, 1
-			};
+				-1, 1, 0, 1);
 
 			shader.SetMatrix("View", view);
 		}
 
 		public ModelRenderProxy RenderAsync(
 			WorldRenderer wr, IEnumerable<ModelAnimation> models, in WRot camera, float scale,
-			in WRot groundOrientation, in WRot lightSource, ImmutableArray<float> lightAmbientColor, ImmutableArray<float> lightDiffuseColor,
+			in WRot groundOrientation, in WRot lightSource, Vector3 lightAmbientColor, Vector3 lightDiffuseColor,
 			PaletteReference color, PaletteReference normals, PaletteReference shadowPalette)
 		{
 			if (!isInFrame)
@@ -109,15 +107,16 @@ namespace OpenRA.Mods.Cnc.Traits
 			var lightYaw = Util.MakeFloatMatrix(new WRot(WAngle.Zero, WAngle.Zero, -lightSource.Yaw).AsMatrix());
 			var lightPitch = Util.MakeFloatMatrix(new WRot(WAngle.Zero, -lightSource.Pitch, WAngle.Zero).AsMatrix());
 			var ground = Util.MakeFloatMatrix(groundOrientation.AsMatrix());
-			var shadowTransform = Util.MatrixMultiply(Util.MatrixMultiply(lightPitch, lightYaw), Util.MatrixInverse(ground));
+			var shadowTransform = Util.MatrixMultiply(Util.MatrixMultiply(lightPitch, lightYaw), Util.MatrixInverse(ground).Value);
 
 			var groundNormal = Util.MatrixVectorMultiply(ground, GroundNormal);
 
-			var invShadowTransform = Util.MatrixInverse(shadowTransform);
+			var invShadowTransform = Util.MatrixInverse(shadowTransform).Value;
 			var cameraTransform = Util.MakeFloatMatrix(camera.AsMatrix());
-			var invCameraTransform = Util.MatrixInverse(cameraTransform);
-			if (invCameraTransform == null)
+			var invCameraTransformNullable = Util.MatrixInverse(cameraTransform);
+			if (invCameraTransformNullable == null)
 				throw new InvalidOperationException("Failed to invert the cameraTransform matrix during RenderAsync.");
+			var invCameraTransform = invCameraTransformNullable.Value;
 
 			// Sprite rectangle
 			var tl = new float2(float.MaxValue, float.MaxValue);
@@ -143,10 +142,10 @@ namespace OpenRA.Mods.Cnc.Traits
 				var shadowBounds = Util.MatrixAABBMultiply(shadowTransform, worldBounds);
 
 				// Aggregate bounds rects
-				tl = float2.Min(tl, new float2(screenBounds[0], screenBounds[1]));
-				br = float2.Max(br, new float2(screenBounds[3], screenBounds[4]));
-				stl = float2.Min(stl, new float2(shadowBounds[0], shadowBounds[1]));
-				sbr = float2.Max(sbr, new float2(shadowBounds[3], shadowBounds[4]));
+				tl = float2.Min(tl, new float2(screenBounds.MinX, screenBounds.MinY));
+				br = float2.Max(br, new float2(screenBounds.MaxX, screenBounds.MaxY));
+				stl = float2.Min(stl, new float2(shadowBounds.MinX, shadowBounds.MinY));
+				sbr = float2.Max(sbr, new float2(shadowBounds.MaxX, shadowBounds.MaxY));
 			}
 
 			// Inflate rects to ensure rendering is within bounds
@@ -156,12 +155,12 @@ namespace OpenRA.Mods.Cnc.Traits
 			sbr += SpritePadding;
 
 			// Corners of the shadow quad, in shadow-space
-			var corners = new float[][]
+			var corners = new Vector4[]
 			{
-				[stl.X, stl.Y, 0, 1],
-				[sbr.X, sbr.Y, 0, 1],
-				[sbr.X, stl.Y, 0, 1],
-				[stl.X, sbr.Y, 0, 1]
+				new(stl.X, stl.Y, 0, 1),
+				new(sbr.X, sbr.Y, 0, 1),
+				new(sbr.X, stl.Y, 0, 1),
+				new(stl.X, sbr.Y, 0, 1),
 			};
 
 			var shadowScreenTransform = Util.MatrixMultiply(cameraTransform, invShadowTransform);
@@ -214,7 +213,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					var shadow = Util.MatrixMultiply(shadowTransform, worldTransform);
 					shadow = Util.MatrixMultiply(shadowCorrectionTransform, shadow);
 
-					var lightTransform = Util.MatrixMultiply(Util.MatrixInverse(rotations), invShadowTransform);
+					var lightTransform = Util.MatrixMultiply(Util.MatrixInverse(rotations).Value, invShadowTransform);
 
 					var frame = m.FrameFunc();
 					for (uint i = 0; i < m.Model.Sections; i++)
@@ -226,7 +225,7 @@ namespace OpenRA.Mods.Cnc.Traits
 							throw new InvalidOperationException($"Failed to invert the transformed matrix of frame {i} during RenderAsync.");
 
 						// Transform light vector from shadow -> world -> limb coords
-						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(it, lightTransform));
+						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(it.Value, lightTransform));
 
 						Render(rd, ModelCache, Util.MatrixMultiply(transform, t), lightDirection,
 							lightAmbientColor, lightDiffuseColor, color.TextureIndex, normals.TextureIndex);
@@ -261,7 +260,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			size = new Size(width, height);
 		}
 
-		static float[] ExtractRotationVector(float[] mtx)
+		static Vector4 ExtractRotationVector(Matrix4x4 mtx)
 		{
 			var tVec = Util.MatrixVectorMultiply(mtx, ZVector);
 			var tOrigin = Util.MatrixVectorMultiply(mtx, ZeroVector);
@@ -282,16 +281,16 @@ namespace OpenRA.Mods.Cnc.Traits
 		void Render(
 			ModelRenderData renderData,
 			IModelCache cache,
-			float[] t, float[] lightDirection,
-			ImmutableArray<float> ambientLight, ImmutableArray<float> diffuseLight,
+			Matrix4x4 t, Vector4 lightDirection,
+			Vector3 ambientLight, Vector3 diffuseLight,
 			float colorPaletteTextureIndex, float normalsPaletteTextureIndex)
 		{
 			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
 			shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
 			shader.SetMatrix("TransformMatrix", t);
-			shader.SetVec("LightDirection", lightDirection, 4);
-			shader.SetVec("AmbientLight", ambientLight.AsMemory(), 3);
-			shader.SetVec("DiffuseLight", diffuseLight.AsMemory(), 3);
+			shader.SetVec("LightDirection", lightDirection);
+			shader.SetVec("AmbientLight", ambientLight);
+			shader.SetVec("DiffuseLight", diffuseLight);
 
 			shader.PrepareRender();
 			renderer.DrawBatch(cache.VertexBuffer, shader, renderData.Start, renderData.Count, PrimitiveType.TriangleList);

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -84,12 +84,12 @@ namespace OpenRA.Mods.Cnc.Traits
 			sheetSize = info.RenderBufferSize;
 			var a = 2f / sheetSize;
 			var view = new Matrix4x4(
-				a, 0, 0, 0,
-				0, -a, 0, 0,
+				a, 0, 0, -1,
+				0, -a, 0, 1,
 				0, 0, -2 * a, 0,
-				-1, 1, 0, 1);
+				0, 0, 0, 1);
 
-			shader.SetMatrix("View", view);
+			shader.SetMatrixRowMajor("View", view);
 		}
 
 		public ModelRenderProxy RenderAsync(
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var lightPitch = new WRot(WAngle.Zero, -lightSource.Pitch, WAngle.Zero).ToFloatMatrix();
 			var ground = groundOrientation.ToFloatMatrix();
 			Matrix4x4.Invert(ground, out var groundInverse);
-			var shadowTransform = groundInverse * lightYaw * lightPitch;
+			var shadowTransform = lightPitch * lightYaw * groundInverse;
 
 			var groundNormal = Vector4.Transform(GroundNormal, ground);
 			Matrix4x4.Invert(shadowTransform, out var invShadowTransform);
@@ -131,8 +131,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				var offsetTransform = Matrix4x4.CreateTranslation(offsetVec.X, offsetVec.Y, offsetVec.Z);
 
 				var worldTransform = m.RotationFunc().ToFloatMatrix();
-				worldTransform *= scaleTransform;
-				worldTransform *= offsetTransform;
+				worldTransform = scaleTransform * worldTransform;
+				worldTransform = offsetTransform * worldTransform;
 
 				var bounds = m.Model.Bounds(m.FrameFunc());
 				var worldBounds = AABB.Transform(bounds, worldTransform);
@@ -202,7 +202,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					var offsetTransform = Matrix4x4.CreateTranslation(offsetVec.X, offsetVec.Y, offsetVec.Z);
 
 					var rotations = m.RotationFunc().ToFloatMatrix();
-					var worldTransform = rotations * scaleTransform;
+					var worldTransform = scaleTransform * rotations;
 					worldTransform *= offsetTransform;
 
 					var transform = worldTransform * cameraTransform;
@@ -285,7 +285,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
 			shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
-			shader.SetMatrix("TransformMatrix", t);
+			shader.SetMatrixRowMajor("TransformMatrix", t);
 			shader.SetVec("LightDirection", lightDirection);
 			shader.SetVec("AmbientLight", ambientLight);
 			shader.SetVec("DiffuseLight", diffuseLight);

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -51,8 +51,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		static readonly float2 SpritePadding = new(2, 2);
 		static readonly Vector4 ZeroVector = new(0, 0, 0, 1);
 		static readonly Vector4 ZVector = new(0, 0, 1, 1);
-		static readonly Matrix4x4 FlipMtx = Util.ScaleMatrix(1, -1, 1);
-		static readonly Matrix4x4 ShadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
+		static readonly Matrix4x4 FlipMtx = Matrix4x4.CreateScale(1, -1, 1);
+		static readonly Matrix4x4 ShadowScaleFlipMtx = Matrix4x4.CreateScale(2, -2, 2);
 		static readonly Vector4 GroundNormal = new(0, 0, 1, 1);
 
 		readonly Renderer renderer;
@@ -101,22 +101,20 @@ namespace OpenRA.Mods.Cnc.Traits
 				throw new InvalidOperationException("BeginFrame has not been called. You cannot render until a frame has been started.");
 
 			// Correct for inverted y-axis
-			var scaleTransform = Util.ScaleMatrix(scale, scale, scale);
+			var scaleTransform = Matrix4x4.CreateScale(scale);
 
 			// Correct for bogus light source definition
-			var lightYaw = Util.MakeFloatMatrix(new WRot(WAngle.Zero, WAngle.Zero, -lightSource.Yaw).AsMatrix());
-			var lightPitch = Util.MakeFloatMatrix(new WRot(WAngle.Zero, -lightSource.Pitch, WAngle.Zero).AsMatrix());
-			var ground = Util.MakeFloatMatrix(groundOrientation.AsMatrix());
-			var shadowTransform = Util.MatrixMultiply(Util.MatrixInverse(ground).Value, Util.MatrixMultiply(lightYaw, lightPitch));
+			var lightYaw = new WRot(WAngle.Zero, WAngle.Zero, -lightSource.Yaw).ToFloatMatrix();
+			var lightPitch = new WRot(WAngle.Zero, -lightSource.Pitch, WAngle.Zero).ToFloatMatrix();
+			var ground = groundOrientation.ToFloatMatrix();
+			Matrix4x4.Invert(ground, out var groundInverse);
+			var shadowTransform = groundInverse * lightYaw * lightPitch;
 
-			var groundNormal = Util.MatrixVectorMultiply(ground, GroundNormal);
-
-			var invShadowTransform = Util.MatrixInverse(shadowTransform).Value;
-			var cameraTransform = Util.MakeFloatMatrix(camera.AsMatrix());
-			var invCameraTransformNullable = Util.MatrixInverse(cameraTransform);
-			if (invCameraTransformNullable == null)
+			var groundNormal = Vector4.Transform(GroundNormal, ground);
+			Matrix4x4.Invert(shadowTransform, out var invShadowTransform);
+			var cameraTransform = camera.ToFloatMatrix();
+			if (!Matrix4x4.Invert(cameraTransform, out var invCameraTransform))
 				throw new InvalidOperationException("Failed to invert the cameraTransform matrix during RenderAsync.");
-			var invCameraTransform = invCameraTransformNullable.Value;
 
 			// Sprite rectangle
 			var tl = new float2(float.MaxValue, float.MaxValue);
@@ -129,17 +127,17 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var m in models)
 			{
 				// Convert screen offset back to world coords
-				var offsetVec = Util.MatrixVectorMultiply(invCameraTransform, wr.ScreenVector(m.OffsetFunc()));
-				var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
+				var offsetVec = Vector4.Transform(wr.ScreenVector(m.OffsetFunc()), invCameraTransform);
+				var offsetTransform = Matrix4x4.CreateTranslation(offsetVec.X, offsetVec.Y, offsetVec.Z);
 
-				var worldTransform = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
-				worldTransform = Util.MatrixMultiply(worldTransform, scaleTransform);
-				worldTransform = Util.MatrixMultiply(worldTransform, offsetTransform);
+				var worldTransform = m.RotationFunc().ToFloatMatrix();
+				worldTransform *= scaleTransform;
+				worldTransform *= offsetTransform;
 
 				var bounds = m.Model.Bounds(m.FrameFunc());
-				var worldBounds = Util.MatrixAABBMultiply(worldTransform, bounds);
-				var screenBounds = Util.MatrixAABBMultiply(cameraTransform, worldBounds);
-				var shadowBounds = Util.MatrixAABBMultiply(shadowTransform, worldBounds);
+				var worldBounds = AABB.Transform(bounds, worldTransform);
+				var screenBounds = AABB.Transform(worldBounds, cameraTransform);
+				var shadowBounds = AABB.Transform(worldBounds, shadowTransform);
 
 				// Aggregate bounds rects
 				tl = float2.Min(tl, new float2(screenBounds.MinX, screenBounds.MinY));
@@ -163,8 +161,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				new(stl.X, sbr.Y, 0, 1),
 			};
 
-			var shadowScreenTransform = Util.MatrixMultiply(invShadowTransform, cameraTransform);
-			var shadowGroundNormal = Util.MatrixVectorMultiply(shadowTransform, groundNormal);
+			var shadowScreenTransform = invShadowTransform * cameraTransform;
+			var shadowGroundNormal = Vector4.Transform(groundNormal, shadowTransform);
 			var screenCorners = new float3[4];
 			for (var j = 0; j < 4; j++)
 			{
@@ -173,7 +171,7 @@ namespace OpenRA.Mods.Cnc.Traits
 								  corners[j][0] * shadowGroundNormal[0] / shadowGroundNormal[2]);
 
 				// Rotate to camera-space
-				corners[j] = Util.MatrixVectorMultiply(shadowScreenTransform, corners[j]);
+				corners[j] = Vector4.Transform(corners[j], shadowScreenTransform);
 				screenCorners[j] = new float3(corners[j][0], corners[j][1], 0);
 			}
 
@@ -190,49 +188,49 @@ namespace OpenRA.Mods.Cnc.Traits
 			var spriteCenter = new float2(sb.Left + sb.Width / 2, sb.Top + sb.Height / 2);
 			var shadowCenter = new float2(ssb.Left + ssb.Width / 2, ssb.Top + ssb.Height / 2);
 
-			var translateMtx = Util.TranslationMatrix(spriteCenter.X - spriteOffset.X, sheetSize - (spriteCenter.Y - spriteOffset.Y), 0);
-			var shadowTranslateMtx = Util.TranslationMatrix(shadowCenter.X - shadowSpriteOffset.X, sheetSize - (shadowCenter.Y - shadowSpriteOffset.Y), 0);
-			var correctionTransform = Util.MatrixMultiply(FlipMtx, translateMtx);
-			var shadowCorrectionTransform = Util.MatrixMultiply(ShadowScaleFlipMtx, shadowTranslateMtx);
+			var translateMtx = Matrix4x4.CreateTranslation(spriteCenter.X - spriteOffset.X, sheetSize - (spriteCenter.Y - spriteOffset.Y), 0);
+			var shadowTranslateMtx = Matrix4x4.CreateTranslation(shadowCenter.X - shadowSpriteOffset.X, sheetSize - (shadowCenter.Y - shadowSpriteOffset.Y), 0);
+			var correctionTransform = FlipMtx * translateMtx;
+			var shadowCorrectionTransform = ShadowScaleFlipMtx * shadowTranslateMtx;
 
 			void RenderFunc()
 			{
 				foreach (var m in models)
 				{
 					// Convert screen offset to world offset
-					var offsetVec = Util.MatrixVectorMultiply(invCameraTransform, wr.ScreenVector(m.OffsetFunc()));
-					var offsetTransform = Util.TranslationMatrix(offsetVec[0], offsetVec[1], offsetVec[2]);
+					var offsetVec = Vector4.Transform(wr.ScreenVector(m.OffsetFunc()), invCameraTransform);
+					var offsetTransform = Matrix4x4.CreateTranslation(offsetVec.X, offsetVec.Y, offsetVec.Z);
 
-					var rotations = Util.MakeFloatMatrix(m.RotationFunc().AsMatrix());
-					var worldTransform = Util.MatrixMultiply(rotations, scaleTransform);
-					worldTransform = Util.MatrixMultiply(worldTransform, offsetTransform);
+					var rotations = m.RotationFunc().ToFloatMatrix();
+					var worldTransform = rotations * scaleTransform;
+					worldTransform *= offsetTransform;
 
-					var transform = Util.MatrixMultiply(worldTransform, cameraTransform);
-					transform = Util.MatrixMultiply(transform, correctionTransform);
+					var transform = worldTransform * cameraTransform;
+					transform *= correctionTransform;
 
-					var shadow = Util.MatrixMultiply(worldTransform, shadowTransform);
-					shadow = Util.MatrixMultiply(shadow, shadowCorrectionTransform);
+					var shadow = worldTransform * shadowTransform;
+					shadow *= shadowCorrectionTransform;
 
-					var lightTransform = Util.MatrixMultiply(invShadowTransform, Util.MatrixInverse(rotations).Value);
+					Matrix4x4.Invert(rotations, out var rotationsInverse);
+					var lightTransform = invShadowTransform * rotationsInverse;
 
 					var frame = m.FrameFunc();
 					for (uint i = 0; i < m.Model.Sections; i++)
 					{
 						var rd = m.Model.RenderData(i);
 						var t = m.Model.TransformationMatrix(i, frame);
-						var it = Util.MatrixInverse(t);
-						if (it == null)
+						if (!Matrix4x4.Invert(t, out var it))
 							throw new InvalidOperationException($"Failed to invert the transformed matrix of frame {i} during RenderAsync.");
 
 						// Transform light vector from shadow -> world -> limb coords
-						var lightDirection = ExtractRotationVector(Util.MatrixMultiply(lightTransform, it.Value));
+						var lightDirection = ExtractRotationVector(lightTransform * it);
 
-						Render(rd, ModelCache, Util.MatrixMultiply(t, transform), lightDirection,
+						Render(rd, ModelCache, t * transform, lightDirection,
 							lightAmbientColor, lightDiffuseColor, color.TextureIndex, normals.TextureIndex);
 
 						// Disable shadow normals by forcing zero diffuse and identity ambient light
 						if (m.ShowShadow)
-							Render(rd, ModelCache, Util.MatrixMultiply(t, shadow), lightDirection,
+							Render(rd, ModelCache, t * shadow, lightDirection,
 								ShadowAmbient, ShadowDiffuse, shadowPalette.TextureIndex, normals.TextureIndex);
 					}
 				}
@@ -240,8 +238,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			doRender.Add((sprite.Sheet, RenderFunc));
 
-			var screenLightVector = Util.MatrixVectorMultiply(invShadowTransform, ZVector);
-			screenLightVector = Util.MatrixVectorMultiply(cameraTransform, screenLightVector);
+			var screenLightVector = Vector4.Transform(ZVector, invShadowTransform);
+			screenLightVector = Vector4.Transform(screenLightVector, cameraTransform);
 			return new ModelRenderProxy(sprite, shadowSprite, screenCorners, -screenLightVector[2] / screenLightVector[1]);
 		}
 
@@ -262,8 +260,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		static Vector4 ExtractRotationVector(Matrix4x4 mtx)
 		{
-			var tVec = Util.MatrixVectorMultiply(mtx, ZVector);
-			var tOrigin = Util.MatrixVectorMultiply(mtx, ZeroVector);
+			var tVec = Vector4.Transform(ZVector, mtx);
+			var tOrigin = Vector4.Transform(ZeroVector, mtx);
 			tVec[0] -= tOrigin[0] * tVec[3] / tOrigin[3];
 			tVec[1] -= tOrigin[1] * tVec[3] / tOrigin[3];
 			tVec[2] -= tOrigin[2] * tVec[3] / tOrigin[3];

--- a/OpenRA.Mods.Cnc/Util.cs
+++ b/OpenRA.Mods.Cnc/Util.cs
@@ -85,10 +85,7 @@ namespace OpenRA.Mods.Cnc
 			return Matrix4x4.CreateTranslation(x, y, z);
 		}
 
-		/// <summary>
-		/// Warning: Arguments are backwards.
-		/// </summary>
-		public static Matrix4x4 MatrixMultiply(Matrix4x4 rhs, Matrix4x4 lhs)
+		public static Matrix4x4 MatrixMultiply(Matrix4x4 lhs, Matrix4x4 rhs)
 		{
 			return lhs * rhs;
 		}

--- a/OpenRA.Mods.Cnc/Util.cs
+++ b/OpenRA.Mods.Cnc/Util.cs
@@ -9,10 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Numerics;
-using OpenRA.Primitives;
-
 namespace OpenRA.Mods.Cnc
 {
 	public static class Util
@@ -68,88 +64,6 @@ namespace OpenRA.Mods.Cnc
 				return SpriteFacings[ClassicIndexFacing(facing, steps)];
 
 			return Common.Util.QuantizeFacing(facing, steps);
-		}
-
-		public static Matrix4x4 IdentityMatrix()
-		{
-			return Matrix4x4.Identity;
-		}
-
-		public static Matrix4x4 ScaleMatrix(float sx, float sy, float sz)
-		{
-			return Matrix4x4.CreateScale(sx, sy, sz);
-		}
-
-		public static Matrix4x4 TranslationMatrix(float x, float y, float z)
-		{
-			return Matrix4x4.CreateTranslation(x, y, z);
-		}
-
-		public static Matrix4x4 MatrixMultiply(Matrix4x4 lhs, Matrix4x4 rhs)
-		{
-			return lhs * rhs;
-		}
-
-		public static Vector4 MatrixVectorMultiply(Matrix4x4 mtx, Vector4 vec)
-		{
-			return Vector4.Transform(vec, mtx);
-		}
-
-		public static Matrix4x4? MatrixInverse(Matrix4x4 m)
-		{
-			if (Matrix4x4.Invert(m, out var r))
-				return r;
-
-			return null;
-		}
-
-		public static Matrix4x4 MakeFloatMatrix(Int32Matrix4x4 imtx)
-		{
-			var multipler = 1f / imtx.M44;
-			return new Matrix4x4(
-				imtx.M11 * multipler,
-				imtx.M12 * multipler,
-				imtx.M13 * multipler,
-				imtx.M14 * multipler,
-				imtx.M21 * multipler,
-				imtx.M22 * multipler,
-				imtx.M23 * multipler,
-				imtx.M24 * multipler,
-				imtx.M31 * multipler,
-				imtx.M32 * multipler,
-				imtx.M33 * multipler,
-				imtx.M34 * multipler,
-				imtx.M41 * multipler,
-				imtx.M42 * multipler,
-				imtx.M43 * multipler,
-				1f);
-		}
-
-		public static AABB MatrixAABBMultiply(Matrix4x4 mtx, AABB bounds)
-		{
-			// Vectors to opposing corner.
-			var minX = float.MaxValue;
-			var minY = float.MaxValue;
-			var minZ = float.MaxValue;
-			var maxX = float.MinValue;
-			var maxY = float.MinValue;
-			var maxZ = float.MinValue;
-
-			// Transform vectors and find new bounding box.
-			for (var i = 0; i < 8; i++)
-			{
-				var vec = bounds.Corner(i);
-				var tvec = MatrixVectorMultiply(mtx, vec);
-
-				minX = Math.Min(minX, tvec[0] / tvec[3]);
-				minY = Math.Min(minY, tvec[1] / tvec[3]);
-				minZ = Math.Min(minZ, tvec[2] / tvec[3]);
-				maxX = Math.Max(maxX, tvec[0] / tvec[3]);
-				maxY = Math.Max(maxY, tvec[1] / tvec[3]);
-				maxZ = Math.Max(maxZ, tvec[2] / tvec[3]);
-			}
-
-			return new AABB(minX, minY, minZ, maxX, maxY, maxZ);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Util.cs
+++ b/OpenRA.Mods.Cnc/Util.cs
@@ -10,6 +10,8 @@
 #endregion
 
 using System;
+using System.Numerics;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc
 {
@@ -68,248 +70,89 @@ namespace OpenRA.Mods.Cnc
 			return Common.Util.QuantizeFacing(facing, steps);
 		}
 
-		public static float[] IdentityMatrix()
+		public static Matrix4x4 IdentityMatrix()
 		{
-			return
-			[
-				1, 0, 0, 0,
-				0, 1, 0, 0,
-				0, 0, 1, 0,
-				0, 0, 0, 1,
-			];
+			return Matrix4x4.Identity;
 		}
 
-		public static float[] ScaleMatrix(float sx, float sy, float sz)
+		public static Matrix4x4 ScaleMatrix(float sx, float sy, float sz)
 		{
-			return
-			[
-				sx, 0, 0, 0,
-				0, sy, 0, 0,
-				0, 0, sz, 0,
-				0, 0, 0, 1,
-			];
+			return Matrix4x4.CreateScale(sx, sy, sz);
 		}
 
-		public static float[] TranslationMatrix(float x, float y, float z)
+		public static Matrix4x4 TranslationMatrix(float x, float y, float z)
 		{
-			return
-			[
-				1, 0, 0, 0,
-				0, 1, 0, 0,
-				0, 0, 1, 0,
-				x, y, z, 1,
-			];
+			return Matrix4x4.CreateTranslation(x, y, z);
 		}
 
-		public static float[] MatrixMultiply(float[] lhs, float[] rhs)
+		/// <summary>
+		/// Warning: Arguments are backwards.
+		/// </summary>
+		public static Matrix4x4 MatrixMultiply(Matrix4x4 rhs, Matrix4x4 lhs)
 		{
-			var mtx = new float[16];
-			for (var i = 0; i < 4; i++)
-				for (var j = 0; j < 4; j++)
-				{
-					mtx[4 * i + j] = 0;
-					for (var k = 0; k < 4; k++)
-						mtx[4 * i + j] += lhs[4 * k + j] * rhs[4 * i + k];
-				}
-
-			return mtx;
+			return lhs * rhs;
 		}
 
-		public static float[] MatrixVectorMultiply(float[] mtx, float[] vec)
+		public static Vector4 MatrixVectorMultiply(Matrix4x4 mtx, Vector4 vec)
 		{
-			var ret = new float[4];
-			for (var j = 0; j < 4; j++)
-			{
-				ret[j] = 0;
-				for (var k = 0; k < 4; k++)
-					ret[j] += mtx[4 * k + j] * vec[k];
-			}
-
-			return ret;
+			return Vector4.Transform(vec, mtx);
 		}
 
-		public static float[] MatrixInverse(float[] m)
+		public static Matrix4x4? MatrixInverse(Matrix4x4 m)
 		{
-			var mtx = new float[16];
+			if (Matrix4x4.Invert(m, out var r))
+				return r;
 
-			mtx[0] = m[5] * m[10] * m[15] -
-				m[5] * m[11] * m[14] -
-				m[9] * m[6] * m[15] +
-				m[9] * m[7] * m[14] +
-				m[13] * m[6] * m[11] -
-				m[13] * m[7] * m[10];
-
-			mtx[4] = -m[4] * m[10] * m[15] +
-				m[4] * m[11] * m[14] +
-				m[8] * m[6] * m[15] -
-				m[8] * m[7] * m[14] -
-				m[12] * m[6] * m[11] +
-				m[12] * m[7] * m[10];
-
-			mtx[8] = m[4] * m[9] * m[15] -
-				m[4] * m[11] * m[13] -
-				m[8] * m[5] * m[15] +
-				m[8] * m[7] * m[13] +
-				m[12] * m[5] * m[11] -
-				m[12] * m[7] * m[9];
-
-			mtx[12] = -m[4] * m[9] * m[14] +
-				m[4] * m[10] * m[13] +
-				m[8] * m[5] * m[14] -
-				m[8] * m[6] * m[13] -
-				m[12] * m[5] * m[10] +
-				m[12] * m[6] * m[9];
-
-			mtx[1] = -m[1] * m[10] * m[15] +
-				m[1] * m[11] * m[14] +
-				m[9] * m[2] * m[15] -
-				m[9] * m[3] * m[14] -
-				m[13] * m[2] * m[11] +
-				m[13] * m[3] * m[10];
-
-			mtx[5] = m[0] * m[10] * m[15] -
-				m[0] * m[11] * m[14] -
-				m[8] * m[2] * m[15] +
-				m[8] * m[3] * m[14] +
-				m[12] * m[2] * m[11] -
-				m[12] * m[3] * m[10];
-
-			mtx[9] = -m[0] * m[9] * m[15] +
-				m[0] * m[11] * m[13] +
-				m[8] * m[1] * m[15] -
-				m[8] * m[3] * m[13] -
-				m[12] * m[1] * m[11] +
-				m[12] * m[3] * m[9];
-
-			mtx[13] = m[0] * m[9] * m[14] -
-				m[0] * m[10] * m[13] -
-				m[8] * m[1] * m[14] +
-				m[8] * m[2] * m[13] +
-				m[12] * m[1] * m[10] -
-				m[12] * m[2] * m[9];
-
-			mtx[2] = m[1] * m[6] * m[15] -
-				m[1] * m[7] * m[14] -
-				m[5] * m[2] * m[15] +
-				m[5] * m[3] * m[14] +
-				m[13] * m[2] * m[7] -
-				m[13] * m[3] * m[6];
-
-			mtx[6] = -m[0] * m[6] * m[15] +
-				m[0] * m[7] * m[14] +
-				m[4] * m[2] * m[15] -
-				m[4] * m[3] * m[14] -
-				m[12] * m[2] * m[7] +
-				m[12] * m[3] * m[6];
-
-			mtx[10] = m[0] * m[5] * m[15] -
-				m[0] * m[7] * m[13] -
-				m[4] * m[1] * m[15] +
-				m[4] * m[3] * m[13] +
-				m[12] * m[1] * m[7] -
-				m[12] * m[3] * m[5];
-
-			mtx[14] = -m[0] * m[5] * m[14] +
-				m[0] * m[6] * m[13] +
-				m[4] * m[1] * m[14] -
-				m[4] * m[2] * m[13] -
-				m[12] * m[1] * m[6] +
-				m[12] * m[2] * m[5];
-
-			mtx[3] = -m[1] * m[6] * m[11] +
-				m[1] * m[7] * m[10] +
-				m[5] * m[2] * m[11] -
-				m[5] * m[3] * m[10] -
-				m[9] * m[2] * m[7] +
-				m[9] * m[3] * m[6];
-
-			mtx[7] = m[0] * m[6] * m[11] -
-				m[0] * m[7] * m[10] -
-				m[4] * m[2] * m[11] +
-				m[4] * m[3] * m[10] +
-				m[8] * m[2] * m[7] -
-				m[8] * m[3] * m[6];
-
-			mtx[11] = -m[0] * m[5] * m[11] +
-				m[0] * m[7] * m[9] +
-				m[4] * m[1] * m[11] -
-				m[4] * m[3] * m[9] -
-				m[8] * m[1] * m[7] +
-				m[8] * m[3] * m[5];
-
-			mtx[15] = m[0] * m[5] * m[10] -
-				m[0] * m[6] * m[9] -
-				m[4] * m[1] * m[10] +
-				m[4] * m[2] * m[9] +
-				m[8] * m[1] * m[6] -
-				m[8] * m[2] * m[5];
-
-			var det = m[0] * mtx[0] + m[1] * mtx[4] + m[2] * mtx[8] + m[3] * mtx[12];
-			if (det == 0)
-				return null;
-
-			for (var i = 0; i < 16; i++)
-				mtx[i] *= 1 / det;
-
-			return mtx;
+			return null;
 		}
 
-		public static float[] MakeFloatMatrix(Int32Matrix4x4 imtx)
+		public static Matrix4x4 MakeFloatMatrix(Int32Matrix4x4 imtx)
 		{
 			var multipler = 1f / imtx.M44;
-			return
-			[
+			return new Matrix4x4(
 				imtx.M11 * multipler,
 				imtx.M12 * multipler,
 				imtx.M13 * multipler,
 				imtx.M14 * multipler,
-
 				imtx.M21 * multipler,
 				imtx.M22 * multipler,
 				imtx.M23 * multipler,
 				imtx.M24 * multipler,
-
 				imtx.M31 * multipler,
 				imtx.M32 * multipler,
 				imtx.M33 * multipler,
 				imtx.M34 * multipler,
-
 				imtx.M41 * multipler,
 				imtx.M42 * multipler,
 				imtx.M43 * multipler,
-				imtx.M44 * multipler,
-			];
+				1f);
 		}
 
-		public static float[] MatrixAABBMultiply(float[] mtx, float[] bounds)
+		public static AABB MatrixAABBMultiply(Matrix4x4 mtx, AABB bounds)
 		{
-			// Corner offsets.
-			var ix = new uint[] { 0, 0, 0, 0, 3, 3, 3, 3 };
-			var iy = new uint[] { 1, 1, 4, 4, 1, 1, 4, 4 };
-			var iz = new uint[] { 2, 5, 2, 5, 2, 5, 2, 5 };
-
 			// Vectors to opposing corner.
-			var ret = new[]
-			{
-				float.MaxValue, float.MaxValue, float.MaxValue,
-				float.MinValue, float.MinValue, float.MinValue
-			};
+			var minX = float.MaxValue;
+			var minY = float.MaxValue;
+			var minZ = float.MaxValue;
+			var maxX = float.MinValue;
+			var maxY = float.MinValue;
+			var maxZ = float.MinValue;
 
 			// Transform vectors and find new bounding box.
 			for (var i = 0; i < 8; i++)
 			{
-				var vec = new[] { bounds[ix[i]], bounds[iy[i]], bounds[iz[i]], 1 };
+				var vec = bounds.Corner(i);
 				var tvec = MatrixVectorMultiply(mtx, vec);
 
-				ret[0] = Math.Min(ret[0], tvec[0] / tvec[3]);
-				ret[1] = Math.Min(ret[1], tvec[1] / tvec[3]);
-				ret[2] = Math.Min(ret[2], tvec[2] / tvec[3]);
-				ret[3] = Math.Max(ret[3], tvec[0] / tvec[3]);
-				ret[4] = Math.Max(ret[4], tvec[1] / tvec[3]);
-				ret[5] = Math.Max(ret[5], tvec[2] / tvec[3]);
+				minX = Math.Min(minX, tvec[0] / tvec[3]);
+				minY = Math.Min(minY, tvec[1] / tvec[3]);
+				minZ = Math.Min(minZ, tvec[2] / tvec[3]);
+				maxX = Math.Max(maxX, tvec[0] / tvec[3]);
+				maxY = Math.Max(maxY, tvec[1] / tvec[3]);
+				maxZ = Math.Max(maxZ, tvec[2] / tvec[3]);
 			}
 
-			return ret;
+			return new AABB(minX, minY, minZ, maxX, maxY, maxZ);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
+++ b/OpenRA.Mods.Cnc/Widgets/ModelWidget.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Graphics;
 using OpenRA.Mods.Cnc.Traits;
@@ -27,8 +26,8 @@ namespace OpenRA.Mods.Cnc.Widgets
 		public float Scale = 10f;
 		public int LightPitch = 142;
 		public int LightYaw = 682;
-		public ImmutableArray<float> LightAmbientColor = [0.6f, 0.6f, 0.6f];
-		public ImmutableArray<float> LightDiffuseColor = [0.4f, 0.4f, 0.4f];
+		public float3 LightAmbientColor = new(0.6f, 0.6f, 0.6f);
+		public float3 LightDiffuseColor = new(0.4f, 0.4f, 0.4f);
 		public WRot Rotation = WRot.None;
 		public WAngle CameraAngle = WAngle.FromDegrees(40);
 
@@ -36,8 +35,8 @@ namespace OpenRA.Mods.Cnc.Widgets
 		public Func<string> GetPlayerPalette;
 		public Func<string> GetNormalsPalette;
 		public Func<string> GetShadowPalette;
-		public Func<ImmutableArray<float>> GetLightAmbientColor;
-		public Func<ImmutableArray<float>> GetLightDiffuseColor;
+		public Func<float3> GetLightAmbientColor;
+		public Func<float3> GetLightDiffuseColor;
 		public Func<float> GetScale;
 		public Func<int> GetLightPitch;
 		public Func<int> GetLightYaw;

--- a/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
@@ -17,8 +17,10 @@ namespace OpenRA.Mods.Common.Graphics
 	public class RangeCircleAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		const int RangeCircleSegments = 32;
-		static readonly Int32Matrix4x4[] RangeCircleStartRotations = Exts.MakeArray(RangeCircleSegments, i => WRot.FromFacing(8 * i).AsMatrix());
-		static readonly Int32Matrix4x4[] RangeCircleEndRotations = Exts.MakeArray(RangeCircleSegments, i => WRot.FromFacing(8 * i + 6).AsMatrix());
+		static readonly Int32Matrix4x4[] RangeCircleStartRotations =
+			Exts.MakeArray(RangeCircleSegments, i => { WRot.FromFacing(8 * i).AsMatrix(out var m); return m; });
+		static readonly Int32Matrix4x4[] RangeCircleEndRotations =
+			Exts.MakeArray(RangeCircleSegments, i => { WRot.FromFacing(8 * i + 6).AsMatrix(out var m); return m; });
 		readonly WDist radius;
 		readonly Color color;
 		readonly float width;

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -341,17 +341,8 @@ namespace OpenRA.Platforms.Default
 		public delegate void Uniform3f(int location, float v0, float v1, float v2);
 		public static Uniform3f glUniform3f { get; private set; }
 
-		public delegate void Uniform1fv(int location, int count, IntPtr value);
-		public static Uniform1fv glUniform1fv { get; private set; }
-
-		public delegate void Uniform2fv(int location, int count, IntPtr value);
-		public static Uniform2fv glUniform2fv { get; private set; }
-
-		public delegate void Uniform3fv(int location, int count, IntPtr value);
-		public static Uniform3fv glUniform3fv { get; private set; }
-
-		public delegate void Uniform4fv(int location, int count, IntPtr value);
-		public static Uniform4fv glUniform4fv { get; private set; }
+		public delegate void Uniform4f(int location, float v0, float v1, float v2, float v3);
+		public static Uniform4f glUniform4f { get; private set; }
 
 		public delegate void UniformMatrix4fv(int location, int count, bool transpose, IntPtr value);
 		public static UniformMatrix4fv glUniformMatrix4fv { get; private set; }
@@ -588,10 +579,7 @@ namespace OpenRA.Platforms.Default
 				glUniform1f = Bind<Uniform1f>("glUniform1f");
 				glUniform2f = Bind<Uniform2f>("glUniform2f");
 				glUniform3f = Bind<Uniform3f>("glUniform3f");
-				glUniform1fv = Bind<Uniform1fv>("glUniform1fv");
-				glUniform2fv = Bind<Uniform2fv>("glUniform2fv");
-				glUniform3fv = Bind<Uniform3fv>("glUniform3fv");
-				glUniform4fv = Bind<Uniform4fv>("glUniform4fv");
+				glUniform4f = Bind<Uniform4f>("glUniform4f");
 				glUniformMatrix4fv = Bind<UniformMatrix4fv>("glUniformMatrix4fv");
 				glGenBuffers = Bind<GenBuffers>("glGenBuffers");
 				glBindBuffer = Bind<BindBuffer>("glBindBuffer");

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -11,7 +11,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Numerics;
 using System.Text;
 using OpenRA.Graphics;
 
@@ -217,42 +217,32 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
-		public void SetVec(string name, ReadOnlyMemory<float> vec, int length)
+		public void SetVec(string name, Vector3 vec)
 		{
 			VerifyThreadAffinity();
 			var param = uniformCache[name];
-			unsafe
-			{
-				fixed (float* pVec = vec.Span)
-				{
-					var ptr = new IntPtr(pVec);
-					switch (length)
-					{
-						case 1: OpenGL.glUniform1fv(param, 1, ptr); break;
-						case 2: OpenGL.glUniform2fv(param, 1, ptr); break;
-						case 3: OpenGL.glUniform3fv(param, 1, ptr); break;
-						case 4: OpenGL.glUniform4fv(param, 1, ptr); break;
-						default: throw new InvalidDataException("Invalid vector length");
-					}
-				}
-			}
-
+			OpenGL.glUniform3f(param, vec.X, vec.Y, vec.Z);
 			OpenGL.CheckGLError();
 		}
 
-		public void SetMatrix(string name, float[] mtx)
+		public void SetVec(string name, Vector4 vec)
 		{
 			VerifyThreadAffinity();
-			if (mtx.Length != 16)
-				throw new InvalidDataException("Invalid 4x4 matrix");
+			var param = uniformCache[name];
+			OpenGL.glUniform4f(param, vec.X, vec.Y, vec.Z, vec.W);
+			OpenGL.CheckGLError();
+		}
+
+		public void SetMatrix(string name, Matrix4x4 mtx)
+		{
+			VerifyThreadAffinity();
 
 			OpenGL.glUseProgram(program);
 			OpenGL.CheckGLError();
 
 			unsafe
 			{
-				fixed (float* pMtx = mtx)
-					OpenGL.glUniformMatrix4fv(uniformCache[name], 1, false, new IntPtr(pMtx));
+				OpenGL.glUniformMatrix4fv(uniformCache[name], 1, false, new IntPtr((float*)&mtx));
 			}
 
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -247,5 +247,20 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.CheckGLError();
 		}
+
+		public void SetMatrixRowMajor(string name, Matrix4x4 mtx)
+		{
+			VerifyThreadAffinity();
+
+			OpenGL.glUseProgram(program);
+			OpenGL.CheckGLError();
+
+			unsafe
+			{
+				OpenGL.glUniformMatrix4fv(uniformCache[name], 1, true, new IntPtr((float*)&mtx));
+			}
+
+			OpenGL.CheckGLError();
+		}
 	}
 }

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using OpenRA.Primitives;
@@ -777,10 +778,10 @@ namespace OpenRA.Platforms.Default
 			bind = shader.Bind;
 			prepareRender = shader.PrepareRender;
 			setBool = tuple => { var t = ((string, bool))tuple; shader.SetBool(t.Item1, t.Item2); };
-			setMatrix = tuple => { var t = ((string, float[]))tuple; shader.SetMatrix(t.Item1, t.Item2); };
+			setMatrix = tuple => { var t = ((string, Matrix4x4))tuple; shader.SetMatrix(t.Item1, t.Item2); };
 			setTexture = tuple => { var t = ((string, ITexture))tuple; shader.SetTexture(t.Item1, t.Item2); };
 			setVec1 = tuple => { var t = ((string, float))tuple; shader.SetVec(t.Item1, t.Item2); };
-			setVec2 = tuple => { var t = ((string, ReadOnlyMemory<float>, int))tuple; shader.SetVec(t.Item1, t.Item2, t.Item3); };
+			setVec2 = tuple => { var t = ((string, Vector4))tuple; shader.SetVec(t.Item1, t.Item2); };
 			setVec3 = tuple => { var t = ((string, float, float))tuple; shader.SetVec(t.Item1, t.Item2, t.Item3); };
 			setVec4 = tuple => { var t = ((string, float, float, float))tuple; shader.SetVec(t.Item1, t.Item2, t.Item3, t.Item4); };
 		}
@@ -800,7 +801,7 @@ namespace OpenRA.Platforms.Default
 			device.Post(setBool, (name, value));
 		}
 
-		public void SetMatrix(string param, float[] mtx)
+		public void SetMatrix(string param, Matrix4x4 mtx)
 		{
 			device.Post(setMatrix, (param, mtx));
 		}
@@ -815,9 +816,14 @@ namespace OpenRA.Platforms.Default
 			device.Post(setVec1, (name, x));
 		}
 
-		public void SetVec(string name, ReadOnlyMemory<float> vec, int length)
+		public void SetVec(string name, Vector3 vec)
 		{
-			device.Post(setVec2, (name, vec, length));
+			device.Post(setVec4, (name, vec.X, vec.Y, vec.Z));
+		}
+
+		public void SetVec(string name, Vector4 vec)
+		{
+			device.Post(setVec2, (name, vec));
 		}
 
 		public void SetVec(string name, float x, float y)

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -765,6 +765,7 @@ namespace OpenRA.Platforms.Default
 		readonly Action prepareRender;
 		readonly Action<object> setBool;
 		readonly Action<object> setMatrix;
+		readonly Action<object> setMatrixRowMajor;
 		readonly Action<object> setTexture;
 		readonly Action<object> setVec1;
 		readonly Action<object> setVec2;
@@ -779,6 +780,7 @@ namespace OpenRA.Platforms.Default
 			prepareRender = shader.PrepareRender;
 			setBool = tuple => { var t = ((string, bool))tuple; shader.SetBool(t.Item1, t.Item2); };
 			setMatrix = tuple => { var t = ((string, Matrix4x4))tuple; shader.SetMatrix(t.Item1, t.Item2); };
+			setMatrixRowMajor = tuple => { var t = ((string, Matrix4x4))tuple; shader.SetMatrixRowMajor(t.Item1, t.Item2); };
 			setTexture = tuple => { var t = ((string, ITexture))tuple; shader.SetTexture(t.Item1, t.Item2); };
 			setVec1 = tuple => { var t = ((string, float))tuple; shader.SetVec(t.Item1, t.Item2); };
 			setVec2 = tuple => { var t = ((string, Vector4))tuple; shader.SetVec(t.Item1, t.Item2); };
@@ -804,6 +806,11 @@ namespace OpenRA.Platforms.Default
 		public void SetMatrix(string param, Matrix4x4 mtx)
 		{
 			device.Post(setMatrix, (param, mtx));
+		}
+
+		public void SetMatrixRowMajor(string param, Matrix4x4 mtx)
+		{
+			device.Post(setMatrixRowMajor, (param, mtx));
 		}
 
 		public void SetTexture(string param, ITexture texture)


### PR DESCRIPTION
In mods with voxels, 4x4 matrices and axis-aligned bounding boxes were previously represented with float arrays. Performing calculations with these would allocate lots of small arrays.

Switch to System.Numerics.Matrix4x4 and introduce OpenRA.AABB, which are structs. These introduce some additional type safety as well as avoiding heap allocations.

----

In this 10 second profile on the TS shellmap, 116 million total bytes were allocated. Allocations from the highlighted methods are removed in this PR, saving 41 million bytes.

<img width="580" height="208" alt="image" src="https://github.com/user-attachments/assets/9d80b717-dfab-41e5-9893-e9f866050b17" />