### PR TITLE
Deduplicate observer translation strings

### DIFF
--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -229,6 +229,26 @@ label-no-music-title = Music Not Installed
 label-no-music-desc-a = The game music can be installed
 label-no-music-desc-b = from the "Manage Content" menu.
 
+## ingame-observer.yaml
+button-replay-pause-tooltip = Pause
+button-replay-play-tooltip = Play
+
+button-replay-slow =
+    .tooltip = Slow speed
+    .label = 50%
+
+button-replay-regular =
+    .tooltip = Regular speed
+    .label = 100%
+
+button-replay-fast =
+    .tooltip = Fast speed
+    .label = 200%
+
+button-replay-maximum =
+    .tooltip = Maximum speed
+    .label = MAX
+
 ## lobby-options.yaml
 label-lobby-options-bin-title = Map Options
 

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -249,6 +249,37 @@ button-replay-maximum =
     .tooltip = Maximum speed
     .label = MAX
 
+label-basic-stats-player-header = Player
+label-basic-stats-cash-header = Cash
+label-basic-stats-power-header = Power
+label-basic-stats-kills-header = Kills
+label-basic-stats-deaths-header = Deaths
+label-basic-stats-assets-destroyed-header = Destroyed
+label-basic-stats-assets-lost-header = Lost
+label-basic-stats-experience-header = Score
+label-basic-stats-actions-min-header = APM
+label-economy-stats-player-header = Player
+label-economy-stats-cash-header = Cash
+label-economy-stats-income-header = Income
+label-economy-stats-assets-header = Assets
+label-economy-stats-earned-header = Earned
+label-economy-stats-spent-header = Spent
+label-production-stats-player-header = Player
+label-production-stats-header = Production
+label-support-powers-player-header = Player
+label-support-powers-header = Support Powers
+label-army-player-header = Player
+label-army-header = Army
+label-combat-stats-player-header = Player
+label-combat-stats-assets-destroyed-header = Destroyed
+label-combat-stats-assets-lost-header = Lost
+label-combat-stats-units-killed-header = U. Killed
+label-combat-stats-units-dead-header = U. Lost
+label-combat-stats-buildings-killed-header = B. Killed
+label-combat-stats-buildings-dead-header = B. Lost
+label-combat-stats-army-value-header = Army Value
+label-combat-stats-vision-header = Vision
+
 ## lobby-options.yaml
 label-lobby-options-bin-title = Map Options
 

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -118,7 +118,7 @@ Container@OBSERVER_WIDGETS:
 							Width: 26
 							Height: 26
 							Key: Pause
-							TooltipText: button-replay-player-pause-tooltip
+							TooltipText: button-replay-pause-tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
@@ -134,7 +134,7 @@ Container@OBSERVER_WIDGETS:
 							Height: 26
 							Key: Pause
 							IgnoreChildMouseOver: true
-							TooltipText: button-replay-player-play-tooltip
+							TooltipText: button-replay-play-tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
 								Image@IMAGE_PLAY:
@@ -148,9 +148,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 36
 							Height: 20
 							Key: ReplaySpeedSlow
-							TooltipText: button-replay-player-slow.tooltip
+							TooltipText: button-replay-slow.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-slow.label
+							Text: button-replay-slow.label
 							Font: TinyBold
 						Button@BUTTON_REGULAR:
 							X: 55 + 45
@@ -158,9 +158,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedRegular
-							TooltipText: button-replay-player-regular.tooltip
+							TooltipText: button-replay-regular.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-regular.label
+							Text: button-replay-regular.label
 							Font: TinyBold
 						Button@BUTTON_FAST:
 							X: 55 + 45 * 2
@@ -168,9 +168,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedFast
-							TooltipText: button-replay-player-fast.tooltip
+							TooltipText: button-replay-fast.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-fast.label
+							Text: button-replay-fast.label
 							Font: TinyBold
 						Button@BUTTON_MAXIMUM:
 							X: 55 + 45 * 3
@@ -178,9 +178,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedMax
-							TooltipText: button-replay-player-maximum.tooltip
+							TooltipText: button-replay-maximum.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-maximum.label
+							Text: button-replay-maximum.label
 							Font: TinyBold
 		Container@INGAME_OBSERVERSTATS_BG:
 			Logic: ObserverStatsLogic

--- a/mods/d2k/fluent/chrome.ftl
+++ b/mods/d2k/fluent/chrome.ftl
@@ -6,38 +6,8 @@ label-menu-buttons-title = Options
 
 ## ingame-observer.yaml
 button-observer-widget-options = Options (Esc)
-label-basic-stats-player-header = Player
-label-basic-stats-cash-header = Cash
-label-basic-stats-power-header = Power
-label-basic-stats-kills-header = Kills
-label-basic-stats-deaths-header = Deaths
-label-basic-stats-assets-destroyed-header = Destroyed
-label-basic-stats-assets-lost-header = Lost
-label-basic-stats-experience-header = Score
-label-basic-stats-actions-min-header = APM
-label-economy-stats-player-header = Player
-label-economy-stats-cash-header = Cash
-label-economy-stats-income-header = Income
-label-economy-stats-assets-header = Assets
-label-economy-stats-earned-header = Earned
-label-economy-stats-spent-header = Spent
 label-economy-stats-harvesters-header = Harvesters
 label-economy-stats-carryalls-header = Carryalls
-label-production-stats-player-header = Player
-label-production-stats-header = Production
-label-support-powers-player-header = Player
-label-support-powers-header = Support Powers
-label-army-player-header = Player
-label-army-header = Army
-label-combat-stats-player-header = Player
-label-combat-stats-assets-destroyed-header = Destroyed
-label-combat-stats-assets-lost-header = Lost
-label-combat-stats-units-killed-header = U. Killed
-label-combat-stats-units-dead-header = U. Lost
-label-combat-stats-buildings-killed-header = B. Killed
-label-combat-stats-buildings-dead-header = B. Lost
-label-combat-stats-army-value-header = Army Value
-label-combat-stats-vision-header = Vision
 label-deliver-in-timer = DELIVERY IN: { $time }
 
 ## ingame-observer.yaml, ingame-player.yaml

--- a/mods/d2k/fluent/chrome.ftl
+++ b/mods/d2k/fluent/chrome.ftl
@@ -6,25 +6,6 @@ label-menu-buttons-title = Options
 
 ## ingame-observer.yaml
 button-observer-widget-options = Options (Esc)
-button-replay-player-pause-tooltip = Pause
-button-replay-player-play-tooltip = Play
-
-button-replay-player-slow =
-    .tooltip = Slow speed
-    .label = 50%
-
-button-replay-player-regular =
-    .tooltip = Regular speed
-    .label = 100%
-
-button-replay-player-fast =
-    .tooltip = Fast speed
-    .label = 200%
-
-button-replay-player-maximum =
-    .tooltip = Maximum speed
-    .label = MAX
-
 label-basic-stats-player-header = Player
 label-basic-stats-cash-header = Cash
 label-basic-stats-power-header = Power

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -146,7 +146,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 28
 					Background: sidebar-button-observer
 					Key: Pause
-					TooltipText: button-observer-widgets-pause-tooltip
+					TooltipText: button-replay-pause-tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
 					Children:
@@ -162,7 +162,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 28
 					Background: sidebar-button-observer
 					Key: Pause
-					TooltipText: button-observer-widgets-play-tooltip
+					TooltipText: button-replay-play-tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
 					Children:
@@ -178,10 +178,10 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					Background: sidebar-button-observer
 					Key: ReplaySpeedSlow
-					TooltipText: button-observer-widgets-slow.tooltip
+					TooltipText: button-replay-slow.tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
-					Text: button-observer-widgets-slow.label
+					Text: button-replay-slow.label
 					Font: TinyBold
 				Button@BUTTON_REGULAR:
 					X: 95
@@ -190,10 +190,10 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					Background: sidebar-button-observer
 					Key: ReplaySpeedRegular
-					TooltipText: button-observer-widgets-regular.tooltip
+					TooltipText: button-replay-regular.tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
-					Text: button-observer-widgets-regular.label
+					Text: button-replay-regular.label
 					Font: TinyBold
 				Button@BUTTON_FAST:
 					X: 141
@@ -202,10 +202,10 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					Background: sidebar-button-observer
 					Key: ReplaySpeedFast
-					TooltipText: button-observer-widgets-fast.tooltip
+					TooltipText: button-replay-fast.tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
-					Text: button-observer-widgets-fast.label
+					Text: button-replay-fast.label
 					Font: TinyBold
 				Button@BUTTON_MAXIMUM:
 					X: 187
@@ -214,10 +214,10 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					Background: sidebar-button-observer
 					Key: ReplaySpeedMax
-					TooltipText: button-observer-widgets-maximum.tooltip
+					TooltipText: button-replay-maximum.tooltip
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
-					Text: button-observer-widgets-maximum.label
+					Text: button-replay-maximum.label
 					Font: TinyBold
 		Container@INGAME_OBSERVERSTATS_BG:
 			Logic: ObserverStatsLogic

--- a/mods/ra/fluent/chrome.ftl
+++ b/mods/ra/fluent/chrome.ftl
@@ -2,26 +2,6 @@
 label-gamesave-loading-screen-title = Loading Saved Game
 label-gamesave-loading-screen-desc = Press Escape to cancel loading and return to the main menu
 
-## ingame-observer.yaml
-button-observer-widgets-pause-tooltip = Pause
-button-observer-widgets-play-tooltip = Play
-
-button-observer-widgets-slow =
-    .tooltip = Slow speed
-    .label = 50%
-
-button-observer-widgets-regular =
-    .tooltip = Regular speed
-    .label = 100%
-
-button-observer-widgets-fast =
-    .tooltip = Fast speed
-    .label = 200%
-
-button-observer-widgets-maximum =
-    .tooltip = Maximum speed
-    .label = MAX
-
 label-basic-stats-player-header = Player
 label-basic-stats-cash-header = Cash
 label-basic-stats-power-header = Power

--- a/mods/ra/fluent/chrome.ftl
+++ b/mods/ra/fluent/chrome.ftl
@@ -2,38 +2,9 @@
 label-gamesave-loading-screen-title = Loading Saved Game
 label-gamesave-loading-screen-desc = Press Escape to cancel loading and return to the main menu
 
-label-basic-stats-player-header = Player
-label-basic-stats-cash-header = Cash
-label-basic-stats-power-header = Power
-label-basic-stats-kills-header = Kills
-label-basic-stats-deaths-header = Deaths
-label-basic-stats-assets-destroyed-header = Destroyed
-label-basic-stats-assets-lost-header = Lost
-label-basic-stats-experience-header = Score
-label-basic-stats-actions-min-header = APM
-label-economy-stats-player-header = Player
-label-economy-stats-cash-header = Cash
-label-economy-stats-income-header = Income
-label-economy-stats-assets-header = Assets
-label-economy-stats-earned-header = Earned
-label-economy-stats-spent-header = Spent
+## ingame-observer.yaml
 label-economy-stats-harvesters-header = Harvesters
 label-economy-stats-derricks-header = Oil Derricks
-label-production-stats-player-header = Player
-label-production-stats-header = Production
-label-support-powers-player-header = Player
-label-support-powers-header = Support Powers
-label-army-player-header = Player
-label-army-header = Army
-label-combat-stats-player-header = Player
-label-combat-stats-assets-destroyed-header = Destroyed
-label-combat-stats-assets-lost-header = Lost
-label-combat-stats-units-killed-header = U. Killed
-label-combat-stats-units-dead-header = U. Lost
-label-combat-stats-buildings-killed-header = B. Killed
-label-combat-stats-buildings-dead-header = B. Lost
-label-combat-stats-army-value-header = Army Value
-label-combat-stats-vision-header = Vision
 
 ## ingame-observer.yaml, ingame-player.yaml
 label-mute-indicator = Audio Muted

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -118,7 +118,7 @@ Container@OBSERVER_WIDGETS:
 							Width: 26
 							Height: 26
 							Key: Pause
-							TooltipText: button-replay-player-pause-tooltip
+							TooltipText: button-replay-pause-tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
@@ -133,7 +133,7 @@ Container@OBSERVER_WIDGETS:
 							Width: 26
 							Height: 26
 							Key: Pause
-							TooltipText: button-replay-player-play-tooltip
+							TooltipText: button-replay-play-tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
@@ -148,9 +148,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 36
 							Height: 20
 							Key: ReplaySpeedSlow
-							TooltipText: button-replay-player-slow.tooltip
+							TooltipText: button-replay-slow.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-slow.label
+							Text: button-replay-slow.label
 							Font: TinyBold
 						Button@BUTTON_REGULAR:
 							X: 55 + 45
@@ -158,9 +158,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedRegular
-							TooltipText: button-replay-player-regular.tooltip
+							TooltipText: button-replay-regular.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-regular.label
+							Text: button-replay-regular.label
 							Font: TinyBold
 						Button@BUTTON_FAST:
 							X: 55 + 45 * 2
@@ -168,9 +168,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedFast
-							TooltipText: button-replay-player-fast.tooltip
+							TooltipText: button-replay-fast.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-fast.label
+							Text: button-replay-fast.label
 							Font: TinyBold
 						Button@BUTTON_MAXIMUM:
 							X: 55 + 45 * 3
@@ -178,9 +178,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							Key: ReplaySpeedMax
-							TooltipText: button-replay-player-maximum.tooltip
+							TooltipText: button-replay-maximum.tooltip
 							TooltipContainer: TOOLTIP_CONTAINER
-							Text: button-replay-player-maximum.label
+							Text: button-replay-maximum.label
 							Font: TinyBold
 		Container@INGAME_OBSERVERSTATS_BG:
 			Logic: ObserverStatsLogic

--- a/mods/ts/fluent/chrome.ftl
+++ b/mods/ts/fluent/chrome.ftl
@@ -9,25 +9,6 @@ checkbox-debug-panel-show-depth-preview = Show Depth Data
 
 ## ingame-observer.yaml
 button-observer-widget-options = Options (Esc)
-button-replay-player-pause-tooltip = Pause
-button-replay-player-play-tooltip = Play
-
-button-replay-player-slow =
-    .tooltip = Slow speed
-    .label = 50%
-
-button-replay-player-regular =
-    .tooltip = Regular speed
-    .label = 100%
-
-button-replay-player-fast =
-    .tooltip = Fast speed
-    .label = 200%
-
-button-replay-player-maximum =
-    .tooltip = Maximum speed
-    .label = MAX
-
 label-basic-stats-player-header = Player
 label-basic-stats-cash-header = Cash
 label-basic-stats-power-header = Power

--- a/mods/ts/fluent/chrome.ftl
+++ b/mods/ts/fluent/chrome.ftl
@@ -9,37 +9,7 @@ checkbox-debug-panel-show-depth-preview = Show Depth Data
 
 ## ingame-observer.yaml
 button-observer-widget-options = Options (Esc)
-label-basic-stats-player-header = Player
-label-basic-stats-cash-header = Cash
-label-basic-stats-power-header = Power
-label-basic-stats-kills-header = Kills
-label-basic-stats-deaths-header = Deaths
-label-basic-stats-assets-destroyed-header = Destroyed
-label-basic-stats-assets-lost-header = Lost
-label-basic-stats-experience-header = Score
-label-basic-stats-actions-min-header = APM
-label-economy-stats-player-header = Player
-label-economy-stats-cash-header = Cash
-label-economy-stats-income-header = Income
-label-economy-stats-assets-header = Assets
-label-economy-stats-earned-header = Earned
-label-economy-stats-spent-header = Spent
 label-economy-stats-harvesters-header = Harvesters
-label-production-stats-player-header = Player
-label-production-stats-header = Production
-label-support-powers-player-header = Player
-label-support-powers-header = Support Powers
-label-army-player-header = Player
-label-army-header = Army
-label-combat-stats-player-header = Player
-label-combat-stats-assets-destroyed-header = Destroyed
-label-combat-stats-assets-lost-header = Lost
-label-combat-stats-units-killed-header = U. Killed
-label-combat-stats-units-dead-header = U. Lost
-label-combat-stats-buildings-killed-header = B. Killed
-label-combat-stats-buildings-dead-header = B. Lost
-label-combat-stats-army-value-header = Army Value
-label-combat-stats-vision-header = Vision
 
 ## ingame-observer.yaml, ingame-player.yaml
 label-mute-indicator = Audio Muted


### PR DESCRIPTION
These are identical except for the translation keys and options button with icon ⚙️ vs. text. This merges them back together and also exposes them for re-use in third-party mods.