### PR TITLE
Fix sequence lint checks for map-defined actors.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				CheckRules(modData, map.Rules);
 				if (map.SequenceDefinitions != null)
-					CheckSequences(modData, modData.DefaultRules, map.Sequences);
+					CheckSequences(modData, map.Rules, map.Sequences);
 			}
 
 			// Run all map-level checks here.


### PR DESCRIPTION
Fixes an issue reported by Sluyer/Uienbrok on Discord.

Testcase: https://resource.openra.net/maps/66736, which incorrectly passes `--check-yaml` because the actors with missing sequences aren't in the `modData.DefaultRules` and therefore aren't checked.