### PR TITLE
Move load and save notifications to transient

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -269,6 +269,11 @@ namespace OpenRA
 			return new Order(order, null, false) { IsImmediate = isImmediate, TargetString = targetString };
 		}
 
+		public static Order FromTargetString(string order, string targetString, bool isImmediate, uint extraData)
+		{
+			return new Order(order, null, false) { IsImmediate = isImmediate, TargetString = targetString, ExtraData = extraData };
+		}
+
 		public static Order FromGroupedOrder(Order grouped, Actor subject)
 		{
 			return new Order(

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -211,7 +211,7 @@ namespace OpenRA.Network
 
 				case "GameSaved":
 					foreach (var nsr in orderManager.World.WorldActor.TraitsImplementing<INotifyGameSaved>())
-						nsr.GameSaved(orderManager.World);
+						nsr.GameSaved(orderManager.World, order.ExtraData != 0);
 					break;
 
 				case "PauseGame":

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -30,9 +30,6 @@ namespace OpenRA.Network
 		[FluentReference]
 		const string GameStarted = "notification-game-has-started";
 
-		[FluentReference]
-		const string GameSaved = "notification-game-saved";
-
 		[FluentReference("player")]
 		const string GamePaused = "notification-game-paused";
 
@@ -213,9 +210,6 @@ namespace OpenRA.Network
 				}
 
 				case "GameSaved":
-					if (!orderManager.World.IsReplay)
-						TextNotificationsManager.AddSystemLine(GameSaved);
-
 					foreach (var nsr in orderManager.World.WorldActor.TraitsImplementing<INotifyGameSaved>())
 						nsr.GameSaved(orderManager.World);
 					break;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -52,9 +52,6 @@ namespace OpenRA.Server
 		const string CustomRules = "notification-custom-rules";
 
 		[FluentReference]
-		const string BotsDisabled = "notification-map-bots-disabled";
-
-		[FluentReference]
 		const string TwoHumansRequired = "notification-two-humans-required";
 
 		[FluentReference]
@@ -587,7 +584,8 @@ namespace OpenRA.Server
 
 						Log.Write("server", $"{client.Name} ({newConn.EndPoint}) has joined the game.");
 
-						SendFluentMessage(Joined, "player", client.Name);
+						var otherConns = Conns.Where(c => c != newConn).ToArray();
+						SendFluentMessage(otherConns.AsSpan(), Joined, "player", client.Name);
 
 						if (Type == ServerType.Dedicated)
 						{
@@ -598,15 +596,13 @@ namespace OpenRA.Server
 							var motd = File.ReadAllText(motdFile);
 							if (!string.IsNullOrEmpty(motd))
 								SendOrderTo(newConn, "Message", motd);
+
+							if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
+								SendFluentMessageTo(newConn, TwoHumansRequired);
 						}
 
-						if ((LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
+						if (Type != ServerType.Local && (LobbyInfo.GlobalSettings.MapStatus & Session.MapStatus.UnsafeCustomRules) != 0)
 							SendFluentMessageTo(newConn, CustomRules);
-
-						if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
-							SendFluentMessageTo(newConn, TwoHumansRequired);
-						else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
-							SendFluentMessageTo(newConn, BotsDisabled);
 					}
 				}
 
@@ -893,6 +889,17 @@ namespace OpenRA.Server
 			RecordOrder(frame, data, From);
 		}
 
+		public void DispatchServerOrdersToClients(ReadOnlySpan<Connection> conns, byte[] data, int frame = 0)
+		{
+			const int From = 0;
+			var frameData = CreateFrame(From, frame, data);
+			foreach (var c in conns)
+				if (c.Validated)
+					DispatchFrameToClient(c, From, frameData);
+
+			RecordOrder(frame, data, From);
+		}
+
 		public void ReceiveOrders(Connection conn, int frame, byte[] data)
 		{
 			// Make sure we don't accidentally forward on orders from clients who we have just dropped
@@ -953,8 +960,14 @@ namespace OpenRA.Server
 
 		public void SendFluentMessage(string key, params object[] args)
 		{
+			var conns = Conns.ToArray();
+			SendFluentMessage(conns, key, args);
+		}
+
+		public void SendFluentMessage(ReadOnlySpan<Connection> conns, string key, params object[] args)
+		{
 			var text = FluentMessage.Serialize(key, args);
-			DispatchServerOrdersToClients(Order.FromTargetString("FluentMessage", text, true));
+			DispatchServerOrdersToClients(conns, Order.FromTargetString("FluentMessage", text, true).Serialize());
 
 			if (Type == ServerType.Dedicated)
 				WriteLineWithTimeStamp(FluentProvider.GetMessage(key, args));

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1056,7 +1056,7 @@ namespace OpenRA.Server
 								Directory.CreateDirectory(baseSavePath);
 
 							GameSave.Save(Path.Combine(baseSavePath, filename));
-							DispatchServerOrdersToClients(Order.FromTargetString("GameSaved", filename, true));
+							DispatchServerOrdersToClients(Order.FromTargetString("GameSaved", filename, true, o.ExtraData));
 						}
 
 						break;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -373,7 +373,7 @@ namespace OpenRA.Traits
 	public interface IPostWorldLoaded { void PostWorldLoaded(World w, WorldRenderer wr); }
 	public interface INotifyGameLoading { void GameLoading(World w); }
 	public interface INotifyGameLoaded { void GameLoaded(World w); }
-	public interface INotifyGameSaved { void GameSaved(World w); }
+	public interface INotifyGameSaved { void GameSaved(World w, bool isAutoSave); }
 
 	public interface IGameSaveTraitData
 	{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -562,7 +562,7 @@ namespace OpenRA
 			}
 		}
 
-		public void RequestGameSave(string filename)
+		public void RequestGameSave(string filename, bool isAutosave)
 		{
 			// Allow traits to save arbitrary data that will be passed back via IGameSaveTraitData.ResolveTraitData
 			// at the end of the save restoration
@@ -580,7 +580,8 @@ namespace OpenRA
 				i++;
 			}
 
-			IssueOrder(Order.FromTargetString("CreateGameSave", filename, true));
+			var extraData = isAutosave ? 1u : 0u;
+			IssueOrder(Order.FromTargetString("CreateGameSave", filename, true, extraData));
 		}
 
 		public bool Disposing;

--- a/OpenRA.Mods.Common/Traits/World/AutoSave.cs
+++ b/OpenRA.Mods.Common/Traits/World/AutoSave.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var dateTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture);
 			var fileName = $"{AutoSavePattern}{dateTime}{SaveFileExtension}";
-			self.World.RequestGameSave(fileName);
+			self.World.RequestGameSave(fileName, true);
 			ticksUntilAutoSave = GetTicksBetweenAutosaves(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -64,11 +64,13 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void INotifyGameSaved.GameSaved(World world)
+		void INotifyGameSaved.GameSaved(World world, bool isAutosave)
 		{
 			if (!world.IsReplay)
 			{
-				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer?.Faction.InternalName);
+				if (!isAutosave)
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer?.Faction.InternalName);
+
 				TextNotificationsManager.AddTransientLine(null, info.SavedTextNotification);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -377,7 +377,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			void Inner()
 			{
-				world.RequestGameSave(filename);
+				world.RequestGameSave(filename, false);
 				Ui.CloseWindow();
 				onExit();
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string ConfigureBots = "options-slot-admin.configure-bots";
 
+		[FluentReference]
+		const string BotsDisabled = "notification-map-bots-disabled";
+
 		[FluentReference("count")]
 		const string NumberTeams = "options-slot-admin.teams-count";
 
@@ -588,6 +591,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				playerLeftSound = yaml.Value;
 			if (logicArgs.TryGetValue("LobbyOptionChangedSound", out yaml))
 				lobbyOptionChangedSound = yaml.Value;
+
+			Game.Sound.PlayNotification(modRules, null, "Sounds", playerJoinedSound, null);
 		}
 
 		bool disposed;
@@ -708,6 +713,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var o in allOptions)
 				if (newLobbyOptions.TryGetValue(o.Id, out var s) && (lobbyOptions.TryGetValue(o.Id, out var old) ? s.Value != old.Value : s.Value != o.DefaultValue))
 					TextNotificationsManager.AddSystemLine(OptionValue, "name", o.Name, "value", o.Label(s.Value));
+
+			if (map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
+				TextNotificationsManager.AddSystemLine(BotsDisabled);
 
 			lobbyOptions = newLobbyOptions;
 		}

--- a/mods/cnc/fluent/rules.ftl
+++ b/mods/cnc/fluent/rules.ftl
@@ -21,6 +21,8 @@ notification-ally-under-attack = Our ally is under attack.
 notification-silos-needed = Silos needed.
 
 ## world.yaml
+notification-game-saved = Game saved.
+
 options-starting-units =
     .mcv-only = MCV Only
     .light-support = Light Support

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -265,6 +265,11 @@ World:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	RadarPings:
+	StartGameNotification:
+		Notification:
+		LoadedNotification:
+		SavedNotification:
+		SavedTextNotification: notification-game-saved
 	LoadWidgetAtGameStart:
 		ShellmapRoot: MENU_BACKGROUND
 	ScriptTriggers:

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -7,7 +7,6 @@ button-quit = Quit
 
 ## Server Orders
 notification-custom-rules = This map contains custom rules. Game experience may change.
-notification-map-bots-disabled = Bots have been disabled on this map.
 notification-two-humans-required = This server requires at least two human players to start a match.
 notification-unknown-server-command = Unknown server command: { $command }.
 notification-admin-start-game = Only the host can start the game.
@@ -204,6 +203,7 @@ label-bot-player = AI Player
 ## LobbyLogic
 notification-lobby-option = { $name }: { $value }.
 notification-lobby-option-changed = { $name } changed to { $value }.
+notification-map-bots-disabled = Bots have been disabled on this map.
 
 ## IngameMenuLogic
 menu-ingame =

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -87,7 +87,6 @@ notification-lobby-disconnected = { $player } has left.
 
 ## UnitOrders
 notification-game-has-started = The game has started.
-notification-game-saved = Game saved.
 notification-game-paused = The game has been paused by { $player }.
 notification-game-unpaused = The game has been un-paused by { $player }.
 

--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -22,6 +22,8 @@ notification-cannot-build-here = Cannot build here.
 notification-one-of-our-buildings-has-been-captured = One of our buildings has been captured.
 
 ## world.yaml
+notification-game-saved = Game saved.
+
 dropdown-map-worms =
     .label = Worms
     .description = Worms roam the map, devouring unprepared forces

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -246,6 +246,7 @@ World:
 	ScriptTriggers:
 	CellTriggerOverlay:
 	StartGameNotification:
+		SavedTextNotification: notification-game-saved
 	FlashPostProcessEffect:
 		Type: flash
 		Color: E2DD8F4D

--- a/mods/ra/fluent/rules.ftl
+++ b/mods/ra/fluent/rules.ftl
@@ -27,6 +27,8 @@ notification-ally-under-attack = Our ally is under attack.
 notification-silos-needed = Silos needed.
 
 ## world.yaml
+notification-game-saved = Game saved.
+
 options-starting-units =
     .mcv-only = MCV Only
     .light-support = Light Support

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -271,6 +271,7 @@ World:
 	DebugPauseState:
 	RadarPings:
 	StartGameNotification:
+		SavedTextNotification: notification-game-saved
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:

--- a/mods/ts/fluent/rules.ftl
+++ b/mods/ts/fluent/rules.ftl
@@ -19,6 +19,8 @@ notification-harvester-under-attack = Harvester under attack.
 notification-silos-needed = Silos needed.
 
 ## World
+notification-game-saved = Game saved.
+
 options-starting-units =
     .mcv-only = MCV Only
     .light = Light

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -381,6 +381,7 @@ World:
 	ScreenShaker:
 	RadarPings:
 	StartGameNotification:
+		SavedTextNotification: notification-game-saved
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:


### PR DESCRIPTION
Closes #21711

- TD now gains save and load notifications (though is sill lacking sounds)
- Saving no longer has chat sounds
- Loading a game from another game no longer has chat sounds
- Text notifications moved to transient chat
- Silences autosave notifications