### PR TITLE
Implement keyboard navigation across UI

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -1,4 +1,4 @@
-#region Copyright & License Information
+﻿#region Copyright & License Information
 /*
  * Copyright (c) The OpenRA Developers and Contributors
  * This file is part of OpenRA, which is free software. It is made
@@ -28,6 +28,9 @@ namespace OpenRA.Widgets
 	public interface IKeyboardScrollable
 	{
 		bool HandleScrollKeyPress(KeyInput e);
+
+		// Scrolls the container so that the given widget is visible.
+		void ScrollIntoView(Widget widget);
 	}
 
 	public static class Ui
@@ -138,6 +141,9 @@ namespace OpenRA.Widgets
 			// Set focus to new widget
 			newFocusWidget.OnTabFocusGained();
 
+			// Scroll the new focus widget into view if it is inside a scroll container.
+			ScrollTabFocusIntoView(newFocusWidget);
+
 			return true;
 		}
 
@@ -184,6 +190,22 @@ namespace OpenRA.Widgets
 			}
 
 			return false;
+		}
+
+		// Scrolls a scroll container ancestor to bring the given widget into view.
+		static void ScrollTabFocusIntoView(Widget widget)
+		{
+			var parent = widget.Parent;
+			while (parent != null)
+			{
+				if (parent is IKeyboardScrollable scrollable)
+				{
+					scrollable.ScrollIntoView(widget);
+					return;
+				}
+
+				parent = parent.Parent;
+			}
 		}
 
 		// Clears the current TAB focus

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -91,19 +91,19 @@ namespace OpenRA.Widgets
 			if (focusableWidgets.Count == 0)
 				return false;
 
-			// Sort by TabIndex, then by visual position (top to bottom, left to right)
+			// Sort by TabIndex, then by document position (stable order unaffected by scroll).
 			focusableWidgets.Sort((a, b) =>
 			{
 				var tabIndexCompare = a.TabIndex.CompareTo(b.TabIndex);
 				if (tabIndexCompare != 0)
 					return tabIndexCompare;
 
-				// If same TabIndex, sort by Y position then X position
-				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
+				// If same TabIndex, sort by document Y then X (not RenderBounds, which changes with scroll).
+				var yCompare = GetDocumentY(a).CompareTo(GetDocumentY(b));
 				if (yCompare != 0)
 					return yCompare;
 
-				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
+				return GetDocumentX(a).CompareTo(GetDocumentX(b));
 			});
 
 			// Find current focused widget index
@@ -192,6 +192,35 @@ namespace OpenRA.Widgets
 			return false;
 		}
 
+		// Returns the sum of Bounds.Y up the parent chain, giving a stable document Y
+		// position that is unaffected by scroll offsets of ancestor scroll containers.
+		static int GetDocumentY(Widget widget)
+		{
+			var y = 0;
+			var current = widget;
+			while (current != null)
+			{
+				y += current.Bounds.Y;
+				current = current.Parent;
+			}
+
+			return y;
+		}
+
+		// Returns the sum of Bounds.X up the parent chain, giving a stable document X position.
+		static int GetDocumentX(Widget widget)
+		{
+			var x = 0;
+			var current = widget;
+			while (current != null)
+			{
+				x += current.Bounds.X;
+				current = current.Parent;
+			}
+
+			return x;
+		}
+
 		// Scrolls a scroll container ancestor to bring the given widget into view.
 		static void ScrollTabFocusIntoView(Widget widget)
 		{
@@ -229,18 +258,18 @@ namespace OpenRA.Widgets
 			if (focusableWidgets.Count == 0)
 				return;
 
-			// Sort by TabIndex, then by visual position
+			// Sort by TabIndex, then by document position
 			focusableWidgets.Sort((a, b) =>
 			{
 				var tabIndexCompare = a.TabIndex.CompareTo(b.TabIndex);
 				if (tabIndexCompare != 0)
 					return tabIndexCompare;
 
-				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
+				var yCompare = GetDocumentY(a).CompareTo(GetDocumentY(b));
 				if (yCompare != 0)
 					return yCompare;
 
-				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
+				return GetDocumentX(a).CompareTo(GetDocumentX(b));
 			});
 
 			var newFocusWidget = focusableWidgets[0];

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -21,6 +21,15 @@ using OpenRA.Support;
 
 namespace OpenRA.Widgets
 {
+	/// <summary>
+	/// Implemented by scroll containers that support keyboard-driven scrolling
+	/// (PAGE UP, PAGE DOWN, HOME, END) when a child widget has focus.
+	/// </summary>
+	public interface IKeyboardScrollable
+	{
+		bool HandleScrollKeyPress(KeyInput e);
+	}
+
 	public static class Ui
 	{
 		public const int Timestep = 40;
@@ -37,6 +46,10 @@ namespace OpenRA.Widgets
 
 		// Currently focused widget for TAB navigation (separate from KeyboardFocusWidget used for text input)
 		public static Widget TabFocusWidget;
+
+		// Whether the current tab focus was obtained via keyboard (true) or mouse (false).
+		// Focus indicators are only shown when focus was obtained via keyboard.
+		public static bool TabFocusFromKeyboard;
 
 		static readonly Mediator Mediator = new();
 		static ModData modData;
@@ -112,15 +125,17 @@ namespace OpenRA.Widgets
 			// so that OnTabFocusLost can check where focus is going
 			var oldFocusWidget = TabFocusWidget;
 			TabFocusWidget = newFocusWidget;
+			TabFocusFromKeyboard = true;
 
-			if (oldFocusWidget != null)
-			{
-				oldFocusWidget.HasTabFocus = false;
-				oldFocusWidget.OnTabFocusLost();
-			}
+			oldFocusWidget?.OnTabFocusLost();
+
+			// Revoke KeyboardFocus from the previous widget if it was a focusable widget
+			// (e.g., leaving a text field via TAB should release its keyboard capture)
+			if (KeyboardFocusWidget != null && KeyboardFocusWidget != newFocusWidget
+				&& KeyboardFocusWidget.IsFocusable)
+				KeyboardFocusWidget.YieldKeyboardFocus();
 
 			// Set focus to new widget
-			newFocusWidget.HasTabFocus = true;
 			newFocusWidget.OnTabFocusGained();
 
 			return true;
@@ -154,25 +169,15 @@ namespace OpenRA.Widgets
 			if (TabFocusWidget.OnTabFocusKeyPress(e))
 				return true;
 
-			// For PAGE UP/DOWN/HOME/END, propagate to parent ScrollPanelWidget if not handled
+			// For PAGE UP/DOWN/HOME/END, propagate to parent scroll container if not handled.
 			if (e.Key == Keycode.PAGEUP || e.Key == Keycode.PAGEDOWN ||
 				e.Key == Keycode.HOME || e.Key == Keycode.END)
 			{
 				var parent = TabFocusWidget.Parent;
 				while (parent != null)
 				{
-					// Check if parent can handle scroll navigation via HandleKeyPress
-					// Use reflection to check for ScrollPanelWidget type since we're in OpenRA.Game
-					var handleMethod = parent.GetType().GetMethod("HandleKeyPress",
-						System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
-						null, [typeof(KeyInput)], null);
-
-					if (handleMethod != null && parent.GetType().Name == "ScrollPanelWidget")
-					{
-						var result = handleMethod.Invoke(parent, [e]);
-						if (result is bool handled && handled)
-							return true;
-					}
+					if (parent is IKeyboardScrollable scrollable && scrollable.HandleScrollKeyPress(e))
+						return true;
 
 					parent = parent.Parent;
 				}
@@ -186,9 +191,10 @@ namespace OpenRA.Widgets
 		{
 			if (TabFocusWidget != null)
 			{
-				TabFocusWidget.HasTabFocus = false;
-				TabFocusWidget.OnTabFocusLost();
+				var old = TabFocusWidget;
 				TabFocusWidget = null;
+				TabFocusFromKeyboard = false;
+				old.OnTabFocusLost();
 			}
 		}
 
@@ -222,14 +228,9 @@ namespace OpenRA.Widgets
 			var oldFocusWidget = TabFocusWidget;
 			TabFocusWidget = newFocusWidget;
 
-			if (oldFocusWidget != null)
-			{
-				oldFocusWidget.HasTabFocus = false;
-				oldFocusWidget.OnTabFocusLost();
-			}
+			oldFocusWidget?.OnTabFocusLost();
 
 			// Set focus to new widget
-			newFocusWidget.HasTabFocus = true;
 			newFocusWidget.OnTabFocusGained();
 		}
 
@@ -337,7 +338,42 @@ namespace OpenRA.Widgets
 
 		public static void PrepareRenderables() { Root.PrepareRenderablesOuter(); }
 
-		public static void Draw() { Root.DrawOuter(); }
+		public static void Draw()
+		{
+			Root.DrawOuter();
+
+			// Draw focus indicator on top of everything, only when focus was obtained via keyboard.
+			if (TabFocusWidget != null && TabFocusFromKeyboard && TabFocusWidget.IsVisible())
+				DrawFocusIndicator(TabFocusWidget);
+		}
+
+		static void DrawFocusIndicator(Widget widget)
+		{
+			if (!ChromeMetrics.TryGet("TabFocusColor", out Color focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet("TabFocusWidth", out int focusWidth))
+				focusWidth = 2;
+
+			var rect = widget.GetFocusIndicatorBounds();
+			var l = rect.Left - focusWidth;
+			var t = rect.Top - focusWidth;
+			var r = rect.Right;
+			var b = rect.Bottom;
+			var cr = Game.Renderer.RgbaColorRenderer;
+
+			// Top border.
+			cr.FillRect(new float2(l, t), new float2(r + focusWidth, t + focusWidth), focusColor);
+
+			// Bottom border.
+			cr.FillRect(new float2(l, b), new float2(r + focusWidth, b + focusWidth), focusColor);
+
+			// Left border.
+			cr.FillRect(new float2(l, t), new float2(l + focusWidth, b + focusWidth), focusColor);
+
+			// Right border.
+			cr.FillRect(new float2(r, t), new float2(r + focusWidth, b + focusWidth), focusColor);
+		}
 
 		public static bool HandleInput(MouseInput mi)
 		{
@@ -374,7 +410,12 @@ namespace OpenRA.Widgets
 		/// <param name="e">Key input data.</param>
 		public static bool HandleKeyPress(KeyInput e)
 		{
-			// Handle TAB navigation first (highest priority for UI navigation)
+			// The widget with KeyboardFocus has absolute priority
+			// (allows tab autocomplete in text fields, etc.)
+			if (KeyboardFocusWidget != null && KeyboardFocusWidget.HandleKeyPressOuter(e))
+				return true;
+
+			// Handle TAB navigation
 			if (e.Key == Keycode.TAB && HandleTabNavigation(e))
 				return true;
 
@@ -477,8 +518,8 @@ namespace OpenRA.Widgets
 		// Whether this widget can receive TAB focus
 		public bool IsFocusable = false;
 
-		// Whether this widget currently has TAB focus (set by the Ui class)
-		public bool HasTabFocus = false;
+		// Whether this widget currently has TAB focus (derived from Ui.TabFocusWidget)
+		public bool HasTabFocus => Ui.TabFocusWidget == this;
 
 		// Calculated internally
 		public WidgetBounds Bounds;
@@ -697,6 +738,10 @@ namespace OpenRA.Widgets
 		// Returns true if this widget can currently receive TAB focus
 		// Override to add additional conditions (e.g., not disabled)
 		public virtual bool IsTabNavigable() { return IsFocusable && IsVisible(); }
+
+		// Returns the bounds used for drawing the focus indicator.
+		// Override to customize (e.g., ColorBlockWidget uses inner bounds).
+		public virtual Rectangle GetFocusIndicatorBounds() { return RenderBounds; }
 
 		/// <summary>Possibly handles mouse input (click, drag, scroll, etc).</summary>
 		/// <returns><c>true</c>, if mouse input was handled, <c>false</c> if the input should bubble to the parent widget.</returns>

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -197,9 +197,8 @@ namespace OpenRA.Widgets
 			if (e.Key != Keycode.RETURN && e.Key != Keycode.KP_ENTER && e.Key != Keycode.SPACE)
 				return false;
 
-			// Ensure the widget is still visible before activating
-			// If it has TAB focus, it was navigable when it received focus, so allow activation
-			if (!TabFocusWidget.IsVisible())
+			// Ensure the widget and all its ancestors are still visible before activating.
+			if (!TabFocusWidget.IsFullyVisible())
 				return false;
 
 			return TabFocusWidget.OnTabFocusActivate(e);
@@ -443,7 +442,7 @@ namespace OpenRA.Widgets
 			Root.DrawOuter();
 
 			// Draw focus indicator on top of everything, only when focus was obtained via keyboard.
-			if (TabFocusWidget != null && TabFocusFromKeyboard && TabFocusWidget.IsVisible())
+			if (TabFocusWidget != null && TabFocusFromKeyboard && TabFocusWidget.IsFullyVisible())
 				DrawFocusIndicator(TabFocusWidget);
 		}
 
@@ -839,6 +838,20 @@ namespace OpenRA.Widgets
 		// Override to handle keys like LEFT/RIGHT for sliders, etc.
 		// Returns true if the key was handled
 		public virtual bool OnTabFocusKeyPress(KeyInput e) { return false; }
+
+		// Returns true if this widget and all its ancestors are visible.
+		public bool IsFullyVisible()
+		{
+			var w = this;
+			while (w != null)
+			{
+				if (!w.IsVisible())
+					return false;
+				w = w.Parent;
+			}
+
+			return true;
+		}
 
 		// Returns true if this widget can currently receive TAB focus
 		// Override to add additional conditions (e.g., not disabled)

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -124,9 +124,13 @@ namespace OpenRA.Widgets
 
 			var newFocusWidget = focusableWidgets[nextIndex];
 
-			// Clear focus from previous widget, but set new TabFocusWidget first
-			// so that OnTabFocusLost can check where focus is going
+			// Allow the current widget to perform cleanup before focus changes
+			// (e.g. closing an open dropdown panel).
 			var oldFocusWidget = TabFocusWidget;
+			oldFocusWidget?.OnBeforeTabNavigation();
+
+			// Set new TabFocusWidget before calling OnTabFocusLost so that
+			// OnTabFocusLost can check where focus is going.
 			TabFocusWidget = newFocusWidget;
 			TabFocusFromKeyboard = true;
 
@@ -776,6 +780,11 @@ namespace OpenRA.Widgets
 
 		// Called when this widget loses TAB focus
 		public virtual void OnTabFocusLost() { }
+
+		// Called before TAB navigation moves focus away from this widget.
+		// Unlike OnTabFocusLost, this is called before TabFocusWidget is changed,
+		// allowing cleanup (e.g. closing dropdowns) without interfering with navigation.
+		public virtual void OnBeforeTabNavigation() { }
 
 		// Called when ENTER or SPACE is pressed while this widget has TAB focus
 		// Returns true if the activation was handled

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -328,6 +328,14 @@ namespace OpenRA.Widgets
 
 		static void CollectFocusableWidgets(Widget widget, List<Widget> result)
 		{
+			if (widget == null || widget.IsVisible == null)
+			{
+				var widgetType = widget?.GetType().Name ?? "null";
+				var widgetId = widget?.Id ?? "null";
+				Log.Write("debug", $"CollectFocusableWidgets: null widget or IsVisible delegate (type={widgetType}, id={widgetId})");
+				return;
+			}
+
 			if (!widget.IsVisible())
 				return;
 

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -35,12 +35,238 @@ namespace OpenRA.Widgets
 		public static Widget KeyboardFocusWidget;
 		public static Widget MouseOverWidget;
 
+		// Currently focused widget for TAB navigation (separate from KeyboardFocusWidget used for text input)
+		public static Widget TabFocusWidget;
+
 		static readonly Mediator Mediator = new();
 		static ModData modData;
 
 		public static void Initialize(ModData modData)
 		{
 			Ui.modData = modData;
+		}
+
+		// Handles TAB and SHIFT+TAB navigation between focusable widgets
+		public static bool HandleTabNavigation(KeyInput e)
+		{
+			if (e.Key != Keycode.TAB || e.Event != KeyInputEvent.Down)
+				return false;
+
+			var reverse = e.Modifiers.HasModifier(Modifiers.Shift);
+
+			// Determine the scope for TAB navigation:
+			// If the current TAB focus widget has a parent that is not part of CurrentWindow,
+			// navigate within that parent's tree (e.g., dropdown panels added to Root)
+			Widget navigationScope;
+			if (TabFocusWidget != null)
+			{
+				// Find the topmost parent that contains focusable widgets
+				navigationScope = FindNavigationScope(TabFocusWidget);
+			}
+			else
+			{
+				navigationScope = CurrentWindow() ?? Root;
+			}
+
+			// Collect all focusable widgets in tab order
+			var focusableWidgets = new List<Widget>();
+			CollectFocusableWidgets(navigationScope, focusableWidgets);
+
+			if (focusableWidgets.Count == 0)
+				return false;
+
+			// Sort by TabIndex, then by visual position (top to bottom, left to right)
+			focusableWidgets.Sort((a, b) =>
+			{
+				var tabIndexCompare = a.TabIndex.CompareTo(b.TabIndex);
+				if (tabIndexCompare != 0)
+					return tabIndexCompare;
+
+				// If same TabIndex, sort by Y position then X position
+				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
+				if (yCompare != 0)
+					return yCompare;
+
+				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
+			});
+
+			// Find current focused widget index
+			var currentIndex = -1;
+			if (TabFocusWidget != null)
+				currentIndex = focusableWidgets.IndexOf(TabFocusWidget);
+
+			// Calculate next index
+			int nextIndex;
+			if (reverse)
+			{
+				nextIndex = currentIndex <= 0 ? focusableWidgets.Count - 1 : currentIndex - 1;
+			}
+			else
+			{
+				nextIndex = currentIndex >= focusableWidgets.Count - 1 ? 0 : currentIndex + 1;
+			}
+
+			var newFocusWidget = focusableWidgets[nextIndex];
+
+			// Clear focus from previous widget, but set new TabFocusWidget first
+			// so that OnTabFocusLost can check where focus is going
+			var oldFocusWidget = TabFocusWidget;
+			TabFocusWidget = newFocusWidget;
+
+			if (oldFocusWidget != null)
+			{
+				oldFocusWidget.HasTabFocus = false;
+				oldFocusWidget.OnTabFocusLost();
+			}
+
+			// Set focus to new widget
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+
+			return true;
+		}
+
+		// Handles ENTER and SPACE to activate the currently tab-focused widget
+		public static bool HandleTabFocusActivation(KeyInput e)
+		{
+			if (TabFocusWidget == null || e.Event != KeyInputEvent.Down)
+				return false;
+
+			if (e.Key != Keycode.RETURN && e.Key != Keycode.KP_ENTER && e.Key != Keycode.SPACE)
+				return false;
+
+			// Ensure the widget is still visible before activating
+			// If it has TAB focus, it was navigable when it received focus, so allow activation
+			if (!TabFocusWidget.IsVisible())
+				return false;
+
+			return TabFocusWidget.OnTabFocusActivate(e);
+		}
+
+		// Handles arrow keys and other navigation keys for the currently tab-focused widget
+		// This allows widgets like sliders to handle arrow keys even when another widget has keyboard focus
+		public static bool HandleTabFocusKeyPress(KeyInput e)
+		{
+			if (TabFocusWidget == null || e.Event != KeyInputEvent.Down)
+				return false;
+
+			// Let the tab-focused widget handle navigation keys (arrows, home, end, etc.)
+			if (TabFocusWidget.OnTabFocusKeyPress(e))
+				return true;
+
+			// For PAGE UP/DOWN/HOME/END, propagate to parent ScrollPanelWidget if not handled
+			if (e.Key == Keycode.PAGEUP || e.Key == Keycode.PAGEDOWN ||
+				e.Key == Keycode.HOME || e.Key == Keycode.END)
+			{
+				var parent = TabFocusWidget.Parent;
+				while (parent != null)
+				{
+					// Check if parent can handle scroll navigation via HandleKeyPress
+					// Use reflection to check for ScrollPanelWidget type since we're in OpenRA.Game
+					var handleMethod = parent.GetType().GetMethod("HandleKeyPress",
+						System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+						null, [typeof(KeyInput)], null);
+
+					if (handleMethod != null && parent.GetType().Name == "ScrollPanelWidget")
+					{
+						var result = handleMethod.Invoke(parent, [e]);
+						if (result is bool handled && handled)
+							return true;
+					}
+
+					parent = parent.Parent;
+				}
+			}
+
+			return false;
+		}
+
+		// Clears the current TAB focus
+		public static void ClearTabFocus()
+		{
+			if (TabFocusWidget != null)
+			{
+				TabFocusWidget.HasTabFocus = false;
+				TabFocusWidget.OnTabFocusLost();
+				TabFocusWidget = null;
+			}
+		}
+
+		// Sets the initial TAB focus to the first focusable widget in a window
+		public static void SetInitialFocus(Widget window)
+		{
+			var focusableWidgets = new List<Widget>();
+			CollectFocusableWidgets(window, focusableWidgets);
+
+			if (focusableWidgets.Count == 0)
+				return;
+
+			// Sort by TabIndex, then by visual position
+			focusableWidgets.Sort((a, b) =>
+			{
+				var tabIndexCompare = a.TabIndex.CompareTo(b.TabIndex);
+				if (tabIndexCompare != 0)
+					return tabIndexCompare;
+
+				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
+				if (yCompare != 0)
+					return yCompare;
+
+				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
+			});
+
+			var newFocusWidget = focusableWidgets[0];
+
+			// Clear focus from previous widget, but set new TabFocusWidget first
+			// so that OnTabFocusLost can check where focus is going
+			var oldFocusWidget = TabFocusWidget;
+			TabFocusWidget = newFocusWidget;
+
+			if (oldFocusWidget != null)
+			{
+				oldFocusWidget.HasTabFocus = false;
+				oldFocusWidget.OnTabFocusLost();
+			}
+
+			// Set focus to new widget
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+		}
+
+		static void CollectFocusableWidgets(Widget widget, List<Widget> result)
+		{
+			if (!widget.IsVisible())
+				return;
+
+			if (widget.IsTabNavigable())
+				result.Add(widget);
+
+			foreach (var child in widget.Children)
+				CollectFocusableWidgets(child, result);
+		}
+
+		// Find the appropriate navigation scope for a widget
+		// Returns the topmost container that should be used for TAB navigation
+		static Widget FindNavigationScope(Widget widget)
+		{
+			// Walk up the parent chain to find the navigation scope
+			var current = widget;
+			while (current.Parent != null)
+			{
+				// If we reach a child of Root that is not the current window,
+				// that child is our navigation scope (e.g., a dropdown panel)
+				if (current.Parent == Root)
+				{
+					var currentWindow = CurrentWindow();
+					if (currentWindow != null && current != currentWindow)
+						return current;
+				}
+
+				current = current.Parent;
+			}
+
+			// Default to current window or root
+			return CurrentWindow() ?? Root;
 		}
 
 		public static void CloseWindow()
@@ -79,6 +305,10 @@ namespace OpenRA.Widgets
 			if (WindowList.Count > 0)
 				Root.HideChild(WindowList.Peek());
 			WindowList.Push(window);
+
+			// Set initial TAB focus to the first focusable widget in the new window
+			SetInitialFocus(window);
+
 			return window;
 		}
 
@@ -144,6 +374,18 @@ namespace OpenRA.Widgets
 		/// <param name="e">Key input data.</param>
 		public static bool HandleKeyPress(KeyInput e)
 		{
+			// Handle TAB navigation first (highest priority for UI navigation)
+			if (e.Key == Keycode.TAB && HandleTabNavigation(e))
+				return true;
+
+			// Handle ENTER/SPACE activation of tab-focused widget
+			if (TabFocusWidget != null && HandleTabFocusActivation(e))
+				return true;
+
+			// Handle arrow keys and other navigation for tab-focused widget (e.g., sliders)
+			if (TabFocusWidget != null && HandleTabFocusKeyPress(e))
+				return true;
+
 			if (KeyboardFocusWidget != null)
 				return KeyboardFocusWidget.HandleKeyPressOuter(e);
 
@@ -160,6 +402,7 @@ namespace OpenRA.Widgets
 
 		public static void ResetAll()
 		{
+			ClearTabFocus();
 			Root.RemoveChildren();
 
 			while (WindowList.Count > 0)
@@ -227,6 +470,16 @@ namespace OpenRA.Widgets
 		public bool IgnoreMouseOver;
 		public bool IgnoreChildMouseOver;
 
+		// TAB navigation properties
+		// TabIndex determines the order of focus when pressing TAB (lower values come first)
+		public int TabIndex = 0;
+
+		// Whether this widget can receive TAB focus
+		public bool IsFocusable = false;
+
+		// Whether this widget currently has TAB focus (set by the Ui class)
+		public bool HasTabFocus = false;
+
 		// Calculated internally
 		public WidgetBounds Bounds;
 		public Widget Parent = null;
@@ -250,6 +503,10 @@ namespace OpenRA.Widgets
 			IsVisible = widget.IsVisible;
 			IgnoreChildMouseOver = widget.IgnoreChildMouseOver;
 			IgnoreMouseOver = widget.IgnoreMouseOver;
+
+			// Copy TAB navigation properties
+			TabIndex = widget.TabIndex;
+			IsFocusable = widget.IsFocusable;
 
 			defaultCursor = widget.defaultCursor;
 
@@ -421,6 +678,26 @@ namespace OpenRA.Widgets
 		public virtual void MouseEntered() { }
 		public virtual void MouseExited() { }
 
+		// TAB navigation virtual methods
+		// Called when this widget gains TAB focus
+		public virtual void OnTabFocusGained() { }
+
+		// Called when this widget loses TAB focus
+		public virtual void OnTabFocusLost() { }
+
+		// Called when ENTER or SPACE is pressed while this widget has TAB focus
+		// Returns true if the activation was handled
+		public virtual bool OnTabFocusActivate(KeyInput e) { return false; }
+
+		// Called when arrow keys or other navigation keys are pressed while this widget has TAB focus
+		// Override to handle keys like LEFT/RIGHT for sliders, etc.
+		// Returns true if the key was handled
+		public virtual bool OnTabFocusKeyPress(KeyInput e) { return false; }
+
+		// Returns true if this widget can currently receive TAB focus
+		// Override to add additional conditions (e.g., not disabled)
+		public virtual bool IsTabNavigable() { return IsFocusable && IsVisible(); }
+
 		/// <summary>Possibly handles mouse input (click, drag, scroll, etc).</summary>
 		/// <returns><c>true</c>, if mouse input was handled, <c>false</c> if the input should bubble to the parent widget.</returns>
 		/// <param name="mi">Mouse input data.</param>
@@ -566,6 +843,10 @@ namespace OpenRA.Widgets
 			ForceYieldKeyboardFocus();
 			ForceYieldMouseFocus();
 
+			// Clear TAB focus if this widget had it
+			if (Ui.TabFocusWidget == this)
+				Ui.ClearTabFocus();
+
 			// PERF: Avoid LINQ.
 			for (var i = Children.Count - 1; i >= 0; --i)
 				Children[i].Hidden();
@@ -577,6 +858,10 @@ namespace OpenRA.Widgets
 			// have been removed
 			ForceYieldKeyboardFocus();
 			ForceYieldMouseFocus();
+
+			// Clear TAB focus if this widget had it
+			if (Ui.TabFocusWidget == this)
+				Ui.ClearTabFocus();
 
 			// PERF: Avoid LINQ.
 			for (var i = Children.Count - 1; i >= 0; --i)
@@ -652,15 +937,27 @@ namespace OpenRA.Widgets
 		public InputWidget()
 		{
 			IsDisabled = () => Disabled;
+
+			// InputWidgets are focusable by default for TAB navigation
+			IsFocusable = true;
 		}
 
 		public InputWidget(InputWidget other)
 			: base(other)
 		{
 			IsDisabled = () => other.Disabled;
+
+			// InputWidgets are focusable by default for TAB navigation
+			IsFocusable = true;
 		}
 
 		public override InputWidget Clone() { return new InputWidget(this); }
+
+		// InputWidgets are not tab navigable when disabled
+		public override bool IsTabNavigable()
+		{
+			return base.IsTabNavigable() && !IsDisabled();
+		}
 	}
 
 	public class WidgetArgs : Dictionary<string, object>

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -129,6 +129,43 @@ namespace OpenRA.Widgets
 			var oldFocusWidget = TabFocusWidget;
 			oldFocusWidget?.OnBeforeTabNavigation();
 
+			// OnBeforeTabNavigation may have changed the widget tree (e.g. closing a dropdown
+			// removes its children). If the target widget is no longer in the tree, recalculate.
+			var updatedFocusableWidgets = new List<Widget>();
+			CollectFocusableWidgets(navigationScope, updatedFocusableWidgets);
+			if (!updatedFocusableWidgets.Contains(newFocusWidget))
+			{
+				if (updatedFocusableWidgets.Count == 0)
+					return false;
+
+				// Re-sort and pick the next widget from the updated list.
+				updatedFocusableWidgets.Sort((a, b) =>
+				{
+					var tabIndexCompare = a.TabIndex.CompareTo(b.TabIndex);
+					if (tabIndexCompare != 0)
+						return tabIndexCompare;
+
+					var yCompare = GetDocumentY(a).CompareTo(GetDocumentY(b));
+					if (yCompare != 0)
+						return yCompare;
+
+					return GetDocumentX(a).CompareTo(GetDocumentX(b));
+				});
+
+				var updatedCurrentIndex = oldFocusWidget != null
+					? updatedFocusableWidgets.IndexOf(oldFocusWidget) : -1;
+
+				int updatedNextIndex;
+				if (reverse)
+					updatedNextIndex = updatedCurrentIndex <= 0
+						? updatedFocusableWidgets.Count - 1 : updatedCurrentIndex - 1;
+				else
+					updatedNextIndex = updatedCurrentIndex >= updatedFocusableWidgets.Count - 1
+						? 0 : updatedCurrentIndex + 1;
+
+				newFocusWidget = updatedFocusableWidgets[updatedNextIndex];
+			}
+
 			// Set new TabFocusWidget before calling OnTabFocusLost so that
 			// OnTabFocusLost can check where focus is going.
 			TabFocusWidget = newFocusWidget;

--- a/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ColorPickerManager.cs
@@ -219,11 +219,22 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var finalColor = initialColor;
+
+			// When ENTER/SPACE is pressed on the mixer or palette swatches, close the panel
+			// AND apply the selected color via onExit. Without calling onExit here, the color
+			// would only be updated visually in the preview but not applied to the player.
+			void OnConfirmSelection()
+			{
+				dropdownButton.RemovePanel();
+				onExit(finalColor);
+			}
+
 			var colorChooser = Game.LoadWidget(worldRenderer.World, "COLOR_CHOOSER", null, new WidgetArgs()
 			{
 				{ "onChange", (Action<Color>)(c => { finalColor = c; OnColorPickerColorUpdate(c); }) },
 				{ "initialColor", initialColor },
 				{ "extraLogic", (Action<Widget>)AddActorPreview },
+				{ "onConfirm", OnConfirmSelection },
 			});
 
 			dropdownButton.AttachPanel(colorChooser, () => onExit(finalColor));

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -271,10 +271,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var hover = Ui.MouseOverWidget == this || Children.FirstOrDefault(c => c == Ui.MouseOverWidget) != null;
 
-			// Draw TAB focus indicator (border) when this button has TAB focus
-			if (HasTabFocus && !disabled)
-				DrawTabFocusIndicator(rb);
-
 			DrawBackground(rb, disabled, Depressed, hover || HasTabFocus, highlighted);
 			if (Contrast)
 				font.DrawTextWithContrast(text, position + stateOffset,
@@ -320,31 +316,6 @@ namespace OpenRA.Mods.Common.Widgets
 			var imageName = WidgetUtils.GetStatefulImageName(variantName, disabled, pressed, hover);
 
 			WidgetUtils.DrawPanel(imageName, rect);
-		}
-
-		// Draws a visual indicator around the button when it has TAB focus
-		protected virtual void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			// Draw a border around the button
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -161,6 +161,28 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
+		// TAB focus activation: handle ENTER/SPACE when this button has TAB focus
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			if (IsDisabled())
+			{
+				if (!DisableKeySound)
+					Game.Sound.PlayNotification(ModRules, null, "Sounds", ClickDisabledSound, null);
+				return true;
+			}
+
+			// Some buttons use OnMouseDown instead of OnClick (e.g., dropdown buttons, color buttons)
+			// Trigger both OnMouseDown and OnKeyPress to support all button configurations
+			var mi = new MouseInput(MouseInputEvent.Down, MouseButton.Left, RenderBounds.Location, int2.Zero, Modifiers.None, 0);
+			OnMouseDown(mi);
+			OnKeyPress(e);
+
+			if (!DisableKeySound)
+				Game.Sound.PlayNotification(ModRules, null, "Sounds", ClickSound, null);
+
+			return true;
+		}
+
 		public override bool HandleMouseInput(MouseInput mi)
 		{
 			if (mi.Button != MouseButton.Left)
@@ -248,7 +270,12 @@ namespace OpenRA.Mods.Common.Widgets
 			var position = GetTextPosition(text, font, rb);
 
 			var hover = Ui.MouseOverWidget == this || Children.FirstOrDefault(c => c == Ui.MouseOverWidget) != null;
-			DrawBackground(rb, disabled, Depressed, hover, highlighted);
+
+			// Draw TAB focus indicator (border) when this button has TAB focus
+			if (HasTabFocus && !disabled)
+				DrawTabFocusIndicator(rb);
+
+			DrawBackground(rb, disabled, Depressed, hover || HasTabFocus, highlighted);
 			if (Contrast)
 				font.DrawTextWithContrast(text, position + stateOffset,
 					disabled ? colordisabled : color, bgDark, bgLight, ContrastRadius);
@@ -293,6 +320,31 @@ namespace OpenRA.Mods.Common.Widgets
 			var imageName = WidgetUtils.GetStatefulImageName(variantName, disabled, pressed, hover);
 
 			WidgetUtils.DrawPanel(imageName, rect);
+		}
+
+		// Draws a visual indicator around the button when it has TAB focus
+		protected virtual void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			// Draw a border around the button
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -65,10 +65,6 @@ namespace OpenRA.Mods.Common.Widgets
 			var text = GetText();
 			var rect = new Rectangle(RenderBounds.Location, new Size(Bounds.Height, Bounds.Height));
 
-			// Draw TAB focus indicator when this checkbox has TAB focus
-			if (HasTabFocus && !disabled)
-				DrawTabFocusIndicator(RenderBounds);
-
 			DrawBackground(Background, rect, disabled, Depressed, hover, IsHighlighted());
 
 			var textPosition = new float2(RenderBounds.Left + RenderBounds.Height * 1.5f, RenderOrigin.Y + (Bounds.Height - font.Measure(text).Y - font.TopOffset) / 2);

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -59,11 +59,15 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var disabled = IsDisabled();
 			var font = Game.Renderer.Fonts[Font];
-			var hover = Ui.MouseOverWidget == this;
+			var hover = Ui.MouseOverWidget == this || HasTabFocus;
 			var color = GetColor();
 			var colordisabled = GetColorDisabled();
 			var text = GetText();
 			var rect = new Rectangle(RenderBounds.Location, new Size(Bounds.Height, Bounds.Height));
+
+			// Draw TAB focus indicator when this checkbox has TAB focus
+			if (HasTabFocus && !disabled)
+				DrawTabFocusIndicator(RenderBounds);
 
 			DrawBackground(Background, rect, disabled, Depressed, hover, IsHighlighted());
 

--- a/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
@@ -21,6 +21,16 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<Color> GetColor;
 		public Action<MouseInput> OnMouseDown = _ => { };
 		public Action<MouseInput> OnMouseUp = _ => { };
+
+		// Called when the swatch is activated via keyboard (ENTER/SPACE)
+		public Action OnKeyboardSelect;
+
+		// Callback for arrow key navigation
+		public Func<Keycode, bool> OnArrowKey;
+
+		// Callback when this swatch gains TAB focus (for updating preview)
+		public Action OnSwatchFocusGained;
+
 		public string ClickSound = null;
 
 		readonly Ruleset modRules;
@@ -30,6 +40,9 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			modRules = modData.DefaultRules;
 			GetColor = () => Color;
+
+			// Not focusable by default; only enabled in ColorPickerLogic for palette swatches
+			IsFocusable = false;
 		}
 
 		protected ColorBlockWidget(ColorBlockWidget widget)
@@ -38,6 +51,9 @@ namespace OpenRA.Mods.Common.Widgets
 			modRules = widget.modRules;
 			GetColor = widget.GetColor;
 			ClickSound = widget.ClickSound;
+			OnKeyboardSelect = widget.OnKeyboardSelect;
+			OnArrowKey = widget.OnArrowKey;
+			OnSwatchFocusGained = widget.OnSwatchFocusGained;
 		}
 
 		public override ColorBlockWidget Clone()
@@ -48,6 +64,17 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Draw()
 		{
 			WidgetUtils.FillRectWithColor(RenderBounds, GetColor());
+
+			if (HasTabFocus)
+			{
+				var bounds = RenderBounds;
+
+				// Draw a white border around the focused swatch
+				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Y, bounds.Width, 2), Color.White);
+				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Bottom - 2, bounds.Width, 2), Color.White);
+				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Y, 2, bounds.Height), Color.White);
+				WidgetUtils.FillRectWithColor(new Rectangle(bounds.Right - 2, bounds.Y, 2, bounds.Height), Color.White);
+			}
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -75,6 +102,45 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			return false;
+		}
+
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			if (OnKeyboardSelect != null)
+			{
+				Game.Sound.PlayNotification(modRules, null, "Sounds", ClickSound, null);
+				OnKeyboardSelect();
+				return true;
+			}
+
+			// Fallback: trigger the mouse up handler with a dummy input
+			if (OnMouseUp != null)
+			{
+				Game.Sound.PlayNotification(modRules, null, "Sounds", ClickSound, null);
+				OnMouseUp(default);
+				return true;
+			}
+
+			return false;
+		}
+
+		public override bool OnTabFocusKeyPress(KeyInput e)
+		{
+			if (e.Key == Keycode.LEFT || e.Key == Keycode.RIGHT ||
+				e.Key == Keycode.UP || e.Key == Keycode.DOWN)
+			{
+				return OnArrowKey?.Invoke(e.Key) ?? false;
+			}
+
+			return false;
+		}
+
+		public override void OnTabFocusGained()
+		{
+			base.OnTabFocusGained();
+
+			// Notify that this swatch has gained focus (for updating preview color)
+			OnSwatchFocusGained?.Invoke();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
@@ -64,17 +64,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Draw()
 		{
 			WidgetUtils.FillRectWithColor(RenderBounds, GetColor());
-
-			if (HasTabFocus)
-			{
-				var bounds = RenderBounds;
-
-				// Draw a white border around the focused swatch
-				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Y, bounds.Width, 2), Color.White);
-				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Bottom - 2, bounds.Width, 2), Color.White);
-				WidgetUtils.FillRectWithColor(new Rectangle(bounds.X, bounds.Y, 2, bounds.Height), Color.White);
-				WidgetUtils.FillRectWithColor(new Rectangle(bounds.Right - 2, bounds.Y, 2, bounds.Height), Color.White);
-			}
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public event Action OnChange = () => { };
 
+		// Called when ENTER/SPACE is pressed to confirm the color selection
+		public Action OnConfirm;
+
 		public float H { get; private set; }
 		public float S { get; private set; }
 		public float V { get; private set; }
@@ -37,6 +40,9 @@ namespace OpenRA.Mods.Common.Widgets
 		public ColorMixerWidget(ModData modData)
 		{
 			modRules = modData.DefaultRules;
+
+			// ColorMixerWidget is focusable for TAB navigation
+			IsFocusable = true;
 		}
 
 		public ColorMixerWidget(ColorMixerWidget other)
@@ -45,6 +51,7 @@ namespace OpenRA.Mods.Common.Widgets
 			modRules = other.modRules;
 			ClickSound = other.ClickSound;
 			OnChange = other.OnChange;
+			OnConfirm = other.OnConfirm;
 			H = other.H;
 			S = other.S;
 			V = other.V;
@@ -52,6 +59,9 @@ namespace OpenRA.Mods.Common.Widgets
 			maxSat = other.maxSat;
 			minVal = other.minVal;
 			maxVal = other.maxVal;
+
+			// ColorMixerWidget is focusable for TAB navigation
+			IsFocusable = true;
 		}
 
 		public void SetColorLimits(float minSaturation, float maxSaturation, float minValue, float maxValue, float? newHue = null)
@@ -99,12 +109,42 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
+			var rb = RenderBounds;
+
+			// Draw TAB focus indicator when this color mixer has TAB focus
+			if (HasTabFocus)
+				DrawTabFocusIndicator(rb);
+
 			WidgetUtils.DrawSprite(mixerSprite, RenderOrigin, RenderBounds.Size);
 
 			var sprite = ChromeProvider.GetImage("lobby-bits", "colorpicker");
 			var pos = RenderOrigin + PxFromValue() - new int2((int)sprite.Size.X, (int)sprite.Size.Y) / 2;
 			WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X + 1, pos.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), Color);
 			WidgetUtils.DrawSprite(sprite, pos);
+		}
+
+		// Draws a visual indicator around the color mixer when it has TAB focus
+		static void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		void SetValueFromPx(int2 xy)
@@ -159,6 +199,51 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			return true;
+		}
+
+		// Handle ENTER/SPACE to confirm the color selection
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			if (OnConfirm != null)
+			{
+				OnConfirm();
+				return true;
+			}
+
+			return false;
+		}
+
+		// Handle arrow keys when this color mixer has TAB focus
+		public override bool OnTabFocusKeyPress(KeyInput e)
+		{
+			// Calculate step size (1/20th of the range for smooth movement)
+			var stepX = (maxVal - minVal) / 20f;
+			var stepY = (maxSat - minSat) / 20f;
+
+			switch (e.Key)
+			{
+				case Keycode.LEFT:
+					V = (V - stepX).Clamp(minVal, maxVal);
+					OnChange();
+					return true;
+
+				case Keycode.RIGHT:
+					V = (V + stepX).Clamp(minVal, maxVal);
+					OnChange();
+					return true;
+
+				case Keycode.UP:
+					S = (S + stepY).Clamp(minSat, maxSat);
+					OnChange();
+					return true;
+
+				case Keycode.DOWN:
+					S = (S - stepY).Clamp(minSat, maxSat);
+					OnChange();
+					return true;
+			}
+
+			return false;
 		}
 
 		public Color Color => Color.FromAhsv(H, S, V);

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -109,42 +109,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			var rb = RenderBounds;
-
-			// Draw TAB focus indicator when this color mixer has TAB focus
-			if (HasTabFocus)
-				DrawTabFocusIndicator(rb);
-
 			WidgetUtils.DrawSprite(mixerSprite, RenderOrigin, RenderBounds.Size);
 
 			var sprite = ChromeProvider.GetImage("lobby-bits", "colorpicker");
 			var pos = RenderOrigin + PxFromValue() - new int2((int)sprite.Size.X, (int)sprite.Size.Y) / 2;
 			WidgetUtils.FillEllipseWithColor(new Rectangle(pos.X + 1, pos.Y + 1, (int)sprite.Size.X - 2, (int)sprite.Size.Y - 2), Color);
 			WidgetUtils.DrawSprite(sprite, pos);
-		}
-
-		// Draws a visual indicator around the color mixer when it has TAB focus
-		static void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		void SetValueFromPx(int2 xy)

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -194,14 +194,10 @@ namespace OpenRA.Mods.Common.Widgets
 			// Restore TAB focus to this dropdown button
 			if (IsVisible() && IsFocusable)
 			{
-				if (Ui.TabFocusWidget != null)
-				{
-					Ui.TabFocusWidget.HasTabFocus = false;
+				if (Ui.TabFocusWidget != null && Ui.TabFocusWidget != this)
 					Ui.TabFocusWidget.OnTabFocusLost();
-				}
 
 				Ui.TabFocusWidget = this;
-				HasTabFocus = true;
 				OnTabFocusGained();
 			}
 

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -121,6 +121,16 @@ namespace OpenRA.Mods.Common.Widgets
 			return base.OnTabFocusActivate(e);
 		}
 
+		// Close the dropdown before TAB navigation moves focus away.
+		// Called while TabFocusWidget still equals this, so RemovePanel can
+		// safely restore TAB focus to this button without conflicting with navigation.
+		// HandleTabNavigation will then overwrite TabFocusWidget with the next widget.
+		public override void OnBeforeTabNavigation()
+		{
+			if (IsDropDownOpen)
+				RemovePanel();
+		}
+
 		// Close the dropdown panel when TAB focus is lost,
 		// unless the new focus is within the panel itself
 		public override void OnTabFocusLost()
@@ -261,9 +271,9 @@ namespace OpenRA.Mods.Common.Widgets
 				scrollPanel.OnEscapeKey = () => { RemovePanel(); onCancel?.Invoke(); return true; };
 				scrollPanel.TakeKeyboardFocus();
 
-				// Set TAB focus to the first focusable widget in the panel
-				// This enables keyboard navigation for panels with checkboxes or other focusable widgets
-				Ui.SetInitialFocus(panel);
+				// Prevent the dropdown panel from being collected as a TAB-navigable widget.
+				// Navigation within the dropdown is handled via KeyboardFocus (UP/DOWN arrows).
+				scrollPanel.IsFocusable = false;
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -30,6 +30,8 @@ namespace OpenRA.Mods.Common.Widgets
 		Widget panel;
 		MaskWidget fullscreenMask;
 		Widget panelRoot;
+		Widget previousKeyboardFocusWidget;
+		Widget ownerWindow;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getMarkerImage;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getSeparatorImage;
 
@@ -49,6 +51,13 @@ namespace OpenRA.Mods.Common.Widgets
 			RemovePanel();
 			return base.YieldKeyboardFocus();
 		}
+
+		/// <summary>
+		/// Invoked after the dropdown panel has been removed.
+		/// </summary>
+		public Action DropDownClosed;
+
+		public bool IsDropDownOpen => panel != null;
 
 		[ObjectCreator.UseCtor]
 		public DropDownButtonWidget(ModData modData)
@@ -71,7 +80,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var rb = RenderBounds;
 			var isDisabled = IsDisabled();
-			var isHover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
+			var isHover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget) || HasTabFocus;
 
 			getMarkerImage ??= WidgetUtils.GetCachedStatefulImage(Decorations, DecorationMarker);
 
@@ -97,15 +106,73 @@ namespace OpenRA.Mods.Common.Widgets
 		// This is crap
 		public override int UsableWidth => Bounds.Width - Bounds.Height; /* space for button */
 
+		// TAB focus activation: open or close the dropdown panel
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			// If the dropdown is already open, close it (toggle behavior)
+			if (IsDropDownOpen)
+			{
+				RemovePanel();
+				return true;
+			}
+
+			// Use base implementation which handles both OnMouseDown and OnKeyPress/OnClick
+			// This supports dropdowns using OnMouseDown (most dropdowns) and OnClick (e.g., Battlefield News)
+			return base.OnTabFocusActivate(e);
+		}
+
+		// Close the dropdown panel when TAB focus is lost,
+		// unless the new focus is within the panel itself
+		public override void OnTabFocusLost()
+		{
+			if (!IsDropDownOpen)
+				return;
+
+			// Don't close if the new TAB focus is within the dropdown panel
+			if (Ui.TabFocusWidget != null && IsWidgetWithinPanel(Ui.TabFocusWidget, panel))
+				return;
+
+			RemovePanel();
+		}
+
 		public override void Hidden()
 		{
 			base.Hidden();
-			RemovePanel();
+			CloseDropdownUnlessInKeyboardNavigation();
 		}
 
 		public override void Removed()
 		{
 			base.Removed();
+			CloseDropdownUnlessInKeyboardNavigation();
+		}
+
+		static bool IsWidgetWithinPanel(Widget widget, Widget panel)
+		{
+			for (var w = widget; w != null; w = w.Parent)
+				if (ReferenceEquals(w, panel))
+					return true;
+
+			return false;
+		}
+
+		void CloseDropdownUnlessInKeyboardNavigation()
+		{
+			if (panel == null)
+				return;
+
+			// Always close if the dropdown belongs to a window that is no longer current.
+			if (ownerWindow != null && !ReferenceEquals(ownerWindow, Ui.CurrentWindow()))
+			{
+				RemovePanel();
+				return;
+			}
+
+			// Keep the panel open if the user is actively navigating it with the keyboard.
+			// This prevents dropdowns from closing when the source widget is replaced by a UI refresh (e.g. selecting bots in the lobby).
+			if (IsWidgetWithinPanel(Ui.KeyboardFocusWidget, panel))
+				return;
+
 			RemovePanel();
 		}
 
@@ -117,9 +184,30 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.RemoveChild(fullscreenMask);
 			panelRoot.RemoveChild(panel);
 			panel = fullscreenMask = null;
+			ownerWindow = null;
+
+			var focusToRestore = previousKeyboardFocusWidget;
+			previousKeyboardFocusWidget = null;
+			if (focusToRestore != null && focusToRestore.IsVisible())
+				focusToRestore.TakeKeyboardFocus();
+
+			// Restore TAB focus to this dropdown button
+			if (IsVisible() && IsFocusable)
+			{
+				if (Ui.TabFocusWidget != null)
+				{
+					Ui.TabFocusWidget.HasTabFocus = false;
+					Ui.TabFocusWidget.OnTabFocusLost();
+				}
+
+				Ui.TabFocusWidget = this;
+				HasTabFocus = true;
+				OnTabFocusGained();
+			}
 
 			YieldKeyboardFocus();
 			Ui.ResetTooltips();
+			DropDownClosed?.Invoke();
 		}
 
 		public void AttachPanel(Widget p) { AttachPanel(p, null); }
@@ -128,6 +216,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (panel != null)
 				throw new InvalidOperationException("Attempted to attach a panel to an open dropdown");
 			panel = p;
+			previousKeyboardFocusWidget = Ui.KeyboardFocusWidget;
 			TakeKeyboardFocus();
 
 			// Mask to prevent any clicks from being sent to other widgets
@@ -137,10 +226,13 @@ namespace OpenRA.Mods.Common.Widgets
 			};
 
 			fullscreenMask.OnMouseDown += mi => { Game.Sound.PlayNotification(ModRules, null, "Sounds", ClickSound, null); RemovePanel(); };
+			fullscreenMask.OnEscapeKey = () => { RemovePanel(); onCancel?.Invoke(); return true; };
 			if (onCancel != null)
 				fullscreenMask.OnMouseDown += _ => onCancel();
 
 			panelRoot = PanelRoot == null ? Ui.Root : Ui.Root.Get(PanelRoot);
+
+			ownerWindow = Ui.CurrentWindow();
 
 			panelRoot.AddChild(fullscreenMask);
 
@@ -167,6 +259,25 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.AddChild(panel);
 
 			(panel as ScrollPanelWidget)?.ScrollToSelectedItem();
+
+			if (panel is ScrollPanelWidget scrollPanel)
+			{
+				scrollPanel.OnEscapeKey = () => { RemovePanel(); onCancel?.Invoke(); return true; };
+				scrollPanel.TakeKeyboardFocus();
+
+				// Set TAB focus to the first focusable widget in the panel
+				// This enables keyboard navigation for panels with checkboxes or other focusable widgets
+				Ui.SetInitialFocus(panel);
+			}
+			else
+			{
+				// For non-scroll panels (like color picker), give focus to the mask
+				// so it can handle ESC to close the dropdown.
+				fullscreenMask.TakeKeyboardFocus();
+
+				// Set TAB focus to the first focusable widget in the panel
+				Ui.SetInitialFocus(panel);
+			}
 		}
 
 		public void ShowDropDown<T>(
@@ -184,6 +295,9 @@ namespace OpenRA.Mods.Common.Widgets
 				var item = setupItem(o, itemTemplate);
 				var onClick = item.OnClick;
 				item.OnClick = () => { onClick(); RemovePanel(); };
+
+				var onKeyboardSelect = item.OnKeyboardSelect;
+				item.OnKeyboardSelect = () => { onKeyboardSelect?.Invoke(); RemovePanel(); };
 
 				panel.AddChild(item);
 			}
@@ -207,7 +321,8 @@ namespace OpenRA.Mods.Common.Widgets
 				var group = kv.Key;
 				if (group.Length > 0 && headerTemplate != null)
 				{
-					var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+					// Headers are visual separators and should not be part of keyboard navigation.
+					var header = ScrollItemWidget.SetupHeader(headerTemplate);
 					header.Get<LabelWidget>("LABEL").GetText = () => group;
 					panel.AddChild(header);
 				}
@@ -219,6 +334,9 @@ namespace OpenRA.Mods.Common.Widgets
 					var item = setupItem(o, itemTemplate);
 					var onClick = item.OnClick;
 					item.OnClick = () => { onClick(); RemovePanel(); };
+
+					var onKeyboardSelect = item.OnKeyboardSelect;
+					item.OnKeyboardSelect = () => { onKeyboardSelect?.Invoke(); RemovePanel(); };
 
 					panel.AddChild(item);
 				}
@@ -232,11 +350,13 @@ namespace OpenRA.Mods.Common.Widgets
 	public class MaskWidget : Widget
 	{
 		public event Action<MouseInput> OnMouseDown = _ => { };
+		public Func<bool> OnEscapeKey;
 		public MaskWidget() { }
 		public MaskWidget(MaskWidget other)
 			: base(other)
 		{
 			OnMouseDown = other.OnMouseDown;
+			OnEscapeKey = other.OnEscapeKey;
 		}
 
 		public override bool HandleMouseInput(MouseInput mi)
@@ -248,6 +368,14 @@ namespace OpenRA.Mods.Common.Widgets
 				OnMouseDown(mi);
 
 			return true;
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (e.Event == KeyInputEvent.Down && e.Key == Keycode.ESCAPE && OnEscapeKey != null)
+				return OnEscapeKey();
+
+			return false;
 		}
 
 		public override string GetCursor(int2 pos) { return null; }

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -35,23 +35,6 @@ namespace OpenRA.Mods.Common.Widgets
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getMarkerImage;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getSeparatorImage;
 
-		public override bool HandleKeyPress(KeyInput e)
-		{
-			if (HasKeyboardFocus && e.Event == KeyInputEvent.Down && e.Key == Keycode.ESCAPE)
-			{
-				RemovePanel();
-				return true;
-			}
-
-			return base.HandleKeyPress(e);
-		}
-
-		public override bool YieldKeyboardFocus()
-		{
-			RemovePanel();
-			return base.YieldKeyboardFocus();
-		}
-
 		/// <summary>
 		/// Invoked after the dropdown panel has been removed.
 		/// </summary>
@@ -211,7 +194,6 @@ namespace OpenRA.Mods.Common.Widgets
 				OnTabFocusGained();
 			}
 
-			YieldKeyboardFocus();
 			Ui.ResetTooltips();
 			DropDownClosed?.Invoke();
 		}
@@ -223,7 +205,6 @@ namespace OpenRA.Mods.Common.Widgets
 				throw new InvalidOperationException("Attempted to attach a panel to an open dropdown");
 			panel = p;
 			previousKeyboardFocusWidget = Ui.KeyboardFocusWidget;
-			TakeKeyboardFocus();
 
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -33,7 +33,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public Color TextColorDisabled = ChromeMetrics.Get<Color>("HotkeyColorDisabled");
 		public Color TextColorInvalid = ChromeMetrics.Get<Color>("HotkeyColorInvalid");
 
-		public HotkeyEntryWidget() { }
+		public HotkeyEntryWidget()
+		{
+			// HotkeyEntryWidget uses KeyboardFocusWidget for hotkey capture, not TAB navigation
+			IsFocusable = false;
+		}
+
 		protected HotkeyEntryWidget(HotkeyEntryWidget widget)
 			: base(widget)
 		{
@@ -42,6 +47,9 @@ namespace OpenRA.Mods.Common.Widgets
 			TextColorDisabled = widget.TextColorDisabled;
 			TextColorInvalid = widget.TextColorInvalid;
 			VisualHeight = widget.VisualHeight;
+
+			// HotkeyEntryWidget uses KeyboardFocusWidget for hotkey capture, not TAB navigation
+			IsFocusable = false;
 		}
 
 		public override bool YieldKeyboardFocus()

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -59,10 +59,72 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var ro = RenderOrigin;
 			var rb = RenderBounds;
+
+			// Draw TAB focus indicator when this hue slider has TAB focus
+			if (HasTabFocus && !IsDisabled())
+				DrawTabFocusIndicator(rb);
+
 			WidgetUtils.DrawSprite(hueSprite, ro, rb.Size);
 
 			var pos = RenderOrigin + new int2(PxFromValue(Value).Clamp(0, rb.Width - 1) - (int)pickerSprite.Size.X / 2, (rb.Height - (int)pickerSprite.Size.Y) / 2);
 			WidgetUtils.DrawSprite(pickerSprite, pos);
+		}
+
+		// Draws a visual indicator around the hue slider when it has TAB focus
+		static void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
+		}
+
+		// Override to use a smaller step for the hue slider (1/50 instead of 1/10)
+		public override bool OnTabFocusKeyPress(KeyInput e)
+		{
+			if (IsDisabled())
+				return false;
+
+			// Use a finer step for hue selection (50 steps across the full range)
+			var valueStep = (MaximumValue - MinimumValue) / 50f;
+
+			switch (e.Key)
+			{
+				case Keycode.LEFT:
+				case Keycode.DOWN:
+					UpdateValue(Value - valueStep);
+					return true;
+
+				case Keycode.RIGHT:
+				case Keycode.UP:
+					UpdateValue(Value + valueStep);
+					return true;
+
+				case Keycode.HOME:
+					UpdateValue(MinimumValue);
+					return true;
+
+				case Keycode.END:
+					UpdateValue(MaximumValue);
+					return true;
+			}
+
+			return false;
 		}
 
 		public override void Removed()

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -60,38 +60,10 @@ namespace OpenRA.Mods.Common.Widgets
 			var ro = RenderOrigin;
 			var rb = RenderBounds;
 
-			// Draw TAB focus indicator when this hue slider has TAB focus
-			if (HasTabFocus && !IsDisabled())
-				DrawTabFocusIndicator(rb);
-
 			WidgetUtils.DrawSprite(hueSprite, ro, rb.Size);
 
 			var pos = RenderOrigin + new int2(PxFromValue(Value).Clamp(0, rb.Width - 1) - (int)pickerSprite.Size.X / 2, (rb.Height - (int)pickerSprite.Size.Y) / 2);
 			WidgetUtils.DrawSprite(pickerSprite, pos);
-		}
-
-		// Draws a visual indicator around the hue slider when it has TAB focus
-		static void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		// Override to use a smaller step for the hue slider (1/50 instead of 1/10)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -81,6 +81,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		float modelScale;
 		AssetType assetTypesToDisplay = AssetType.Sprite | AssetType.Model | AssetType.Audio | AssetType.Video;
 
+		// Maps ItemKey to (Package, Filepath) for keyboard navigation preview updates
+		readonly Dictionary<string, (IReadOnlyPackage Package, string Filepath)> assetLookup = [];
+
 		readonly string allPackages;
 
 		[ObjectCreator.UseCtor]
@@ -411,6 +414,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			assetList = panel.Get<ScrollPanelWidget>("ASSET_LIST");
 			template = panel.Get<ScrollItemWidget>("ASSET_TEMPLATE");
+
+			// Update preview when navigating with keyboard (UP/DOWN arrows)
+			assetList.OnKeyboardFocusChanged = item =>
+			{
+				if (item != null && item.ItemKey != null && assetLookup.TryGetValue(item.ItemKey, out var asset))
+					LoadAsset(asset.Package, asset.Filepath);
+			};
+
 			PopulateAssetList();
 
 			var closeButton = panel.GetOrNull<ButtonWidget>("CLOSE_BUTTON");
@@ -470,6 +481,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var item = ScrollItemWidget.Setup(template,
 				() => currentFilename == filepath && currentPackage == package,
 				() => LoadAsset(package, filepath));
+
+			// Store a unique key for keyboard navigation lookup
+			item.ItemKey = $"{package.Name}|{filepath}";
+			assetLookup[item.ItemKey] = (package, filepath);
 
 			var label = item.Get<LabelWithTooltipWidget>("TITLE");
 			WidgetUtils.TruncateLabelToTooltip(label, filepath);
@@ -622,6 +637,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void PopulateAssetList()
 		{
 			assetList.RemoveChildren();
+			assetLookup.Clear();
 
 			var files = new SortedList<string, List<IReadOnlyPackage>>();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -24,10 +24,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static bool paletteTabOpenedLast;
 		int paletteTabHighlighted = 0;
 
+		// All color swatches in the palette for keyboard navigation
+		readonly List<ColorBlockWidget> allSwatches = [];
+		readonly int paletteCols;
+
+		// Callback to update the preview when navigating swatches with arrow keys
+		readonly Action<Color> onColorChange;
+
 		[ObjectCreator.UseCtor]
 		public ColorPickerLogic(Widget widget, ModData modData, World world, Color initialColor, Action<Color> onChange, Action<Widget> extraLogic,
-			Dictionary<string, MiniYaml> logicArgs)
+			Action onConfirm, Dictionary<string, MiniYaml> logicArgs)
 		{
+			onColorChange = onChange;
 			var mixer = widget.Get<ColorMixerWidget>("MIXER");
 			var hueSlider = widget.Get<HueSliderWidget>("HUE_SLIDER");
 
@@ -40,6 +48,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mixer.SetColorLimits(sMin, sMax, vMin, vMax);
 			mixer.OnChange += () => onChange(mixer.Color);
 			mixer.Set(initialColor);
+
+			// Configure confirmation callback for ENTER/SPACE in mixer
+			mixer.OnConfirm = onConfirm;
 
 			hueSlider.OnChange += h =>
 			{
@@ -94,18 +105,29 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			paletteTabButton.OnClick = () => paletteTabOpenedLast = true;
 			paletteTabButton.IsHighlighted = () => paletteTab.IsVisible() || paletteTabHighlighted > 0;
 
-			var paletteCols = 8;
 			var palettePresetRows = 2;
 			var paletteCustomRows = 1;
 
-			if (logicArgs.TryGetValue("PaletteColumns", out var yaml) && !int.TryParse(yaml.Value, out paletteCols))
-				throw new YamlException($"Invalid value for PaletteColumns: {yaml.Value}");
+			if (logicArgs.TryGetValue("PaletteColumns", out var yaml))
+			{
+				if (!int.TryParse(yaml.Value, out var cols))
+					throw new YamlException($"Invalid value for PaletteColumns: {yaml.Value}");
+				paletteCols = cols;
+			}
+			else
+			{
+				paletteCols = 8;
+			}
+
 			if (logicArgs.TryGetValue("PalettePresetRows", out yaml) && !int.TryParse(yaml.Value, out palettePresetRows))
 				throw new YamlException($"Invalid value for PalettePresetRows: {yaml.Value}");
 			if (logicArgs.TryGetValue("PaletteCustomRows", out yaml) && !int.TryParse(yaml.Value, out paletteCustomRows))
 				throw new YamlException($"Invalid value for PaletteCustomRows: {yaml.Value}");
 
 			var presetColors = colorManager.PresetColors;
+			var tabIndex = 0;
+
+			// Create preset color swatches
 			for (var j = 0; j < palettePresetRows; j++)
 			{
 				for (var i = 0; i < paletteCols; i++)
@@ -121,16 +143,36 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					newSwatch.IsVisible = () => true;
 					newSwatch.Bounds.X = i * newSwatch.Bounds.Width;
 					newSwatch.Bounds.Y = j * newSwatch.Bounds.Height;
+					newSwatch.TabIndex = tabIndex++;
+					newSwatch.IsFocusable = true;
+
+					// Mouse selection
 					newSwatch.OnMouseUp = m =>
 					{
 						mixer.Set(color);
 						hueSlider.UpdateValue(color.ToAhsv().H);
 					};
 
+					// Keyboard selection (ENTER/SPACE) - select color and close picker
+					newSwatch.OnKeyboardSelect = () =>
+					{
+						mixer.Set(color);
+						hueSlider.UpdateValue(color.ToAhsv().H);
+						onConfirm?.Invoke();
+					};
+
+					// Arrow key navigation
+					newSwatch.OnArrowKey = key => HandleSwatchArrowKey(newSwatch, key);
+
+					// TAB focus gained - update preview color
+					newSwatch.OnSwatchFocusGained = () => onColorChange?.Invoke(color);
+
 					presetArea.AddChild(newSwatch);
+					allSwatches.Add(newSwatch);
 				}
 			}
 
+			// Create custom color swatches
 			for (var j = 0; j < paletteCustomRows; j++)
 			{
 				for (var i = 0; i < paletteCols; i++)
@@ -144,14 +186,34 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					newSwatch.IsVisible = () => Game.Settings.Player.CustomColors.Length > colorIndex;
 					newSwatch.Bounds.X = i * newSwatch.Bounds.Width;
 					newSwatch.Bounds.Y = j * newSwatch.Bounds.Height;
+					newSwatch.TabIndex = tabIndex++;
+					newSwatch.IsFocusable = true;
+
+					// Mouse selection
 					newSwatch.OnMouseUp = m =>
 					{
-						var color = newSwatch.GetColor();
-						mixer.Set(color);
-						hueSlider.UpdateValue(color.ToAhsv().H);
+						var c = newSwatch.GetColor();
+						mixer.Set(c);
+						hueSlider.UpdateValue(c.ToAhsv().H);
 					};
 
+					// Keyboard selection (ENTER/SPACE) - select color and close picker
+					newSwatch.OnKeyboardSelect = () =>
+					{
+						var c = newSwatch.GetColor();
+						mixer.Set(c);
+						hueSlider.UpdateValue(c.ToAhsv().H);
+						onConfirm?.Invoke();
+					};
+
+					// Arrow key navigation
+					newSwatch.OnArrowKey = key => HandleSwatchArrowKey(newSwatch, key);
+
+					// TAB focus gained - update preview color
+					newSwatch.OnSwatchFocusGained = () => onColorChange?.Invoke(newSwatch.GetColor());
+
 					customArea.AddChild(newSwatch);
+					allSwatches.Add(newSwatch);
 				}
 			}
 
@@ -180,6 +242,62 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Attach logic to preview actor.
 			extraLogic(widget);
+		}
+
+		// Handle arrow key navigation between color swatches
+		bool HandleSwatchArrowKey(ColorBlockWidget currentSwatch, Keycode key)
+		{
+			var currentIndex = allSwatches.IndexOf(currentSwatch);
+			if (currentIndex < 0)
+				return false;
+
+			// Filter to only visible swatches
+			var visibleSwatches = allSwatches.Where(s => s.IsVisible()).ToList();
+			var visibleIndex = visibleSwatches.IndexOf(currentSwatch);
+			if (visibleIndex < 0)
+				return false;
+
+			var newIndex = visibleIndex;
+			var cols = paletteCols;
+			var totalVisible = visibleSwatches.Count;
+
+			switch (key)
+			{
+				case Keycode.LEFT:
+					newIndex = visibleIndex > 0 ? visibleIndex - 1 : totalVisible - 1;
+					break;
+				case Keycode.RIGHT:
+					newIndex = visibleIndex < totalVisible - 1 ? visibleIndex + 1 : 0;
+					break;
+				case Keycode.UP:
+					newIndex = visibleIndex >= cols ? visibleIndex - cols : visibleIndex;
+					break;
+				case Keycode.DOWN:
+					newIndex = visibleIndex + cols < totalVisible ? visibleIndex + cols : visibleIndex;
+					break;
+				default:
+					return false;
+			}
+
+			if (newIndex != visibleIndex && newIndex >= 0 && newIndex < totalVisible)
+			{
+				var newSwatch = visibleSwatches[newIndex];
+
+				// Transfer TAB focus to the new swatch
+				currentSwatch.HasTabFocus = false;
+				currentSwatch.OnTabFocusLost();
+
+				Ui.TabFocusWidget = newSwatch;
+				newSwatch.HasTabFocus = true;
+				newSwatch.OnTabFocusGained();
+
+				// Update the preview with the newly focused swatch's color
+				onColorChange?.Invoke(newSwatch.GetColor());
+
+				return true;
+			}
+
+			return false;
 		}
 
 		public override void Tick()

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -284,11 +284,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var newSwatch = visibleSwatches[newIndex];
 
 				// Transfer TAB focus to the new swatch
-				currentSwatch.HasTabFocus = false;
-				currentSwatch.OnTabFocusLost();
-
 				Ui.TabFocusWidget = newSwatch;
-				newSwatch.HasTabFocus = true;
+				currentSwatch.OnTabFocusLost();
 				newSwatch.OnTabFocusGained();
 
 				// Update the preview with the newly focused swatch's color

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -98,10 +98,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var customColorTemplate = paletteTabPanel.Get<ColorBlockWidget>("COLORCUSTOM");
 
 			mixerTab.IsVisible = () => !paletteTabOpenedLast;
+			mixerTabButton.TabIndex = 0;
 			mixerTabButton.OnClick = () => paletteTabOpenedLast = false;
 			mixerTabButton.IsHighlighted = mixerTab.IsVisible;
 
 			paletteTab.IsVisible = () => paletteTabOpenedLast;
+			paletteTabButton.TabIndex = 1;
 			paletteTabButton.OnClick = () => paletteTabOpenedLast = true;
 			paletteTabButton.IsHighlighted = () => paletteTab.IsVisible() || paletteTabHighlighted > 0;
 
@@ -124,8 +126,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (logicArgs.TryGetValue("PaletteCustomRows", out yaml) && !int.TryParse(yaml.Value, out paletteCustomRows))
 				throw new YamlException($"Invalid value for PaletteCustomRows: {yaml.Value}");
 
+			if (randomButton != null)
+				randomButton.TabIndex = 2;
+
+			var storeButton = widget.Get<ButtonWidget>("STORE_BUTTON");
+			if (storeButton != null)
+				storeButton.TabIndex = 3;
+
 			var presetColors = colorManager.PresetColors;
-			var tabIndex = 0;
+
+			// Swatches start at TabIndex 10 to leave room for the fixed buttons above.
+			var tabIndex = 10;
 
 			// Create preset color swatches
 			for (var j = 0; j < palettePresetRows; j++)
@@ -218,7 +229,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			// Store color button
-			var storeButton = widget.Get<ButtonWidget>("STORE_BUTTON");
 			if (storeButton != null)
 			{
 				storeButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -62,6 +62,31 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 
 			actorList = widget.Get<ScrollPanelWidget>("ACTOR_LIST");
+			actorList.OnEscapeKey = () =>
+			{
+				Game.Disconnect();
+				Ui.CloseWindow();
+				onExit();
+				return true;
+			};
+
+			// Update preview and info when navigating with keyboard (arrow keys, Page Up/Down, Home, End)
+			actorList.OnKeyboardFocusChanged = item =>
+			{
+				if (item == null)
+					return;
+
+				// Find the actor associated with this item
+				var actor = info.Keys.FirstOrDefault(a =>
+				{
+					var name = a.TraitInfos<TooltipInfo>().FirstOrDefault(i => i.EnabledByDefault)?.Name;
+					return !string.IsNullOrEmpty(name) && item.GetOrNull<LabelWithTooltipWidget>("TITLE") != null;
+				});
+
+				// Use the item's OnClick action to select the actor
+				// This ensures the preview and info are updated
+				item.OnClick?.Invoke();
+			};
 
 			headerTemplate = widget.Get<ScrollItemWidget>("HEADER");
 			template = widget.Get<ScrollItemWidget>("TEMPLATE");
@@ -134,7 +159,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void CreateActorGroup(string title, IEnumerable<ActorInfo> actors)
 		{
-			var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+			var header = ScrollItemWidget.SetupHeader(headerTemplate);
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			actorList.AddChild(header);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -220,6 +220,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "onMapUpdate", (Action<string>)(_ => { }) },
 			});
 
+			// Update selected save when navigating with keyboard (UP/DOWN arrows)
+			gameList.OnKeyboardFocusChanged = item =>
+			{
+				if (item != null)
+					Select(item.ItemKey);
+			};
+
 			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
 			renameButton.IsDisabled = () => selectedSave == null;
 			renameButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -254,6 +254,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onCancel: () => { });
 			};
 
+			gameList.OnDeleteKey = () =>
+			{
+				if (!deleteButton.IsDisabled())
+					deleteButton.OnClick();
+				return true;
+			};
+
 			var deleteAllButton = panel.Get<ButtonWidget>("DELETE_ALL_BUTTON");
 			deleteAllButton.IsDisabled = () => games.Count == 0;
 			deleteAllButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -220,13 +220,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "onMapUpdate", (Action<string>)(_ => { }) },
 			});
 
-			// Update selected save when navigating with keyboard (UP/DOWN arrows)
-			gameList.OnKeyboardFocusChanged = item =>
-			{
-				if (item != null)
-					Select(item.ItemKey);
-			};
-
 			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
 			renameButton.IsDisabled = () => selectedSave == null;
 			renameButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (teams.Count > 1)
 				{
-					var teamHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+					var teamHeader = ScrollItemWidget.SetupHeader(teamTemplate);
 					var team = t.Key > 0
 						? FluentProvider.GetMessage(TeamNumber, "team", t.Key)
 						: FluentProvider.GetMessage(NoTeam);
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var spectators = orderManager.LobbyInfo.Clients.Where(c => c.IsObserver).ToList();
 			if (spectators.Count > 0)
 			{
-				var spectatorHeader = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+				var spectatorHeader = ScrollItemWidget.SetupHeader(teamTemplate);
 				var spectatorTeam = FluentProvider.GetMessage(Spectators);
 				spectatorHeader.Get<LabelWidget>("TEAM").GetText = () => spectatorTeam;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -282,7 +282,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (hasTeams)
 				{
-					var tt = ScrollItemWidget.Setup(teamTemplate, () => false, () => { });
+					var tt = ScrollItemWidget.SetupHeader(teamTemplate);
 					tt.IgnoreMouseOver = true;
 
 					var teamLabel = tt.Get<LabelWidget>("TEAM");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -792,6 +792,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					join.IsVisible = () => !slot.Closed;
 					join.IsDisabled = () => orderManager.LocalClient.IsReady;
 					join.OnClick = () => orderManager.IssueOrder(Order.Command("slot " + key));
+
+					// Assign TabIndex to focusable widgets in empty slot
+					SetSlotWidgetTabIndex(template, idx);
 				}
 				else if ((client.Index == orderManager.LocalClient.Index) ||
 						 (client.Bot != null && isHost))
@@ -813,6 +816,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager);
 					LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
 					LobbyUtils.SetupEditableReadyWidget(template, client, orderManager, map, MapIsPlayable);
+
+					// Assign TabIndex to focusable widgets in editable player slot
+					SetSlotWidgetTabIndex(template, idx);
 				}
 				else
 				{
@@ -841,6 +847,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 
 					LobbyUtils.SetupReadyWidget(template, client);
+
+					// Assign TabIndex to focusable widgets in non-editable player slot
+					SetSlotWidgetTabIndex(template, idx);
 				}
 
 				template.IsVisible = () => true;
@@ -923,6 +932,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				btn.IsVisible = () => orderManager.LobbyInfo.GlobalSettings.AllowSpectators
 					|| orderManager.LocalClient.IsAdmin;
 
+				// Spectate button comes after slots but before Change Map
+				btn.TabIndex = 100;
+
 				spec.IsVisible = () => true;
 
 				if (idx >= players.Children.Count)
@@ -937,6 +949,64 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				players.RemoveChild(players.Children[idx]);
 
 			tabCompletion.Names = orderManager.LobbyInfo.Clients.Where(c => !c.IsBot).Select(c => c.Name).Distinct().ToList();
+		}
+
+		// Assigns TabIndex to focusable widgets in a player slot template
+		// Each slot gets a base TabIndex calculated from its position (idx * 10)
+		// Widgets within the slot are ordered: SLOT_OPTIONS/NAME (0), COLOR (1), FACTION (2), TEAM (3), HANDICAP (4), SPAWN (5), STATUS (6), JOIN (7)
+		static void SetSlotWidgetTabIndex(Widget template, int slotIndex)
+		{
+			var baseTabIndex = slotIndex * 10;
+
+			// Slot options dropdown (for selecting Open/Closed/Bot type)
+			var slotOptions = template.GetOrNull("SLOT_OPTIONS");
+			if (slotOptions != null)
+				slotOptions.TabIndex = baseTabIndex;
+
+			// Name text field (for editable player name)
+			var name = template.GetOrNull("NAME");
+			if (name != null)
+				name.TabIndex = baseTabIndex;
+
+			// Player action dropdown (for host to kick/move players)
+			var playerAction = template.GetOrNull("PLAYER_ACTION");
+			if (playerAction != null)
+				playerAction.TabIndex = baseTabIndex;
+
+			// Color dropdown
+			var color = template.GetOrNull("COLOR");
+			if (color != null)
+				color.TabIndex = baseTabIndex + 1;
+
+			// Faction dropdown
+			var faction = template.GetOrNull("FACTION");
+			if (faction != null)
+				faction.TabIndex = baseTabIndex + 2;
+
+			// Team dropdown
+			var team = template.GetOrNull("TEAM_DROPDOWN");
+			if (team != null)
+				team.TabIndex = baseTabIndex + 3;
+
+			// Handicap dropdown
+			var handicap = template.GetOrNull("HANDICAP_DROPDOWN");
+			if (handicap != null)
+				handicap.TabIndex = baseTabIndex + 4;
+
+			// Spawn dropdown
+			var spawn = template.GetOrNull("SPAWN_DROPDOWN");
+			if (spawn != null)
+				spawn.TabIndex = baseTabIndex + 5;
+
+			// Ready checkbox
+			var status = template.GetOrNull("STATUS_CHECKBOX");
+			if (status != null)
+				status.TabIndex = baseTabIndex + 6;
+
+			// Join button (for empty slots)
+			var join = template.GetOrNull("JOIN");
+			if (join != null)
+				join.TabIndex = baseTabIndex + 7;
 		}
 
 		void UpdateDiscordStatus()

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -417,6 +417,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			tabScrollpanel.OnEscapeKey = () => { canceling(); return true; };
 
+			if (tab == MapClassification.User)
+			{
+				var deleteMapButton = widget.Get<ButtonWidget>("DELETE_MAP_BUTTON");
+				tabScrollpanel.OnDeleteKey = () =>
+				{
+					if (!deleteMapButton.IsDisabled())
+						deleteMapButton.OnClick();
+					return true;
+				};
+			}
+
 			// Update selected map when navigating with keyboard (UP/DOWN arrows)
 			tabScrollpanel.OnKeyboardFocusChanged = item =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -284,9 +284,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				modData.MapCache.QueryRemoteMapDetails(services.MapRepository, remoteMapPool);
 			}
 
-			SetupMapPanel(MapClassification.User, "USER_MAPS_TAB");
-			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB");
-			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB");
+			SetupMapPanel(MapClassification.User, "USER_MAPS_TAB", approving, canceling);
+			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB", approving, canceling);
+			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB", approving, canceling);
 
 			var hasGenerator = modData.DefaultRules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorMapGeneratorInfo>();
 			if (onSelectGenerated != null && hasGenerator)
@@ -397,12 +397,33 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		void SetupMapPanel(MapClassification tab, string tabContainerName)
+		void SetupMapPanel(MapClassification tab, string tabContainerName, Action approving, Action canceling)
 		{
 			var tabContainer = widget.Get<ContainerWidget>(tabContainerName);
 			tabContainer.IsVisible = () => currentTab == tab;
 			var tabScrollpanel = tabContainer.Get<ScrollPanelWidget>("MAP_LIST");
 			tabScrollpanel.Layout = new GridLayout(tabScrollpanel);
+
+			tabScrollpanel.OnEnterKey = () =>
+			{
+				if (onSelect != null && !(currentTab == MapClassification.Generated && generatedMapArgs == null))
+				{
+					approving();
+					return true;
+				}
+
+				return false;
+			};
+
+			tabScrollpanel.OnEscapeKey = () => { canceling(); return true; };
+
+			// Update selected map when navigating with keyboard (UP/DOWN arrows)
+			tabScrollpanel.OnKeyboardFocusChanged = item =>
+			{
+				if (item != null && item.ItemKey != null)
+					selectedUid = item.ItemKey;
+			};
+
 			scrollpanels.Add(tab, tabScrollpanel);
 
 			RefreshMaps(tab);
@@ -551,7 +572,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var item = ScrollItemWidget.Setup(preview.Uid, itemTemplate, () => selectedUid == preview.Uid,
 					() => selectedUid = preview.Uid, DblClick);
-				item.IsVisible = () => item.RenderBounds.IntersectsWith(scrollpanels[tab].RenderBounds);
+
+				// Use IsCulledForRendering instead of IsVisible for culling optimization.
+				// This allows keyboard navigation to items outside the visible area while
+				// still avoiding the rendering cost for off-screen items.
+				item.IsCulledForRendering = () => !item.RenderBounds.IntersectsWith(scrollpanels[tab].RenderBounds);
 
 				var titleLabel = item.Get<LabelWithTooltipWidget>("TITLE");
 				if (titleLabel != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -68,6 +68,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollItemWidget headerTemplate;
 		readonly ScrollItemWidget template;
 
+		// Map UIDs to their previews for keyboard navigation
+		readonly Dictionary<string, MapPreview> missionPreviews = [];
+
 		readonly Widget miniOptions;
 		readonly DropDownButtonWidget difficultyButton;
 		readonly DropDownButtonWidget gameSpeedButton;
@@ -93,6 +96,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.BeforeGameStart += OnGameStart;
 
 			missionList = widget.Get<ScrollPanelWidget>("MISSION_LIST");
+			missionList.OnEnterKey = () =>
+			{
+				if (selectedMap != null)
+				{
+					StartMissionClicked(onExit);
+					return true;
+				}
+
+				return false;
+			};
+			missionList.OnEscapeKey = () =>
+			{
+				StopVideo(videoPlayer);
+				Ui.CloseWindow();
+				onExit();
+				return true;
+			};
+
+			// Update preview when navigating with keyboard (UP/DOWN arrows)
+			missionList.OnKeyboardFocusChanged = item =>
+			{
+				if (item != null && item.ItemKey != null && missionPreviews.TryGetValue(item.ItemKey, out var preview))
+					SelectMap(preview);
+			};
 
 			headerTemplate = widget.Get<ScrollItemWidget>("HEADER");
 			template = widget.Get<ScrollItemWidget>("TEMPLATE");
@@ -104,7 +131,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				title.GetText = () => playingVideo != PlayingVideo.None ? selectedMap.Title : titleText;
 			}
 
-			widget.Get("MISSION_INFO").IsVisible = () => selectedMap != null;
+			widget.Get("MISSION_INFO").IsVisible = () => selectedMap != null && playingVideo == PlayingVideo.None;
 
 			var previewWidget = widget.Get<MapPreviewWidget>("MISSION_PREVIEW");
 			previewWidget.Preview = () => selectedMap;
@@ -115,6 +142,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			fullscreenVideoPlayer = Ui.LoadWidget<BackgroundWidget>("FULLSCREEN_PLAYER", Ui.Root, new WidgetArgs { { "world", world } });
 
 			missionDetail = widget.Get("MISSION_DETAIL");
+			missionList.IsVisible = () => playingVideo == PlayingVideo.None;
 
 			descriptionPanel = missionDetail.Get<ScrollPanelWidget>("MISSION_DESCRIPTION_PANEL");
 			descriptionPanel.IsVisible = () => panel == PanelType.MissionInfo;
@@ -128,19 +156,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdownRowTemplate = optionsContainer.Get("DROPDOWN_ROW_TEMPLATE");
 
 			startBriefingVideoButton = widget.Get<ButtonWidget>("START_BRIEFING_VIDEO_BUTTON");
+			startBriefingVideoButton.IsDisabled = () => playingVideo == PlayingVideo.Info;
 			stopBriefingVideoButton = widget.Get<ButtonWidget>("STOP_BRIEFING_VIDEO_BUTTON");
 			stopBriefingVideoButton.IsVisible = () => playingVideo == PlayingVideo.Briefing;
 			stopBriefingVideoButton.OnClick = () => StopVideo(videoPlayer);
 
 			startInfoVideoButton = widget.Get<ButtonWidget>("START_INFO_VIDEO_BUTTON");
+			startInfoVideoButton.IsDisabled = () => playingVideo == PlayingVideo.Briefing;
 			stopInfoVideoButton = widget.Get<ButtonWidget>("STOP_INFO_VIDEO_BUTTON");
+			stopInfoVideoButton.IsDisabled = () => playingVideo == PlayingVideo.Briefing;
 			stopInfoVideoButton.IsVisible = () => playingVideo == PlayingVideo.Info;
 			stopInfoVideoButton.OnClick = () => StopVideo(videoPlayer);
 
 			miniOptions = widget.GetOrNull("MISSION_MINIFIED_OPTIONS");
 			if (miniOptions != null)
 			{
-				miniOptions.IsVisible = () => minifiedOptions;
+				miniOptions.IsVisible = () => minifiedOptions && playingVideo == PlayingVideo.None;
 				difficultyButton = miniOptions.GetOrNull<DropDownButtonWidget>("DIFFICULTY");
 				gameSpeedButton = miniOptions.GetOrNull<DropDownButtonWidget>("GAMESPEED");
 				unsetDifficulty = FluentProvider.GetMessage(difficultyButton.Text);
@@ -226,7 +257,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var tabContainer = widget.Get("MISSION_TABS");
-			tabContainer.IsVisible = () => !minifiedOptions;
+			tabContainer.IsVisible = () => !minifiedOptions && playingVideo == PlayingVideo.None;
 
 			var optionsTab = tabContainer.Get<ButtonWidget>("OPTIONS_TAB");
 			optionsTab.IsHighlighted = () => panel == PanelType.Options;
@@ -260,13 +291,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void CreateMissionGroup(string title, IEnumerable<MapPreview> previews, Action onExit)
 		{
-			var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+			var header = ScrollItemWidget.SetupHeader(headerTemplate);
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			missionList.AddChild(header);
 
 			foreach (var preview in previews)
 			{
-				var item = ScrollItemWidget.Setup(template,
+				// Store the preview for keyboard navigation lookup
+				missionPreviews[preview.Uid] = preview;
+
+				var item = ScrollItemWidget.Setup(preview.Uid, template,
 					() => selectedMap != null && selectedMap.Uid == preview.Uid,
 					() => SelectMap(preview),
 					() => StartMissionClicked(onExit));

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -113,6 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollItemWidget playerTemplate, playerHeader;
 		readonly List<ReplayMetadata> replays = [];
 		readonly Dictionary<ReplayMetadata, ReplayState> replayState = [];
+		readonly Dictionary<string, ReplayMetadata> replayLookup = [];
 		readonly Action onStart;
 		readonly ModData modData;
 		readonly WebServices services;
@@ -138,9 +139,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
 			playerList.RemoveChildren();
 
-			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { cancelLoadingReplays = true; Ui.CloseWindow(); onExit(); };
+			var cancelAction = new Action(() => { cancelLoadingReplays = true; Ui.CloseWindow(); onExit(); });
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = cancelAction;
 
 			replayList = panel.Get<ScrollPanelWidget>("REPLAY_LIST");
+			replayList.OnEnterKey = () =>
+			{
+				if (selectedReplay != null && map.Status == MapStatus.Available)
+				{
+					WatchReplay();
+					return true;
+				}
+
+				return false;
+			};
+			replayList.OnEscapeKey = () => { cancelAction(); return true; };
+
+			replayList.OnKeyboardFocusChanged = item =>
+			{
+				if (item != null && item.ItemKey != null && replayLookup.TryGetValue(item.ItemKey, out var replay))
+					SelectReplay(replay);
+			};
+
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			var mod = modData.Manifest;
@@ -565,7 +585,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			try
 			{
 				var item = replayState[replay].Item;
+				var oldPath = replay.FilePath;
+
 				replay.RenameFile(newFilenameWithoutExtension);
+
+				// Update lookup with new file path
+				replayLookup.Remove(oldPath);
+				replayLookup[replay.FilePath] = replay;
+				item.ItemKey = replay.FilePath;
+
 				item.GetText = () => newFilenameWithoutExtension;
 
 				var label = item.Get<LabelWithTooltipWidget>("TITLE");
@@ -596,6 +624,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			replayList.RemoveChild(replayState[replay].Item);
 			replays.Remove(replay);
 			replayState.Remove(replay);
+			replayLookup.Remove(replay.FilePath);
 		}
 
 		static bool EvaluateReplayVisibility(ReplayMetadata replay)
@@ -739,7 +768,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var group = kv.Key;
 					if (group.Length > 0)
 					{
-						var header = ScrollItemWidget.Setup(playerHeader, () => false, () => { });
+						var header = ScrollItemWidget.SetupHeader(playerHeader);
 						header.Get<LabelWidget>("LABEL").GetText = () => group;
 						playerList.AddChild(header);
 					}
@@ -750,7 +779,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						var color = o.Color;
 
-						var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+						var item = ScrollItemWidget.SetupHeader(playerTemplate);
 
 						var label = item.Get<LabelWidget>("LABEL");
 						var font = Game.Renderer.Fonts[label.Font];
@@ -795,6 +824,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				() => selectedReplay == replay,
 				() => SelectReplay(replay),
 				WatchReplay);
+
+			item.ItemKey = replay.FilePath;
+			replayLookup[replay.FilePath] = replay;
 
 			replayState[replay] = new ReplayState
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -549,6 +549,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
+			replayList.OnDeleteKey = () =>
+			{
+				if (!deleteButton.IsDisabled())
+					deleteButton.OnClick();
+				return true;
+			};
+
 			var deleteAllButton = panel.Get<ButtonWidget>("MNG_DELALL_BUTTON");
 			deleteAllButton.IsDisabled = () => !replayState.Any(kvp => kvp.Value.Visible);
 			deleteAllButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly WebServices services;
 		readonly Probe lanGameProbe;
 
-		readonly Widget serverList;
+		readonly ScrollPanelWidget serverList;
 		readonly ScrollItemWidget serverTemplate;
 		readonly ScrollItemWidget headerTemplate;
 		readonly Widget noticeContainer;
@@ -190,6 +190,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			incompatibleGameStartedColor = ChromeMetrics.Get<Color>("IncompatibleGameStartedColor");
 
 			serverList = widget.Get<ScrollPanelWidget>("SERVER_LIST");
+			serverList.OnEnterKey = () =>
+			{
+				if (currentServer != null && currentServer.IsJoinable)
+				{
+					onJoin(currentServer);
+					return true;
+				}
+
+				return false;
+			};
+
 			headerTemplate = serverList.Get<ScrollItemWidget>("HEADER_TEMPLATE");
 			serverTemplate = serverList.Get<ScrollItemWidget>("SERVER_TEMPLATE");
 
@@ -600,7 +611,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var group = kv.Key;
 				if (group.Length > 0)
 				{
-					var header = ScrollItemWidget.Setup(clientHeader, () => false, () => { });
+					var header = ScrollItemWidget.SetupHeader(clientHeader);
 					header.Get<LabelWidget>("LABEL").GetText = () => group;
 					clientList.AddChild(header);
 				}
@@ -617,7 +628,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return WidgetUtils.TruncateText(name, s.Item2, s.Item3);
 					});
 
-					var item = ScrollItemWidget.Setup(clientTemplate, () => false, () => { });
+					var item = ScrollItemWidget.SetupHeader(clientTemplate);
 					if (!o.IsSpectator && server.Mod == modData.Manifest.Id)
 					{
 						var label = item.Get<LabelWidget>("LABEL");
@@ -699,7 +710,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (modGames.All(Filtered))
 					continue;
 
-				var header = ScrollItemWidget.Setup(headerTemplate, () => false, () => { });
+				var header = ScrollItemWidget.SetupHeader(headerTemplate);
 
 				var headerTitle = modGames.First().ModLabel;
 				header.Get<LabelWidget>("LABEL").GetText = () => headerTitle;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AdvancedSettingsLogic.cs
@@ -64,6 +64,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () => serverSettings.DiscoverNatDevices != originalServerSettings.DiscoverNatDevices;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -114,6 +114,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () =>
 			{
 				soundSettings.Device = soundDevice.Device;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -239,6 +239,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var origHeightText = windowHeight.Text = graphicSettings.WindowedSize.Y.ToString(NumberFormatInfo.CurrentInfo);
 			windowHeight.Text = graphicSettings.WindowedSize.Y.ToString(NumberFormatInfo.CurrentInfo);
 
+			windowWidth.OnEnterKey = _ => { windowWidth.YieldKeyboardFocus(); return true; };
+			windowHeight.OnEnterKey = _ => { windowHeight.YieldKeyboardFocus(); return true; };
+
 			var resolutionPresetDropdown = panel.GetOrNull<DropDownButtonWidget>("RESOLUTION_PRESET_DROPDOWN");
 			if (resolutionPresetDropdown != null)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -271,6 +271,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () =>
 			{
 				int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var x);

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
@@ -116,6 +116,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () =>
 			{
 				nameTextfield.YieldKeyboardFocus();

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -159,6 +159,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				InitHotkeyList();
 			}
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () =>
 			{
 				hotkeyEntryWidget.Key =

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -111,8 +111,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			hotkeyList.AddChild(key);
 		}
 
+		Widget hotkeyPanel;
+
 		Func<bool> InitPanel(Widget panel)
 		{
+			hotkeyPanel = panel;
 			hotkeyList = panel.Get<ScrollPanelWidget>("HOTKEY_LIST");
 			hotkeyList.Layout = new GridLayout(hotkeyList);
 			headerTemplate = hotkeyList.Get("HEADER");
@@ -158,9 +161,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				InitHotkeyRemapDialog(panel);
 				InitHotkeyList();
 			}
-
-			// Assign TabIndex to panel elements so they are navigated after menu tabs
-			SettingsUtils.AssignPanelTabIndexes(panel);
 
 			return () =>
 			{
@@ -229,6 +229,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			remapDialog.Visible = selectedHotkeyDefinition != null;
 
 			hotkeyList.ScrollToTop();
+
+			// Reassign TabIndexes after rebuilding the list so hotkey buttons are included in the correct order.
+			if (hotkeyPanel != null)
+				SettingsUtils.AssignPanelTabIndexes(hotkeyPanel);
 		}
 
 		void InitHotkeyRemapDialog(Widget panel)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -134,6 +134,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
+			// Assign TabIndex to panel elements so they are navigated after menu tabs
+			SettingsUtils.AssignPanelTabIndexes(panel);
+
 			return () => false;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -77,6 +77,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool needsRestart = false;
 
+		// TabIndex counter for menu buttons (starts at 0 so they are navigated first)
+		int menuTabIndex = 0;
+
 		[ObjectCreator.UseCtor]
 		public SettingsLogic(Widget widget, Action onExit, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs, ModData modData)
 		{
@@ -110,7 +113,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 			}
 
-			widget.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
+			var backButton = widget.Get<ButtonWidget>("BACK_BUTTON");
+			backButton.TabIndex = 201; // Navigated after Reset button
+			backButton.OnClick = () =>
 			{
 				needsRestart |= leavePanelActions[activePanel]();
 				Game.Settings.Save();
@@ -142,7 +147,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					CloseAndExit();
 			};
 
-			widget.Get<ButtonWidget>("RESET_BUTTON").OnClick = () =>
+			var resetButton = widget.Get<ButtonWidget>("RESET_BUTTON");
+			resetButton.TabIndex = 200; // Navigated after panel elements
+			resetButton.OnClick = () =>
 			{
 				void Reset()
 				{
@@ -189,6 +196,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Settings.Save();
 				activePanel = panelID;
 			};
+
+			// Assign sequential TabIndex to menu buttons (0, 1, 2, ...) so they are navigated first
+			tab.TabIndex = menuTabIndex++;
 
 			tabContainer.AddChild(tab);
 			buttons.Add(tab);

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var backButton = widget.Get<ButtonWidget>("BACK_BUTTON");
-			backButton.TabIndex = 201; // Navigated after Reset button
+			backButton.TabIndex = 10001; // Navigated after all panel elements and Reset button
 			backButton.OnClick = () =>
 			{
 				needsRestart |= leavePanelActions[activePanel]();
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var resetButton = widget.Get<ButtonWidget>("RESET_BUTTON");
-			resetButton.TabIndex = 200; // Navigated after panel elements
+			resetButton.TabIndex = 10000; // Navigated after all panel elements
 			resetButton.OnClick = () =>
 			{
 				void Reset()

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public static class SettingsUtils
 	{
-		// Starting TabIndex for settings panel elements (menu tabs use 0-9, bottom buttons use 200+)
+		// Starting TabIndex for settings panel elements (menu tabs use 0-9, bottom buttons use 10000+)
 		const int PanelElementsBaseTabIndex = 100;
 
 		// Assigns sequential TabIndex values to all focusable widgets in a panel
@@ -27,17 +27,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var focusableWidgets = new List<Widget>();
 			CollectFocusableWidgets(panel, focusableWidgets);
 
-			// Sort by visual position (top to bottom, left to right) to determine navigation order
-			focusableWidgets.Sort((a, b) =>
-			{
-				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
-				if (yCompare != 0)
-					return yCompare;
-
-				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
-			});
-
-			// Assign sequential TabIndex starting from PanelElementsBaseTabIndex
+			// Use DFS traversal order (= YAML declaration order), which is the correct logical
+			// document order. Sorting by screen/document coordinates is unreliable because
+			// items inside a ScrollPanel occupy coordinates that overlap with fixed widgets
+			// outside the panel (e.g. the remap dialog at the bottom).
 			for (var i = 0; i < focusableWidgets.Count; i++)
 				focusableWidgets[i].TabIndex = PanelElementsBaseTabIndex + i;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsUtils.cs
@@ -10,12 +10,49 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public static class SettingsUtils
 	{
+		// Starting TabIndex for settings panel elements (menu tabs use 0-9, bottom buttons use 200+)
+		const int PanelElementsBaseTabIndex = 100;
+
+		// Assigns sequential TabIndex values to all focusable widgets in a panel
+		// This ensures panel elements are navigated after menu tabs but before bottom buttons
+		public static void AssignPanelTabIndexes(Widget panel)
+		{
+			var focusableWidgets = new List<Widget>();
+			CollectFocusableWidgets(panel, focusableWidgets);
+
+			// Sort by visual position (top to bottom, left to right) to determine navigation order
+			focusableWidgets.Sort((a, b) =>
+			{
+				var yCompare = a.RenderBounds.Y.CompareTo(b.RenderBounds.Y);
+				if (yCompare != 0)
+					return yCompare;
+
+				return a.RenderBounds.X.CompareTo(b.RenderBounds.X);
+			});
+
+			// Assign sequential TabIndex starting from PanelElementsBaseTabIndex
+			for (var i = 0; i < focusableWidgets.Count; i++)
+				focusableWidgets[i].TabIndex = PanelElementsBaseTabIndex + i;
+		}
+
+		static void CollectFocusableWidgets(Widget parent, List<Widget> result)
+		{
+			foreach (var child in parent.Children)
+			{
+				if (child.IsFocusable)
+					result.Add(child);
+
+				CollectFocusableWidgets(child, result);
+			}
+		}
+
 		public static void BindCheckboxPref(Widget parent, string id, object group, string pref)
 		{
 			var field = group.GetType().GetField(pref);

--- a/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
@@ -22,6 +22,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly bool EnableChildMouseOver = false;
 		public string ItemKey;
 
+		/// <summary>
+		/// When true, this item is culled from rendering due to being outside the visible scroll area.
+		/// Unlike IsVisible, culled items should still be navigable via keyboard.
+		/// </summary>
+		public Func<bool> IsCulledForRendering = () => false;
+
 		readonly CachedTransform<(bool, bool, bool, bool, bool), Sprite[]> getPanelCache;
 
 		[ObjectCreator.UseCtor]
@@ -31,6 +37,9 @@ namespace OpenRA.Mods.Common.Widgets
 			IsVisible = () => false;
 			VisualHeight = 0;
 			getPanelCache = WidgetUtils.GetCachedStatefulPanelImages(Background);
+
+			// ScrollItemWidget is navigated via its parent ScrollPanelWidget (UP/DOWN keys), not TAB
+			IsFocusable = false;
 		}
 
 		protected ScrollItemWidget(ScrollItemWidget other)
@@ -41,7 +50,11 @@ namespace OpenRA.Mods.Common.Widgets
 			Key = other.Key;
 			Background = other.Background;
 			EnableChildMouseOver = other.EnableChildMouseOver;
+			IsCulledForRendering = other.IsCulledForRendering;
 			getPanelCache = WidgetUtils.GetCachedStatefulPanelImages(Background);
+
+			// ScrollItemWidget is navigated via its parent ScrollPanelWidget (UP/DOWN keys), not TAB
+			IsFocusable = false;
 		}
 
 		public override void Initialize(WidgetArgs args)
@@ -54,6 +67,29 @@ namespace OpenRA.Mods.Common.Widgets
 		}
 
 		public Func<bool> IsSelected = () => false;
+		public Func<bool> IsKeyboardFocused = () => false;
+		public Action OnKeyboardSelect;
+		public bool IsSelectable = true;
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Event == MouseInputEvent.Down && mi.Button == MouseButton.Left && Parent is ScrollPanelWidget scrollPanel)
+			{
+				scrollPanel.ClearKeyboardFocusedItem();
+				scrollPanel.TakeKeyboardFocus();
+			}
+
+			return base.HandleMouseInput(mi);
+		}
+
+		public override void DrawOuter()
+		{
+			// Skip rendering if culled (outside visible scroll area) but keep IsVisible for logical filtering
+			if (IsCulledForRendering())
+				return;
+
+			base.DrawOuter();
+		}
 
 		public override void Draw()
 		{
@@ -65,7 +101,9 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!IgnoreChildMouseOver && !hover)
 				hover = Children.Contains(Ui.MouseOverWidget);
 
-			WidgetUtils.DrawPanel(RenderBounds, getPanelCache.Update((IsDisabled(), Depressed, hover, false, IsSelected() || IsHighlighted())));
+			var parentHasKeyboardFocus = Parent is ScrollPanelWidget sp && sp.HasKeyboardFocusedItem;
+			var highlighted = IsKeyboardFocused() || (!parentHasKeyboardFocus && (IsSelected() || IsHighlighted()));
+			WidgetUtils.DrawPanel(RenderBounds, getPanelCache.Update((IsDisabled(), Depressed, hover, false, highlighted)));
 		}
 
 		public override ScrollItemWidget Clone() { return new ScrollItemWidget(this); }
@@ -76,6 +114,7 @@ namespace OpenRA.Mods.Common.Widgets
 			w.IsVisible = () => true;
 			w.IsSelected = isSelected;
 			w.OnClick = onClick;
+			w.OnKeyboardSelect = onClick;
 			return w;
 		}
 
@@ -91,6 +130,15 @@ namespace OpenRA.Mods.Common.Widgets
 			var w = Setup(template, isSelected, onClick);
 			w.OnDoubleClick = onDoubleClick;
 			w.ItemKey = key;
+			return w;
+		}
+
+		public static ScrollItemWidget SetupHeader(ScrollItemWidget template)
+		{
+			var w = template.Clone();
+			w.IsVisible = () => true;
+			w.IsSelected = () => false;
+			w.IsSelectable = false;
 			return w;
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -1,4 +1,4 @@
-#region Copyright & License Information
+﻿#region Copyright & License Information
 /*
  * Copyright (c) The OpenRA Developers and Contributors
  * This file is part of OpenRA, which is free software. It is made
@@ -459,6 +459,22 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (item != null)
 				ScrollToItem(item);
+		}
+
+		public void ScrollIntoView(Widget widget)
+		{
+			// Use screen-space RenderBounds to determine whether the widget is outside the visible area of this panel.
+			var widgetTop = widget.RenderBounds.Top - RenderBounds.Top;
+			var widgetBottom = widget.RenderBounds.Bottom - RenderBounds.Top;
+
+			float? newOffset = null;
+			if (widgetTop < 0)
+				newOffset = currentListOffset - widgetTop + ItemSpacing;
+			else if (widgetBottom > RenderBounds.Height)
+				newOffset = currentListOffset - widgetBottom + RenderBounds.Height - ItemSpacing;
+
+			if (newOffset.HasValue)
+				SetListOffset(newOffset.Value, false);
 		}
 
 		void UpdateSmoothScrolling()

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets
 		Hidden
 	}
 
-	public class ScrollPanelWidget : Widget
+	public class ScrollPanelWidget : Widget, IKeyboardScrollable
 	{
 		readonly Ruleset modRules;
 		public int ScrollbarWidth = 24;
@@ -295,9 +295,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var rb = RenderBounds;
 
-			// Draw TAB focus indicator when this scroll panel has TAB focus
-			if (HasTabFocus)
-				DrawTabFocusIndicator(rb);
 			var scrollbarHeight = rb.Height - 2 * ScrollbarWidth;
 
 			// Scroll thumb is only visible if the content does not fit within the panel bounds
@@ -376,30 +373,6 @@ namespace OpenRA.Mods.Common.Widgets
 			Game.Renderer.DisableScissor();
 		}
 
-		// Draws a visual indicator around the scroll panel when it has TAB focus
-		static void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
-		}
-
 		public override int2 ChildOrigin => RenderOrigin + new int2(ScrollBar == ScrollBar.Left ? ScrollbarWidth : 0, (int)currentListOffset);
 
 		public override bool EventBoundsContains(int2 location)
@@ -430,6 +403,30 @@ namespace OpenRA.Mods.Common.Widgets
 				Math.Max(0, Bounds.Height - ContentHeight);
 
 			SetListOffset(value, smooth);
+		}
+
+		public bool HandleScrollKeyPress(KeyInput e)
+		{
+			if (e.Event != KeyInputEvent.Down)
+				return false;
+
+			switch (e.Key)
+			{
+				case Keycode.PAGEUP:
+					Scroll(1);
+					return true;
+				case Keycode.PAGEDOWN:
+					Scroll(-1);
+					return true;
+				case Keycode.HOME:
+					ScrollToTop(true);
+					return true;
+				case Keycode.END:
+					ScrollToBottom(true);
+					return true;
+			}
+
+			return false;
 		}
 
 		public bool ScrolledToBottom => targetListOffset == Math.Min(0, Bounds.Height - ContentHeight) || ContentHeight <= Bounds.Height;
@@ -751,14 +748,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var newFocusWidget = focusableWidgets[newIndex];
 
 			// Transfer TAB focus
-			if (Ui.TabFocusWidget != null)
-			{
-				Ui.TabFocusWidget.HasTabFocus = false;
-				Ui.TabFocusWidget.OnTabFocusLost();
-			}
-
+			var oldFocusWidget = Ui.TabFocusWidget;
 			Ui.TabFocusWidget = newFocusWidget;
-			newFocusWidget.HasTabFocus = true;
+
+			oldFocusWidget?.OnTabFocusLost();
+
 			newFocusWidget.OnTabFocusGained();
 
 			return true;
@@ -900,14 +894,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var newFocusWidget = focusableWidgets[newIndex];
 
-			if (Ui.TabFocusWidget != null)
-			{
-				Ui.TabFocusWidget.HasTabFocus = false;
-				Ui.TabFocusWidget.OnTabFocusLost();
-			}
-
+			var oldFocusWidget = Ui.TabFocusWidget;
 			Ui.TabFocusWidget = newFocusWidget;
-			newFocusWidget.HasTabFocus = true;
+
+			oldFocusWidget?.OnTabFocusLost();
+
 			newFocusWidget.OnTabFocusGained();
 
 			return true;
@@ -921,14 +912,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var newFocusWidget = focusableWidgets[0];
 
-			if (Ui.TabFocusWidget != null)
-			{
-				Ui.TabFocusWidget.HasTabFocus = false;
-				Ui.TabFocusWidget.OnTabFocusLost();
-			}
-
+			var oldFocusWidget = Ui.TabFocusWidget;
 			Ui.TabFocusWidget = newFocusWidget;
-			newFocusWidget.HasTabFocus = true;
+
+			oldFocusWidget?.OnTabFocusLost();
+
 			newFocusWidget.OnTabFocusGained();
 
 			return true;
@@ -942,14 +930,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var newFocusWidget = focusableWidgets[^1];
 
-			if (Ui.TabFocusWidget != null)
-			{
-				Ui.TabFocusWidget.HasTabFocus = false;
-				Ui.TabFocusWidget.OnTabFocusLost();
-			}
-
+			var oldFocusWidget = Ui.TabFocusWidget;
 			Ui.TabFocusWidget = newFocusWidget;
-			newFocusWidget.HasTabFocus = true;
+
+			oldFocusWidget?.OnTabFocusLost();
+
 			newFocusWidget.OnTabFocusGained();
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -51,6 +51,9 @@ namespace OpenRA.Mods.Common.Widgets
 		// Called when Escape is pressed. Return true if the key was handled.
 		public Func<bool> OnEscapeKey;
 
+		// Called when Delete is pressed. Return true if the key was handled.
+		public Func<bool> OnDeleteKey;
+
 		// Called when the keyboard-focused item changes (e.g., via UP/DOWN arrow keys).
 		// The parameter is the newly focused item, or null if focus is cleared.
 		public Action<ScrollItemWidget> OnKeyboardFocusChanged;
@@ -622,6 +625,11 @@ namespace OpenRA.Mods.Common.Widgets
 						return OnEscapeKey();
 					return false;
 
+				case Keycode.DELETE:
+					if (OnDeleteKey != null)
+						return OnDeleteKey();
+					return false;
+
 				default:
 					return false;
 			}
@@ -666,6 +674,11 @@ namespace OpenRA.Mods.Common.Widgets
 						return OnEscapeKey();
 					return false;
 
+				case Keycode.DELETE:
+					if (OnDeleteKey != null)
+						return OnDeleteKey();
+					return false;
+
 				default:
 					return false;
 			}
@@ -703,6 +716,11 @@ namespace OpenRA.Mods.Common.Widgets
 				case Keycode.ESCAPE:
 					if (OnEscapeKey != null)
 						return OnEscapeKey();
+					return false;
+
+				case Keycode.DELETE:
+					if (OnDeleteKey != null)
+						return OnDeleteKey();
 					return false;
 
 				default:

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
@@ -39,6 +40,20 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		readonly Ruleset modRules;
 		public int ScrollbarWidth = 24;
+
+		ScrollItemWidget keyboardFocusedItem;
+		public bool HasKeyboardFocusedItem => keyboardFocusedItem != null;
+
+		// Called when Enter or Space is pressed. Return true if the key was handled.
+		// If null or returns false, the focused item's OnClick will be invoked.
+		public Func<bool> OnEnterKey;
+
+		// Called when Escape is pressed. Return true if the key was handled.
+		public Func<bool> OnEscapeKey;
+
+		// Called when the keyboard-focused item changes (e.g., via UP/DOWN arrow keys).
+		// The parameter is the newly focused item, or null if focus is cleared.
+		public Action<ScrollItemWidget> OnKeyboardFocusChanged;
 		public int BorderWidth = 1;
 		public int TopBottomSpacing = 2;
 		public int ItemSpacing = 0;
@@ -115,6 +130,130 @@ namespace OpenRA.Mods.Common.Widgets
 
 			getUpArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollUp);
 			getDownArrowImage = WidgetUtils.GetCachedStatefulImage(Decorations, DecorationScrollDown);
+
+			// ScrollPanelWidget can be focusable by TAB when it contains selectable items.
+			// When it receives TAB focus, it takes KeyboardFocus and allows arrow-key navigation of items.
+			IsFocusable = true;
+		}
+
+		// Override to check if this panel has content before allowing TAB focus
+		public override bool IsTabNavigable()
+		{
+			if (!base.IsTabNavigable())
+				return false;
+
+			// Allow TAB focus if there are selectable items in the list
+			if (GetSelectableItems().Count > 0)
+				return true;
+
+			// Also allow TAB focus if there's scrollable content (like Credits)
+			// This enables keyboard scrolling with PAGE UP/DOWN, HOME, END
+			if (ContentHeight > Bounds.Height)
+				return true;
+
+			// Also allow TAB focus if there are focusable widgets (like checkboxes in Options)
+			if (GetFocusableWidgets().Count > 0)
+				return true;
+
+			return false;
+		}
+
+		public override bool TakeKeyboardFocus()
+		{
+			if (!base.TakeKeyboardFocus())
+				return false;
+
+			// Initialize keyboard focus to the currently selected item (if any)
+			// so that pressing ENTER/SPACE immediately confirms the current selection.
+			InitializeKeyboardFocusToSelectedItem();
+			return true;
+		}
+
+		// Called when this panel gains TAB focus
+		public override void OnTabFocusGained()
+		{
+			base.OnTabFocusGained();
+
+			// Take KeyboardFocus to enable arrow-key navigation
+			TakeKeyboardFocus();
+
+			// Initialize focus to the first selectable item if none is selected
+			if (keyboardFocusedItem == null)
+			{
+				var selectableItems = GetSelectableItems();
+				if (selectableItems.Count > 0)
+					SetKeyboardFocus(selectableItems[0]);
+			}
+		}
+
+		// Called when this panel loses TAB focus
+		public override void OnTabFocusLost()
+		{
+			base.OnTabFocusLost();
+
+			// Clear keyboard focus when losing TAB focus
+			ClearKeyboardFocusedItem();
+		}
+
+		// Handle ENTER/SPACE activation when this panel has TAB focus
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			// Activate the currently keyboard-focused item
+			return ActivateFocusedItem();
+		}
+
+		// Handle arrow keys when this panel has TAB focus
+		public override bool OnTabFocusKeyPress(KeyInput e)
+		{
+			if (e.Event != KeyInputEvent.Down)
+				return false;
+
+			// Check what kind of content we have
+			var selectableItems = GetSelectableItems();
+			var hasScrollItems = selectableItems.Count > 0;
+
+			// If we have ScrollItemWidgets, use item-based navigation
+			if (hasScrollItems)
+			{
+				switch (e.Key)
+				{
+					case Keycode.UP:
+						return FocusAdjacentItem(forward: false);
+
+					case Keycode.DOWN:
+						return FocusAdjacentItem(forward: true);
+
+					case Keycode.PAGEUP:
+						return FocusItemByPage(forward: false);
+
+					case Keycode.PAGEDOWN:
+						return FocusItemByPage(forward: true);
+
+					case Keycode.HOME:
+						return FocusFirstItem();
+
+					case Keycode.END:
+						return FocusLastItem();
+				}
+
+				return false;
+			}
+
+			// Check for focusable widgets (like checkboxes in Options)
+			var focusableWidgets = GetFocusableWidgets();
+			if (focusableWidgets.Count > 0)
+				return HandleFocusableWidgetKeyPress(e);
+
+			// No items and no focusable widgets - use pure scroll navigation (like Credits)
+			return HandlePureScrollKeyPress(e);
+		}
+
+		void InitializeKeyboardFocusToSelectedItem()
+		{
+			var selectableItems = GetSelectableItems();
+			var selectedItem = selectableItems.Find(item => item.IsSelected());
+			if (selectedItem != null)
+				SetKeyboardFocus(selectedItem);
 		}
 
 		public override void RemoveChildren()
@@ -155,6 +294,10 @@ namespace OpenRA.Mods.Common.Widgets
 			UpdateSmoothScrolling();
 
 			var rb = RenderBounds;
+
+			// Draw TAB focus indicator when this scroll panel has TAB focus
+			if (HasTabFocus)
+				DrawTabFocusIndicator(rb);
 			var scrollbarHeight = rb.Height - 2 * ScrollbarWidth;
 
 			// Scroll thumb is only visible if the content does not fit within the panel bounds
@@ -231,6 +374,30 @@ namespace OpenRA.Mods.Common.Widgets
 					child.DrawOuter();
 
 			Game.Renderer.DisableScissor();
+		}
+
+		// Draws a visual indicator around the scroll panel when it has TAB focus
+		static void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		public override int2 ChildOrigin => RenderOrigin + new int2(ScrollBar == ScrollBar.Left ? ScrollbarWidth : 0, (int)currentListOffset);
@@ -389,6 +556,444 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			return upPressed || downPressed || thumbPressed;
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (e.Event != KeyInputEvent.Down)
+				return false;
+
+			// Check if we have ScrollItemWidget children for standard navigation
+			var selectableItems = GetSelectableItems();
+			var hasScrollItems = selectableItems.Count > 0;
+
+			// If no ScrollItemWidget children, use focusable widget navigation instead
+			if (!hasScrollItems)
+				return HandleFocusableWidgetKeyPress(e);
+
+			switch (e.Key)
+			{
+				case Keycode.UP:
+					if (e.Modifiers.HasFlag(Modifiers.Meta) && Platform.CurrentPlatform == PlatformType.OSX)
+						return FocusFirstItem();
+					else
+						return FocusAdjacentItem(forward: false);
+
+				case Keycode.DOWN:
+					if (e.Modifiers.HasFlag(Modifiers.Meta) && Platform.CurrentPlatform == PlatformType.OSX)
+						return FocusLastItem();
+					else
+						return FocusAdjacentItem(forward: true);
+
+				case Keycode.PAGEUP:
+					return FocusItemByPage(forward: false);
+
+				case Keycode.PAGEDOWN:
+					return FocusItemByPage(forward: true);
+
+				case Keycode.HOME:
+					return FocusFirstItem();
+
+				case Keycode.END:
+					return FocusLastItem();
+
+				case Keycode.RETURN:
+				case Keycode.KP_ENTER:
+				case Keycode.SPACE:
+					if (OnEnterKey != null && OnEnterKey())
+						return true;
+					return ActivateFocusedItem();
+
+				case Keycode.ESCAPE:
+					if (OnEscapeKey != null)
+						return OnEscapeKey();
+					return false;
+
+				default:
+					return false;
+			}
+		}
+
+		// Handle keyboard navigation for panels with focusable widgets (like checkboxes) instead of ScrollItemWidgets
+		bool HandleFocusableWidgetKeyPress(KeyInput e)
+		{
+			var focusableWidgets = GetFocusableWidgets();
+
+			// If no focusable widgets, use pure scroll navigation (for panels like Credits)
+			if (focusableWidgets.Count == 0)
+				return HandlePureScrollKeyPress(e);
+
+			switch (e.Key)
+			{
+				case Keycode.UP:
+					return FocusAdjacentFocusableWidget(forward: false);
+
+				case Keycode.DOWN:
+					return FocusAdjacentFocusableWidget(forward: true);
+
+				case Keycode.PAGEUP:
+					return FocusFocusableWidgetByPage(forward: false);
+
+				case Keycode.PAGEDOWN:
+					return FocusFocusableWidgetByPage(forward: true);
+
+				case Keycode.HOME:
+					return FocusFirstFocusableWidget();
+
+				case Keycode.END:
+					return FocusLastFocusableWidget();
+
+				case Keycode.RETURN:
+				case Keycode.KP_ENTER:
+				case Keycode.SPACE:
+					return ActivateFocusedFocusableWidget();
+
+				case Keycode.ESCAPE:
+					if (OnEscapeKey != null)
+						return OnEscapeKey();
+					return false;
+
+				default:
+					return false;
+			}
+		}
+
+		// Handle keyboard scrolling for panels with no selectable items (like Credits)
+		bool HandlePureScrollKeyPress(KeyInput e)
+		{
+			switch (e.Key)
+			{
+				case Keycode.UP:
+					Scroll(1, true);
+					return true;
+
+				case Keycode.DOWN:
+					Scroll(-1, true);
+					return true;
+
+				case Keycode.PAGEUP:
+					ScrollByPixels(Bounds.Height);
+					return true;
+
+				case Keycode.PAGEDOWN:
+					ScrollByPixels(-Bounds.Height);
+					return true;
+
+				case Keycode.HOME:
+					ScrollToTop(true);
+					return true;
+
+				case Keycode.END:
+					ScrollToBottom(true);
+					return true;
+
+				case Keycode.ESCAPE:
+					if (OnEscapeKey != null)
+						return OnEscapeKey();
+					return false;
+
+				default:
+					return false;
+			}
+		}
+
+		void ScrollByPixels(int pixels)
+		{
+			var newTarget = targetListOffset + pixels;
+			newTarget = Math.Min(0, Math.Max(Bounds.Height - ContentHeight, newTarget));
+			SetListOffset(newTarget, true);
+		}
+
+		// Get all focusable widgets in this panel (for panels without ScrollItemWidgets)
+		List<Widget> GetFocusableWidgets()
+		{
+			var widgets = new List<Widget>();
+			CollectFocusableWidgets(this, widgets);
+			return widgets;
+		}
+
+		static void CollectFocusableWidgets(Widget parent, List<Widget> result)
+		{
+			foreach (var child in parent.Children)
+			{
+				if (child.IsVisible() && child.IsFocusable)
+					result.Add(child);
+
+				CollectFocusableWidgets(child, result);
+			}
+		}
+
+		bool FocusAdjacentFocusableWidget(bool forward)
+		{
+			var focusableWidgets = GetFocusableWidgets();
+			if (focusableWidgets.Count == 0)
+				return false;
+
+			// Find the currently focused widget
+			var currentIndex = Ui.TabFocusWidget != null
+				? focusableWidgets.IndexOf(Ui.TabFocusWidget)
+				: -1;
+
+			int newIndex;
+			if (currentIndex == -1)
+				newIndex = forward ? 0 : focusableWidgets.Count - 1;
+			else
+			{
+				newIndex = forward ? currentIndex + 1 : currentIndex - 1;
+
+				// Wrap around
+				if (newIndex < 0)
+					newIndex = focusableWidgets.Count - 1;
+				else if (newIndex >= focusableWidgets.Count)
+					newIndex = 0;
+			}
+
+			var newFocusWidget = focusableWidgets[newIndex];
+
+			// Transfer TAB focus
+			if (Ui.TabFocusWidget != null)
+			{
+				Ui.TabFocusWidget.HasTabFocus = false;
+				Ui.TabFocusWidget.OnTabFocusLost();
+			}
+
+			Ui.TabFocusWidget = newFocusWidget;
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+
+			return true;
+		}
+
+		bool ActivateFocusedFocusableWidget()
+		{
+			if (Ui.TabFocusWidget == null)
+				return false;
+
+			// Check if the focused widget is within this panel
+			var focusableWidgets = GetFocusableWidgets();
+			if (!focusableWidgets.Contains(Ui.TabFocusWidget))
+				return false;
+
+			// Activate the widget using its OnTabFocusActivate
+			var dummyInput = new KeyInput { Key = Keycode.RETURN, Event = KeyInputEvent.Down };
+			return Ui.TabFocusWidget.OnTabFocusActivate(dummyInput);
+		}
+
+		bool ActivateFocusedItem()
+		{
+			if (keyboardFocusedItem == null)
+				return false;
+
+			// Prefer OnKeyboardSelect if defined, otherwise fall back to OnClick.
+			if (keyboardFocusedItem.OnKeyboardSelect != null)
+				keyboardFocusedItem.OnKeyboardSelect();
+			else
+				keyboardFocusedItem.OnClick?.Invoke();
+
+			return true;
+		}
+
+		bool FocusAdjacentItem(bool forward)
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			var currentIndex = keyboardFocusedItem != null
+				? selectableItems.IndexOf(keyboardFocusedItem)
+				: selectableItems.FindIndex(item => item.IsSelected());
+
+			int newIndex;
+			if (currentIndex == -1)
+				newIndex = forward ? 0 : selectableItems.Count - 1;
+			else
+			{
+				newIndex = forward ? currentIndex + 1 : currentIndex - 1;
+
+				if (newIndex < 0 || newIndex >= selectableItems.Count)
+					return true;
+			}
+
+			SetKeyboardFocus(selectableItems[newIndex]);
+			ScrollToItem(selectableItems[newIndex]);
+
+			return true;
+		}
+
+		bool FocusFirstItem()
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			SetKeyboardFocus(selectableItems[0]);
+			ScrollToItem(selectableItems[0]);
+
+			return true;
+		}
+
+		bool FocusLastItem()
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			SetKeyboardFocus(selectableItems[^1]);
+			ScrollToItem(selectableItems[^1]);
+
+			return true;
+		}
+
+		bool FocusItemByPage(bool forward)
+		{
+			var selectableItems = GetSelectableItems();
+			if (selectableItems.Count == 0)
+				return false;
+
+			var currentIndex = keyboardFocusedItem != null
+				? selectableItems.IndexOf(keyboardFocusedItem)
+				: selectableItems.FindIndex(item => item.IsSelected());
+
+			if (currentIndex == -1)
+				currentIndex = forward ? 0 : selectableItems.Count - 1;
+
+			// Calculate how many items fit in the visible area
+			var itemHeight = selectableItems[0].Bounds.Height + ItemSpacing;
+			var itemsPerPage = itemHeight > 0 ? Math.Max(1, Bounds.Height / itemHeight) : 1;
+
+			var newIndex = forward
+				? Math.Min(currentIndex + itemsPerPage, selectableItems.Count - 1)
+				: Math.Max(currentIndex - itemsPerPage, 0);
+
+			if (newIndex == currentIndex)
+				return true;
+
+			SetKeyboardFocus(selectableItems[newIndex]);
+			ScrollToItem(selectableItems[newIndex]);
+
+			return true;
+		}
+
+		bool FocusFocusableWidgetByPage(bool forward)
+		{
+			var focusableWidgets = GetFocusableWidgets();
+			if (focusableWidgets.Count == 0)
+				return false;
+
+			var currentIndex = Ui.TabFocusWidget != null
+				? focusableWidgets.IndexOf(Ui.TabFocusWidget)
+				: -1;
+
+			if (currentIndex == -1)
+				currentIndex = forward ? 0 : focusableWidgets.Count - 1;
+
+			// Estimate items per page based on first widget height
+			var itemHeight = focusableWidgets[0].Bounds.Height + ItemSpacing;
+			var itemsPerPage = itemHeight > 0 ? Math.Max(1, Bounds.Height / itemHeight) : 1;
+
+			var newIndex = forward
+				? Math.Min(currentIndex + itemsPerPage, focusableWidgets.Count - 1)
+				: Math.Max(currentIndex - itemsPerPage, 0);
+
+			if (newIndex == currentIndex)
+				return true;
+
+			var newFocusWidget = focusableWidgets[newIndex];
+
+			if (Ui.TabFocusWidget != null)
+			{
+				Ui.TabFocusWidget.HasTabFocus = false;
+				Ui.TabFocusWidget.OnTabFocusLost();
+			}
+
+			Ui.TabFocusWidget = newFocusWidget;
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+
+			return true;
+		}
+
+		bool FocusFirstFocusableWidget()
+		{
+			var focusableWidgets = GetFocusableWidgets();
+			if (focusableWidgets.Count == 0)
+				return false;
+
+			var newFocusWidget = focusableWidgets[0];
+
+			if (Ui.TabFocusWidget != null)
+			{
+				Ui.TabFocusWidget.HasTabFocus = false;
+				Ui.TabFocusWidget.OnTabFocusLost();
+			}
+
+			Ui.TabFocusWidget = newFocusWidget;
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+
+			return true;
+		}
+
+		bool FocusLastFocusableWidget()
+		{
+			var focusableWidgets = GetFocusableWidgets();
+			if (focusableWidgets.Count == 0)
+				return false;
+
+			var newFocusWidget = focusableWidgets[^1];
+
+			if (Ui.TabFocusWidget != null)
+			{
+				Ui.TabFocusWidget.HasTabFocus = false;
+				Ui.TabFocusWidget.OnTabFocusLost();
+			}
+
+			Ui.TabFocusWidget = newFocusWidget;
+			newFocusWidget.HasTabFocus = true;
+			newFocusWidget.OnTabFocusGained();
+
+			return true;
+		}
+
+		void SetKeyboardFocus(ScrollItemWidget item)
+		{
+			if (keyboardFocusedItem == item)
+				return;
+
+			if (keyboardFocusedItem != null)
+				keyboardFocusedItem.IsKeyboardFocused = () => false;
+
+			keyboardFocusedItem = item;
+
+			if (keyboardFocusedItem != null)
+				keyboardFocusedItem.IsKeyboardFocused = () => true;
+
+			// Notify listeners that the keyboard focus has changed
+			OnKeyboardFocusChanged?.Invoke(item);
+		}
+
+		// Called when an item is clicked with the mouse to clear keyboard navigation state.
+		// This allows the visual highlight to fall back to the selected item.
+		public void ClearKeyboardFocusedItem()
+		{
+			SetKeyboardFocus(null);
+		}
+
+		List<ScrollItemWidget> GetSelectableItems()
+		{
+			var items = new List<ScrollItemWidget>();
+
+			foreach (var child in Children)
+			{
+				// Filter by IsVisible() for logical visibility (e.g. filtered items in AssetBrowser).
+				// Note: Items using IsCulledForRendering for geometric culling are still included
+				// because IsVisible() remains true for them - they are just not rendered when outside
+				// the visible scroll area but should still be navigable via keyboard.
+				if (child is ScrollItemWidget scrollItem && scrollItem.IsVisible() && scrollItem.IsSelectable)
+					items.Add(scrollItem);
+			}
+
+			return items;
 		}
 
 		IObservableCollection collection;

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -85,6 +85,53 @@ namespace OpenRA.Mods.Common.Widgets
 			return ThumbRect.Contains(mi.Location);
 		}
 
+		// TAB focus activation: sliders use arrow keys instead of ENTER/SPACE
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			// Sliders don't activate with ENTER/SPACE, they use arrow keys
+			return false;
+		}
+
+		// Handle arrow keys when this slider has TAB focus
+		public override bool OnTabFocusKeyPress(KeyInput e)
+		{
+			if (IsDisabled())
+				return false;
+
+			// Use pixel-based stepping for consistent behavior with both linear and exponential sliders
+			// Calculate step in pixels (use ticks if defined, otherwise divide track into 10 steps)
+			var trackWidth = RenderBounds.Width - RenderBounds.Height;
+			var pixelStep = Ticks > 1
+				? trackWidth / (Ticks - 1)
+				: trackWidth / 10;
+
+			// Get current position in pixels
+			var currentPx = PxFromValue(Value);
+
+			switch (e.Key)
+			{
+				case Keycode.LEFT:
+				case Keycode.DOWN:
+					UpdateValue(ValueFromPx(currentPx - pixelStep));
+					return true;
+
+				case Keycode.RIGHT:
+				case Keycode.UP:
+					UpdateValue(ValueFromPx(currentPx + pixelStep));
+					return true;
+
+				case Keycode.HOME:
+					UpdateValue(MinimumValue);
+					return true;
+
+				case Keycode.END:
+					UpdateValue(MaximumValue);
+					return true;
+			}
+
+			return false;
+		}
+
 		protected virtual float ValueFromPx(int x)
 		{
 			return MinimumValue + (MaximumValue - MinimumValue) * (x - 0.5f * RenderBounds.Height) / (RenderBounds.Width - RenderBounds.Height);
@@ -123,6 +170,10 @@ namespace OpenRA.Mods.Common.Widgets
 			var trackOrigin = rb.X + rb.Height / 2;
 			var trackRect = new Rectangle(trackOrigin - 1, rb.Y + (rb.Height - TrackHeight) / 2, trackWidth + 2, TrackHeight);
 
+			// Draw TAB focus indicator when this slider has TAB focus
+			if (HasTabFocus && !IsDisabled())
+				DrawTabFocusIndicator(rb);
+
 			// Tickmarks
 			var tick = ChromeProvider.GetImage("slider", "tick");
 			for (var i = 0; i < Ticks; i++)
@@ -139,7 +190,32 @@ namespace OpenRA.Mods.Common.Widgets
 
 			// Thumb
 			var thumbHover = Ui.MouseOverWidget == this && tr.Contains(Viewport.LastMousePos);
-			ButtonWidget.DrawBackground(Thumb, tr, IsDisabled(), isMoving, thumbHover, false);
+			ButtonWidget.DrawBackground(Thumb, tr, IsDisabled(), isMoving, thumbHover || HasTabFocus, false);
+		}
+
+		// Draws a visual indicator around the slider when it has TAB focus
+		static void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			// Draw a border around the slider
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -170,10 +170,6 @@ namespace OpenRA.Mods.Common.Widgets
 			var trackOrigin = rb.X + rb.Height / 2;
 			var trackRect = new Rectangle(trackOrigin - 1, rb.Y + (rb.Height - TrackHeight) / 2, trackWidth + 2, TrackHeight);
 
-			// Draw TAB focus indicator when this slider has TAB focus
-			if (HasTabFocus && !IsDisabled())
-				DrawTabFocusIndicator(rb);
-
 			// Tickmarks
 			var tick = ChromeProvider.GetImage("slider", "tick");
 			for (var i = 0; i < Ticks; i++)
@@ -191,31 +187,6 @@ namespace OpenRA.Mods.Common.Widgets
 			// Thumb
 			var thumbHover = Ui.MouseOverWidget == this && tr.Contains(Viewport.LastMousePos);
 			ButtonWidget.DrawBackground(Thumb, tr, IsDisabled(), isMoving, thumbHover || HasTabFocus, false);
-		}
-
-		// Draws a visual indicator around the slider when it has TAB focus
-		static void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			// Draw a border around the slider
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -247,7 +247,10 @@ namespace OpenRA.Mods.Common.Widgets
 				case Keycode.TAB:
 					if (OnTabKey(e))
 						return true;
-					break;
+
+					// Release keyboard focus so the global TAB navigation can handle this key.
+					YieldKeyboardFocus();
+					return false;
 
 				case Keycode.ESCAPE:
 					ClearSelection();

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -75,7 +75,11 @@ namespace OpenRA.Mods.Common.Widgets
 		protected int selectionEndIndex = -1;
 		protected bool mouseSelectionActive = false;
 
-		public TextFieldWidget() { }
+		public TextFieldWidget()
+		{
+			// TextFieldWidget can be TAB focused; pressing ENTER/SPACE takes keyboard focus for text input
+			IsFocusable = true;
+		}
 
 		protected TextFieldWidget(TextFieldWidget widget)
 			: base(widget)
@@ -91,6 +95,20 @@ namespace OpenRA.Mods.Common.Widgets
 			TextColorInvalid = widget.TextColorInvalid;
 			TextColorHighlight = widget.TextColorHighlight;
 			VisualHeight = widget.VisualHeight;
+
+			// TextFieldWidget can be TAB focused; pressing ENTER/SPACE takes keyboard focus for text input
+			IsFocusable = true;
+		}
+
+		// When TAB focus is activated (ENTER/SPACE), take keyboard focus for text input
+		public override bool OnTabFocusActivate(KeyInput e)
+		{
+			if (IsDisabled())
+				return false;
+
+			TakeKeyboardFocus();
+			ResetBlinkCycle();
+			return true;
 		}
 
 		public override bool YieldKeyboardFocus()
@@ -572,6 +590,11 @@ namespace OpenRA.Mods.Common.Widgets
 			WidgetUtils.DrawPanel(state,
 				new Rectangle(pos.X, pos.Y, Bounds.Width, Bounds.Height));
 
+			// Draw TAB focus indicator when this text field has TAB focus but not keyboard focus
+			// (keyboard focus shows the blinking cursor instead)
+			if (HasTabFocus && !HasKeyboardFocus)
+				DrawTabFocusIndicator(new Rectangle(pos.X, pos.Y, Bounds.Width, Bounds.Height));
+
 			// Inset text by the margin and center vertically
 			var verticalMargin = (Bounds.Height - textSize.Y) / 2 - VisualHeight;
 			var textPos = pos + new int2(LeftMargin, verticalMargin);
@@ -610,6 +633,30 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (isTextOverflowing)
 				Game.Renderer.DisableScissor();
+		}
+
+		// Draws a visual indicator around the text field when it has TAB focus
+		static void DrawTabFocusIndicator(Rectangle rect)
+		{
+			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
+				focusColor = Color.FromArgb(128, 255, 255, 255);
+
+			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
+				focusWidth = 2;
+
+			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
+
+			// Top border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
+
+			// Bottom border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
+
+			// Left border
+			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
+
+			// Right border
+			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		public override TextFieldWidget Clone() { return new TextFieldWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -590,11 +590,6 @@ namespace OpenRA.Mods.Common.Widgets
 			WidgetUtils.DrawPanel(state,
 				new Rectangle(pos.X, pos.Y, Bounds.Width, Bounds.Height));
 
-			// Draw TAB focus indicator when this text field has TAB focus but not keyboard focus
-			// (keyboard focus shows the blinking cursor instead)
-			if (HasTabFocus && !HasKeyboardFocus)
-				DrawTabFocusIndicator(new Rectangle(pos.X, pos.Y, Bounds.Width, Bounds.Height));
-
 			// Inset text by the margin and center vertically
 			var verticalMargin = (Bounds.Height - textSize.Y) / 2 - VisualHeight;
 			var textPos = pos + new int2(LeftMargin, verticalMargin);
@@ -633,30 +628,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (isTextOverflowing)
 				Game.Renderer.DisableScissor();
-		}
-
-		// Draws a visual indicator around the text field when it has TAB focus
-		static void DrawTabFocusIndicator(Rectangle rect)
-		{
-			if (!ChromeMetrics.TryGet<Color>("TabFocusColor", out var focusColor))
-				focusColor = Color.FromArgb(128, 255, 255, 255);
-
-			if (!ChromeMetrics.TryGet<int>("TabFocusWidth", out var focusWidth))
-				focusWidth = 2;
-
-			var outer = rect.InflateBy(focusWidth, focusWidth, focusWidth, focusWidth);
-
-			// Top border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, outer.Y, outer.Width, focusWidth), focusColor);
-
-			// Bottom border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Bottom, outer.Width, focusWidth), focusColor);
-
-			// Left border
-			WidgetUtils.FillRectWithColor(new Rectangle(outer.X, rect.Y, focusWidth, rect.Height), focusColor);
-
-			// Right border
-			WidgetUtils.FillRectWithColor(new Rectangle(rect.Right, rect.Y, focusWidth, rect.Height), focusColor);
 		}
 
 		public override TextFieldWidget Clone() { return new TextFieldWidget(this); }

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -93,6 +93,7 @@ Container@LOBBY_PLAYER_BIN:
 							LeftMargin: 24
 							MaxLength: 16
 							Visible: false
+							TabIndex: 10
 							Children:
 								Image@PROFILE:
 									ImageCollection: lobby-bits
@@ -113,12 +114,14 @@ Container@LOBBY_PLAYER_BIN:
 							Text: label-lobby-players-name
 							Font: Regular
 							Visible: false
+							TabIndex: 10
 						DropDownButton@COLOR:
 							X: 210
 							Width: 94
 							Height: 25
 							Font: Regular
 							IgnoreChildMouseOver: true
+							TabIndex: 11
 							Children:
 								ColorBlock@COLORBLOCK:
 									X: 5
@@ -133,6 +136,7 @@ Container@LOBBY_PLAYER_BIN:
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
 							PanelRoot: FACTION_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
+							TabIndex: 12
 							Children:
 								Image@FACTIONFLAG:
 									X: 4
@@ -149,6 +153,7 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 50
 							Height: 25
 							Font: Regular
+							TabIndex: 13
 						DropDownButton@HANDICAP_DROPDOWN:
 							X: 491
 							Width: 75
@@ -156,11 +161,13 @@ Container@LOBBY_PLAYER_BIN:
 							Font: Regular
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipText: dropdownbutton-lobby-players-handicap-tooltip
+							TabIndex: 14
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 571
 							Width: 50
 							Height: 25
 							Font: Regular
+							TabIndex: 15
 						Image@STATUS_IMAGE:
 							X: 629
 							Y: 4
@@ -175,6 +182,7 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 20
 							Height: 20
 							Visible: false
+							TabIndex: 16
 				Container@TEMPLATE_NONEDITABLE_PLAYER:
 					X: 5
 					Width: 530
@@ -310,6 +318,7 @@ Container@LOBBY_PLAYER_BIN:
 							Text: label-lobby-players-name
 							Font: Regular
 							Visible: false
+							TabIndex: 20
 						Label@NAME:
 							X: 20
 							Width: 195
@@ -321,6 +330,7 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 25
 							Text: button-lobby-players-join
 							Font: Regular
+							TabIndex: 21
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 530
@@ -472,9 +482,11 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 20
 							Font: Regular
 							Text: checkbox-lobby-players-new-spectator-toggle
+							TabIndex: 90
 						Button@SPECTATE:
 							X: 210
 							Width: 438
 							Height: 25
 							Text: button-lobby-players-spectate
 							Font: Regular
+							TabIndex: 91

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -35,12 +35,14 @@ Container@SERVER_LOBBY:
 					Width: 211
 					Height: 25
 					Text: dropdownbutton-bg-slots
+					TabIndex: 102
 				Button@RESET_OPTIONS_BUTTON:
 					X: 15
 					Y: 254
 					Width: 211
 					Height: 25
 					Text: button-bg-reset-options
+					TabIndex: 102
 				Container@SKIRMISH_TABS:
 					X: 697 - WIDTH
 					Width: 465
@@ -51,18 +53,21 @@ Container@SERVER_LOBBY:
 							Width: 151
 							Height: 31
 							Text: button-skirmish-tabs-players-tab
+							TabIndex: 103
 						Button@OPTIONS_TAB:
 							X: 157
 							Y: 248
 							Width: 151
 							Height: 31
 							Text: button-skirmish-tabs-options-tab
+							TabIndex: 104
 						Button@MUSIC_TAB:
 							X: 314
 							Y: 248
 							Width: 151
 							Height: 31
 							Text: label-music-title
+							TabIndex: 105
 				Container@MULTIPLAYER_TABS:
 					X: 697 - WIDTH
 					Width: 465
@@ -73,30 +78,35 @@ Container@SERVER_LOBBY:
 							Width: 112
 							Height: 31
 							Text: button-multiplayer-tabs-players-tab
+							TabIndex: 103
 						Button@OPTIONS_TAB:
 							X: 118
 							Y: 248
 							Width: 112
 							Height: 31
 							Text: button-multiplayer-tabs-options-tab
+							TabIndex: 104
 						Button@MUSIC_TAB:
 							X: 236
 							Y: 248
 							Width: 112
 							Height: 31
 							Text: label-music-title
+							TabIndex: 105
 						Button@SERVERS_TAB:
 							X: 354
 							Y: 248
 							Width: 111
 							Height: 31
 							Text: button-multiplayer-tabs-servers-tab
+							TabIndex: 106
 				Button@CHANGEMAP_BUTTON:
 					X: PARENT_WIDTH - WIDTH - 15
 					Y: 254
 					Width: 174
 					Height: 25
 					Text: button-bg-changemap
+					TabIndex: 101
 				Container@TOP_PANELS_ROOT:
 					X: 15
 					Y: 30
@@ -127,16 +137,19 @@ Container@SERVER_LOBBY:
 							Y: PARENT_HEIGHT - HEIGHT
 							Width: PARENT_WIDTH - 55
 							Height: 25
+							TabIndex: 107
 		Button@DISCONNECT_BUTTON:
 			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-server-lobby-disconnect
+			TabIndex: 109
 		Button@START_GAME_BUTTON:
 			X: PARENT_WIDTH - WIDTH
 			Y: PARENT_HEIGHT - 1
 			Width: 140
 			Height: 35
 			Text: button-server-lobby-start-game
+			TabIndex: 108
 		Container@FACTION_DROPDOWN_PANEL_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -92,6 +92,7 @@ Container@LOBBY_PLAYER_BIN:
 							LeftMargin: 24
 							MaxLength: 16
 							Visible: false
+							TabIndex: 10
 							Children:
 								Image@PROFILE:
 									ImageCollection: lobby-bits
@@ -112,11 +113,13 @@ Container@LOBBY_PLAYER_BIN:
 							Text: label-lobby-players-name
 							Font: Regular
 							Visible: false
+							TabIndex: 10
 						DropDownButton@COLOR:
 							X: 190
 							Width: 70
 							Height: 25
 							IgnoreChildMouseOver: true
+							TabIndex: 11
 							Children:
 								ColorBlock@COLORBLOCK:
 									X: 5
@@ -130,6 +133,7 @@ Container@LOBBY_PLAYER_BIN:
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
 							PanelRoot: FACTION_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
+							TabIndex: 12
 							Children:
 								Image@FACTIONFLAG:
 									X: 5
@@ -146,23 +150,27 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: label-lobby-players-team
+							TabIndex: 13
 						DropDownButton@HANDICAP_DROPDOWN:
 							X: 478
 							Width: 72
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipText: dropdownbutton-lobby-players-handicap-tooltip
+							TabIndex: 14
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 560
 							Width: 48
 							Height: 25
 							Text: label-lobby-players-spawn
+							TabIndex: 15
 						Checkbox@STATUS_CHECKBOX:
 							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
+							TabIndex: 16
 						Image@STATUS_IMAGE:
 							X: 619
 							Y: 4
@@ -308,11 +316,13 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 25
 							Text: label-lobby-players-name
 							Visible: false
+							TabIndex: 20
 						Button@JOIN:
 							X: 190
 							Text: button-lobby-players-join
 							Width: 418
 							Height: 25
+							TabIndex: 21
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 475
@@ -463,12 +473,14 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 20
 							Font: Regular
 							Text: checkbox-lobby-players-new-spectator-toggle
+							TabIndex: 90
 						Button@SPECTATE:
 							X: 190
 							Width: 418
 							Height: 25
 							Text: button-lobby-players-spectate
 							Font: Regular
+							TabIndex: 91
 
 ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -30,6 +30,7 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Font: Bold
 			Text: dropdownbutton-server-lobby-slots
+			TabIndex: 102
 		Button@RESET_OPTIONS_BUTTON:
 			X: 20
 			Y: 291
@@ -48,6 +49,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: button-skirmish-tabs-players-tab
+					TabIndex: 103
 				Button@OPTIONS_TAB:
 					X: 162
 					Y: 285
@@ -55,6 +57,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: button-skirmish-tabs-options-tab
+					TabIndex: 104
 				Button@MUSIC_TAB:
 					X: 2 * 162
 					Y: 285
@@ -62,6 +65,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: label-music-title
+					TabIndex: 105
 		Container@MULTIPLAYER_TABS:
 			X: 695 - WIDTH
 			Width: 486
@@ -73,6 +77,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: button-multiplayer-tabs-players-tab
+					TabIndex: 103
 				Button@OPTIONS_TAB:
 					X: 121
 					Y: 285
@@ -80,6 +85,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: button-multiplayer-tabs-options-tab
+					TabIndex: 104
 				Button@MUSIC_TAB:
 					X: 243
 					Y: 285
@@ -87,6 +93,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: label-music-title
+					TabIndex: 105
 				Button@SERVERS_TAB:
 					X: 364
 					Y: 285
@@ -94,6 +101,7 @@ Background@SERVER_LOBBY:
 					Height: 31
 					Font: Bold
 					Text: button-multiplayer-tabs-servers-tab
+					TabIndex: 106
 		Container@TOP_PANELS_ROOT:
 			X: 20
 			Y: 67
@@ -106,6 +114,7 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Text: button-server-lobby-changemap
 			Font: Bold
+			TabIndex: 101
 		Container@LOBBYCHAT:
 			X: 20
 			Y: PARENT_HEIGHT - HEIGHT - 20
@@ -131,6 +140,7 @@ Background@SERVER_LOBBY:
 					Y: PARENT_HEIGHT - HEIGHT
 					Width: PARENT_WIDTH - 260 - 55
 					Height: 25
+					TabIndex: 107
 		Button@START_GAME_BUTTON:
 			X: PARENT_WIDTH - WIDTH - 150
 			Y: PARENT_HEIGHT - HEIGHT - 20
@@ -138,6 +148,7 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Text: button-server-lobby-start-game
 			Font: Bold
+			TabIndex: 108
 		Button@DISCONNECT_BUTTON:
 			X: PARENT_WIDTH - WIDTH - 20
 			Y: PARENT_HEIGHT - HEIGHT - 20
@@ -145,5 +156,6 @@ Background@SERVER_LOBBY:
 			Height: 25
 			Text: button-server-lobby-disconnect
 			Font: Bold
+			TabIndex: 109
 		Container@FACTION_DROPDOWN_PANEL_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -54,6 +54,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: label-singleplayer-title
 							Font: Bold
+							TabIndex: 0
 						Button@MULTIPLAYER_BUTTON:
 							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 100
@@ -61,6 +62,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: label-multiplayer-title
 							Font: Bold
+							TabIndex: 1
 						Button@SETTINGS_BUTTON:
 							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 140
@@ -68,6 +70,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: button-settings-title
 							Font: Bold
+							TabIndex: 2
 						Button@EXTRAS_BUTTON:
 							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 180
@@ -75,6 +78,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: button-extras-title
 							Font: Bold
+							TabIndex: 3
 						Button@CONTENT_BUTTON:
 							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 220
@@ -82,6 +86,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: button-main-menu-content
 							Font: Bold
+							TabIndex: 4
 						Button@QUIT_BUTTON:
 							X: PARENT_WIDTH / 2 - WIDTH / 2
 							Y: 260
@@ -89,6 +94,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: button-quit
 							Font: Bold
+							TabIndex: 5
 				Background@SINGLEPLAYER_MENU:
 					Width: PARENT_WIDTH
 					Height: PARENT_HEIGHT
@@ -255,6 +261,7 @@ Container@MAINMENU:
 					Height: 25
 					Text: dropdownbutton-news-bg-button
 					Font: Bold
+					TabIndex: 6
 		Container@UPDATE_NOTICE:
 			X: (WINDOW_WIDTH - WIDTH) / 2
 			Y: 95

--- a/mods/common/chrome/playerprofile.yaml
+++ b/mods/common/chrome/playerprofile.yaml
@@ -65,6 +65,7 @@ Container@LOCAL_PROFILE_PANEL:
 					Height: 20
 					Font: TinyBold
 					Text: button-generate-keys-key
+					TabIndex: 7
 		Background@GENERATING_KEYS:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/common/chrome/playerprofile.yaml
+++ b/mods/common/chrome/playerprofile.yaml
@@ -124,6 +124,7 @@ Container@LOCAL_PROFILE_PANEL:
 					Height: 20
 					Font: TinyBold
 					Text: button-cancel
+					TabIndex: 8
 				Button@CHECK_KEY:
 					X: 185
 					Y: 70
@@ -131,6 +132,7 @@ Container@LOCAL_PROFILE_PANEL:
 					Height: 20
 					Font: TinyBold
 					Text: button-continue
+					TabIndex: 7
 		Background@CHECKING_FINGERPRINT:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -92,6 +92,7 @@ Container@LOBBY_PLAYER_BIN:
 							LeftMargin: 24
 							MaxLength: 16
 							Visible: false
+							TabIndex: 10
 							Children:
 								Image@PROFILE:
 									ImageCollection: lobby-bits
@@ -112,11 +113,13 @@ Container@LOBBY_PLAYER_BIN:
 							Text: label-lobby-players-name
 							Font: Regular
 							Visible: false
+							TabIndex: 10
 						DropDownButton@COLOR:
 							X: 190
 							Width: 70
 							Height: 25
 							IgnoreChildMouseOver: true
+							TabIndex: 11
 							Children:
 								ColorBlock@COLORBLOCK:
 									X: 5
@@ -130,6 +133,7 @@ Container@LOBBY_PLAYER_BIN:
 							IgnoreChildMouseOver: true
 							TooltipContainer: TOOLTIP_CONTAINER
 							PanelRoot: FACTION_DROPDOWN_PANEL_ROOT # ensure that tooltips for the options are on top of the dropdown panel
+							TabIndex: 12
 							Children:
 								Image@FACTIONFLAG:
 									X: 4
@@ -146,23 +150,27 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: label-lobby-players-team
+							TabIndex: 13
 						DropDownButton@HANDICAP_DROPDOWN:
 							X: 478
 							Width: 72
 							Height: 25
 							TooltipContainer: TOOLTIP_CONTAINER
 							TooltipText: dropdownbutton-lobby-players-handicap-tooltip
+							TabIndex: 14
 						DropDownButton@SPAWN_DROPDOWN:
 							X: 560
 							Width: 48
 							Height: 25
 							Text: label-lobby-players-spawn
+							TabIndex: 15
 						Checkbox@STATUS_CHECKBOX:
 							X: 617
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
+							TabIndex: 16
 						Image@STATUS_IMAGE:
 							X: 619
 							Y: 4
@@ -308,11 +316,13 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 25
 							Text: label-lobby-players-name
 							Visible: false
+							TabIndex: 20
 						Button@JOIN:
 							X: 190
 							Width: 418
 							Height: 25
 							Text: button-lobby-players-join
+							TabIndex: 21
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
 					Width: 475
@@ -463,12 +473,14 @@ Container@LOBBY_PLAYER_BIN:
 							Height: 20
 							Text: checkbox-lobby-players-new-spectator-toggle
 							Font: Regular
+							TabIndex: 90
 						Button@SPECTATE:
 							X: 190
 							Width: 418
 							Height: 25
 							Text: button-lobby-players-spectate
 							Font: Regular
+							TabIndex: 91
 
 ScrollPanel@FACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH


### PR DESCRIPTION
This PR adds keyboard navigation support on UI elements (buttons, drop-down menus, checkboxes, lists, ...).

Based on OpenRA#22281 - Allow keyboard navigation (Up, Down, Home, End) on scrollable lists

Fixes: 
OpenRA#15347 - Add shortcuts (hotkeys) in the menus
OpenRA#21004 - Allow to press Arrow Up and Arrow Down to browse files in the Asset Browser
OpenRA#10682 - Key-support for the replay-section
OpenRA#21649 - Select items in menu by using arrow keys
OpenRA#19715 - Allow us to use keyboard in map browser and server list


- Navigate on UI elements with TAB (hops to next UI element) and SHIFT+TAB (hops to previous UI element).
- Activate the selected element with ENTER or SPACE. 
- Close drop-down menus with ESC. 
- Increase or decrease sliders with LEFT and RIGHT arrow keys.
- Scroll lists with UP/DOWN/PAGE UP/PAGE DOWN/HOME/END keys.
- Delete savegames or custom maps with DEL key.

https://github.com/user-attachments/assets/fade1863-d766-437b-8335-5d838f59478b




