### PR TITLE
Resolution presets dropdown with guardrails

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -60,6 +60,9 @@ namespace OpenRA
 		int CurrentDisplay { get; }
 		bool HasInputFocus { get; }
 		bool IsSuspended { get; }
+		Size DisplayResolution { get; }
+		Size MaxEffectiveWindowSize { get; }
+		Size MaxUsableWindowSize { get; }
 
 		event Action<float, float, float, float> OnWindowScaleChanged;
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -383,6 +383,9 @@ namespace OpenRA
 
 		public Size Resolution => Window.EffectiveWindowSize;
 		public Size NativeResolution => Window.NativeWindowSize;
+		public Size DisplayResolution => Window.DisplayResolution;
+		public Size MaxEffectiveWindowSize => Window.MaxEffectiveWindowSize;
+		public Size MaxUsableWindowSize => Window.MaxUsableWindowSize;
 		public float WindowScale => Window.EffectiveWindowScale;
 		public float NativeWindowScale => Window.NativeWindowScale;
 		public GLProfile GLProfile => Window.GLProfile;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -239,14 +239,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var origHeightText = windowHeight.Text = graphicSettings.WindowedSize.Y.ToString(NumberFormatInfo.CurrentInfo);
 			windowHeight.Text = graphicSettings.WindowedSize.Y.ToString(NumberFormatInfo.CurrentInfo);
 
+			var maxUsableSize = Game.Renderer.MaxUsableWindowSize;
+			windowWidth.OnLoseFocus = () =>
+			{
+				if (int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w) && w > maxUsableSize.Width)
+					windowWidth.Text = maxUsableSize.Width.ToString(NumberFormatInfo.CurrentInfo);
+			};
+
+			windowHeight.OnLoseFocus = () =>
+			{
+				if (int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h) && h > maxUsableSize.Height)
+					windowHeight.Text = maxUsableSize.Height.ToString(NumberFormatInfo.CurrentInfo);
+			};
+
 			var resolutionPresetDropdown = panel.GetOrNull<DropDownButtonWidget>("RESOLUTION_PRESET_DROPDOWN");
 			if (resolutionPresetDropdown != null)
 			{
 				resolutionPresetDropdown.GetText = () =>
 				{
-					if (int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w)
-						&& int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h)
-						&& CommonResolutions.Contains(new Size(w, h)))
+					if (!int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w)
+						|| !int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h))
+						return selectPreset;
+
+					var selected = new Size(w, h);
+					if (CommonResolutions.Contains(selected) || selected == maxUsableSize)
 						return $"{w}x{h}";
 
 					return selectPreset;
@@ -403,18 +419,26 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static void ShowResolutionPresetDropdown(DropDownButtonWidget dropdown, TextFieldWidget windowWidth, TextFieldWidget windowHeight)
 		{
-			var sortedModes = CommonResolutions
+			var maxUsableSize = Game.Renderer.MaxUsableWindowSize;
+
+			var commonModes = CommonResolutions
+				.Where(res => res.Width <= maxUsableSize.Width && res.Height <= maxUsableSize.Height)
 				.OrderBy(res => res.Width)
 					.ThenBy(res => res.Height)
 				.ToArray();
 
+			var includeMaxWindowed = !CommonResolutions.Contains(maxUsableSize);
+			var allModes = includeMaxWindowed
+				? commonModes.Append(maxUsableSize).ToArray()
+				: commonModes;
+
 			ScrollItemWidget SetupItem(Size resolution, ScrollItemWidget itemTemplate)
 			{
-				var currentWidth = int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w) ? w : 0;
-				var currentHeight = int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h) ? h : 0;
+				var hasCurrentWidth = int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var currentWidth);
+				var hasCurrentHeight = int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var currentHeight);
 
 				var item = ScrollItemWidget.Setup(itemTemplate,
-					() => currentWidth == resolution.Width && currentHeight == resolution.Height,
+					() => hasCurrentWidth && hasCurrentHeight && currentWidth == resolution.Width && currentHeight == resolution.Height,
 					() =>
 					{
 						windowWidth.Text = resolution.Width.ToString(NumberFormatInfo.CurrentInfo);
@@ -422,11 +446,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					});
 
 				var label = $"{resolution.Width}x{resolution.Height}";
+
 				item.Get<LabelWidget>("LABEL").GetText = () => label;
 				return item;
 			}
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 300, sortedModes, SetupItem);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 300, allModes, SetupItem);
 		}
 
 		static void ShowGLProfileDropdown(DropDownButtonWidget dropdown, GraphicSettings graphicSettings)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -240,16 +240,29 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			windowHeight.Text = graphicSettings.WindowedSize.Y.ToString(NumberFormatInfo.CurrentInfo);
 
 			var maxUsableSize = Game.Renderer.MaxUsableWindowSize;
+			const int MinWidth = 1024;
+			const int MinHeight = 720;
+
 			windowWidth.OnLoseFocus = () =>
 			{
-				if (int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w) && w > maxUsableSize.Width)
-					windowWidth.Text = maxUsableSize.Width.ToString(NumberFormatInfo.CurrentInfo);
+				if (int.TryParse(windowWidth.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var w))
+				{
+					if (w < MinWidth)
+						windowWidth.Text = MinWidth.ToString(NumberFormatInfo.CurrentInfo);
+					else if (w > maxUsableSize.Width)
+						windowWidth.Text = maxUsableSize.Width.ToString(NumberFormatInfo.CurrentInfo);
+				}
 			};
 
 			windowHeight.OnLoseFocus = () =>
 			{
-				if (int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h) && h > maxUsableSize.Height)
-					windowHeight.Text = maxUsableSize.Height.ToString(NumberFormatInfo.CurrentInfo);
+				if (int.TryParse(windowHeight.Text, NumberStyles.Integer, NumberFormatInfo.CurrentInfo, out var h))
+				{
+					if (h < MinHeight)
+						windowHeight.Text = MinHeight.ToString(NumberFormatInfo.CurrentInfo);
+					else if (h > maxUsableSize.Height)
+						windowHeight.Text = maxUsableSize.Height.ToString(NumberFormatInfo.CurrentInfo);
+				}
 			};
 
 			var resolutionPresetDropdown = panel.GetOrNull<DropDownButtonWidget>("RESOLUTION_PRESET_DROPDOWN");

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Platforms.Default
 					if (Platform.CurrentPlatform == PlatformType.OSX)
 						return new Size(usable.w, usable.h - titleBarHeight);
 
-				return new Size((int)(usable.w / windowScale), (int)((usable.h - titleBarHeight) / windowScale));
+					return new Size((int)(usable.w / windowScale), (int)((usable.h - titleBarHeight) / windowScale));
 				}
 			}
 		}
@@ -324,7 +324,7 @@ namespace OpenRA.Platforms.Default
 				else
 					windowSize = new Size((int)(surfaceSize.Width / windowScale), (int)(surfaceSize.Height / windowScale));
 
-			if (windowMode == WindowMode.Windowed)
+				if (windowMode == WindowMode.Windowed)
 				{
 					SDL.SDL_GetWindowPosition(window, out var wx, out var wy);
 					SDL.SDL_GetDisplayUsableBounds(videoDisplay, out var usable);

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -96,6 +96,51 @@ namespace OpenRA.Platforms.Default
 
 		public int DisplayCount => SDL.SDL_GetNumVideoDisplays();
 
+		public Size DisplayResolution
+		{
+			get
+			{
+				SDL.SDL_GetCurrentDisplayMode(CurrentDisplay, out var display);
+				return new Size(display.w, display.h);
+			}
+		}
+
+		public Size MaxEffectiveWindowSize
+		{
+			get
+			{
+				lock (syncObject)
+				{
+					SDL.SDL_GetCurrentDisplayMode(CurrentDisplay, out var display);
+
+					if (Platform.CurrentPlatform == PlatformType.OSX)
+						return new Size(display.w, display.h);
+
+					return new Size((int)(display.w / windowScale), (int)(display.h / windowScale));
+				}
+			}
+		}
+
+		public Size MaxUsableWindowSize
+		{
+			get
+			{
+				lock (syncObject)
+				{
+					SDL.SDL_GetDisplayUsableBounds(CurrentDisplay, out var usable);
+
+					var titleBarHeight = 0;
+					if (SDL.SDL_GetWindowBordersSize(window, out var top, out _, out _, out _) == 0)
+						titleBarHeight = top;
+
+					if (Platform.CurrentPlatform == PlatformType.OSX)
+						return new Size(usable.w, usable.h - titleBarHeight);
+
+				return new Size((int)(usable.w / windowScale), (int)((usable.h - titleBarHeight) / windowScale));
+				}
+			}
+		}
+
 		public bool HasInputFocus { get; internal set; }
 
 		public bool IsSuspended { get; internal set; }
@@ -278,6 +323,26 @@ namespace OpenRA.Platforms.Default
 				}
 				else
 					windowSize = new Size((int)(surfaceSize.Width / windowScale), (int)(surfaceSize.Height / windowScale));
+
+			if (windowMode == WindowMode.Windowed)
+				{
+					SDL.SDL_GetWindowPosition(window, out var wx, out var wy);
+					SDL.SDL_GetDisplayUsableBounds(videoDisplay, out var usable);
+
+					SDL.SDL_GetWindowSize(window, out var nativeW, out var nativeH);
+
+					var titleBarHeight = 0;
+					if (SDL.SDL_GetWindowBordersSize(window, out var top, out _, out _, out _) == 0)
+						titleBarHeight = top;
+
+					var minY = usable.y + titleBarHeight;
+					var maxY = Math.Max(minY, usable.y + usable.h - nativeH);
+					var clampedX = Math.Clamp(wx, usable.x, Math.Max(usable.x, usable.x + usable.w - nativeW));
+					var clampedY = Math.Clamp(wy, minY, maxY);
+
+					if (clampedX != wx || clampedY != wy)
+						SDL.SDL_SetWindowPosition(window, clampedX, clampedY);
+				}
 
 				if (Game.Settings.Game.LockMouseWindow)
 					GrabWindowMouseFocus();


### PR DESCRIPTION
Add a drop-down in Settings > Display to quickly fill the two 'Window size' fields with resolutions presets.

The drop-down should not display resolutions not supported by the monitor.

Sadly the dropdown is not wide enough to display all the resolution descriptions (SXGA 5:4, Full HD 1080p, UltraWide Full HD,  ...) in full. If this PR is accepted, we could:
- do nothing (leave the resolution descriptions this way)
- remove the resolution descriptions
- make the whole settings window slightly wider to show these resolution descriptions in full



