### PR TITLE
Add debug command for changing target lines visibility rules

### DIFF
--- a/OpenRA.Game/Traits/World/DebugVisualizations.cs
+++ b/OpenRA.Game/Traits/World/DebugVisualizations.cs
@@ -11,6 +11,8 @@
 
 namespace OpenRA.Traits
 {
+	public enum DebugTargetLines { Default, AllPlayers, AlwaysAllPlayers }
+
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Enables visualization commands. Attach this to the world actor.")]
 	public class DebugVisualizationsInfo : TraitInfo<DebugVisualizations> { }
@@ -21,6 +23,7 @@ namespace OpenRA.Traits
 		public bool RenderGeometry;
 		public bool ScreenMap;
 		public bool ActorTags;
+		public DebugTargetLines TargetLines = DebugTargetLines.Default;
 
 		// The depth buffer may have been left enabled by the previous world
 		// Initializing this as dirty forces us to reset the default rendering before the first render

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -48,6 +48,18 @@ namespace OpenRA.Mods.Common.Commands
 		[FluentReference]
 		const string ActorTagsOverlayDescription = "description-actor-tags-overlay";
 
+		[FluentReference]
+		const string TargetLinesDescription = "description-target-lines";
+
+		[FluentReference]
+		const string TargetLinesDefault = "notification-target-lines-default";
+
+		[FluentReference]
+		const string TargetLinesAllPlayers = "notification-target-lines-all-players";
+
+		[FluentReference]
+		const string TargetLinesAlways = "notification-target-lines-always";
+
 		public static class Commands
 		{
 			public const string CombatGeometry = "combat-geometry";
@@ -55,6 +67,7 @@ namespace OpenRA.Mods.Common.Commands
 			public const string ScreenMap = "screen-map";
 			public const string DepthBuffer = "depth-buffer";
 			public const string ActorTags = "actor-tags";
+			public const string TargetLines = "target-lines";
 		}
 
 		public static class Orders
@@ -64,17 +77,19 @@ namespace OpenRA.Mods.Common.Commands
 			public const string ScreenMap = "DevScreenMap";
 			public const string DepthBuffer = "DevDepthBuffer";
 			public const string ActorTags = "DevActorTags";
+			public const string TargetLines = "DevTargetLines";
 		}
 
 		readonly Dictionary<string,
-			(string Description, Action<DebugVisualizations> Handler, string CheatName, Func<DebugVisualizations, bool> GetState)>
+			(string Description, Action<HandlerContext> Handler)>
 			commandHandlers = new()
 			{
-				{ Commands.CombatGeometry, (CombatGeometryDescription, CombatGeometry, Orders.CombatGeometry, d => d.CombatGeometry) },
-				{ Commands.RenderGeometry, (RenderGeometryDescription, RenderGeometry, Orders.RenderGeometry, d => d.RenderGeometry) },
-				{ Commands.ScreenMap, (ScreenMapOverlayDescription, ScreenMap, Orders.ScreenMap, d => d.ScreenMap) },
-				{ Commands.DepthBuffer, (DepthBufferDescription, DepthBuffer, Orders.DepthBuffer, d => d.DepthBuffer) },
-				{ Commands.ActorTags, (ActorTagsOverlayDescription, ActorTags, Orders.ActorTags, d => d.ActorTags) },
+				{ Commands.CombatGeometry, (CombatGeometryDescription, CombatGeometry) },
+				{ Commands.RenderGeometry, (RenderGeometryDescription, RenderGeometry) },
+				{ Commands.ScreenMap, (ScreenMapOverlayDescription, ScreenMap) },
+				{ Commands.DepthBuffer, (DepthBufferDescription, DepthBuffer) },
+				{ Commands.ActorTags, (ActorTagsOverlayDescription, ActorTags) },
+				{ Commands.TargetLines, (TargetLinesDescription, TargetLines) },
 			};
 
 		DebugVisualizations debugVis;
@@ -103,32 +118,68 @@ namespace OpenRA.Mods.Common.Commands
 			}
 		}
 
-		static void CombatGeometry(DebugVisualizations debugVis)
+		static void CombatGeometry(HandlerContext context)
 		{
-			debugVis.CombatGeometry ^= true;
+			context.DebugVis.CombatGeometry ^= true;
+
+			context.SendCheatNotification(context.DebugVis.CombatGeometry, Orders.CombatGeometry);
 		}
 
-		static void RenderGeometry(DebugVisualizations debugVis)
+		static void RenderGeometry(HandlerContext context)
 		{
-			debugVis.RenderGeometry ^= true;
+			context.DebugVis.RenderGeometry ^= true;
+
+			context.SendCheatNotification(context.DebugVis.RenderGeometry, Orders.RenderGeometry);
 		}
 
-		static void ScreenMap(DebugVisualizations debugVis)
+		static void ScreenMap(HandlerContext context)
 		{
-			debugVis.ScreenMap ^= true;
+			context.DebugVis.ScreenMap ^= true;
+
+			context.SendCheatNotification(context.DebugVis.ScreenMap, Orders.ScreenMap);
 		}
 
-		static void DepthBuffer(DebugVisualizations debugVis)
+		static void DepthBuffer(HandlerContext context)
 		{
-			debugVis.DepthBuffer ^= true;
+			context.DebugVis.DepthBuffer ^= true;
+
+			context.SendCheatNotification(context.DebugVis.DepthBuffer, Orders.DepthBuffer);
 		}
 
-		static void ActorTags(DebugVisualizations debugVis)
+		static void ActorTags(HandlerContext context)
 		{
-			debugVis.ActorTags ^= true;
+			context.DebugVis.ActorTags ^= true;
+
+			context.SendCheatNotification(context.DebugVis.ActorTags, Orders.ActorTags);
 		}
 
-		public void InvokeCommand(string name, string _)
+		static void TargetLines(HandlerContext context)
+		{
+			var value = context.Argument?.ToLowerInvariant()?.Trim();
+			if (string.IsNullOrEmpty(value))
+				value = context.DebugVis.TargetLines == DebugTargetLines.Default ? "always" : "default";
+
+			string key;
+			switch (value)
+			{
+				case "all-players":
+					context.DebugVis.TargetLines = DebugTargetLines.AllPlayers;
+					key = TargetLinesAllPlayers;
+					break;
+				case "always":
+					context.DebugVis.TargetLines = DebugTargetLines.AlwaysAllPlayers;
+					key = TargetLinesAlways;
+					break;
+				default:
+					context.DebugVis.TargetLines = DebugTargetLines.Default;
+					key = TargetLinesDefault;
+					break;
+			}
+
+			TextNotificationsManager.Debug(FluentProvider.GetMessage(key));
+		}
+
+		public void InvokeCommand(string name, string arg)
 		{
 			if (!commandHandlers.TryGetValue(name, out var command))
 				return;
@@ -139,17 +190,20 @@ namespace OpenRA.Mods.Common.Commands
 				return;
 			}
 
-			command.Handler(debugVis);
-			SendNotification(command.GetState(debugVis), command.CheatName);
+			var context = new HandlerContext(world, debugVis, arg);
+			command.Handler(context);
 		}
 
-		void SendNotification(bool enabled, string cheatName)
+		sealed record class HandlerContext(World World, DebugVisualizations DebugVis, string Argument)
 		{
-			var notification = enabled ? CheatEnabled : CheatDisabled;
-			var playerName = world.LocalPlayer != null ? world.LocalPlayer.ResolvedPlayerName : "";
-			TextNotificationsManager.Debug(FluentProvider.GetMessage(notification,
-				"cheat", cheatName,
-				"player", playerName));
+			public void SendCheatNotification(bool enabled, string cheatName)
+			{
+				var notification = enabled ? CheatEnabled : CheatDisabled;
+				var playerName = World.LocalPlayer != null ? World.LocalPlayer.ResolvedPlayerName : "";
+				TextNotificationsManager.Debug(FluentProvider.GetMessage(notification,
+					"cheat", cheatName,
+					"player", playerName));
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Commands
 		const string DepthBufferDescription = "description-depth-buffer";
 
 		[FluentReference]
-		const string ActorTagsOverlayDescripition = "description-actor-tags-overlay";
+		const string ActorTagsOverlayDescription = "description-actor-tags-overlay";
 
 		public static class Commands
 		{
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Commands
 				{ Commands.RenderGeometry, (RenderGeometryDescription, RenderGeometry, Orders.RenderGeometry, d => d.RenderGeometry) },
 				{ Commands.ScreenMap, (ScreenMapOverlayDescription, ScreenMap, Orders.ScreenMap, d => d.ScreenMap) },
 				{ Commands.DepthBuffer, (DepthBufferDescription, DepthBuffer, Orders.DepthBuffer, d => d.DepthBuffer) },
-				{ Commands.ActorTags, (ActorTagsOverlayDescripition, ActorTags, Orders.ActorTags, d => d.ActorTags) },
+				{ Commands.ActorTags, (ActorTagsOverlayDescription, ActorTags, Orders.ActorTags, d => d.ActorTags) },
 			};
 
 		DebugVisualizations debugVis;

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -39,18 +39,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Palette used for rendering sprites.")]
 		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
-		public override object Create(ActorInitializer init) { return new DrawLineToTarget(this); }
+		public override object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
-	public class DrawLineToTarget : IRenderAboveShroud, IRenderAnnotationsWhenSelected, INotifySelected
+	public class DrawLineToTarget : IRenderAboveShroud, IRenderAnnotationsWhenSelected, IRenderAnnotations, INotifySelected
 	{
 		readonly DrawLineToTargetInfo info;
+		readonly DebugVisualizations debugVis;
 		readonly List<IRenderable> renderableCache = [];
 		long lifetime;
 
-		public DrawLineToTarget(DrawLineToTargetInfo info)
+		public DrawLineToTarget(Actor self, DrawLineToTargetInfo info)
 		{
 			this.info = info;
+			debugVis = self.World.WorldActor.TraitOrDefault<DebugVisualizations>();
 		}
 
 		public void ShowTargetLines(Actor self)
@@ -69,8 +71,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldRender(Actor self)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer) || Game.Settings.Game.TargetLines == TargetLinesType.Disabled || !Ui.WidgetsVisible)
+			if (!Ui.WidgetsVisible)
 				return false;
+
+			if (debugVis?.TargetLines == DebugTargetLines.AlwaysAllPlayers)
+				return true;
+
+			if (debugVis == null || debugVis.TargetLines == DebugTargetLines.Default)
+			{
+				if (!self.Owner.IsAlliedWith(self.World.LocalPlayer) || Game.Settings.Game.TargetLines == TargetLinesType.Disabled)
+					return false;
+			}
 
 			// Players want to see the lines when in waypoint mode.
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift) || self.World.OrderGenerator is ForceModifiersOrderGenerator;
@@ -99,7 +110,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IRenderAboveShroud.SpatiallyPartitionable => false;
 
-		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr) => RenderAnnotations(self);
+
+		IEnumerable<IRenderable> RenderAnnotations(Actor self)
 		{
 			if (!ShouldRender(self))
 				return [];
@@ -134,7 +147,11 @@ namespace OpenRA.Mods.Common.Traits
 			return renderableCache.ToArray();
 		}
 
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr) => RenderAnnotations(self);
+
 		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable => false;
+
+		bool IRenderAnnotations.SpatiallyPartitionable => false;
 	}
 
 	public static class LineTargetExts

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -717,6 +717,10 @@ description-render-geometry = toggles render geometry overlay.
 description-screen-map-overlay = toggles screen map overlay.
 description-depth-buffer = toggles depth buffer overlay.
 description-actor-tags-overlay = toggles actor tags overlay.
+description-target-lines = sets target lines visibility.
+notification-target-lines-default = Using default target lines settings.
+notification-target-lines-all-players = Show target lines for all players.
+notification-target-lines-always = Always show target lines for all players.
 
 ## DevCommands
 notification-invalid-cash-amount = Invalid cash amount.


### PR DESCRIPTION
New debug command `/target-lines` allows player to change visibility rules of target lines. On top of default behavior, it adds two additional modes:
- (default) show only for local/allied players on Shift and on select + hide after some time
- `allplayers`: show target lines for all players (not just) on Shift
- `always`: show target lines for all players and always (without holding Shift)

This can be useful for debugging AI bot behavior during normal game (and not just replay, when the bot logic doesn't run).

https://github.com/user-attachments/assets/55b956d1-daa5-4a70-be46-cec9bbb6ad13


