### PR TITLE
Rewrite trigonometry functions for maximum speed.

### DIFF
--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -10,6 +10,8 @@
 #endregion
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Eluant;
 using Eluant.ObjectBinding;
 using OpenRA.Scripting;
@@ -27,9 +29,8 @@ namespace OpenRA
 
 		public WAngle(int a)
 		{
-			Angle = a % 1024;
-			if (Angle < 0)
-				Angle += 1024;
+			// Bitwise mask handles wrapping and negatives.
+			Angle = a & 1023;
 		}
 
 		public static readonly WAngle Zero = new(0);
@@ -39,130 +40,179 @@ namespace OpenRA
 		public static WAngle operator -(WAngle a, WAngle b) { return new WAngle(a.Angle - b.Angle); }
 		public static WAngle operator -(WAngle a) { return new WAngle(-a.Angle); }
 
+		public static WAngle operator *(WAngle a, int b) { return new WAngle(a.Angle * b); }
+		public static WAngle operator *(int a, WAngle b) { return new WAngle(a * b.Angle); }
+		public static WAngle operator /(WAngle a, int b) { return new WAngle(a.Angle / b); }
+		public static int operator /(WAngle a, WAngle b) { return a.Angle / b.Angle; }
+
 		public static bool operator ==(WAngle me, WAngle other) { return me.Angle == other.Angle; }
 		public static bool operator !=(WAngle me, WAngle other) { return me.Angle != other.Angle; }
 
 		public override int GetHashCode() { return Angle.GetHashCode(); }
 
-		public bool Equals(WAngle other) { return other == this; }
-		public override bool Equals(object obj) { return obj is WAngle angle && Equals(angle); }
+		public bool Equals(WAngle other) { return other.Angle == Angle; }
+		public override bool Equals(object obj) { return obj is WAngle angle && Angle == angle.Angle; }
 
 		public int Facing => Angle / 4;
 
-		public int Sin() { return new WAngle(Angle - 256).Cos(); }
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public int Sin()
+		{
+			return new WAngle(Angle - 256).Cos();
+		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public int Cos()
 		{
-			if (Angle <= 256)
-				return CosineTable[Angle];
-			if (Angle <= 512)
-				return -CosineTable[512 - Angle];
-			return -new WAngle(Angle - 512).Cos();
+			// Use symmetry to map the 1024-unit circle into a 0-256 quadrant index.
+			// Cosine is negative in the Q2 and Q3.
+			var angle = Angle;
+
+			// Maps 0-511 into a 0-256 mirrored triangle wave.
+			var qIndex = angle & 511;
+			var mirrored = 256 - qIndex;
+
+			// Branchless Abs(256 - qIndex).
+			var mask = mirrored >> 31;
+			var finalIndex = 256 - ((mirrored ^ mask) - mask);
+
+			// Phase-shift by 90 degrees (256-units) to align negative hemisphere with 9th bit.
+			// Maps bit value 0 -> 1 and 1 -> -1 branchlessly.
+			var signBit = (int)((uint)(angle + 256) >> 9) & 1;
+			var sign = 1 - (signBit << 1);
+
+			ref var table = ref MemoryMarshal.GetArrayDataReference(CosineTable);
+			return sign * Unsafe.Add(ref table, (nint)(uint)finalIndex);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public int Tan()
 		{
-			if (Angle <= 256)
-				return TanTable[Angle];
-			if (Angle <= 512)
-				return -TanTable[512 - Angle];
-			return new WAngle(Angle - 512).Tan();
+			var angle = Angle & 511;
+
+			// Shift by 257 to keep the 90 degree asymptote (256) positive.
+			var shifted = angle - 257;
+			var mask = shifted >> 31;
+
+			// Branchless Abs(angle - 256) to map 0-511 range to a 256-0-255 triangle.
+			var triangle = ((angle - 256) ^ (angle - 256 >> 31)) - (angle - 256 >> 31);
+			var finalIndex = 256 - triangle;
+
+			// Maps bit value -1 -> 1 and 0 -> -1 branchlessly.
+			var sign = -1 - (mask << 1);
+
+			ref var table = ref MemoryMarshal.GetArrayDataReference(TanTable);
+			return sign * Unsafe.Add(ref table, (nint)(uint)finalIndex);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static WAngle Lerp(WAngle a, WAngle b, int mul, int div)
 		{
-			// Map 1024 <-> 0 wrapping into linear space
-			var aa = a.Angle;
-			var bb = b.Angle;
-			if (aa > bb && aa - bb > 512)
-				aa -= 1024;
+			// Linearize endpoints by shifting across the 1024-unit wrap if it yields a shorter path.
+			var start = a.Angle;
+			var diff = b.Angle - start;
 
-			if (bb > aa && bb - aa > 512)
-				bb -= 1024;
+			// Shift difference to take shortest path around the circle.
+			var mask1 = (511 - diff) >> 31;
+			var mask2 = (diff + 512) >> 31;
+			diff += (mask1 & -1024) | (mask2 & 1024);
 
-			return new WAngle(aa + (bb - aa) * mul / div);
+			return new WAngle(start + diff * mul / div);
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static WAngle ArcSin(int d)
 		{
-			if (d < -1024 || d > 1024)
-				throw new ArgumentException($"ArcSin is only valid for values between -1024 and 1024. Received {d}");
+			// Range check using unsigned trick
+			if ((uint)(d + 1024) > 2048)
+				ThrowOutOfRange();
 
-			var a = ClosestCosineIndex(Math.Abs(d));
-			return new WAngle(d < 0 ? 768 + a : 256 - a);
+			var index = GetClosestCosineIndex(Math.Abs(d));
+			var sign = d >> 31;
+
+			// Map positive to Q1 (0-256) and negative to Q4 (768-1024).
+			return new WAngle((sign & (768 + index)) | (~sign & (256 - index)));
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static WAngle ArcCos(int d)
 		{
-			if (d < -1024 || d > 1024)
-				throw new ArgumentException($"ArcCos is only valid for values between -1024 and 1024. Received {d}");
+			if ((uint)(d + 1024) > 2048)
+				ThrowOutOfRange();
 
-			var a = ClosestCosineIndex(Math.Abs(d));
-			return new WAngle(d < 0 ? 512 - a : a);
+			var index = GetClosestCosineIndex(Math.Abs(d));
+			var sign = d >> 31;
+
+			return new WAngle((sign & (512 - index)) | (~sign & index));
 		}
 
-		/// <summary>
-		/// Find the index of CosineTable that has the value closest to the given value.
-		/// The first or last index will be returned for values above or below the valid range.
-		/// </summary>
-		static int ClosestCosineIndex(int value)
+		static void ThrowOutOfRange() => throw new ArgumentOutOfRangeException();
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		static int GetClosestCosineIndex(int value)
 		{
-			var aboveIndex = 0;
-			var belowIndex = 256;
-			while (aboveIndex != belowIndex - 1)
-			{
-				var index = (aboveIndex + belowIndex) / 2;
-				var val = CosineTable[index];
+			ref var table = ref MemoryMarshal.GetArrayDataReference(CosineTable);
+			var index = 0;
 
-				if (val == value)
-					return index;
+			// Waterfall binary search finds the lower bound; this picks the closest neighbor.
+			index |= (Unsafe.Add(ref table, index | 128) > value) ? 128 : 0;
+			index |= (Unsafe.Add(ref table, index | 64) > value) ? 64 : 0;
+			index |= (Unsafe.Add(ref table, index | 32) > value) ? 32 : 0;
+			index |= (Unsafe.Add(ref table, index | 16) > value) ? 16 : 0;
+			index |= (Unsafe.Add(ref table, index | 8) > value) ? 8 : 0;
+			index |= (Unsafe.Add(ref table, index | 4) > value) ? 4 : 0;
+			index |= (Unsafe.Add(ref table, index | 2) > value) ? 2 : 0;
+			index |= (Unsafe.Add(ref table, index | 1) > value) ? 1 : 0;
 
-				if (val < value)
-					belowIndex = index;
-				else
-					aboveIndex = index;
-			}
+			int val0 = Unsafe.Add(ref table, index);
+			int val1 = Unsafe.Add(ref table, Math.Min(index + 1, 256));
 
-			// Take the index with the smallest error
-			return CosineTable[aboveIndex] - value > value - CosineTable[belowIndex] ? belowIndex : aboveIndex;
+			// Pick the one with the smallest absolute difference.
+			return (val0 - value > value - val1) ? index + 1 : index;
 		}
 
-		public static WAngle ArcTan(int y, int x) { return ArcTan(y, x, 1); }
-		public static WAngle ArcTan(int y, int x, int stride)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static WAngle ArcTan(int y, int x)
 		{
 			if (y == 0)
 				return new WAngle(x >= 0 ? 0 : 512);
 
 			if (x == 0)
-				return new WAngle(Math.Sign(y) * 256);
+				return new WAngle(y > 0 ? 256 : 768);
 
-			var ay = Math.Abs(y);
-			var ax = Math.Abs(x);
+			var ay = Math.Abs((long)y);
+			var ax = Math.Abs((long)x);
 
-			// Find the closest angle that satisfies y = x*tan(theta)
-			// Uses a long to store bestVal to eliminate integer overflow issues in the common cases
-			// (may still fail for unrealistically large ax and ay)
-			var bestVal = long.MaxValue;
-			var bestAngle = 0;
-			for (var i = 0; i < 256; i += stride)
-			{
-				var val = Math.Abs(1024 * ay - (long)ax * TanTable[i]);
-				if (val < bestVal)
-				{
-					bestVal = val;
-					bestAngle = i;
-				}
-			}
+			// Return 90 degrees if the ratio exceeds the tangent table's precision limit (~89.6 deg).
+			if (ay >= ax * 167)
+				return new WAngle(y > 0 ? 256 : 768);
 
-			// Calculate quadrant
-			if (x < 0 && y > 0)
-				bestAngle = 512 - bestAngle;
-			else if (x < 0 && y < 0)
-				bestAngle = 512 + bestAngle;
-			else if (x > 0 && y < 0)
-				bestAngle = 1024 - bestAngle;
+			// Use a bitshift and single division to find the target ratio.
+			// This allows the binary search to compare simple integers instead of performing multiplications.
+			var target = (int)((ay << 10) / ax);
 
-			return new WAngle(bestAngle);
+			ref var table = ref MemoryMarshal.GetArrayDataReference(TanTable);
+			var index = 0;
+
+			// Waterfall binary search avoids loop overhead and branch mispredicts.
+			index |= (Unsafe.Add(ref table, index | 128) <= target) ? 128 : 0;
+			index |= (Unsafe.Add(ref table, index | 64) <= target) ? 64 : 0;
+			index |= (Unsafe.Add(ref table, index | 32) <= target) ? 32 : 0;
+			index |= (Unsafe.Add(ref table, index | 16) <= target) ? 16 : 0;
+			index |= (Unsafe.Add(ref table, index | 8) <= target) ? 8 : 0;
+			index |= (Unsafe.Add(ref table, index | 4) <= target) ? 4 : 0;
+			index |= (Unsafe.Add(ref table, index | 2) <= target) ? 2 : 0;
+			index |= (Unsafe.Add(ref table, index | 1) <= target) ? 1 : 0;
+
+			var val = Unsafe.Add(ref table, index);
+			var nextVal = Unsafe.Add(ref table, index + 1);
+			index += (target - val > nextVal - target) ? 1 : 0;
+
+			// Map the reference angle into the correct Cartesian quadrant.
+			var xNegResult = 512 + (y < 0 ? index : -index);
+			var xPosResult = y < 0 ? 1024 - index : index;
+
+			return new WAngle(x < 0 ? xNegResult : xPosResult);
 		}
 
 		// Must not be used outside rendering code
@@ -171,7 +221,7 @@ namespace OpenRA
 
 		public override string ToString() { return Angle.ToStringInvariant(); }
 
-		static readonly int[] CosineTable =
+		static readonly short[] CosineTable =
 		[
 			1024, 1023, 1023, 1023, 1023, 1023, 1023, 1023, 1022, 1022, 1022, 1021,
 			1021, 1020, 1020, 1019, 1019, 1018, 1017, 1017, 1016, 1015, 1014, 1013,

--- a/OpenRA.Test/OpenRA.Game/WAngleTest.cs
+++ b/OpenRA.Test/OpenRA.Game/WAngleTest.cs
@@ -1,0 +1,203 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	sealed class WAngleTest
+	{
+		[TestCase(0, ExpectedResult = 0, TestName = "Zero")]
+		[TestCase(512, ExpectedResult = 512, TestName = "Pi")]
+		[TestCase(1023, ExpectedResult = 1023, TestName = "Max Bound")]
+		[TestCase(1024, ExpectedResult = 0, TestName = "Positive Wrap 360")]
+		[TestCase(2048, ExpectedResult = 0, TestName = "Positive Wrap 720")]
+		[TestCase(-1, ExpectedResult = 1023, TestName = "Negative Wrap 1")]
+		[TestCase(-1025, ExpectedResult = 1023, TestName = "Negative Wrap Multi")]
+		public int ConstructorMaskingAndEquality(int input)
+		{
+			var angle = new WAngle(input);
+
+			Assert.That(angle.Angle, Is.EqualTo(new WAngle(input + 1024).Angle), "Adding 360 degrees must result in identical internal state.");
+			Assert.That(angle.Angle, Is.EqualTo(new WAngle(input - 1024).Angle), "Subtracting 360 degrees must result in identical internal state.");
+
+			return angle.Angle;
+		}
+
+		[Test]
+		public void ArithmeticAndDivision()
+		{
+			var angle = new WAngle(1000);
+
+			Assert.That((angle * 10000).Angle, Is.EqualTo((1000 * 10000) & 1023), "Multiplication must wrap within the 10-bit mask.");
+			Assert.That((angle / 10).Angle, Is.EqualTo(100), "Integer division of WAngle returned unexpected value.");
+		}
+
+		[Test]
+		public void ShortestPathInterpolationExhaustive()
+		{
+			for (var i = 0; i < 1024; i += 64)
+			{
+				var start = new WAngle(i);
+				var end = new WAngle((i + 512) & 1023);
+
+				Assert.That(WAngle.Lerp(start, end, 0, 1).Angle, Is.EqualTo(start.Angle), $"Lerp start bound (mul=0) failed at angle {i}.");
+				Assert.That(WAngle.Lerp(start, end, 1, 1).Angle, Is.EqualTo(end.Angle), $"Lerp end bound (mul=div) failed at angle {i}.");
+			}
+
+			// Crossing the zero-wrap seam
+			var nearMax = new WAngle(1014);
+			var nearZero = new WAngle(10);
+
+			Assert.That(WAngle.Lerp(nearMax, nearZero, 1, 2).Angle, Is.EqualTo(0), "Lerp failed to take the positive shortest path across the 1024/0 seam.");
+			Assert.That(WAngle.Lerp(nearZero, nearMax, 1, 2).Angle, Is.EqualTo(0), "Lerp failed to take the negative shortest path across the 1024/0 seam.");
+
+			var start2 = new WAngle(0);
+			var end2 = new WAngle(512);
+
+			// At exactly 180 degrees apart, the shortest path is ambiguous.
+			// This verifies the mask1/mask2 logic resolves to a valid perpendicular axis.
+			var midpoint = WAngle.Lerp(start2, end2, 1, 2);
+
+			Assert.That(midpoint.Angle, Is.AnyOf(256, 768),
+				"Lerp failed to resolve the 180-degree midpoint tie-break to a 90 or 270 degree axis.");
+		}
+
+		[Test]
+		public void TrigonometrySymmetryAndPythagorasExhaustive()
+		{
+			for (var i = -1024; i < 2048; i++)
+			{
+				var angle = new WAngle(i);
+				var sin = angle.Sin();
+				var cos = angle.Cos();
+
+				// Even/Odd Identities
+				Assert.That(cos, Is.EqualTo(new WAngle(-i).Cos()), $"Cosine symmetry failure: Cos({i}) != Cos({-i})");
+
+				// Shift Identities
+				Assert.That(sin, Is.EqualTo(new WAngle(i - 256).Cos()), $"Sine shift failure: Sin({i}) != Cos({i}-90deg)");
+
+				// Pythagorean Identity: Radius^2 = 1024^2 = 1,048,576
+				var squareSum = (long)cos * cos + (long)sin * sin;
+				Assert.That(squareSum, Is.EqualTo(1048576).Within(4096), $"Trig table drift (Sin^2 + Cos^2) exceeded tolerance at angle {i}.");
+
+				// Tangent Periodicity
+				var wrapped = i & 1023;
+				if (wrapped != 256 && wrapped != 768)
+				{
+					Assert.That(angle.Tan(), Is.EqualTo(new WAngle(i + 512).Tan()), $"Tangent periodicity failure at angle {i}.");
+				}
+			}
+		}
+
+		[Test]
+		public void TangentAsymptoteAndSignTransitions()
+		{
+			Assert.That(new WAngle(256).Tan(), Is.EqualTo(int.MaxValue), "Tan(90deg) must return int.MaxValue (Infinity).");
+			Assert.That(new WAngle(768).Tan(), Is.EqualTo(int.MaxValue), "Tan(270deg) must return int.MaxValue (Infinity).");
+
+			Assert.That(new WAngle(255).Tan(), Is.GreaterThan(0), "Tangent must be positive approaching 90deg from below.");
+			Assert.That(new WAngle(257).Tan(), Is.LessThan(0), "Tangent must be negative approaching 90deg from above.");
+		}
+
+		[Test]
+		public void InverseTrigFullCircleRoundTripExhaustive()
+		{
+			for (var i = 0; i < 1024; i++)
+			{
+				var original = new WAngle(i);
+				var s = original.Sin();
+				var c = original.Cos();
+
+				// ArcTan Round-trip
+				var resultAtan = WAngle.ArcTan(s, c);
+				var deltaAtan = Math.Abs(original.Angle - resultAtan.Angle);
+				if (deltaAtan > 512) deltaAtan = 1024 - deltaAtan;
+
+				Assert.That(deltaAtan, Is.LessThanOrEqualTo(1), $"ArcTan precision loss at {i} units. Input ({c}, {s}) produced {resultAtan.Angle}.");
+
+				// ArcSin/ArcCos range and identity checks
+				var asin = WAngle.ArcSin(s);
+				var acos = WAngle.ArcCos(c);
+
+				Assert.That(Math.Abs(asin.Sin() - s), Is.LessThanOrEqualTo(3), $"ArcSin round-trip precision failure for value {s}.");
+				Assert.That(Math.Abs(acos.Cos() - c), Is.LessThanOrEqualTo(3), $"ArcCos round-trip precision failure for value {c}.");
+			}
+		}
+
+		[TestCase(1, 1, 128, "Q1")]
+		[TestCase(1, -1, 384, "Q2")]
+		[TestCase(-1, -1, 640, "Q3")]
+		[TestCase(-1, 1, 896, "Q4")]
+		public void InverseTrigQuadrantAlignment(int y, int x, int expected, string label)
+		{
+			Assert.That(WAngle.ArcTan(y, x).Angle, Is.EqualTo(expected).Within(2), $"ArcTan quadrant multiplexer failed for {label}.");
+		}
+
+		[Test]
+		public void InverseTrigMemorySafetyAndGuards()
+		{
+			// Safe domain
+			Assert.DoesNotThrow(() => WAngle.ArcSin(1024), "ArcSin max boundary lookup crashed.");
+			Assert.DoesNotThrow(() => WAngle.ArcSin(-1024), "ArcSin min boundary lookup crashed.");
+			Assert.DoesNotThrow(() => WAngle.ArcSin(0), "ArcSin zero-point lookup crashed.");
+			Assert.DoesNotThrow(() => WAngle.ArcTan(166, 1), "ArcTan high-ratio precision limit lookup crashed.");
+
+			// Out of range domain
+			Assert.Throws<ArgumentOutOfRangeException>(() => WAngle.ArcSin(1025), "ArcSin failed to guard against value > 1024.");
+			Assert.Throws<ArgumentOutOfRangeException>(() => WAngle.ArcSin(-1025), "ArcSin failed to guard against value < -1024.");
+
+			// Fuzzing extreme integers for overflow in internal logic
+			Assert.DoesNotThrow(() => WAngle.ArcTan(int.MinValue, 1), "ArcTan failed to handle int.MinValue safely.");
+			Assert.DoesNotThrow(() => WAngle.ArcTan(int.MaxValue, int.MaxValue), "ArcTan failed to handle int.MaxValue safely.");
+		}
+
+		[TestCase(0, ExpectedResult = 0, TestName = "0 deg")]
+		[TestCase(90, ExpectedResult = 256, TestName = "90 deg")]
+		[TestCase(180, ExpectedResult = 512, TestName = "180 deg")]
+		[TestCase(360, ExpectedResult = 0, TestName = "360 deg")]
+		public int DegreesConversionIntegrity(int degrees)
+		{
+			var angle = WAngle.FromDegrees(degrees);
+			Assert.That(angle.Angle, Is.InRange(0, 1023), "FromDegrees produced an internal angle outside the 10-bit mask range.");
+			return angle.Angle;
+		}
+
+		[Test]
+		public void InverseTrigTableAccessAndRounding()
+		{
+			// CosineTable[256] is 0. This forces the search to the end of the table.
+			// We verify the neighbor check (index + 1) is clamped or safe.
+			Assert.DoesNotThrow(() => WAngle.ArcSin(0), "ArcSin(0) caused an out-of-bounds neighbor check.");
+			Assert.That(WAngle.ArcSin(0).Angle, Is.EqualTo(0), "ArcSin(0) should return 0 units.");
+
+			Assert.DoesNotThrow(() => WAngle.ArcSin(1024), "ArcSin(1024) caused an out-of-bounds neighbor check.");
+			Assert.That(WAngle.ArcSin(1024).Angle, Is.EqualTo(256), "ArcSin(1024) should return 256 units (90 degrees).");
+		}
+
+		[Test]
+		public void ArcTanPrecisionLimitGuard()
+		{
+			// The ratio ay > ax * 167 triggers an early return to prevent table overflow.
+			Assert.DoesNotThrow(() => WAngle.ArcTan(166, 1), "ArcTan failed precision lookup just below the guard threshold.");
+
+			var result = WAngle.ArcTan(167, 1);
+			Assert.That(result.Angle, Is.EqualTo(256), "ArcTan failed to snap to 90 degrees at/above the precision limit.");
+
+			var extremeResult = WAngle.ArcTan(int.MaxValue, 1);
+			Assert.That(extremeResult.Angle, Is.EqualTo(256), "ArcTan failed to snap extreme ratios to 90 degrees.");
+		}
+	}
+}


### PR DESCRIPTION
DORF uses these functions not sparingly so the slowdows were being felt. As well as the bugs.

Development of this PR was guided by compiler explorer. I removed basically all branching, added unrolled binary search, reduced stack usage, reduced insturction numbers, especially looking at avoiding divides.

As I'm doing unsafe, I've also created thorough unit tests.

We are now moving at the speed of light. We could only be faster if we did SIMD, or when optimising for a specific machine. We may want SIMD versions of functions later on as well.

WAngle constructor
- Removed branching

Sin/Cos
- Removed recursion
- Removed  branching
- No longer uses the stack
- 43% fewer instructions

Tan
- Removed recursion
- Removed  branching
- No longer uses the stack
- 40% fewer instructions

ArcCos/ArcSin
- Functional change: The results are now more precise
- Using binary search instead of linear search
- Unrolled the binary search
- Throwing is now outside the functions for inlining
- Reduced to 19 branch instructiuons, they are all forward jumps
- Stack is only used to satisfy the ABI
- About 77% fewer instructions

ArcTan
- Functional change: The results are now more precise
- Using binary search instead of linear search
- Unrolled the binary search
- Reduced to only 1 divide operation
- Reduced to 17 branch instructiuons, they are all forward jumps
- Stack is only used to satisfy the ABI
- About 12% fewer instructions

Lerp
- Removed branching
- No longer uses the stack
- 27% fewer instructions