### PR TITLE
Add registered player tooltip to lobby chat names.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -659,8 +659,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			switch (notification.Pool)
 			{
 				case TextNotificationPool.Chat:
+				{
+					var profileTooltip = chatLine.GetOrNull<ClientTooltipRegionWidget>("PROFILE_TOOLTIP");
+					var prefix = chatLine.GetOrNull("PREFIX");
+					var c = orderManager.LobbyInfo.ClientWithIndex(notification.ClientId);
+					if (profileTooltip != null && prefix != null && c != null)
+					{
+						profileTooltip.Bounds = prefix.Bounds;
+						if (c.Fingerprint != null)
+							profileTooltip.Template = "REGISTERED_PLAYER_TOOLTIP";
+
+						profileTooltip.IsVisible = () => true;
+						profileTooltip.Bind(orderManager, worldRenderer, c);
+					}
+
 					Game.Sound.PlayNotification(modRules, null, "Sounds", chatLineSound, null);
 					break;
+				}
+
 				case TextNotificationPool.System:
 					Game.Sound.PlayNotification(modRules, null, "Sounds", lobbyOptionChangedSound, null);
 					break;

--- a/mods/common/chrome/text-notifications.yaml
+++ b/mods/common/chrome/text-notifications.yaml
@@ -11,6 +11,10 @@ Container@CHAT_LINE_TEMPLATE:
 			X: 5
 			Height: 16
 			Shadow: True
+		ClientTooltipRegion@PROFILE_TOOLTIP:
+			Visible: false
+			TooltipContainer: TOOLTIP_CONTAINER
+			Template: ANONYMOUS_PLAYER_TOOLTIP
 		Label@TEXT:
 			X: 5
 			Height: 16


### PR DESCRIPTION
Allows chat messages to be associated with a registered account, even after the client has left.

<img width="326" height="248" alt="Screenshot 2026-01-27 at 17 11 29" src="https://github.com/user-attachments/assets/75dd537b-2e08-48f0-be4f-b3ddb1000a86" />
