### PR TITLE
Add a new "Map Discovery" entry in the Statistics drop-down menu

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -54,6 +54,12 @@ namespace OpenRA.Mods.Common.Traits
 		public int ArmyValue;
 		public int AssetsValue;
 
+		// Track buildings built by actor type (for Map Discovery stats)
+		public readonly Dictionary<string, int> BuildingsBuiltByType = [];
+
+		// Track support power activations by OrderName (for Map Discovery stats)
+		public readonly Dictionary<string, int> SupportPowerActivations = [];
+
 		// High resolution (every second) record of earnings, limited to the last minute
 		readonly Queue<int> earnedSeconds = new(60);
 
@@ -130,6 +136,28 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!incomeGraphDisabled)
 				IncomeSamples.Add(Income);
+		}
+
+		public void IncrementBuildingsBuilt(string actorType)
+		{
+			BuildingsBuiltByType.TryGetValue(actorType, out var count);
+			BuildingsBuiltByType[actorType] = count + 1;
+		}
+
+		public int GetBuildingsBuiltCount(string actorType)
+		{
+			return BuildingsBuiltByType.TryGetValue(actorType, out var count) ? count : 0;
+		}
+
+		public void IncrementSupportPowerActivation(string orderName)
+		{
+			SupportPowerActivations.TryGetValue(orderName, out var count);
+			SupportPowerActivations[orderName] = count + 1;
+		}
+
+		public int GetSupportPowerActivationCount(string orderName)
+		{
+			return SupportPowerActivations.TryGetValue(orderName, out var count) ? count : 0;
 		}
 	}
 
@@ -263,6 +291,10 @@ namespace OpenRA.Mods.Common.Traits
 			includedInAssetsValue = info.AddToAssetsValue;
 			if (includedInAssetsValue)
 				playerStats.AssetsValue += cost;
+
+			// Track buildings built by type for Map Discovery stats
+			if (self.Info.HasTraitInfo<BuildingInfo>())
+				playerStats.IncrementBuildingsBuilt(actorName);
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -262,6 +262,10 @@ namespace OpenRA.Mods.Common.Traits
 			remainingSubTicks = TotalTicks * 100;
 			notifiedCharging = notifiedReady = false;
 
+			// Track support power activation for Map Discovery stats
+			var playerStats = Manager.Self.TraitOrDefault<PlayerStatistics>();
+			playerStats?.IncrementSupportPowerActivation(Info.OrderName);
+
 			if (Info.OneShot)
 			{
 				PrerequisitesAvailable(false);

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -122,6 +122,10 @@ namespace OpenRA.Mods.Common.Traits
 		PaletteReference shroudPaletteReference, fogPaletteReference;
 		bool disposed;
 
+		// Controlled by ObserverStatsLogic checkboxes to show colored borders on gamefield
+		public bool ShowShroudBordersOnGamefield { get; set; }
+		public bool ShowFogBordersOnGamefield { get; set; }
+
 		public ShroudRenderer(World world, ShroudRendererInfo info)
 		{
 			if (info.ShroudVariants.Length != info.FogVariants.Length)
@@ -356,6 +360,129 @@ namespace OpenRA.Mods.Common.Traits
 			UpdateShroud(map.ProjectedCells);
 			fogLayer.Draw(wr.Viewport);
 			shroudLayer.Draw(wr.Viewport);
+
+			// Render colored borders on gamefield if enabled
+			if (ShowShroudBordersOnGamefield || ShowFogBordersOnGamefield)
+				RenderColoredBorders(wr);
+		}
+
+		// Maps neighbor direction to edge indices for rectangular grids
+		// Corner order: TopLeft=0, TopRight=1, BottomRight=2, BottomLeft=3
+		static readonly (CVec Offset, int CornerIndex)[] RectangularNeighborToEdge =
+		[
+			(new CVec(0, -1), 0),  // Top neighbor -> draw from TopLeft to TopRight
+			(new CVec(1, 0), 1),   // Right neighbor -> draw from TopRight to BottomRight
+			(new CVec(0, 1), 2),   // Bottom neighbor -> draw from BottomRight to BottomLeft
+			(new CVec(-1, 0), 3),  // Left neighbor -> draw from BottomLeft to TopLeft
+		];
+
+		// Maps neighbor direction to edge indices for isometric grids (diamond shape)
+		// Corner order: Top=0, Right=1, Bottom=2, Left=3
+		static readonly (CVec Offset, int CornerIndex)[] IsometricNeighborToEdge =
+		[
+			(new CVec(0, -1), 0),  // Top-left neighbor -> draw from Top to Right
+			(new CVec(1, 0), 1),   // Top-right neighbor -> draw from Right to Bottom
+			(new CVec(0, 1), 2),   // Bottom-right neighbor -> draw from Bottom to Left
+			(new CVec(-1, 0), 3),  // Bottom-left neighbor -> draw from Left to Top
+		];
+
+	void RenderColoredBorders(WorldRenderer wr)
+	{
+		// Get players to show borders for based on dropdown selection
+		Player[] playersToShow;
+		var renderPlayer = world.RenderPlayer;
+		var isAllPlayersMode = renderPlayer == null || renderPlayer.InternalName == "Everyone";
+		if (isAllPlayersMode)
+			playersToShow = world.Players.Where(p => !p.NonCombatant && p.Playable).ToArray();
+		else
+			playersToShow = new[] { renderPlayer };
+
+		var screenWidth = wr.ScreenVector(new WVec(new WDist(64), WDist.Zero, WDist.Zero))[0];
+			var cr = Game.Renderer.WorldRgbaColorRenderer;
+
+			// Use the flat ramp corners from the grid (handles both rectangular and isometric)
+			// Ramp 0 is always flat with corners at ground level
+			var baseCorners = map.Grid.Ramps[0].Corners;
+
+			// Create flat corners (Z=0) for shroud border rendering
+			var cellCorners = new WVec[]
+			{
+				new(baseCorners[0].X, baseCorners[0].Y, 0),
+				new(baseCorners[1].X, baseCorners[1].Y, 0),
+				new(baseCorners[2].X, baseCorners[2].Y, 0),
+				new(baseCorners[3].X, baseCorners[3].Y, 0)
+			};
+
+			// Select the appropriate neighbor-to-edge mapping based on grid type
+			var isIsometric = map.Grid.Type == MapGridType.RectangularIsometric;
+			var neighborToEdge = isIsometric ? IsometricNeighborToEdge : RectangularNeighborToEdge;
+
+			// Only process visible cells for performance
+			var visibleCells = wr.Viewport.AllVisibleCells;
+
+		foreach (var player in playersToShow)
+		{
+			var playerShroud = player.Shroud;
+			var playerColor = player.Color;
+
+				foreach (var uv in visibleCells.CandidateMapCoords)
+				{
+					var cell = uv.ToCPos(map);
+					if (!map.Contains(cell))
+						continue;
+
+					var puv = (PPos)uv;
+
+					// Get cell center position (same as shroud sprites use, flattened to Z=0)
+					var cellPos = map.CenterOfCell(cell);
+					var pos = cellPos - new WVec(0, 0, cellPos.Z);
+
+					var isExplored = playerShroud.IsExplored(puv);
+					var isVisible = playerShroud.IsVisible(puv);
+
+					// Check each neighbor and draw border if there's a transition
+					foreach (var (offset, cornerIndex) in neighborToEdge)
+					{
+						var neighborCell = cell + offset;
+						if (!map.Contains(neighborCell))
+							continue;
+
+						var neighborPuv = (PPos)neighborCell.ToMPos(map);
+						var drawShroudBorder = false;
+						var drawFogBorder = false;
+
+						// Shroud border: explored cell adjacent to unexplored cell
+						if (ShowShroudBordersOnGamefield && isExplored && !playerShroud.IsExplored(neighborPuv))
+							drawShroudBorder = true;
+
+						// Fog border: visible cell adjacent to explored-but-not-visible cell
+						if (ShowFogBordersOnGamefield && isVisible)
+						{
+							var neighborExplored = playerShroud.IsExplored(neighborPuv);
+							var neighborVisible = playerShroud.IsVisible(neighborPuv);
+							if (neighborExplored && !neighborVisible)
+								drawFogBorder = true;
+						}
+
+						if (!drawShroudBorder && !drawFogBorder)
+							continue;
+
+						// Use Screen3DPosition with WorldRgbaColorRenderer like BeamRenderable does
+						// No WorldToViewPx needed - coordinates go directly to WorldSpriteRenderer
+						var startPos = pos + cellCorners[cornerIndex];
+						var endPos = pos + cellCorners[(cornerIndex + 1) % 4];
+						var start = wr.Screen3DPosition(startPos);
+						var end = wr.Screen3DPosition(endPos);
+
+						// Fog borders use 50% opacity to distinguish from shroud borders
+						var borderColor = drawFogBorder && !drawShroudBorder
+							? Color.FromArgb(128, playerColor.R, playerColor.G, playerColor.B)
+							: playerColor;
+
+						cr.DrawLine(start, end, screenWidth, borderColor);
+					}
+				}
+			}
 		}
 
 		void UpdateShroudCell(PPos puv)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -22,7 +22,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public enum ObserverStatsPanel { None, Basic, Economy, Production, SupportPowers, Combat, Army, Graph, ArmyGraph }
+	public enum ObserverStatsPanel { None, Basic, Economy, Production, SupportPowers, Combat, Army, Graph, ArmyGraph, MapDiscovery }
 
 	[ChromeLogicArgsHotkeys(
 		"StatisticsBasicKey",
@@ -32,7 +32,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		"StatisticsCombatKey",
 		"StatisticsArmyKey",
 		"StatisticsGraphKey",
-		"StatisticsArmyGraphKey")]
+		"StatisticsArmyGraphKey",
+		"StatisticsMapDiscoveryKey")]
 	public class ObserverStatsLogic : ChromeLogic
 	{
 		[FluentReference]
@@ -62,6 +63,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string ArmyGraph = "options-observer-stats.army-graph";
 
+		[FluentReference]
+		const string MapDiscovery = "options-observer-stats.map-discovery";
+
 		[FluentReference("team")]
 		const string TeamNumber = "label-team-name";
 
@@ -74,6 +78,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContainerWidget supportPowerStatsHeaders;
 		readonly ContainerWidget combatStatsHeaders;
 		readonly ContainerWidget armyHeaders;
+		readonly ContainerWidget mapDiscoveryStatsHeaders;
 		readonly ScrollPanelWidget playerStatsPanel;
 		readonly ScrollItemWidget basicPlayerTemplate;
 		readonly ScrollItemWidget economyPlayerTemplate;
@@ -81,11 +86,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ScrollItemWidget supportPowersPlayerTemplate;
 		readonly ScrollItemWidget armyPlayerTemplate;
 		readonly ScrollItemWidget combatPlayerTemplate;
+		readonly ScrollItemWidget mapDiscoveryPlayerTemplate;
 		readonly ContainerWidget incomeGraphContainer;
 		readonly ContainerWidget armyValueGraphContainer;
 		readonly ScrollableLineGraphWidget incomeGraph;
 		readonly ScrollableLineGraphWidget armyValueGraph;
 		readonly ScrollItemWidget teamTemplate;
+		readonly DropDownButtonWidget displayOptionsDropdown;
+		readonly ContainerWidget displayOptionsPanel;
+		readonly RadarWidget radarWidget;
+		readonly ShroudRenderer shroudRenderer;
 		readonly Player[] players;
 		readonly IGrouping<int, Player>[] teams;
 		readonly bool hasTeams;
@@ -93,6 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly WorldRenderer worldRenderer;
 
 		readonly string clickSound = ChromeMetrics.Get<string>("ClickSound");
+		readonly string modId;
 		ObserverStatsPanel activePanel;
 
 		[ObjectCreator.UseCtor]
@@ -100,6 +111,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			this.world = world;
 			this.worldRenderer = worldRenderer;
+			modId = modData.Manifest.Id;
 
 			MiniYaml yaml;
 			var keyNames = Enum.GetNames<ObserverStatsPanel>();
@@ -120,6 +132,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			supportPowerStatsHeaders = widget.Get<ContainerWidget>("SUPPORT_POWERS_HEADERS");
 			armyHeaders = widget.Get<ContainerWidget>("ARMY_HEADERS");
 			combatStatsHeaders = widget.Get<ContainerWidget>("COMBAT_STATS_HEADERS");
+			mapDiscoveryStatsHeaders = widget.GetOrNull<ContainerWidget>("MAP_DISCOVERY_STATS_HEADERS");
 
 			playerStatsPanel = widget.Get<ScrollPanelWidget>("PLAYER_STATS_PANEL");
 			playerStatsPanel.Layout = new GridLayout(playerStatsPanel);
@@ -135,6 +148,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				AdjustHeader(supportPowerStatsHeaders);
 				AdjustHeader(combatStatsHeaders);
 				AdjustHeader(armyHeaders);
+				if (mapDiscoveryStatsHeaders != null)
+					AdjustHeader(mapDiscoveryStatsHeaders);
 			}
 
 			basicPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("BASIC_PLAYER_TEMPLATE");
@@ -143,6 +158,71 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			supportPowersPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("SUPPORT_POWERS_PLAYER_TEMPLATE");
 			armyPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("ARMY_PLAYER_TEMPLATE");
 			combatPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("COMBAT_PLAYER_TEMPLATE");
+			mapDiscoveryPlayerTemplate = playerStatsPanel.GetOrNull<ScrollItemWidget>("MAP_DISCOVERY_PLAYER_TEMPLATE");
+
+			// Get radar widget and shroud renderer for borders display
+			// Try different radar widget names depending on mod architecture
+			radarWidget = Ui.Root.GetOrNull<RadarWidget>("INGAME_RADAR"); // RA, D2K, TS (observer mode)
+			radarWidget ??= Ui.Root.GetOrNull<RadarWidget>("RADAR_MINIMAP"); // CNC (monolithic ingame.yaml)
+
+			shroudRenderer = world.WorldActor.TraitOrDefault<ShroudRenderer>();
+
+			// Load display options panel and setup dropdown
+			displayOptionsPanel = Ui.LoadWidget<ContainerWidget>("MAP_DISCOVERY_DISPLAY_OPTIONS_PANEL", null, []);
+
+			// Shroud borders on minimap
+			var showShroudBordersMinimapCheckbox = displayOptionsPanel.Get<CheckboxWidget>("SHOW_SHROUD_BORDERS_MINIMAP");
+			showShroudBordersMinimapCheckbox.IsChecked = () => radarWidget?.ShowShroudBorders ?? false;
+			showShroudBordersMinimapCheckbox.OnClick = () =>
+			{
+				if (radarWidget != null)
+					radarWidget.ShowShroudBorders = !radarWidget.ShowShroudBorders;
+			};
+
+			// Shroud borders on gamefield
+			var showShroudBordersGamefieldCheckbox = displayOptionsPanel.Get<CheckboxWidget>("SHOW_SHROUD_BORDERS_GAMEFIELD");
+			showShroudBordersGamefieldCheckbox.IsChecked = () => shroudRenderer?.ShowShroudBordersOnGamefield ?? false;
+			showShroudBordersGamefieldCheckbox.OnClick = () =>
+			{
+				if (shroudRenderer != null)
+					shroudRenderer.ShowShroudBordersOnGamefield = !shroudRenderer.ShowShroudBordersOnGamefield;
+			};
+
+			// Fog borders on minimap
+			var showFogBordersMinimapCheckbox = displayOptionsPanel.Get<CheckboxWidget>("SHOW_FOG_BORDERS_MINIMAP");
+			showFogBordersMinimapCheckbox.IsChecked = () => radarWidget?.ShowFogBorders ?? false;
+			showFogBordersMinimapCheckbox.OnClick = () =>
+			{
+				if (radarWidget != null)
+					radarWidget.ShowFogBorders = !radarWidget.ShowFogBorders;
+			};
+
+			// Fog borders on gamefield
+			var showFogBordersGamefieldCheckbox = displayOptionsPanel.Get<CheckboxWidget>("SHOW_FOG_BORDERS_GAMEFIELD");
+			showFogBordersGamefieldCheckbox.IsChecked = () => shroudRenderer?.ShowFogBordersOnGamefield ?? false;
+			showFogBordersGamefieldCheckbox.OnClick = () =>
+			{
+				if (shroudRenderer != null)
+					shroudRenderer.ShowFogBordersOnGamefield = !shroudRenderer.ShowFogBordersOnGamefield;
+			};
+
+			// Hide already explored areas on minimap (show only currently visible areas)
+			var hideExploredAreasMinimapCheckbox = displayOptionsPanel.Get<CheckboxWidget>("HIDE_EXPLORED_AREAS_MINIMAP");
+			hideExploredAreasMinimapCheckbox.IsChecked = () => radarWidget?.HideExploredAreasOnMinimap ?? false;
+			hideExploredAreasMinimapCheckbox.OnClick = () =>
+			{
+				if (radarWidget != null)
+					radarWidget.HideExploredAreasOnMinimap = !radarWidget.HideExploredAreasOnMinimap;
+			};
+
+			// Setup display options dropdown
+			displayOptionsDropdown = widget.Get<DropDownButtonWidget>("DISPLAY_OPTIONS_DROPDOWN");
+			displayOptionsDropdown.IsVisible = () => activePanel == ObserverStatsPanel.MapDiscovery;
+			displayOptionsDropdown.OnMouseDown = _ =>
+			{
+				displayOptionsDropdown.RemovePanel();
+				displayOptionsDropdown.AttachPanel(displayOptionsPanel);
+			};
 
 			incomeGraphContainer = widget.Get<ContainerWidget>("INCOME_GRAPH_CONTAINER");
 			incomeGraph = incomeGraphContainer.Get<ScrollableLineGraphWidget>("INCOME_GRAPH");
@@ -155,6 +235,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var statsDropDown = widget.Get<DropDownButtonWidget>("STATS_DROPDOWN");
 			StatsDropDownOption CreateStatsOption(string title, ObserverStatsPanel panel, ScrollItemWidget template, Action a)
 			{
+				// Return null if the option requires a template that doesn't exist (e.g., MapDiscovery in mods without it)
+				if (panel == ObserverStatsPanel.MapDiscovery && template == null)
+					return null;
+
 				title = FluentProvider.GetMessage(title);
 				return new StatsDropDownOption
 				{
@@ -198,7 +282,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				CreateStatsOption(Army, ObserverStatsPanel.Army, armyPlayerTemplate, () => DisplayStats(ArmyStats)),
 				CreateStatsOption(EarningsGraph, ObserverStatsPanel.Graph, null, IncomeGraph),
 				CreateStatsOption(ArmyGraph, ObserverStatsPanel.ArmyGraph, null, ArmyValueGraph),
-			};
+				CreateStatsOption(MapDiscovery, ObserverStatsPanel.MapDiscovery, mapDiscoveryPlayerTemplate, () => DisplayStats(MapDiscoveryStats)),
+			}.Where(option => option != null).ToArray();
 
 			ScrollItemWidget SetupItem(StatsDropDownOption option, ScrollItemWidget template)
 			{
@@ -209,7 +294,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var statsDropDownPanelTemplate = logicArgs.TryGetValue("StatsDropDownPanelTemplate", out yaml) ? yaml.Value : "LABEL_DROPDOWN_TEMPLATE";
 
-			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown(statsDropDownPanelTemplate, 230, statsDropDownOptions, SetupItem);
+			var dropdownHeight = statsDropDownOptions.Length * 25 + 10;
+			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown(statsDropDownPanelTemplate, dropdownHeight, statsDropDownOptions, SetupItem);
 			statsDropDownOptions[0].OnClick();
 
 			var keyListener = statsDropDown.Get<LogicKeyListenerWidget>("STATS_DROPDOWN_KEYHANDLER");
@@ -244,12 +330,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			supportPowerStatsHeaders.Visible = false;
 			armyHeaders.Visible = false;
 			combatStatsHeaders.Visible = false;
+			if (mapDiscoveryStatsHeaders != null)
+				mapDiscoveryStatsHeaders.Visible = false;
 
 			incomeGraphContainer.Visible = false;
 			armyValueGraphContainer.Visible = false;
 
 			incomeGraph.GetSeries = null;
 			armyValueGraph.GetSeries = null;
+
+			// Disable all borders when leaving Map Discovery panel
+			if (radarWidget != null)
+			{
+				radarWidget.ShowShroudBorders = false;
+				radarWidget.ShowFogBorders = false;
+				radarWidget.HideExploredAreasOnMinimap = false;
+			}
+
+			if (shroudRenderer != null)
+			{
+				shroudRenderer.ShowShroudBordersOnGamefield = false;
+				shroudRenderer.ShowFogBordersOnGamefield = false;
+			}
 		}
 
 		void IncomeGraph()
@@ -471,6 +573,157 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.Count(a => a.Owner == player && !a.IsDead).ToString(NumberFormatInfo.CurrentInfo);
 
 			return template;
+		}
+
+		ScrollItemWidget MapDiscoveryStats(Player player)
+		{
+			if (mapDiscoveryStatsHeaders == null || mapDiscoveryPlayerTemplate == null)
+				return null;
+
+			mapDiscoveryStatsHeaders.Visible = true;
+			ConfigureMapDiscoveryHeaders();
+			var template = SetupPlayerScrollItemWidget(mapDiscoveryPlayerTemplate, player);
+
+			AddPlayerFlagAndName(template, player);
+
+			var playerName = template.Get<LabelWithTooltipWidget>("PLAYER");
+			playerName.GetColor = () => Color.White;
+
+			var playerColor = template.Get<ColorBlockWidget>("PLAYER_COLOR");
+			var playerGradient = template.Get<GradientColorBlockWidget>("PLAYER_GRADIENT");
+
+			SetupPlayerColor(player, template, playerColor, playerGradient);
+
+			// Fog of War: percentage of currently visible cells relative to total map size
+			// (fluctuates with unit positions, represents how much of the map is currently visible)
+			template.Get<LabelWidget>("FOG").GetText = () => player.Shroud.Disabled ? "100%" : VisibleCellsPercentage(player);
+
+			// Shroud: percentage of explored cells relative to total map size
+			// (increases as map is discovered, never decreases)
+			template.Get<LabelWidget>("SHROUD").GetText = () => player.Shroud.Disabled ? "100%" : ExploredCellsPercentage(player);
+
+			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
+
+			// Radar building count (mod-specific actor names)
+			var radarLabel = template.GetOrNull<LabelWidget>("RADAR");
+			if (radarLabel != null && stats != null)
+			{
+				var radarActors = GetRadarActorsForMod();
+				radarLabel.GetText = () => GetBuildingsBuiltCount(stats, radarActors);
+			}
+
+			// Spy Plane support power activations (RA Soviet only)
+			var spyPlaneLabel = template.GetOrNull<LabelWidget>("SPY_PLANE");
+			if (spyPlaneLabel != null && stats != null)
+			{
+				if (modId == "ra")
+					spyPlaneLabel.GetText = () => stats.GetSupportPowerActivationCount("SovietSpyPlane").ToString(NumberFormatInfo.CurrentInfo);
+				else
+					spyPlaneLabel.Visible = false;
+			}
+
+			// GPS Satellite support power activations (RA Allied only)
+			var gpsLabel = template.GetOrNull<LabelWidget>("GPS_SAT");
+			if (gpsLabel != null && stats != null)
+			{
+				if (modId == "ra")
+					gpsLabel.GetText = () => stats.GetSupportPowerActivationCount("GpsSatellite").ToString(NumberFormatInfo.CurrentInfo);
+				else
+					gpsLabel.Visible = false;
+			}
+
+			// Gap Generator building count (RA only)
+			var gapLabel = template.GetOrNull<LabelWidget>("GAP");
+			if (gapLabel != null && stats != null)
+			{
+				if (modId == "ra")
+					gapLabel.GetText = () => stats.GetBuildingsBuiltCount("gap").ToString(NumberFormatInfo.CurrentInfo);
+				else
+					gapLabel.Visible = false;
+			}
+
+			return template;
+		}
+
+		string[] GetRadarActorsForMod()
+		{
+			return modId switch
+			{
+				"ra" => ["dome"],
+				"cnc" => ["hq"],
+				"d2k" => ["radar"],
+				"ts" => ["gacnst", "nacnst"],
+				_ => []
+			};
+		}
+
+		static string GetBuildingsBuiltCount(PlayerStatistics stats, string[] actorNames)
+		{
+			var total = 0;
+			foreach (var actorName in actorNames)
+				total += stats.GetBuildingsBuiltCount(actorName);
+			return total.ToString(NumberFormatInfo.CurrentInfo);
+		}
+
+		void ConfigureMapDiscoveryHeaders()
+		{
+			if (mapDiscoveryStatsHeaders == null)
+				return;
+
+			// Hide Spy Plane header for non-RA mods
+			var spyPlaneHeader = mapDiscoveryStatsHeaders.GetOrNull<LabelWidget>("SPY_PLANE_HEADER");
+			if (spyPlaneHeader != null)
+				spyPlaneHeader.Visible = modId == "ra";
+
+			// Hide GPS Satellite header for non-RA mods
+			var gpsHeader = mapDiscoveryStatsHeaders.GetOrNull<LabelWidget>("GPS_SAT_HEADER");
+			if (gpsHeader != null)
+				gpsHeader.Visible = modId == "ra";
+
+			// Hide Gap Generator header for non-RA mods
+			var gapHeader = mapDiscoveryStatsHeaders.GetOrNull<LabelWidget>("GAP_HEADER");
+			if (gapHeader != null)
+				gapHeader.Visible = modId == "ra";
+		}
+
+		string ExploredCellsPercentage(Player player)
+		{
+			var exploredCells = 0;
+			var totalProjectedCells = 0;
+
+			// Count explored cells and total projected cells
+			// Use ProjectedCells instead of AllCells for consistency across all mods (especially TS isometric)
+			foreach (var puv in world.Map.ProjectedCells)
+			{
+				if (world.Map.Contains(puv))
+				{
+					totalProjectedCells++;
+					if (player.Shroud.IsExplored(puv))
+						exploredCells++;
+				}
+			}
+
+			// If no projected cells (shouldn't happen), avoid division by zero
+			if (totalProjectedCells == 0)
+				return 0.ToString("P0", NumberFormatInfo.CurrentInfo);
+
+			var percentage = (double)exploredCells / totalProjectedCells;
+			return percentage.ToString("P0", NumberFormatInfo.CurrentInfo);
+		}
+
+		string VisibleCellsPercentage(Player player)
+		{
+			// Use the same logic as Vision() in CombatStats - RevealedCells is the internal counter
+			// that tracks currently visible cells, maintained by the Shroud system
+			var revealedCells = player.Shroud.RevealedCells;
+			var totalProjectedCells = world.Map.ProjectedCells.Length;
+
+			if (totalProjectedCells == 0)
+				return 0.ToString("P0", NumberFormatInfo.CurrentInfo);
+
+			// Calculate visible cells as percentage of total projected cells (same as Vision())
+			var percentage = (double)revealedCells / totalProjectedCells;
+			return percentage.ToString("P0", NumberFormatInfo.CurrentInfo);
 		}
 
 		ScrollItemWidget BasicStats(Player player)

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -66,9 +66,14 @@ namespace OpenRA.Mods.Common.Widgets
 		Sprite terrainSprite;
 		Sprite actorSprite;
 		Sprite shroudSprite;
+		Sprite shroudBorderSprite;
 		Shroud shroud;
 		PlayerRadarTerrain playerRadarTerrain;
 		Player currentPlayer;
+
+		public bool ShowShroudBorders { get; set; }
+		public bool ShowFogBorders { get; set; }
+		public bool HideExploredAreasOnMinimap { get; set; }
 
 		[ObjectCreator.UseCtor]
 		public RadarWidget(ModData modData, World world, WorldRenderer worldRenderer)
@@ -223,6 +228,7 @@ namespace OpenRA.Mods.Common.Widgets
 			terrainSprite = new Sprite(radarSheet, b, TextureChannel.RGBA);
 			shroudSprite = new Sprite(radarSheet, new Rectangle(b.Location + new Size(previewWidth, 0), b.Size), TextureChannel.RGBA);
 			actorSprite = new Sprite(radarSheet, new Rectangle(b.Location + new Size(0, previewHeight), b.Size), TextureChannel.RGBA);
+			shroudBorderSprite = new Sprite(radarSheet, new Rectangle(b.Location + new Size(previewWidth, previewHeight), b.Size), TextureChannel.RGBA);
 		}
 
 		void UpdateTerrainColor(MPos uv)
@@ -286,6 +292,106 @@ namespace OpenRA.Mods.Common.Widgets
 				}
 			}
 		}
+
+void UpdateBordersLayer()
+{
+	var stride = radarSheet.Size.Width;
+
+	// Get players to show borders for based on dropdown selection
+	// "Everyone" player (All Players option) or null (Disable Shroud) means show all playable players
+	// A specific player means show only that player's borders
+	Player[] playersToShow;
+	var isAllPlayersMode = currentPlayer == null || currentPlayer.InternalName == "Everyone";
+	if (isAllPlayersMode)
+		playersToShow = world.Players.Where(p => !p.NonCombatant && p.Playable).ToArray();
+	else
+		playersToShow = new[] { currentPlayer };
+
+	var neighborOffsets = new[] { new PPos(1, 0), new PPos(-1, 0), new PPos(0, 1), new PPos(0, -1) };
+
+	unsafe
+	{
+		fixed (byte* colorBytes = &radarData[0])
+		{
+			var colors = (uint*)colorBytes;
+
+			// Clear only the border layer quadrant (bottom-right), not the actor layer (bottom-left)
+			// The border sprite starts at (previewWidth, previewHeight) in the texture
+			var bounds = shroudBorderSprite.Bounds;
+			for (var y = bounds.Top; y < bounds.Bottom; y++)
+			{
+				for (var x = bounds.Left; x < bounds.Right; x++)
+				{
+					colors[y * stride + x] = 0;
+				}
+			}
+
+			foreach (var player in playersToShow)
+			{
+					var playerShroud = player.Shroud;
+					var playerColor = player.Color.ToArgb();
+
+					foreach (var puv in world.Map.ProjectedCells)
+					{
+						var isExplored = playerShroud.IsExplored(puv);
+						var isVisible = playerShroud.IsVisible(puv);
+
+						var isShroudBorder = false;
+						var isFogBorder = false;
+
+						// Check each neighbor for border detection
+						foreach (var offset in neighborOffsets)
+						{
+							var neighbor = new PPos(puv.U + offset.U, puv.V + offset.V);
+							if (!world.Map.Contains(neighbor))
+								continue;
+
+							// Shroud border: explored cell adjacent to unexplored cell
+							// (same logic as gamefield: draw border on the explored side)
+							if (ShowShroudBorders && isExplored && !playerShroud.IsExplored(neighbor))
+							{
+								isShroudBorder = true;
+								break;
+							}
+
+							// Fog border: visible cell adjacent to explored-but-not-visible cell
+							// (same logic as gamefield: draw border on the visible side)
+							if (ShowFogBorders && isVisible)
+							{
+								var neighborExplored = playerShroud.IsExplored(neighbor);
+								var neighborVisible = playerShroud.IsVisible(neighbor);
+								if (neighborExplored && !neighborVisible)
+								{
+									isFogBorder = true;
+									break;
+								}
+							}
+						}
+
+						if (!isShroudBorder && !isFogBorder)
+							continue;
+
+						// Draw the border pixel with the player's color
+						foreach (var iuv in world.Map.Unproject(puv))
+						{
+							if (isRectangularIsometric)
+							{
+								// Odd rows are shifted right by 1px
+								var dx = iuv.V & 1;
+								if (iuv.U + dx > 0)
+									colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx - 1 + previewWidth] = playerColor;
+
+								if (2 * iuv.U + dx < stride)
+									colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx + previewWidth] = playerColor;
+							}
+							else
+								colors[(iuv.V + previewHeight) * stride + iuv.U + previewWidth] = playerColor;
+						}
+					}
+				}
+			}
+		}
+	}
 
 		public override string GetCursor(int2 pos)
 		{
@@ -360,34 +466,56 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
-		public override void Draw()
+	public override void Draw()
+	{
+		if (world == null)
+			return;
+
+		radarSheet.CommitBufferedData();
+
+		var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight) / 2);
+		var s = new float2(mapRect.Size.Width, mapRect.Size.Height * radarMinimapHeight);
+
+		var bordersEnabled = ShowShroudBorders || ShowFogBorders;
+
+		if (bordersEnabled)
 		{
-			if (world == null)
-				return;
+			// When borders are enabled, draw in this order: terrain -> shroud -> actors -> borders
+			// This way the shroud masks the terrain, but actors are drawn on top and remain visible
+			WidgetUtils.DrawSprite(terrainSprite, o, s);
 
-			radarSheet.CommitBufferedData();
+			if (shroud != null)
+				WidgetUtils.DrawSprite(shroudSprite, o, s);
 
-			var o = new float2(mapRect.Location.X, mapRect.Location.Y + world.Map.Bounds.Height * previewScale * (1 - radarMinimapHeight) / 2);
-			var s = new float2(mapRect.Size.Width, mapRect.Size.Height * radarMinimapHeight);
-
+			WidgetUtils.DrawSprite(actorSprite, o, s);
+			WidgetUtils.DrawSprite(shroudBorderSprite, o, s);
+		}
+		else
+		{
+			// Normal drawing order: terrain -> actors -> shroud
 			WidgetUtils.DrawSprite(terrainSprite, o, s);
 			WidgetUtils.DrawSprite(actorSprite, o, s);
 
 			if (shroud != null)
 				WidgetUtils.DrawSprite(shroudSprite, o, s);
-
-			// Draw viewport rect
-			if (hasRadar)
-			{
-				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.TopLeft)));
-				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.BottomRight)));
-
-				Game.Renderer.EnableScissor(mapRect);
-				DrawRadarPings();
-				Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.White);
-				Game.Renderer.DisableScissor();
-			}
 		}
+
+		// Mask to show only currently visible areas (hide already explored areas)
+		if (HideExploredAreasOnMinimap)
+			DrawVisibleAreaMask(o, s);
+
+		// Draw viewport rect
+		if (hasRadar)
+		{
+			var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.TopLeft)));
+			var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.BottomRight)));
+
+			Game.Renderer.EnableScissor(mapRect);
+			DrawRadarPings();
+			Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.White);
+			Game.Renderer.DisableScissor();
+		}
+	}
 
 		void DrawRadarPings()
 		{
@@ -403,6 +531,153 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
+void DrawVisibleAreaMask(float2 origin, float2 size)
+{
+	// Get players to show based on dropdown selection
+	// Draw black overlay over all non-visible areas (both unexplored and explored but not visible)	
+	Player[] playersToShow;
+	var isAllPlayersMode = currentPlayer == null || currentPlayer.InternalName == "Everyone";
+	if (isAllPlayersMode)
+		playersToShow = world.Players.Where(p => !p.NonCombatant && p.Playable).ToArray();
+	else
+		playersToShow = new[] { currentPlayer };
+
+	if (playersToShow.Length == 0)
+		return;
+
+	var stride = radarSheet.Size.Width;
+	var blackColor = Color.Black.ToArgb();
+	var transparentColor = Color.Transparent.ToArgb();
+	var neighborOffsets = new[] { new PPos(1, 0), new PPos(-1, 0), new PPos(0, 1), new PPos(0, -1) };
+
+	unsafe
+	{
+		fixed (byte* colorBytes = &radarData[0])
+		{
+			var colors = (uint*)colorBytes;
+
+			// Initialize only the border layer quadrant (bottom-right) to black
+			// This avoids clearing the actor layer (bottom-left)
+			var bounds = shroudBorderSprite.Bounds;
+			for (var y = bounds.Top; y < bounds.Bottom; y++)
+			{
+				for (var x = bounds.Left; x < bounds.Right; x++)
+				{
+					colors[y * stride + x] = blackColor;
+				}
+			}
+
+				// Make visible cells transparent
+				foreach (var puv in world.Map.ProjectedCells)
+				{
+					var isVisibleByAny = false;
+
+					// Check if this cell is visible by any of the selected players
+					foreach (var player in playersToShow)
+					{
+						if (player.Shroud.IsVisible(puv))
+						{
+							isVisibleByAny = true;
+							break;
+						}
+					}
+
+					// If visible by any selected player, make it transparent
+					if (isVisibleByAny)
+					{
+						foreach (var iuv in world.Map.Unproject(puv))
+						{
+							if (isRectangularIsometric)
+							{
+								// Odd rows are shifted right by 1px
+								var dx = iuv.V & 1;
+								if (iuv.U + dx > 0)
+									colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx - 1 + previewWidth] = transparentColor;
+
+								if (2 * iuv.U + dx < stride)
+									colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx + previewWidth] = transparentColor;
+							}
+							else
+								colors[(iuv.V + previewHeight) * stride + iuv.U + previewWidth] = transparentColor;
+						}
+					}
+				}
+
+				// Redraw colored borders on top of the fog mask when border options are enabled
+				// This is necessary because the fog mask overwrites the shroudBorderSprite layer
+				if (ShowShroudBorders || ShowFogBorders)
+				{
+					foreach (var player in playersToShow)
+					{
+							var playerShroud = player.Shroud;
+							var playerColor = player.Color.ToArgb();
+
+							foreach (var puv in world.Map.ProjectedCells)
+							{
+								var isExplored = playerShroud.IsExplored(puv);
+								var isVisible = playerShroud.IsVisible(puv);
+
+								var isShroudBorder = false;
+								var isFogBorder = false;
+
+								// Check each neighbor for border detection
+								foreach (var offset in neighborOffsets)
+								{
+									var neighbor = new PPos(puv.U + offset.U, puv.V + offset.V);
+									if (!world.Map.Contains(neighbor))
+										continue;
+
+									// Shroud border: explored cell adjacent to unexplored cell
+									// (same logic as gamefield: draw border on the explored side)
+									if (ShowShroudBorders && isExplored && !playerShroud.IsExplored(neighbor))
+									{
+										isShroudBorder = true;
+										break;
+									}
+
+									// Fog border: visible cell adjacent to explored-but-not-visible cell
+									// (same logic as gamefield: draw border on the visible side)
+									if (ShowFogBorders && isVisible)
+									{
+										var neighborExplored = playerShroud.IsExplored(neighbor);
+										var neighborVisible = playerShroud.IsVisible(neighbor);
+										if (neighborExplored && !neighborVisible)
+										{
+											isFogBorder = true;
+											break;
+										}
+									}
+								}
+
+								if (!isShroudBorder && !isFogBorder)
+									continue;
+
+								// Draw the border pixel with the player's color
+								foreach (var iuv in world.Map.Unproject(puv))
+								{
+									if (isRectangularIsometric)
+									{
+										// Odd rows are shifted right by 1px
+										var dx = iuv.V & 1;
+										if (iuv.U + dx > 0)
+											colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx - 1 + previewWidth] = playerColor;
+
+										if (2 * iuv.U + dx < stride)
+											colors[(iuv.V + previewHeight) * stride + 2 * iuv.U + dx + previewWidth] = playerColor;
+									}
+									else
+										colors[(iuv.V + previewHeight) * stride + iuv.U + previewWidth] = playerColor;
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Draw the mask sprite
+			WidgetUtils.DrawSprite(shroudBorderSprite, origin, size);
+		}
+
 		public override void Tick()
 		{
 			// Enable/Disable the radar
@@ -411,51 +686,82 @@ namespace OpenRA.Mods.Common.Widgets
 				Game.Sound.Play(SoundType.UI, enabled ? RadarOnlineSound : RadarOfflineSound);
 			cachedEnabled = enabled;
 
-			if (enabled)
+		if (enabled)
+		{
+			// The actor layer is updated every tick
+			var stride = radarSheet.Size.Width;
+			var cells = new List<(CPos Cell, Color Color)>();
+
+			unsafe
 			{
-				// The actor layer is updated every tick
-				var stride = radarSheet.Size.Width;
-				Array.Clear(radarData, 4 * actorSprite.Bounds.Top * stride, 4 * actorSprite.Bounds.Height * stride);
-
-				var cells = new List<(CPos Cell, Color Color)>();
-
-				unsafe
+				fixed (byte* colorBytes = &radarData[0])
 				{
-					fixed (byte* colorBytes = &radarData[0])
-					{
-						var colors = (uint*)colorBytes;
+					var colors = (uint*)colorBytes;
 
-						foreach (var t in world.ActorsWithTrait<IRadarSignature>())
+					// Clear only the actor layer quadrant (bottom-left), not the border layer (bottom-right)
+					var actorBounds = actorSprite.Bounds;
+					for (var y = actorBounds.Top; y < actorBounds.Bottom; y++)
+					{
+						for (var x = actorBounds.Left; x < actorBounds.Right; x++)
 						{
-							if (!t.Actor.IsInWorld || world.FogObscures(t.Actor))
+							colors[y * stride + x] = 0;
+						}
+					}
+
+				// When colored borders are enabled, show player actors regardless of fog
+				// but keep fog check for neutral actors (resources, terrain elements)
+				var bordersEnabled = ShowShroudBorders || ShowFogBorders;
+
+				// "Everyone" player (All Players option) or null (Disable Shroud) means show all players
+				var isAllPlayersMode = currentPlayer == null || currentPlayer.InternalName == "Everyone";
+
+				foreach (var t in world.ActorsWithTrait<IRadarSignature>())
+				{
+					if (!t.Actor.IsInWorld)
+						continue;
+
+					// Only ignore fog for actors belonging to playable players (units, buildings)
+					// Keep fog check for neutral actors (ore, gems, terrain elements)
+					var isPlayerActor = t.Actor.Owner.Playable && !t.Actor.Owner.NonCombatant;
+
+					// When borders are enabled and a specific player is selected, only show that player's actors
+					// When "All Players" or "Disable Shroud" is selected, show all player actors
+					var isSelectedPlayerActor = isAllPlayersMode || t.Actor.Owner == currentPlayer;
+					var ignoreFogForThisActor = bordersEnabled && isPlayerActor && isSelectedPlayerActor;
+
+					if (!ignoreFogForThisActor && world.FogObscures(t.Actor))
+						continue;
+
+						cells.Clear();
+						t.Trait.PopulateRadarSignatureCells(t.Actor, cells);
+						foreach (var cell in cells)
+						{
+							if (!world.Map.Contains(cell.Cell))
 								continue;
 
-							cells.Clear();
-							t.Trait.PopulateRadarSignatureCells(t.Actor, cells);
-							foreach (var cell in cells)
+							var uv = cell.Cell.ToMPos(world.Map.Grid.Type);
+							var color = cell.Color.ToArgb();
+							if (isRectangularIsometric)
 							{
-								if (!world.Map.Contains(cell.Cell))
-									continue;
+								// Odd rows are shifted right by 1px
+								var dx = uv.V & 1;
+								if (uv.U + dx > 0)
+									colors[(uv.V + previewHeight) * stride + 2 * uv.U + dx - 1] = color;
 
-								var uv = cell.Cell.ToMPos(world.Map.Grid.Type);
-								var color = cell.Color.ToArgb();
-								if (isRectangularIsometric)
-								{
-									// Odd rows are shifted right by 1px
-									var dx = uv.V & 1;
-									if (uv.U + dx > 0)
-										colors[(uv.V + previewHeight) * stride + 2 * uv.U + dx - 1] = color;
-
-									if (2 * uv.U + dx < stride)
-										colors[(uv.V + previewHeight) * stride + 2 * uv.U + dx] = color;
-								}
-								else
-									colors[(uv.V + previewHeight) * stride + uv.U] = color;
+								if (2 * uv.U + dx < stride)
+									colors[(uv.V + previewHeight) * stride + 2 * uv.U + dx] = color;
 							}
+							else
+								colors[(uv.V + previewHeight) * stride + uv.U] = color;
 						}
 					}
 				}
 			}
+
+			// Update borders layer when enabled via Map Discovery checkboxes
+			if (ShowShroudBorders || ShowFogBorders)
+				UpdateBordersLayer();
+		}
 
 			var targetFrame = enabled ? AnimationLength : 0;
 			hasRadar = enabled && frame == AnimationLength;

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -261,14 +261,20 @@ slider-thumb-pressed:
 checkbox:
 	Inherits: button
 
+checkbox-pressed:
+	Inherits: button-pressed
+
+checkbox-pressed-hover:
+	Inherits: button-pressed
+
+checkbox-pressed-disabled:
+	Inherits: button-disabled
+
 checkbox-hover:
 	Inherits: button-hover
 
 checkbox-disabled:
 	Inherits: button-disabled
-
-checkbox-pressed:
-	Inherits: button-pressed
 
 checkbox-highlighted:
 	Inherits: button-highlighted-pressed
@@ -277,7 +283,7 @@ checkbox-highlighted-hover:
 	Inherits: button-highlighted-hover
 
 checkbox-highlighted-disabled:
-	Inherits: button-highlighted-disabled
+	Inherits: button-disabled
 
 checkbox-highlighted-pressed:
 	Inherits: button-highlighted-pressed

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -160,7 +160,7 @@ Container@OBSERVER_WIDGETS:
 			Height: 256
 			Background: panel-gray
 			Children:
-				Radar:
+				Radar@INGAME_RADAR:
 					X: 1
 					Y: 1
 					Width: PARENT_WIDTH - 2
@@ -706,6 +706,68 @@ Container@OBSERVER_WIDGETS:
 									Text: label-combat-stats-vision-header
 									Align: Right
 									Shadow: True
+						Container@MAP_DISCOVERY_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: PARENT_HEIGHT
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_HEIGHT
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-player-header
+									Align: Left
+									Shadow: True
+								Label@SHROUD_HEADER:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-shroud-header
+									Align: Right
+									Shadow: True
+								Label@FOG_HEADER:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-fog-header
+									Align: Right
+									Shadow: True
+								Label@RADAR_HEADER:
+									X: 285
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-radar-header
+									Align: Right
+									Shadow: True
+				DropDownButton@DISPLAY_OPTIONS_DROPDOWN:
+					X: 190
+					Y: 0
+					Width: 180
+					Height: 25
+					Text: dropdown-map-discovery-display-options
+					Font: Bold
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
@@ -1123,6 +1185,61 @@ Container@OBSERVER_WIDGETS:
 									X: 700
 									Y: 0
 									Width: 60
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+						ScrollItem@MAP_DISCOVERY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: 24
+							Background: scrollitem-nohover
+							EnableChildMouseOver: true
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_HEIGHT
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_HEIGHT - 4
+									ImageName: random
+									ImageCollection: flags
+								LabelWithTooltip@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Shadow: True
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+								Label@SHROUD:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@FOG:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@RADAR:
+									X: 285
+									Y: 0
+									Width: 80
 									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
@@ -1910,6 +2027,57 @@ Container@PLAYER_WIDGETS:
 			Y: 299
 			Width: 194
 			Height: 20
+
+Container@MAP_DISCOVERY_DISPLAY_OPTIONS_PANEL:
+	Width: 330
+	Height: 120
+	Children:
+		Background@BG:
+			X: 0
+			Y: 0
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Background: button-pressed
+		Checkbox@SHOW_SHROUD_BORDERS_MINIMAP:
+			X: 10
+			Y: 5
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-minimap
+			Font: Regular
+			Background: checkbox-pressed
+		Checkbox@SHOW_FOG_BORDERS_MINIMAP:
+			X: 10
+			Y: 27
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-minimap
+			Font: Regular
+			Background: checkbox-pressed
+		Checkbox@HIDE_EXPLORED_AREAS_MINIMAP:
+			X: 10
+			Y: 49
+			Width: 300
+			Height: 20
+			Text: checkbox-hide-explored-areas-minimap
+			Font: Regular
+			Background: checkbox-pressed
+		Checkbox@SHOW_SHROUD_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 71
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-gamefield
+			Font: Regular
+			Background: checkbox-pressed
+		Checkbox@SHOW_FOG_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 93
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-gamefield
+			Font: Regular
+			Background: checkbox-pressed
 
 Background@FMVPLAYER:
 	Width: WINDOW_WIDTH

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -289,6 +289,20 @@ options-observer-stats =
     .army = Army
     .earnings-graph = Earnings (graph)
     .army-graph = Army (graph)
+    .map-discovery = Map Discovery
+
+label-map-discovery-player-header = Player
+label-map-discovery-shroud-header = Shroud
+label-map-discovery-fog-header = Fog of War
+label-map-discovery-radar-header = Radar
+
+## Map Discovery display options
+dropdown-map-discovery-display-options = Display Options
+checkbox-show-shroud-borders-minimap = Minimap: Show colored shroud borders
+checkbox-show-fog-borders-minimap = Minimap: Show colored fog of war borders
+checkbox-show-shroud-borders-gamefield = Gamefield: Show colored shroud borders
+checkbox-show-fog-borders-gamefield = Gamefield: Show colored fog of war borders
+checkbox-hide-explored-areas-minimap = Minimap: Hide already explored areas
 
 ## WorldTooltipLogic
 label-unrevealed-terrain = Unrevealed Terrain

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -407,6 +407,15 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
+display-options-checkbox:
+	Inherits: button-pressed
+
+display-options-checkbox-hover:
+	Inherits: button-pressed
+
+display-options-checkbox-disabled:
+	Inherits: button-disabled
+
 checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -26,7 +26,7 @@ Container@OBSERVER_WIDGETS:
 		MenuButton@OPTIONS_BUTTON:
 			X: 5
 			Y: 5
-			Width: 160
+			Width: 130
 			Height: 25
 			Text: button-observer-widget-options
 			Font: Bold
@@ -34,7 +34,7 @@ Container@OBSERVER_WIDGETS:
 			DisableWorldSounds: true
 		Container@GAME_TIMER_BLOCK:
 			Logic: GameTimerLogic
-			X: (WINDOW_WIDTH - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2 + 50
 			Width: 100
 			Height: 55
 			Children:
@@ -199,7 +199,7 @@ Container@OBSERVER_WIDGETS:
 			Height: 250
 			Children:
 				DropDownButton@STATS_DROPDOWN:
-					X: 165
+					X: 135
 					Y: 0
 					Width: 185
 					Height: 25
@@ -602,6 +602,68 @@ Container@OBSERVER_WIDGETS:
 									Text: label-combat-stats-vision-header
 									Align: Right
 									Shadow: True
+						Container@MAP_DISCOVERY_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: PARENT_HEIGHT
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_HEIGHT
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-player-header
+									Align: Left
+									Shadow: True
+								Label@SHROUD_HEADER:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-shroud-header
+									Align: Right
+									Shadow: True
+								Label@FOG_HEADER:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-fog-header
+									Align: Right
+									Shadow: True
+								Label@RADAR_HEADER:
+									X: 285
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-radar-header
+									Align: Right
+									Shadow: True
+				DropDownButton@DISPLAY_OPTIONS_DROPDOWN:
+					X: 325
+					Y: 0
+					Width: 180
+					Height: 25
+					Text: dropdown-map-discovery-display-options
+					Font: Bold
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 55
@@ -1015,6 +1077,61 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
+						ScrollItem@MAP_DISCOVERY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: 25
+							Background: scrollitem-nohover
+							EnableChildMouseOver: true
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_HEIGHT
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_HEIGHT - 4
+									ImageName: random
+									ImageCollection: flags
+								LabelWithTooltip@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Shadow: True
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+								Label@SHROUD:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@FOG:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@RADAR:
+									X: 285
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
@@ -1076,3 +1193,54 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 40
 			Width: 175
+
+Container@MAP_DISCOVERY_DISPLAY_OPTIONS_PANEL:
+	Width: 330
+	Height: 120
+	Children:
+		Background@BG:
+			X: 0
+			Y: 0
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Background: button-pressed
+		Checkbox@SHOW_SHROUD_BORDERS_MINIMAP:
+			X: 10
+			Y: 5
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_FOG_BORDERS_MINIMAP:
+			X: 10
+			Y: 27
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@HIDE_EXPLORED_AREAS_MINIMAP:
+			X: 10
+			Y: 49
+			Width: 300
+			Height: 20
+			Text: checkbox-hide-explored-areas-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_SHROUD_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 71
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-gamefield
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_FOG_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 93
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-gamefield
+			Font: Regular
+			Background: display-options-checkbox

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -518,6 +518,15 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
+observer-checkbox:
+	Inherits: observer-scrollpanel-button-pressed
+
+observer-checkbox-hover:
+	Inherits: observer-scrollpanel-button-pressed
+
+observer-checkbox-disabled:
+	Inherits: observer-scrollpanel-button-disabled
+
 checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -642,6 +642,96 @@ Container@OBSERVER_WIDGETS:
 									Text: label-combat-stats-vision-header
 									Align: Right
 									Shadow: True
+						Container@MAP_DISCOVERY_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 640
+							Height: PARENT_HEIGHT
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_HEIGHT
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-player-header
+									Align: Left
+									Shadow: True
+								Label@SHROUD_HEADER:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-shroud-header
+									Align: Right
+									Shadow: True
+								Label@FOG_HEADER:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-fog-header
+									Align: Right
+									Shadow: True
+								Label@RADAR_HEADER:
+									X: 305
+									Y: 0
+									Width: 60
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-radar-header
+									Align: Right
+									Shadow: True
+								Label@GAP_HEADER:
+									X: 385
+									Y: 0
+									Width: 60
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-gap-header
+									Align: Right
+									Shadow: True
+								Label@GPS_SAT_HEADER:
+									X: 445
+									Y: 0
+									Width: 50
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-gps-header
+									Align: Right
+									Shadow: True
+								Label@SPY_PLANE_HEADER:
+									X: 515
+									Y: 0
+									Width: 70
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-spyplane-header
+									Align: Right
+									Shadow: True
+				DropDownButton@DISPLAY_OPTIONS_DROPDOWN:
+					X: 190
+					Y: 0
+					Width: 180
+					Height: 25
+					Text: dropdown-map-discovery-display-options
+					Font: Bold
+					Background: observer-scrollpanel-button
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
@@ -1064,6 +1154,82 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
+						ScrollItem@MAP_DISCOVERY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 640
+							Height: 24
+							Background: scrollitem-nohover
+							EnableChildMouseOver: true
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_HEIGHT
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_HEIGHT - 4
+									ImageName: random
+									ImageCollection: flags
+								LabelWithTooltip@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Shadow: True
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+								Label@SHROUD:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@FOG:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@RADAR:
+									X: 305
+									Y: 0
+									Width: 60
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@GAP:
+									X: 385
+									Y: 0
+									Width: 60
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@GPS_SAT:
+									X: 445
+									Y: 0
+									Width: 50
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@SPY_PLANE:
+									X: 515
+									Y: 0
+									Width: 70
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
@@ -1125,3 +1291,54 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_WIDTH - WIDTH - 255
 			Y: 40
 			Width: 175
+
+Container@MAP_DISCOVERY_DISPLAY_OPTIONS_PANEL:
+	Width: 330
+	Height: 120
+	Children:
+		Background@BG:
+			X: 0
+			Y: 0
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Background: observer-scrollpanel-button-pressed
+		Checkbox@SHOW_SHROUD_BORDERS_MINIMAP:
+			X: 10
+			Y: 5
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-minimap
+			Font: Regular
+			Background: observer-checkbox
+		Checkbox@SHOW_FOG_BORDERS_MINIMAP:
+			X: 10
+			Y: 27
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-minimap
+			Font: Regular
+			Background: observer-checkbox
+		Checkbox@HIDE_EXPLORED_AREAS_MINIMAP:
+			X: 10
+			Y: 49
+			Width: 300
+			Height: 20
+			Text: checkbox-hide-explored-areas-minimap
+			Font: Regular
+			Background: observer-checkbox
+		Checkbox@SHOW_SHROUD_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 71
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-gamefield
+			Font: Regular
+			Background: observer-checkbox
+		Checkbox@SHOW_FOG_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 93
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-gamefield
+			Font: Regular
+			Background: observer-checkbox

--- a/mods/ra/fluent/chrome.ftl
+++ b/mods/ra/fluent/chrome.ftl
@@ -1,6 +1,9 @@
 ## ingame-observer.yaml
 label-economy-stats-harvesters-header = Harvesters
 label-economy-stats-derricks-header = Oil Derricks
+label-map-discovery-spyplane-header = Spy Plane
+label-map-discovery-gps-header = GPS
+label-map-discovery-gap-header = Gap Gen
 
 
 

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -652,6 +652,15 @@ slider-thumb-disabled:
 checkbox:
 	Inherits: button-pressed
 
+display-options-checkbox:
+	Inherits: button-pressed
+
+display-options-checkbox-hover:
+	Inherits: button-pressed
+
+display-options-checkbox-disabled:
+	Inherits: button-disabled
+
 checkmark-tick:
 	Inherits: ^Glyphs
 	Regions:

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -26,7 +26,7 @@ Container@OBSERVER_WIDGETS:
 		MenuButton@OPTIONS_BUTTON:
 			X: 5
 			Y: 5
-			Width: 160
+			Width: 130
 			Height: 25
 			Text: button-observer-widget-options
 			Font: Bold
@@ -34,7 +34,7 @@ Container@OBSERVER_WIDGETS:
 			DisableWorldSounds: true
 		Container@GAME_TIMER_BLOCK:
 			Logic: GameTimerLogic
-			X: (WINDOW_WIDTH - WIDTH) / 2
+			X: (WINDOW_WIDTH - WIDTH) / 2 + 50
 			Width: 100
 			Height: 55
 			Children:
@@ -199,7 +199,7 @@ Container@OBSERVER_WIDGETS:
 			Height: 240
 			Children:
 				DropDownButton@STATS_DROPDOWN:
-					X: 165
+					X: 135
 					Y: 0
 					Width: 185
 					Height: 25
@@ -594,6 +594,68 @@ Container@OBSERVER_WIDGETS:
 									Text: label-combat-stats-vision-header
 									Align: Right
 									Shadow: True
+						Container@MAP_DISCOVERY_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: PARENT_HEIGHT
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_HEIGHT
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-player-header
+									Align: Left
+									Shadow: True
+								Label@SHROUD_HEADER:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-shroud-header
+									Align: Right
+									Shadow: True
+								Label@FOG_HEADER:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-fog-header
+									Align: Right
+									Shadow: True
+								Label@RADAR_HEADER:
+									X: 285
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Text: label-map-discovery-radar-header
+									Align: Right
+									Shadow: True
+				DropDownButton@DISPLAY_OPTIONS_DROPDOWN:
+					X: 325
+					Y: 0
+					Width: 180
+					Height: 25
+					Text: dropdown-map-discovery-display-options
+					Font: Bold
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 0
 					Y: 54
@@ -1009,6 +1071,61 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_HEIGHT
 									Align: Right
 									Shadow: True
+						ScrollItem@MAP_DISCOVERY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 450
+							Height: 24
+							Background: scrollitem-nohover
+							EnableChildMouseOver: true
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_WIDTH - 200
+									Height: PARENT_HEIGHT
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_WIDTH - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_HEIGHT
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_HEIGHT - 4
+									ImageName: random
+									ImageCollection: flags
+								LabelWithTooltip@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_HEIGHT
+									Font: Bold
+									Shadow: True
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+								Label@SHROUD:
+									X: 130
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@FOG:
+									X: 225
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
+								Label@RADAR:
+									X: 285
+									Y: 0
+									Width: 80
+									Height: PARENT_HEIGHT
+									Align: Right
+									Shadow: True
 				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
@@ -1070,3 +1187,54 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_WIDTH - WIDTH - 260
 			Y: 40
 			Width: 175
+
+Container@MAP_DISCOVERY_DISPLAY_OPTIONS_PANEL:
+	Width: 330
+	Height: 120
+	Children:
+		Background@BG:
+			X: 0
+			Y: 0
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Background: button-pressed
+		Checkbox@SHOW_SHROUD_BORDERS_MINIMAP:
+			X: 10
+			Y: 5
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_FOG_BORDERS_MINIMAP:
+			X: 10
+			Y: 27
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@HIDE_EXPLORED_AREAS_MINIMAP:
+			X: 10
+			Y: 49
+			Width: 300
+			Height: 20
+			Text: checkbox-hide-explored-areas-minimap
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_SHROUD_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 71
+			Width: 300
+			Height: 20
+			Text: checkbox-show-shroud-borders-gamefield
+			Font: Regular
+			Background: display-options-checkbox
+		Checkbox@SHOW_FOG_BORDERS_GAMEFIELD:
+			X: 10
+			Y: 93
+			Width: 300
+			Height: 20
+			Text: checkbox-show-fog-borders-gamefield
+			Font: Regular
+			Background: display-options-checkbox


### PR DESCRIPTION
Fixes: https://github.com/OpenRA/OpenRA/issues/4946

This PR adds a new "Map Discovery" entry in the Statistics drop-down menu, which, once it is selected, shows:
- the percentage of discovered shroud (shows what percentage of the total map has been explored)
- the percentage of current fog of war visibility (shows what percentage of explored territory is currently visible)
- Radar, Gap Generator, GPS, Spy Plane counters (depending on the loaded mod, these columns can change)

It also adds a new "Display Options" drop-down menu with checkboxes:
- to show the colored shroud borders on minimap
- to show the colored fog of war borders on minimap
- to hide the already discovered terrain on minimap
- to show the colored shroud borders on gamefield
- to show the colored fog of war borders on gamefield

The colored fog of war border on the gamefield has a 50% opacity to better differentiate it from the shroud border.

The colored fog of war border on the minimap has the same opacity as the shroud because displaying both the colored shroud borders and colored fog of war borders on this small area (the minimap) visually cluttered the minimap).

![ra](https://github.com/user-attachments/assets/d2f6dbe8-2a44-4f0c-85fd-b15aaeb23380)
![cnc](https://github.com/user-attachments/assets/81e1a87c-5ec3-42bb-8a1e-ad380d5ba635)
![d2k](https://github.com/user-attachments/assets/8b88dc15-b9bf-4f04-8405-2939afa95b23)
![ts](https://github.com/user-attachments/assets/7eb62025-3d53-4023-b1b0-b59871cf8f61)

