### PR TITLE
Shift Color Picker panel left if it would extend beyond the right edge of the screen

### DIFF
--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -136,6 +136,10 @@ namespace OpenRA.Mods.Common.Widgets
 			if (panelY + oldBounds.Height > Game.Renderer.Resolution.Height)
 				panelY -= Bounds.Height + oldBounds.Height;
 
+			var buttonRightEdge = RenderOrigin.X + Bounds.Width - panelRoot.RenderOrigin.X;
+			if (panelX + oldBounds.Width > Game.Renderer.Resolution.Width)
+				panelX = buttonRightEdge - oldBounds.Width;
+
 			panel.Bounds = new WidgetBounds(
 				panelX,
 				panelY,


### PR DESCRIPTION
Shift Color Picker panel left if it would extend beyond the right edge of the screen.

If the OpenRA window is wider than 1352 pixels, the color picker panel is displayed correctly (just like it currently is). 
If the OpenRA window is smaller than 1352 pixels, the color picker panel is moved to the left.

Fixes #20466

Window width < 1352 pixels: 

![20466_02](https://github.com/user-attachments/assets/1a86e72d-f6e7-43ef-a302-dcfdb97b39b7)

Window width > 1352 pixels:

![20466_03](https://github.com/user-attachments/assets/f1dd7937-40be-420d-8cff-8d70d6eab220)
