### PR TITLE
Collect and show perf sample totals in widget

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -661,7 +661,7 @@ namespace OpenRA
 
 						world.Tick();
 
-						PerfHistory.Tick();
+						PerfHistory.Tick(!world.Paused);
 					}
 
 					// Wait until we have done our first world Tick before TickRendering
@@ -759,12 +759,13 @@ namespace OpenRA
 				}
 			}
 
-			PerfHistory.Items["render"].Tick();
-			PerfHistory.Items["batches"].Tick();
-			PerfHistory.Items["render_world"].Tick();
-			PerfHistory.Items["render_widgets"].Tick();
-			PerfHistory.Items["render_flip"].Tick();
-			PerfHistory.Items["terrain_lighting"].Tick();
+			var isActive = !(worldRenderer?.World.Paused ?? true);
+			PerfHistory.Items["render"].Tick(isActive);
+			PerfHistory.Items["batches"].Tick(isActive);
+			PerfHistory.Items["render_world"].Tick(isActive);
+			PerfHistory.Items["render_widgets"].Tick(isActive);
+			PerfHistory.Items["render_flip"].Tick(isActive);
+			PerfHistory.Items["terrain_lighting"].Tick(isActive);
 		}
 
 		static void Loop()

--- a/OpenRA.Game/Support/PerfHistory.cs
+++ b/OpenRA.Game/Support/PerfHistory.cs
@@ -41,11 +41,11 @@ namespace OpenRA.Support
 			Items[item].Val += x;
 		}
 
-		public static void Tick()
+		public static void Tick(bool gameIsActive = true)
 		{
 			foreach (var item in Items.Values)
 				if (item.HasNormalTick)
-					item.Tick();
+					item.Tick(gameIsActive);
 		}
 
 		public static void Reset()

--- a/OpenRA.Game/Support/PerfItem.cs
+++ b/OpenRA.Game/Support/PerfItem.cs
@@ -22,6 +22,8 @@ namespace OpenRA.Support
 		public double Val = 0.0;
 		int head = 1, tail = 0;
 		public bool HasNormalTick = true;
+		public double ActiveGameTotal { get; private set; } = 0.0;
+		public int ActiveGameTotalSamples { get; private set; } = 0;
 
 		public PerfItem(string name, Color c)
 		{
@@ -29,9 +31,15 @@ namespace OpenRA.Support
 			C = c;
 		}
 
-		public void Tick()
+		public void Tick(bool gameIsActive = true)
 		{
 			samples[head++] = Val;
+			if (gameIsActive)
+			{
+				ActiveGameTotal += Val;
+				ActiveGameTotalSamples++;
+			}
+
 			if (head == samples.Length) head = 0;
 			if (head == tail && ++tail == samples.Length) tail = 0;
 			Val = 0.0;
@@ -63,6 +71,11 @@ namespace OpenRA.Support
 			return i == 0 ? sum : sum / i;
 		}
 
+		public double ActiveGameTotalAverage()
+		{
+			return ActiveGameTotal / ActiveGameTotalSamples;
+		}
+
 		public double LastValue
 		{
 			get
@@ -78,6 +91,8 @@ namespace OpenRA.Support
 			head = 1;
 			tail = 0;
 			Val = 0.0;
+			ActiveGameTotal = 0.0;
+			ActiveGameTotalSamples = 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -40,12 +40,18 @@ namespace OpenRA.Mods.Common.Widgets
 
 		int GetTextWidth(string text) => font.Measure(text).X;
 
+		// Try to keep the text at 6 characters long to align columns.
 		public void SixCharacterFormatFloat(StringBuilder output, double value)
 		{
-			// Try to keep the text at 6 characters long to align columns.
 			if (double.IsNaN(value))
 			{
 				output.Append("NaN   ");
+				return;
+			}
+
+			if (double.IsInfinity(value))
+			{
+				output.Append(double.IsPositiveInfinity(value) ? "+Inf  " : "-Inf  ");
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -9,7 +9,10 @@
  */
 #endregion
 
+using System;
 using System.Linq;
+using System.Text;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Widgets;
@@ -18,6 +21,92 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class PerfGraphWidget : Widget
 	{
+		readonly int dotWidth;
+		readonly int nextDotAdvance;
+		readonly Cache<string, int> textWidthCache;
+		readonly SpriteFont font = Game.Renderer.Fonts["Tiny"];
+		StringBuilder builder = null;
+
+		public PerfGraphWidget()
+		{
+			textWidthCache = new(GetTextWidth);
+			dotWidth = textWidthCache["."];
+			nextDotAdvance = textWidthCache[".."] - dotWidth;
+		}
+
+		int GetTextWidth(string text) => font.Measure(text).X;
+
+		public void SixCharacterFormatFloat(StringBuilder output, double value)
+		{
+			// Try to keep the text at 6 characters long to align columns.
+			if (double.IsNaN(value))
+			{
+				output.Append("NaN   ");
+				return;
+			}
+
+			if (value < 0)
+			{
+				output.Append("<0    ");
+				return;
+			}
+
+			value += 0.000005; // Do normal rounding instead of floor/trucate;
+			var intValue = (int)value;
+			if (intValue >= 1000000)
+			{
+				output.Append("TooBig");
+				return;
+			}
+
+			var partValue = (int)value;
+			var digit = partValue / 1000000;
+			if (intValue >= 1000000)
+				output.Append((char)(digit + '0'));
+
+			// Append the whole part.
+			for (var p = 1000000; p >= 10;)
+			{
+				var n = p / 10;
+
+				// Skip leading zeros.
+				if (intValue >= n)
+				{
+					partValue -= digit * p;
+					digit = partValue / n;
+					output.Append((char)(digit + '0'));
+				}
+
+				p = n;
+			}
+
+			// Check for room for the '.'.
+			if (intValue >= 1000000)
+				return;
+
+			if (intValue < 100000)
+				output.Append('.');
+
+			if (intValue >= 10000)
+				return;
+
+			// Up to 5 fractional digits may be appended while keeping the total characters at 6.
+			var fractionValue = (int)(value * 100000) - 100000 * intValue;
+			for (var p = 10000; ;)
+			{
+				digit = fractionValue / p;
+				output.Append((char)(digit + '0'));
+				var n = p / 10;
+
+				// Stop if reached 6 characters total.
+				if (intValue >= n)
+					return;
+
+				fractionValue -= digit * p;
+				p = n;
+			}
+		}
+
 		public override void Draw()
 		{
 			var cr = Game.Renderer.RgbaColorRenderer;
@@ -56,9 +145,31 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			k = 0;
+			var maxExtraDotSpace = 0;
+			var maxNameLength = 0;
 			foreach (var item in PerfHistory.Items.Values)
 			{
-				Game.Renderer.Fonts["Tiny"].DrawText(item.Name, new float2(rect.Left, rect.Top) + new float2(18, 10 * k - 3), Color.White);
+				maxExtraDotSpace = Math.Max(maxExtraDotSpace, textWidthCache[item.Name]);
+				maxNameLength = Math.Max(maxNameLength, item.Name.Length);
+			}
+
+			builder ??= new StringBuilder(Math.Max(20, maxExtraDotSpace + 3));
+			maxExtraDotSpace = Math.Max(0, maxExtraDotSpace - dotWidth); // First dot is always printed.
+			var columnTwoStart = maxExtraDotSpace + 3 * nextDotAdvance + 2;
+
+			foreach (var item in PerfHistory.Items.Values)
+			{
+				var nameWidth = textWidthCache[item.Name];
+				var dotsNeeded = (maxExtraDotSpace - nameWidth) / nextDotAdvance + 3; // first + 2 extra dots for spacing before numbers.
+				builder.Append(item.Name);
+				builder.Append('.', dotsNeeded);
+				font.DrawText(builder.ToString(), new float2(rect.Left, rect.Top) + new float2(18, 10 * k - 3), Color.White);
+				builder.Clear();
+				SixCharacterFormatFloat(builder, item.Average(Game.Settings.Debug.Samples));
+				builder.Append(" : ");
+				SixCharacterFormatFloat(builder, item.ActiveGameTotalAverage());
+				font.DrawText(builder.ToString(), new float2(rect.Left, rect.Top) + new float2(18 + columnTwoStart, 10 * k - 3), Color.White);
+				builder.Clear();
 				++k;
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -23,12 +23,16 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		readonly int dotWidth;
 		readonly int nextDotAdvance;
-		readonly Cache<string, int> textWidthCache;
-		readonly SpriteFont font = Game.Renderer.Fonts["Tiny"];
+		readonly Cache<string, int> textWidthCache = null;
+		readonly SpriteFont font = Game.Renderer?.Fonts["Tiny"];
 		StringBuilder builder = null;
 
 		public PerfGraphWidget()
 		{
+			// Skip if running format unit test
+			if (font == null)
+				return;
+
 			textWidthCache = new(GetTextWidth);
 			dotWidth = textWidthCache["."];
 			nextDotAdvance = textWidthCache[".."] - dotWidth;
@@ -51,8 +55,15 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 			}
 
-			value += 0.000005; // Do normal rounding instead of floor/trucate;
 			var intValue = (int)value;
+
+			// Do normal rounding instead of floor/trucate; account for numbers >= 100000 being 6 decimal places or "TooBig".
+			var frontPlaceMultipler = 1;
+			while (frontPlaceMultipler <= intValue && frontPlaceMultipler < 100000)
+				frontPlaceMultipler *= 10;
+			value += 0.000005 * frontPlaceMultipler;
+			intValue = (int)value;
+
 			if (intValue >= 1000000)
 			{
 				output.Append("TooBig");

--- a/OpenRA.Test/OpenRA.Mods.Common/PerfGraphWidgetTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/PerfGraphWidgetTest.cs
@@ -1,0 +1,103 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Text;
+using NUnit.Framework;
+using OpenRA.Mods.Common.Widgets;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	sealed class PerfGraphWidgetTest
+	{
+		readonly PerfGraphWidget widget = new();
+		readonly StringBuilder output = new(6);
+
+		void AssertThat(double input, string expected)
+		{
+			output.Clear();
+			widget.SixCharacterFormatFloat(output, input);
+			Assert.That(output.ToString(), Is.EqualTo(expected));
+		}
+
+		[TestCase(TestName = "NaN is reported with 3 padding spaces after.")]
+		public void NaN()
+		{
+			AssertThat(double.NaN, "NaN   ");
+		}
+
+		[TestCase(TestName = "Negative numbers are discarded as \"<0\" with 4 padding spaces after.")]
+		public void Negative()
+		{
+			AssertThat(-0.000001, "<0    ");
+		}
+
+		[TestCase(TestName = "Numbers < 1 start with a decimal point ('.') and show 5 decimal places after the decimal point.")]
+		public void Fractional()
+		{
+			AssertThat(0, ".00000");
+			AssertThat(0.000001, ".00000");
+			AssertThat(0.000004, ".00000");
+			AssertThat(0.0000049, ".00000");
+			AssertThat(0.000005, ".00001");
+			AssertThat(0.000009, ".00001");
+			AssertThat(0.00001, ".00001");
+			AssertThat(0.00004, ".00004");
+			AssertThat(0.00005, ".00005");
+			AssertThat(0.00009, ".00009");
+			AssertThat(0.0001, ".00010");
+			AssertThat(0.0004, ".00040");
+			AssertThat(0.0005, ".00050");
+			AssertThat(0.0009, ".00090");
+			AssertThat(0.001, ".00100");
+			AssertThat(0.005, ".00500");
+			AssertThat(0.01, ".01000");
+			AssertThat(0.05, ".05000");
+			AssertThat(0.1, ".10000");
+			AssertThat(0.5, ".50000");
+		}
+
+		[TestCase(TestName = "Numbers >= 1 and < 100000 show the 5 most signifcant digits with a decimal point ('.').")]
+		public void FiveSignificantDigits()
+		{
+			AssertThat(1, "1.0000");
+			AssertThat(9, "9.0000");
+			AssertThat(9.00005, "9.0001");
+			AssertThat(10, "10.000");
+			AssertThat(99, "99.000");
+			AssertThat(99.0005, "99.001");
+			AssertThat(100, "100.00");
+			AssertThat(123.4321, "123.43");
+			AssertThat(999.005, "999.01");
+			AssertThat(1000, "1000.0");
+			AssertThat(9999.04999999, "9999.0");
+			AssertThat(9999.05000001, "9999.1"); // Binary conversion causes 9999.05 + 0.05 => 9999.099999999999.
+			AssertThat(10000, "10000.");
+		}
+
+		[TestCase(TestName = "Numbers >= 100000 and < 1000000 show the 5 most signifcant digits with a decimal point ('.').")]
+		public void SixSignificantDigits()
+		{
+			AssertThat(99999.9, "100000");
+			AssertThat(100000, "100000");
+			AssertThat(999999, "999999");
+		}
+
+		[TestCase(TestName = "Numbers >= 1000000 are very unlikely for perf measurements and would require different formatting.")]
+		public void TooBig()
+		{
+			AssertThat(1000000, "TooBig");
+			AssertThat(1234321, "TooBig");
+			AssertThat(10000000, "TooBig");
+			AssertThat(100000000, "TooBig");
+		}
+	}
+}

--- a/OpenRA.Test/OpenRA.Mods.Common/PerfGraphWidgetTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/PerfGraphWidgetTest.cs
@@ -34,6 +34,13 @@ namespace OpenRA.Test
 			AssertThat(double.NaN, "NaN   ");
 		}
 
+		[TestCase(TestName = "Infinities are reported with 2 padding spaces after.")]
+		public void Infinity()
+		{
+			AssertThat(double.PositiveInfinity, "+Inf  ");
+			AssertThat(double.NegativeInfinity, "-Inf  ");
+		}
+
 		[TestCase(TestName = "Negative numbers are discarded as \"<0\" with 4 padding spaces after.")]
 		public void Negative()
 		{


### PR DESCRIPTION
Both the rolling and cumulative active (not paused) means are shown.

The cumulative active means (averages) can be used with repeated runs of (multiple) replays to collect performance data and compare. This does not help in the discovery of slow areas, but does allow anyone (who can run the game and collect numbers) to test performance differences (requiring the ability to checkout code and build for checking code changes in the repository).