### PR TITLE
Remove esc hotkey from the label of the options button in spectator mode

### DIFF
--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -26,7 +26,7 @@ Container@OBSERVER_WIDGETS:
 		MenuButton@OPTIONS_BUTTON:
 			X: 5
 			Y: 5
-			Width: 160
+			Width: 130
 			Height: 25
 			Text: button-observer-widget-options
 			Font: Bold
@@ -199,7 +199,7 @@ Container@OBSERVER_WIDGETS:
 			Height: 250
 			Children:
 				DropDownButton@STATS_DROPDOWN:
-					X: 165
+					X: 135
 					Y: 0
 					Width: 185
 					Height: 25

--- a/mods/d2k/fluent/chrome.ftl
+++ b/mods/d2k/fluent/chrome.ftl
@@ -5,7 +5,7 @@ label-mentat-title = Mentat
 label-menu-buttons-title = Options
 
 ## ingame-observer.yaml
-button-observer-widget-options = Options (Esc)
+button-observer-widget-options = Options
 label-economy-stats-harvesters-header = Harvesters
 label-economy-stats-carryalls-header = Carryalls
 label-deliver-in-timer = DELIVERY IN: { $time }

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -26,7 +26,7 @@ Container@OBSERVER_WIDGETS:
 		MenuButton@OPTIONS_BUTTON:
 			X: 5
 			Y: 5
-			Width: 160
+			Width: 130
 			Height: 25
 			Text: button-observer-widget-options
 			Font: Bold
@@ -199,7 +199,7 @@ Container@OBSERVER_WIDGETS:
 			Height: 240
 			Children:
 				DropDownButton@STATS_DROPDOWN:
-					X: 165
+					X: 135
 					Y: 0
 					Width: 185
 					Height: 25

--- a/mods/ts/fluent/chrome.ftl
+++ b/mods/ts/fluent/chrome.ftl
@@ -8,7 +8,7 @@ label-voxel-selector-yaw = Yaw
 checkbox-debug-panel-show-depth-preview = Show Depth Data
 
 ## ingame-observer.yaml
-button-observer-widget-options = Options (Esc)
+button-observer-widget-options = Options
 label-economy-stats-harvesters-header = Harvesters
 
 ## ingame-player.yaml


### PR DESCRIPTION
This PR removes the "(Esc)" hotkey from the label of the Options button in the Spectator mode (D2K and TS mods).
It also makes the button slightly smaller (130 pixels instead of 160 pixels), enough for most upcoming translations.

<img width="683" height="239" alt="Options_button_130" src="https://github.com/user-attachments/assets/ec252741-872a-4a34-b0ba-3221b2b1aa1a" />
