### PR TITLE
Show the attack range of selected units as circles by pressing a hotkey

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderAttackRangeOnSelect.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderAttackRangeOnSelect.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Draw a circle indicating the unit's attack range when selected and hotkey is held. " +
+		"Only renders if the actor has an AttackBase trait.")]
+	public class RenderAttackRangeOnSelectInfo : TraitInfo
+	{
+		[Desc("Which circle to show. Valid values are `Maximum`, and `Minimum`.")]
+		public readonly RangeCircleMode RangeCircleMode = RangeCircleMode.Maximum;
+
+		public override object Create(ActorInitializer init) { return new RenderAttackRangeOnSelect(init.Self, this); }
+	}
+
+	public class RenderAttackRangeOnSelect : IRenderAnnotationsWhenSelected
+	{
+		readonly RenderAttackRangeOnSelectInfo info;
+		AttackBase attack;
+		AttackRangeCirclesOptions options;
+
+		public RenderAttackRangeOnSelect(Actor self, RenderAttackRangeOnSelectInfo info)
+		{
+			this.info = info;
+		}
+
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			attack ??= self.TraitOrDefault<AttackBase>();
+			if (attack == null)
+				yield break;
+
+			options ??= self.World.WorldActor.TraitOrDefault<AttackRangeCirclesOptions>();
+			if (options == null || !options.ShouldShowCircles)
+				yield break;
+
+			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
+				yield break;
+
+			var range = info.RangeCircleMode == RangeCircleMode.Minimum
+				? attack.GetMinimumRange()
+				: attack.GetMaximumRange();
+
+			if (range == WDist.Zero)
+				yield break;
+
+			yield return new RangeCircleAnnotationRenderable(
+				self.CenterPosition,
+				range,
+				0,
+				options.CircleColor,
+				options.CircleWidth,
+				options.CircleBorderColor,
+				options.CircleBorderWidth);
+		}
+
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable => false;
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/AttackRangeCirclesOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/AttackRangeCirclesOptions.cs
@@ -1,0 +1,91 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.World)]
+	[Desc("Controls the attack range circles lobby option and hotkey state. Attach this to the world actor.")]
+	public class AttackRangeCirclesOptionsInfo : TraitInfo, ILobbyOptions
+	{
+		[FluentReference]
+		[Desc("Descriptive label for the attack range circles checkbox in the lobby.")]
+		public readonly string CheckboxLabel = "checkbox-attack-range-circles.label";
+
+		[FluentReference]
+		[Desc("Tooltip description for the attack range circles checkbox in the lobby.")]
+		public readonly string CheckboxDescription = "checkbox-attack-range-circles.description";
+
+		[Desc("Default value of the attack range circles checkbox in the lobby.")]
+		public readonly bool CheckboxEnabled = false;
+
+		[Desc("Prevent the attack range circles state from being changed in the lobby.")]
+		public readonly bool CheckboxLocked = false;
+
+		[Desc("Whether to display the attack range circles checkbox in the lobby.")]
+		public readonly bool CheckboxVisible = true;
+
+		[Desc("Display order for the attack range circles checkbox in the lobby.")]
+		public readonly int CheckboxDisplayOrder = 11;
+
+		[Desc("Color of the range circle.")]
+		public readonly Color CircleColor = Color.FromArgb(128, Color.Yellow);
+
+		[Desc("Range circle line width.")]
+		public readonly float CircleWidth = 1;
+
+		[Desc("Color of the range circle border.")]
+		public readonly Color CircleBorderColor = Color.FromArgb(96, Color.Black);
+
+		[Desc("Range circle border width.")]
+		public readonly float CircleBorderWidth = 3;
+
+		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(MapPreview map)
+		{
+			yield return new LobbyBooleanOption(map, "attackrangecircles",
+				CheckboxLabel, CheckboxDescription,
+				CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
+		}
+
+		public override object Create(ActorInitializer init) { return new AttackRangeCirclesOptions(this); }
+	}
+
+	public class AttackRangeCirclesOptions : INotifyCreated
+	{
+		readonly AttackRangeCirclesOptionsInfo info;
+		World world;
+
+		public bool FeatureEnabled { get; private set; }
+		public bool HotkeyHeld { get; set; }
+
+		public Color CircleColor => info.CircleColor;
+		public float CircleWidth => info.CircleWidth;
+		public Color CircleBorderColor => info.CircleBorderColor;
+		public float CircleBorderWidth => info.CircleBorderWidth;
+
+		public bool ShouldShowCircles => HotkeyHeld && (FeatureEnabled || world.IsReplay);
+
+		public AttackRangeCirclesOptions(AttackRangeCirclesOptionsInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			world = self.World;
+			FeatureEnabled = world.LobbyInfo.GlobalSettings
+				.OptionOrDefault("attackrangecircles", info.CheckboxEnabled);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/ShowAttackRangeCirclesHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/ShowAttackRangeCirclesHotkeyLogic.cs
@@ -1,0 +1,69 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
+{
+	[ChromeLogicArgsHotkeys("ShowAttackRangeCirclesKey")]
+	public class ShowAttackRangeCirclesHotkeyLogic : ChromeLogic
+	{
+		readonly World world;
+		readonly HotkeyReference hotkeyRef;
+
+		[ObjectCreator.UseCtor]
+		public ShowAttackRangeCirclesHotkeyLogic(Widget widget, World world, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+		{
+			this.world = world;
+
+			hotkeyRef = new HotkeyReference();
+			if (logicArgs.TryGetValue("ShowAttackRangeCirclesKey", out var yaml))
+				hotkeyRef = modData.Hotkeys[yaml.Value];
+
+			var keyhandler = (LogicKeyListenerWidget)widget;
+			keyhandler.AddHandler(HandleKeyPress);
+		}
+
+		bool HandleKeyPress(KeyInput e)
+		{
+			var options = world.WorldActor.TraitOrDefault<AttackRangeCirclesOptions>();
+			if (options == null)
+				return false;
+
+			if (!options.FeatureEnabled && !world.IsReplay)
+				return false;
+
+			var hotkeyValue = hotkeyRef.GetValue();
+			if (hotkeyValue == Hotkey.Invalid)
+				return false;
+
+			if (e.Key != hotkeyValue.Key)
+				return false;
+
+			if (e.Event == KeyInputEvent.Down && e.Modifiers == hotkeyValue.Modifiers)
+			{
+				options.HotkeyHeld = true;
+				return true;
+			}
+
+			if (e.Event == KeyInputEvent.Up && options.HotkeyHeld)
+			{
+				options.HotkeyHeld = false;
+				return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -10,7 +10,7 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic, ShowAttackRangeCirclesHotkeyLogic
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				CycleHarvestersKey: CycleHarvesters
@@ -22,6 +22,7 @@ Container@INGAME_ROOT:
 				PauseKey: Pause
 				SelectAllUnitsKey: SelectAllUnits
 				SelectUnitsByTypeKey: SelectUnitsByType
+				ShowAttackRangeCirclesKey: ShowAttackRangeCircles
 		Container@WORLD_ROOT:
 			Children:
 				LogicTicker@DISCONNECT_WATCHER:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -233,6 +233,7 @@
 	Inherits@3: ^ClassicFacingSpriteActor
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -337,6 +338,7 @@
 	Inherits@3: ^SpriteActor
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -636,6 +638,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^ClassicFacingSpriteActor
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	OwnerLostAction:
 		Action: Kill
 	AppearsOnRadar:
@@ -661,6 +664,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -278,6 +278,8 @@ World:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
 		TerrainFlashPalette: moveflash
+	AttackRangeCirclesOptions:
+		CheckboxDisplayOrder: 11
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -10,7 +10,7 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic, ShowAttackRangeCirclesHotkeyLogic
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				CycleHarvestersKey: CycleHarvesters
@@ -22,6 +22,7 @@ Container@INGAME_ROOT:
 				PauseKey: Pause
 				SelectAllUnitsKey: SelectAllUnits
 				SelectUnitsByTypeKey: SelectUnitsByType
+				ShowAttackRangeCirclesKey: ShowAttackRangeCircles
 		Container@WORLD_ROOT:
 			Logic: LoadIngamePerfLogic
 			Children:

--- a/mods/common/fluent/hotkeys.ftl
+++ b/mods/common/fluent/hotkeys.ftl
@@ -106,6 +106,8 @@ hotkey-description-stanceattackanything = Attack anything
 hotkey-description-stancedefend = Defend
 hotkey-description-stancereturnfire = Return fire
 hotkey-description-stanceholdfire = Hold fire
+hotkey-description-showattackrangecircles = Show attack range circles
+
 hotkey-description-stopmusic = Stop
 hotkey-description-pausemusic = Pause or Resume
 hotkey-description-prevmusic = Previous

--- a/mods/common/fluent/rules.ftl
+++ b/mods/common/fluent/rules.ftl
@@ -55,6 +55,11 @@ dropdown-time-limit =
     .label = Time Limit
     .description = The player or team with the highest score at the end of this time wins
 
+## AttackRangeCirclesOptions
+checkbox-attack-range-circles =
+    .label = Attack Range Circles
+    .description = Allow showing attack range circles for selected units (hold hotkey)
+
 ## Tooltip
 label-tooltip-prefix =
     .ally = Ally

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -113,6 +113,11 @@ StanceHoldFire: F Alt
 	Types: Stance
 	Contexts: player
 
+ShowAttackRangeCircles: R Ctrl, Alt
+	Description: hotkey-description-showattackrangecircles
+	Types: World
+	Contexts: player
+
 StopMusic: AUDIOSTOP
 	Description: hotkey-description-stopmusic
 	Types: Music

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -211,6 +211,7 @@
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
 	Inherits@avalancheKill: ^CliffAvalanche
+	RenderAttackRangeOnSelect:
 	Tooltip:
 		GenericName: meta-vehicle-generic-name
 	Huntable:
@@ -388,6 +389,7 @@
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
 	Inherits@avalancheKill: ^CliffAvalanche
+	RenderAttackRangeOnSelect:
 	Tooltip:
 		GenericName: meta-infantry-generic-name
 	Huntable:
@@ -460,6 +462,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Interactable:
 	Tooltip:
 		GenericName: meta-plane-generic-name

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -258,6 +258,8 @@ World:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
 		TerrainFlashPalette: effect
+	AttackRangeCirclesOptions:
+		CheckboxDisplayOrder: 11
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -241,6 +241,7 @@
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -325,6 +326,7 @@
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -508,6 +510,7 @@
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -585,6 +588,7 @@
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	OwnerLostAction:
 		Action: Kill
 	Armor:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -296,6 +296,8 @@ World:
 		TerrainFlashImage: moveflsh
 		TerrainFlashSequence: idle
 		TerrainFlashPalette: moveflash
+	AttackRangeCirclesOptions:
+		CheckboxDisplayOrder: 11
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -554,6 +554,7 @@
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -778,6 +779,7 @@
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -897,6 +899,7 @@
 	Inherits@3: ^Cloakable
 	Inherits@selection: ^SelectableCombatUnit
 	Inherits@handicaps: ^PlayerHandicaps
+	RenderAttackRangeOnSelect:
 	Huntable:
 	OwnerLostAction:
 		Action: Kill

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -400,6 +400,8 @@ World:
 		TerrainFlashSequence: idle
 		TerrainFlashPalette: moveflash
 		ActorFlashType: Tint
+	AttackRangeCirclesOptions:
+		CheckboxDisplayOrder: 11
 
 EditorWorld:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
Fixes: https://github.com/OpenRA/OpenRA/issues/4767

This PR allows to show the attack range of selected units by pressing a hotkey. 
- It works in skirmish and multiplayer modes.
- To enable this feature, just enable the "Attack range circles" checkbox in Map Options. 
- You can customize the hotkey in Settings > Hotkeys > "Show attack range circles".
- The attack range circles are displayed as long as the hotkey is pressed. 

Note about replays: selecting units and pressing the hotkey will show the attack range circles regardless of the checkbox state in Map Options. 

https://github.com/user-attachments/assets/10292273-da3c-40b3-b10f-0b15d12e7765

https://github.com/user-attachments/assets/216ce88a-68a4-4f14-8a30-73020518d392

