### PR TITLE
Calculate step time less often.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -819,7 +819,7 @@ namespace OpenRA
 
 				// ReplayTimestep = 0 means the replay is paused: we need to keep logicInterval as UI.Timestep to avoid breakage
 				if (logicWorld != null && (!logicWorld.IsReplay || logicWorld.ReplayTimestep != 0))
-					logicInterval = logicWorld == OrderManager.World ? OrderManager.SuggestedTimestep : logicWorld.Timestep;
+					logicInterval = logicWorld == OrderManager.World ? OrderManager.LastTickTime.Timestep : logicWorld.Timestep;
 
 				// Ideal time between screen updates
 				var renderInterval = logicInterval;

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Network
 		/// <summary>Null when watching a replay.</summary>
 		public Session.Client LocalClient => LobbyInfo.ClientWithIndex(Connection.LocalClientId);
 		public World World;
+
 		public int OrderQueueLength => pendingOrders.Count > 0 ? pendingOrders.Min(q => q.Value.Count) : 0;
 
 		public string ServerError = null;
@@ -50,9 +51,12 @@ namespace OpenRA.Network
 
 		public bool GameStarted => NetFrameNumber != 0;
 		public IConnection Connection { get; }
+		public readonly bool IsReplay;
 
 		internal int GameSaveLastFrame = -1;
 		internal int GameSaveLastSyncFrame = -1;
+
+		public bool IsLoadingGameSave => NetFrameNumber <= GameSaveLastFrame;
 
 		readonly List<Order> localOrders = [];
 		readonly List<Order> localImmediateOrders = [];
@@ -109,6 +113,8 @@ namespace OpenRA.Network
 			generateSyncReport = Connection is not ReplayConnection && LobbyInfo.GlobalSettings.EnableSyncReports;
 
 			NetFrameNumber = 1;
+			UpdateTimestep();
+
 			LocalFrameNumber = 0;
 			LastTickTime.Value = Game.RunTime;
 
@@ -118,9 +124,11 @@ namespace OpenRA.Network
 		public OrderManager(IConnection conn)
 		{
 			Connection = conn;
+			IsReplay = Connection is ReplayConnection;
 			syncReport = new SyncReport(this);
 
-			LastTickTime = new TickTime(() => SuggestedTimestep, Game.RunTime);
+			LastTickTime = new TickTime(Ui.Timestep, Game.RunTime);
+			UpdateTimestep();
 		}
 
 		public void IssueOrders(Order[] orders)
@@ -172,6 +180,7 @@ namespace OpenRA.Network
 		public void ReceiveTickScale(float scale)
 		{
 			tickScale = scale;
+			UpdateTimestep();
 		}
 
 		public void ReceiveImmediateOrders(int clientId, OrderPacket orders)
@@ -201,24 +210,26 @@ namespace OpenRA.Network
 
 		bool IsReadyForNextFrame => GameStarted && pendingOrders.All(p => p.Value.Count > 0);
 
-		public int SuggestedTimestep
+		int GetSuggestedTimestep()
 		{
-			get
-			{
-				if (World == null)
-					return Ui.Timestep;
+			if (World == null)
+				return Ui.Timestep;
 
-				if (World.IsLoadingGameSave)
-					return 1;
+			if (IsLoadingGameSave)
+				return 1;
 
-				if (World.IsReplay)
-					return World.ReplayTimestep;
+			if (IsReplay)
+				return World.ReplayTimestep;
 
-				if (tickScale != 1f)
-					return Math.Max((int)(tickScale * World.Timestep), 1);
+			if (tickScale != 1f)
+				return Math.Max((int)(tickScale * World.Timestep), 1);
 
-				return World.Timestep;
-			}
+			return World.Timestep;
+		}
+
+		void UpdateTimestep()
+		{
+			LastTickTime.Timestep = GetSuggestedTimestep();
 		}
 
 		void SendOrders()
@@ -282,6 +293,7 @@ namespace OpenRA.Network
 			processClientsToRemove.Clear();
 
 			++NetFrameNumber;
+			UpdateTimestep();
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Network/TickTime.cs
+++ b/OpenRA.Game/Network/TickTime.cs
@@ -9,17 +9,15 @@
  */
 #endregion
 
-using System;
-
 namespace OpenRA.Network
 {
 	public sealed class TickTime
 	{
-		readonly Func<int> timestep;
+		public int Timestep;
 
-		public TickTime(Func<int> timestep, long lastTickTime)
+		public TickTime(int timestep, long lastTickTime)
 		{
-			this.timestep = timestep;
+			Timestep = timestep;
 			Value = lastTickTime;
 		}
 
@@ -27,25 +25,21 @@ namespace OpenRA.Network
 
 		public bool ShouldAdvance(long tick)
 		{
-			var i = timestep();
-
-			if (i == 0)
+			if (Timestep == 0)
 				return false;
 
 			var tickDelta = tick - Value;
-			return tickDelta >= i;
+			return tickDelta >= Timestep;
 		}
 
 		public void AdvanceTickTime(long tick)
 		{
 			var tickDelta = tick - Value;
 
-			var currentTimestep = timestep();
-
-			var integralTickTimestep = tickDelta / currentTimestep * currentTimestep;
+			var integralTickTimestep = tickDelta / Timestep * Timestep;
 			Value += integralTickTimestep >= Game.TimestepJankThreshold
 				? integralTickTimestep
-				: currentTimestep;
+				: Timestep;
 		}
 	}
 }

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Widgets
 
 		public static Widget Root = new ContainerWidget();
 
-		public static TickTime LastTickTime = new(() => Timestep, Game.RunTime);
+		public static TickTime LastTickTime = new(Timestep, Game.RunTime);
 
 		static readonly Stack<Widget> WindowList = [];
 

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -111,9 +111,9 @@ namespace OpenRA
 		public bool ShroudObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(pos); }
 		public bool ShroudObscures(PPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 
-		public bool IsReplay => OrderManager.Connection is ReplayConnection;
+		public bool IsReplay => OrderManager.IsReplay;
 
-		public bool IsLoadingGameSave => OrderManager.NetFrameNumber <= OrderManager.GameSaveLastFrame;
+		public bool IsLoadingGameSave => OrderManager.IsLoadingGameSave;
 
 		public int GameSaveLoadingPercentage => OrderManager.NetFrameNumber * 100 / OrderManager.GameSaveLastFrame;
 


### PR DESCRIPTION

Only calculate OrderManager suggested step time each net frame.

- Do not call and calculate `SuggestedStepTime` in the game loop continuously in a busy loop.
- Do not additionally call and recalculate it second time from `LastTickTime`.
- Avoid function call from `LastTickTime`.
- `IsReplay` as readonly bool. Avoid doing a dynamic type check on `is ReplayConnection`
- Avoid calling `IsReplay` on `World` that in turn calls `OrderManager` again to check if it is.

Other:
- Less elegant that we now need to update the value at each netframe. Only for `IsLoadingGameSave`.
- `IsLoadingGameSave`  ideally shouldn't be calculated dynamically. If most of the time the value will be false.
- World, OrderManager, Game are all a bit too much intertwined.
- still not sure what `integralTickTimestep` would do. 
- TickTime could perhaps be better integrated with OrderManager and Ui in future. Don't see the advantage. 
- curious if the net `tickScale` in practice works. 