### PR TITLE
Support per-map custom tileset overrides

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -70,6 +70,7 @@ Also thanks to:
     * Fahrradkette
     * Florian Wiesbauer (FiveAces)
     * Frank Razenberg (zzattack)
+    * Frank van Viegen
     * Gareth Needham (Ripley`)
     * Glen Anderson (glen7)
     * Glenn Martin Jensen (Baxxster)

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -163,15 +163,13 @@ namespace OpenRA
 			return ruleset;
 		}
 
-		public static Ruleset LoadDefaultsForTileSet(ModData modData, string tileSet)
+		public static Ruleset LoadDefaultsForTileSet(ModData modData, ITerrainInfo terrainInfo)
 		{
 			var dr = modData.DefaultRules;
-			var terrainInfo = modData.DefaultTerrainInfo[tileSet];
-
 			return new Ruleset(dr.Actors, dr.Weapons, dr.Voices, dr.Notifications, dr.Music, terrainInfo, dr.ModelSequences);
 		}
 
-		public static Ruleset Load(ModData modData, IReadOnlyFileSystem fileSystem, string tileSet,
+		public static Ruleset Load(ModData modData, IReadOnlyFileSystem fileSystem, ITerrainInfo terrainInfo,
 			MiniYaml mapRules, MiniYaml mapWeapons, MiniYaml mapVoices, MiniYaml mapNotifications,
 			MiniYaml mapMusic, MiniYaml mapModelSequences)
 		{
@@ -196,9 +194,6 @@ namespace OpenRA
 
 				var music = MergeOrDefault("Music", fileSystem, m.Music, mapMusic, dr.Music,
 					k => new MusicInfo(k.Key, k.Value));
-
-				// TODO: Add support for merging custom terrain modifications
-				var terrainInfo = modData.DefaultTerrainInfo[tileSet];
 
 				var modelSequences = dr.ModelSequences;
 				if (mapModelSequences != null)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -282,8 +282,11 @@ namespace OpenRA
 						streams.Add(package.GetStream(filename));
 
 				// Take the SHA1
+				// When we simplify the collection, .NET 10.0.102 doesn't know which overload of SHA1Hash to call
+#pragma warning disable IDE0301 // Simplify collection initialization
 				if (streams.Count == 0)
 					return CryptoUtil.SHA1Hash(Array.Empty<byte>());
+#pragma warning restore IDE0301 // Simplify collection initialization
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -283,7 +283,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash([]);
+					return CryptoUtil.SHA1Hash(Array.Empty<byte>());
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)
@@ -440,7 +440,7 @@ namespace OpenRA
 			// This uses the same recursive merge as rules/weapons/etc, so the custom file only needs
 			// to contain additions or overrides rather than duplicating the entire tileset.
 			ITerrainInfo terrainInfo;
-			if (Package.Contains("custom-tileset.yaml"))
+			if (Package != null && Package.Contains("custom-tileset.yaml"))
 			{
 				var terrainType = modData.ObjectCreator.FindType(modData.Manifest.TerrainFormat + "Loader");
 				var terrainCtor = terrainType?.GetConstructor([typeof(ModData)]);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -436,9 +436,37 @@ namespace OpenRA
 
 		void PostInit()
 		{
+			// If the map contains a custom-tileset.yaml, merge it on top of the mod's base tileset.
+			// This uses the same recursive merge as rules/weapons/etc, so the custom file only needs
+			// to contain additions or overrides rather than duplicating the entire tileset.
+			ITerrainInfo terrainInfo;
+			if (Package.Contains("custom-tileset.yaml"))
+			{
+				var terrainType = modData.ObjectCreator.FindType(modData.Manifest.TerrainFormat + "Loader");
+				var terrainCtor = terrainType?.GetConstructor([typeof(ModData)]);
+				if (terrainType == null || !terrainType.GetInterfaces().Contains(typeof(ITerrainLoader)) || terrainCtor == null)
+					throw new InvalidOperationException($"Unable to find a terrain loader for type '{modData.Manifest.TerrainFormat}'.");
+
+				var baseTilesetPath = modData.Manifest.TileSets.FirstOrDefault(f =>
+				{
+					var nodes = MiniYaml.FromStream(modData.DefaultFileSystem.Open(f), f);
+					var general = nodes.FirstOrDefault(n => n.Key == "General");
+					var id = general?.Value.NodeWithKeyOrDefault("Id");
+					return id?.Value.Value == Tileset;
+				});
+
+				if (baseTilesetPath == null)
+					throw new InvalidDataException($"No mod tileset found with Id '{Tileset}' to use as base for custom-tileset.yaml.");
+
+				var terrainLoader = (ITerrainLoader)terrainCtor.Invoke([modData]);
+				terrainInfo = terrainLoader.ParseTerrain(this, [baseTilesetPath, "custom-tileset.yaml"]);
+			}
+			else
+				terrainInfo = modData.DefaultTerrainInfo[Tileset];
+
 			try
 			{
-				Rules = Ruleset.Load(modData, this, Tileset, RuleDefinitions, WeaponDefinitions,
+				Rules = Ruleset.Load(modData, this, terrainInfo, RuleDefinitions, WeaponDefinitions,
 					VoiceDefinitions, NotificationDefinitions, MusicDefinitions, ModelSequenceDefinitions);
 			}
 			catch (Exception e)
@@ -447,7 +475,7 @@ namespace OpenRA
 				Log.Write("debug", e);
 				InvalidCustomRules = true;
 				InvalidCustomRulesException = e;
-				Rules = Ruleset.LoadDefaultsForTileSet(modData, Tileset);
+				Rules = Ruleset.LoadDefaultsForTileSet(modData, terrainInfo);
 			}
 
 			Sequences = new SequenceSet(this, modData, Tileset, SequenceDefinitions);
@@ -465,7 +493,6 @@ namespace OpenRA
 				CustomTerrain[uv] = byte.MaxValue;
 
 			// Replace invalid tiles and cache ramp state
-			var terrainInfo = Rules.TerrainInfo;
 			foreach (var uv in AllCells.MapCoords)
 			{
 				if (!terrainInfo.TryGetTerrainInfo(Tiles[uv], out var info))

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -312,7 +312,7 @@ namespace OpenRA
 
 		public Ruleset LoadRuleset()
 		{
-			return Ruleset.Load(modData, this, TileSet, innerData.RuleDefinitions,
+			return Ruleset.Load(modData, this, modData.DefaultTerrainInfo[TileSet], innerData.RuleDefinitions,
 				innerData.WeaponDefinitions, innerData.VoiceDefinitions, innerData.NotificationDefinitions,
 				innerData.MusicDefinitions, innerData.ModelSequenceDefinitions);
 		}

--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -21,6 +21,7 @@ namespace OpenRA
 	public interface ITerrainLoader
 	{
 		ITerrainInfo ParseTerrain(IReadOnlyFileSystem fileSystem, string path);
+		ITerrainInfo ParseTerrain(IReadOnlyFileSystem fileSystem, IEnumerable<string> paths);
 	}
 
 	public interface ITerrainInfo

--- a/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTerrain.cs
@@ -31,6 +31,11 @@ namespace OpenRA.Mods.Common.Terrain
 		{
 			return new DefaultTerrain(fileSystem, path);
 		}
+
+		public ITerrainInfo ParseTerrain(IReadOnlyFileSystem fileSystem, IEnumerable<string> paths)
+		{
+			return new DefaultTerrain(fileSystem, paths);
+		}
 	}
 
 	public class DefaultTerrainTileInfo : TerrainTileInfo
@@ -97,10 +102,17 @@ namespace OpenRA.Mods.Common.Terrain
 		readonly byte defaultWalkableTerrainIndex;
 
 		public DefaultTerrain(IReadOnlyFileSystem fileSystem, string filepath)
-		{
-			var yaml = MiniYaml.FromStream(fileSystem.Open(filepath), filepath)
-				.ToDictionary(x => x.Key, x => x.Value);
+			: this(MiniYaml.FromStream(fileSystem.Open(filepath), filepath)
+				.ToDictionary(x => x.Key, x => x.Value))
+		{ }
 
+		public DefaultTerrain(IReadOnlyFileSystem fileSystem, IEnumerable<string> paths)
+			: this(MiniYaml.Merge(paths.Select(p => MiniYaml.FromStream(fileSystem.Open(p), p)))
+				.ToDictionary(x => x.Key, x => x.Value))
+		{ }
+
+		DefaultTerrain(Dictionary<string, MiniYaml> yaml)
+		{
 			// General info
 			FieldLoader.Load(this, yaml["General"]);
 
@@ -119,7 +131,7 @@ namespace OpenRA.Mods.Common.Terrain
 				var tt = TerrainInfo[i].Type;
 
 				if (!tiby.TryAdd(tt, i))
-					throw new YamlException($"Duplicate terrain type '{tt}' in '{filepath}'.");
+					throw new YamlException($"Duplicate terrain type '{tt}' in tileset '{Id}'.");
 			}
 
 			terrainIndexByType = tiby.ToFrozenDictionary();

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -30,13 +31,13 @@ namespace OpenRA.Mods.Common.Terrain
 
 		public Sprite MissingTile { get; }
 
-		public DefaultTileCache(DefaultTerrain terrainInfo, Action<uint, string> onMissingImage = null)
+		public DefaultTileCache(DefaultTerrain terrainInfo, Action<uint, string> onMissingImage = null, IReadOnlyFileSystem fileSystem = null)
 		{
 			sheetBuilders = new Cache<SheetType, SheetBuilder>(t => new SheetBuilder(t, terrainInfo.SheetSize));
 
 			random = new MersenneTwister();
 
-			var frameCache = new FrameCache(Game.ModData.DefaultFileSystem, Game.ModData.SpriteLoaders);
+			var frameCache = new FrameCache(fileSystem ?? Game.ModData.DefaultFileSystem, Game.ModData.SpriteLoaders);
 			foreach (var t in terrainInfo.Templates)
 			{
 				var variants = new List<Sprite[]>();

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (terrainInfo == null)
 				throw new InvalidDataException($"{nameof(TerrainRenderer)} can only be used with the {nameof(DefaultTerrain)} parser");
 
-			tileCache = new DefaultTileCache(terrainInfo);
+			tileCache = new DefaultTileCache(terrainInfo, fileSystem: map);
 		}
 
 		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = utility.ModData;
 
-			var rules = Ruleset.LoadDefaultsForTileSet(utility.ModData, "ARRAKIS");
+			var rules = Ruleset.LoadDefaultsForTileSet(utility.ModData, utility.ModData.DefaultTerrainInfo["ARRAKIS"]);
 			var map = D2kMapImporter.Import(args[1], utility.ModData.Manifest.Id, args[2], rules);
 
 			if (map == null)

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -237,7 +237,7 @@ SupportsMapsFrom: cnc
 
 SoundFormats: Aud, Wav
 
-SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA
+SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA, PngSheet
 
 VideoFormats: Vqa, Wsa
 

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -268,7 +268,7 @@ SupportsMapsFrom: ra
 
 SoundFormats: Aud, Wav
 
-SpriteFormats: ShpD2, ShpTD, TmpRA, TmpTD, ShpTS
+SpriteFormats: ShpD2, ShpTD, TmpRA, TmpTD, ShpTS, PngSheet
 
 VideoFormats: Vqa, Wsa
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -261,7 +261,7 @@ SupportsMapsFrom: ts
 
 SoundFormats: Aud, Wav
 
-SpriteFormats: ShpTS, TmpTS, ShpTD
+SpriteFormats: ShpTS, TmpTS, ShpTD, PngSheet
 
 VideoFormats: Vqa
 


### PR DESCRIPTION
This PR allows maps to include a `custom-tileset.yaml` that gets merged on top of the mod's base tileset using `MiniYaml.Merge` (like is done for rule/weapon/sequence overrides). The custom file only needs to contain the additions or changes, not the full tileset.

Here's an impression of the flexibility this allows:

<img width="1573" height="1008" alt="Screenshot_20260209_112824" src="https://github.com/user-attachments/assets/e5ef13d5-985a-49ea-b57d-df520bb0a042" />
<img width="2878" height="1799" alt="Screenshot_20260209_152814" src="https://github.com/user-attachments/assets/81035918-3d4e-4a1c-bac2-a11ca57f96a7" />

Here's the corresponding .oramap (renamed to .zip so that github will accept it):  [Catan.zip](https://github.com/user-attachments/files/25181534/Catan.zip) --It's just a proof-of-concept, not a ready-to-play map.

Tile sprites are resolved from the map package first (via `IReadOnlyFileSystem`), falling back to the mod filesystem. I've added `PngSheet` to `SpriteFormats` for cnc/ra/ts, so each of the mods can work with .png files for custom tilesets.

There's one thing I'm not sure about: how to deal with versions of OpenRA that don't have this feature? Currently, they would silently ignore the custom tileset, but that's not great as the map would likely be unplayable. Incrementing the CurrentMapFormat to 13 wouldn't help though, as the engine doesn't check for maps that are too new (only for maps that are too old to be supported). Such an extra check seems like a sensible thing to do, but that won't help with pre-existing versions yet. Any thoughts on this?

And in general... how does this look to you?