### PR TITLE
FieldLoaderTest DateTime fix.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -526,7 +526,8 @@ namespace OpenRA
 
 		static object ParseDateTime(string fieldName, Type fieldType, string value)
 		{
-			if (DateTime.TryParseExact(value, "yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var dt))
+			if (DateTime.TryParseExact(value, "yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture,
+					DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
 				return dt;
 			return InvalidValueAction(value, fieldType, fieldName);
 		}

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -127,7 +127,13 @@ namespace OpenRA
 			}
 
 			if (v is DateTime d)
+			{
+				// Assume DateTimeKind.Unspecified is already UTC
+				if (d.Kind == DateTimeKind.Local)
+					d = d.ToUniversalTime();
+
 				return d.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture);
+			}
 
 			// Try the TypeConverter
 			var conv = TypeDescriptor.GetConverter(t);

--- a/OpenRA.Test/OpenRA.Game/FieldLoaderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FieldLoaderTest.cs
@@ -304,11 +304,11 @@ namespace OpenRA.Test
 		[Test]
 		public void GetValue_DateTime()
 		{
-			var expected = new DateTime(2000, 1, 1);
+			var expected = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 			var input = expected.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture);
 
 			var actual = FieldLoader.GetValue<DateTime>("field", $"  {input}  ");
-
+			Assert.That(actual.Kind, Is.EqualTo(DateTimeKind.Utc));
 			Assert.That(actual, Is.EqualTo(expected));
 		}
 

--- a/OpenRA.Test/OpenRA.Game/FieldSaverTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FieldSaverTest.cs
@@ -76,11 +76,25 @@ namespace OpenRA.Test
 		[Test]
 		public void FormatValue_DateTime()
 		{
-			var input = new DateTime(2000, 1, 1);
+			var inputToBeAssumedUtc = new DateTime(2000, 1, 1);
+			Assert.That(inputToBeAssumedUtc.Kind, Is.EqualTo(DateTimeKind.Unspecified));
 
-			var actual = FieldSaver.FormatValue(input);
+			var actualUtc = FieldSaver.FormatValue(inputToBeAssumedUtc);
+			Assert.That(actualUtc, Is.EqualTo(inputToBeAssumedUtc.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)));
+			var inputUtc = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+			actualUtc = FieldSaver.FormatValue(inputUtc);
+			Assert.That(actualUtc, Is.EqualTo(inputUtc.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)));
 
-			Assert.That(actual, Is.EqualTo(input.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)));
+			var amsterdamTz = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+			var inputAms = TimeZoneInfo.ConvertTime(inputUtc, TimeZoneInfo.Utc, amsterdamTz);
+			var actualAms = FieldSaver.FormatValue(inputAms);
+			Assert.That(inputAms.Kind, Is.EqualTo(DateTimeKind.Unspecified));
+			Assert.That(actualAms, Is.EqualTo(inputAms.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)));
+
+			var inputLocal = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Local);
+			inputUtc = inputLocal.ToUniversalTime();
+			actualUtc = FieldSaver.FormatValue(inputLocal);
+			Assert.That(actualUtc, Is.EqualTo(inputUtc.ToString("yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture)));
 		}
 
 		[Test]


### PR DESCRIPTION
closes #22230 

DateTime.ToString by default converts to local date time - if Kind is not explicitly set to Utc.

FieldLoader expects UTC as input format - but outputs a local date time.

ParseExact with argument `DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal`is needed to let it also return a date time object in UTC. But changing this may break existing behavior.

Better would be to switch over to ISO date time string format. ToString("o").