### PR TITLE
Take a screenshot of the map in the Map Editor when "Save Map" button is clicked

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -58,7 +58,9 @@ namespace OpenRA
 		public static string EngineVersion { get; private set; }
 		public static LocalPlayerProfile LocalPlayerProfile;
 
-		static bool takeScreenshot = false;
+		static bool takeScreenshot;
+		static bool saveEditorMapAsPngImage;
+		static string editorMapPngImagePath;
 		static Benchmark benchmark = null;
 
 		public static event Action OnShellmapLoaded = () => { };
@@ -698,6 +700,12 @@ namespace OpenRA
 			takeScreenshot = true;
 		}
 
+		public static void SaveEditorMapAsPngImage(string path)
+		{
+			editorMapPngImagePath = path;
+			saveEditorMapAsPngImage = true;
+		}
+
 		static void RenderTick()
 		{
 			using (new PerfSample("render"))
@@ -756,6 +764,40 @@ namespace OpenRA
 				{
 					takeScreenshot = false;
 					TakeScreenshotInner();
+				}
+
+				if (saveEditorMapAsPngImage && worldRenderer != null)
+				{
+					saveEditorMapAsPngImage = false;
+					var pngImagePath = editorMapPngImagePath;
+					editorMapPngImagePath = null;
+
+					var map = worldRenderer.World.Map;
+					var tileSize = map.Rules.TerrainInfo.TileSize;
+
+					// Use the same bounds calculation as Viewport does for the editor:
+					// derive captureSize from MapSize and tileSize, halving the height for
+					// isometric maps because their tiles are displayed at a 2:1 ratio.
+					var captureWidth = map.MapSize.Width * tileSize.Width;
+					var captureHeight = map.MapSize.Height * tileSize.Height;
+					if (map.Grid.Type == MapGridType.RectangularIsometric)
+						captureHeight /= 2;
+
+					var captureSize = new Size(captureWidth, captureHeight);
+					var centerPx = new float2(captureWidth / 2f, captureHeight / 2f);
+
+					// Override the viewport before PrepareRenderables so all actors across the full map are collected.
+					var restoreViewport = worldRenderer.Viewport.OverrideForMapCapture(centerPx, captureSize);
+					worldRenderer.BeginFrame();
+					worldRenderer.PrepareRenderables();
+					Renderer.BeginWorld(centerPx, captureSize);
+					worldRenderer.Draw();
+					worldRenderer.EndFrame();
+					restoreViewport();
+					Renderer.BeginUI();
+					Renderer.EndFrame(null, display: false);
+
+					Renderer.SaveMapAsPngImage(pngImagePath);
 				}
 			}
 

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -352,6 +352,25 @@ namespace OpenRA.Graphics
 			allCellsDirty = true;
 		}
 
+		// Temporarily overrides CenterLocation and ViewportSize for full-map PNG image rendering.
+		// Returns an Action that restores the original values.
+		public Action OverrideForMapCapture(float2 center, Size size)
+		{
+			var savedCenter = CenterLocation;
+			var savedSize = ViewportSize;
+			CenterLocation = center;
+			ViewportSize = size;
+			cellsDirty = true;
+			allCellsDirty = true;
+			return () =>
+			{
+				CenterLocation = savedCenter;
+				ViewportSize = savedSize;
+				cellsDirty = true;
+				allCellsDirty = true;
+			};
+		}
+
 		public void Scroll(float2 delta, bool ignoreBorders)
 		{
 			// Convert scroll delta from world-px to viewport-px

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -328,7 +328,7 @@ namespace OpenRA
 				r.SetPalette(palette);
 		}
 
-		public void EndFrame(IInputHandler inputHandler)
+		public void EndFrame(IInputHandler inputHandler, bool display = true)
 		{
 			if (renderType != RenderType.UI)
 				throw new InvalidOperationException($"EndFrame called with renderType = {renderType}, expected RenderType.UI.");
@@ -337,15 +337,21 @@ namespace OpenRA
 
 			screenBuffer.Unbind();
 
-			// Render the compositor buffers to the screen
-			// HACK / PERF: Fudge the coordinates to cover the actual window while keeping the buffer viewport parameters
-			// This saves us two redundant (and expensive) SetViewportParams each frame
-			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0),
-				new float3(lastBufferSize.Width / screenSprite.Size.X, -lastBufferSize.Height / screenSprite.Size.Y, 1f));
-			Flush();
+			if (display)
+			{
+				// Render the compositor buffers to the screen
+				// HACK / PERF: Fudge the coordinates to cover the actual window while keeping the buffer viewport parameters
+				// This saves us two redundant (and expensive) SetViewportParams each frame
+				RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0),
+					new float3(lastBufferSize.Width / screenSprite.Size.X, -lastBufferSize.Height / screenSprite.Size.Y, 1f));
+				Flush();
+			}
 
-			Window.PumpInput(inputHandler);
-			Context.Present();
+			if (inputHandler != null)
+				Window.PumpInput(inputHandler);
+
+			if (display)
+				Context.Present();
 
 			renderType = RenderType.None;
 		}
@@ -535,6 +541,31 @@ namespace OpenRA
 				var dest = new byte[4 * destWidth * destHeight];
 				for (var y = 0; y < destHeight; y++)
 					Array.Copy(src, 4 * y * srcWidth, dest, 4 * y * destWidth, 4 * destWidth);
+
+				new Png(dest, SpriteFrameType.Bgra32, destWidth, destHeight).Save(path);
+			});
+		}
+
+		public void SaveMapAsPngImage(string path)
+		{
+			// Pull pixel data from the world framebuffer (not the screen framebuffer).
+			// The world buffer is not Y-flipped, so destHeight is positive.
+			var src = worldBuffer.Texture.GetData();
+			var srcWidth = worldSprite.Sheet.Size.Width;
+			var srcHeight = worldSprite.Sheet.Size.Height;
+			var originX = worldSprite.Bounds.X;
+			var originY = worldSprite.Bounds.Y;
+
+			// Clamp to the actual framebuffer dimensions: when the map is larger than the framebuffer,
+			// BeginWorld applies a downscale factor but the sprite bounds may still exceed the buffer.
+			var destWidth = Math.Min(worldSprite.Bounds.Width, srcWidth - originX);
+			var destHeight = Math.Min(worldSprite.Bounds.Height, srcHeight - originY);
+
+			ThreadPool.QueueUserWorkItem(_ =>
+			{
+				var dest = new byte[4 * destWidth * destHeight];
+				for (var y = 0; y < destHeight; y++)
+					Array.Copy(src, 4 * ((y + originY) * srcWidth + originX), dest, 4 * y * destWidth, 4 * destWidth);
 
 				new Png(dest, SpriteFrameType.Bgra32, destWidth, destHeight).Save(path);
 			});

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -179,8 +179,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					typeDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 210, fileTypes, SetupItem);
 			}
 
+			var saveMapPngImage = widget.Get<CheckboxWidget>("SAVE_MAP_PNG_IMAGE");
+
 			var close = widget.Get<ButtonWidget>("BACK_BUTTON");
 			close.OnClick = () => { Ui.CloseWindow(); onExit(); };
+
+			var exportMapAsPngImage = false;
 
 			void SaveMap(string combinedPath)
 			{
@@ -207,7 +211,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							package = new Folder(combinedPath);
 					}
 
-					SaveMapInner(map, package, world, modData);
+					SaveMapInner(map, package, world, modData, exportMapAsPngImage);
 				}
 				catch (Exception e)
 				{
@@ -216,6 +220,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				onSave(map.Uid);
 			}
+
+			saveMapPngImage.IsChecked = () => exportMapAsPngImage;
+			saveMapPngImage.OnClick = () => exportMapAsPngImage ^= true;
 
 			var save = widget.Get<ButtonWidget>("SAVE_BUTTON");
 			save.IsDisabled = () => string.IsNullOrWhiteSpace(filename.Text) || string.IsNullOrWhiteSpace(title.Text) || string.IsNullOrWhiteSpace(author.Text);
@@ -292,7 +299,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SaveMapMarkerTiles(map, modData, world);
 		}
 
-		public static void SaveMapInner(Map map, IReadWritePackage package, World world, ModData modData)
+		public static void SaveMapInner(Map map, IReadWritePackage package, World world, ModData modData, bool exportMapAsPngImage = false)
 		{
 			map.RequiresMod = modData.Manifest.Id;
 
@@ -307,6 +314,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					actionManager.Modified = false;
 
 				TextNotificationsManager.AddTransientLine(world.LocalPlayer, SaveCurrentMap);
+
+				if (exportMapAsPngImage)
+				{
+					var dir = Path.GetDirectoryName(package.Name);
+					var pngPath = Path.Combine(dir, Path.GetFileNameWithoutExtension(package.Name) + ".png");
+					Game.SaveEditorMapAsPngImage(pngPath);
+				}
 			}
 			catch (Exception e)
 			{

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -81,7 +81,7 @@ Container@SAVE_MAP_PANEL:
 	X: (WINDOW_WIDTH - WIDTH) / 2
 	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 345
-	Height: 195
+	Height: 260
 	Children:
 		Label@LABEL_TITLE:
 			Text: label-save-map-panel-title
@@ -168,6 +168,12 @@ Container@SAVE_MAP_PANEL:
 					Width: 110
 					Height: 25
 					Font: Regular
+				Checkbox@SAVE_MAP_PNG_IMAGE:
+					X: 110
+					Y: 192
+					Width: 220
+					Height: 20
+					Text: checkbox-save-map-panel-png-image
 		Button@BACK_BUTTON:
 			Y: PARENT_HEIGHT - 1
 			Width: 140

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -53,6 +53,7 @@ label-save-map-background-visibility = Visibility:
 dropdownbutton-save-map-background-visibility-dropdown = Map Visibility
 label-save-map-background-directory = Directory:
 label-save-map-background-filename = Filename:
+checkbox-save-map-panel-png-image = Save map as PNG image
 button-save-map-panel = Save
 label-actor-edit-panel-id = ID
 button-container-ok = OK

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -77,7 +77,7 @@ Background@SAVE_MAP_PANEL:
 	X: (WINDOW_WIDTH - WIDTH) / 2
 	Y: (WINDOW_HEIGHT - HEIGHT) / 2
 	Width: 350
-	Height: 300
+	Height: 335
 	Children:
 		Label@LABEL_TITLE:
 			X: (PARENT_WIDTH - WIDTH) / 2
@@ -156,6 +156,12 @@ Background@SAVE_MAP_PANEL:
 			Y: 200
 			Width: 110
 			Height: 25
+		Checkbox@SAVE_MAP_PNG_IMAGE:
+			X: 110
+			Y: 237
+			Width: 220
+			Height: 20
+			Text: checkbox-save-map-panel-png-image
 		Button@SAVE_BUTTON:
 			X: 80
 			Y: PARENT_HEIGHT - 45

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -50,6 +50,7 @@ label-save-map-panel-visibility = Visibility:
 dropdownbutton-save-map-panel-visibility-dropdown = Map Visibility
 label-save-map-panel-directory = Directory:
 label-save-map-panel-filename = Filename:
+checkbox-save-map-panel-png-image = Save map as PNG image
 button-save-map-panel = Save
 label-actor-edit-panel-id = ID
 button-container-ok = OK


### PR DESCRIPTION
Fixes: #2762

For testing purposes, currently three screenshots are taken when the "Save Map" button is clicked: 
- JPEG (60% quality)
- PNG (PNG-8)
- AVIF (40% quality)

The final goal of this PR is to create only one screenshot file (and not have three file formats). I suggest we choose AVIF, it's now very well supported: https://caniuse.com/avif and the file size is very small compared to PNG and JPEG.

Screenshots are saved in the \OpenRA\Screenshots\ folder with same name as the oramap file.

File size comparison: 
ra (randomly generated map, 128x128 tiles, screenshot: 1537x1537 pixels):
- avif:    198 KB
- jpeg:   348 KB
- png:    616 KB

cnc (randomly generated map, 128x128 tiles, screenshot: 1537x1537 pixels):
- avif:    222 KB
- jpeg:   355 KB
- png:    676 KB

d2k (randomly generated map, 128x128 tiles, screenshot: 1387x1387 pixels):
- avif:    144 KB
- jpeg:   285 KB
- png: 1,170 KB

ts ([Sunstroke](https://resource.openra.net/maps/12353/) map, tiles: 111x152, screenshot: 2809x1141 pixels):
- avif:    178 KB
- jpeg:   364 KB
- png: 2,150 KB

[ra_map_screenshots.zip](https://github.com/user-attachments/files/25468847/ra_map_screenshots.zip)

[cnc_map_screenshots.zip](https://github.com/user-attachments/files/25468855/cnc_map_screenshots.zip)

[d2K_map_screenshots.zip](https://github.com/user-attachments/files/25468832/d2K_map_screenshots.zip)

[ts_map_screenshots.zip](https://github.com/user-attachments/files/25468930/ts_map_screenshots.zip)






