### PR TITLE
Fix screen drift after ScreenShaker effects expire

### DIFF
--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Traits
 		WorldRenderer worldRenderer;
 		readonly List<ShakeEffect> shakeEffects = [];
 		int ticks = 0;
+		float2 previousOffset = float2.Zero;
 
 		public ScreenShaker(ScreenShakerInfo info)
 		{
@@ -41,10 +42,13 @@ namespace OpenRA.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (shakeEffects.Count > 0)
+			shakeEffects.RemoveAll(t => t.ExpiryTime == ticks);
+
+			var newOffset = shakeEffects.Count > 0 ? GetScrollOffset() : float2.Zero;
+			if (newOffset != previousOffset)
 			{
-				worldRenderer.Viewport.Scroll(GetScrollOffset(), true);
-				shakeEffects.RemoveAll(t => t.ExpiryTime == ticks);
+				worldRenderer.Viewport.Scroll(newOffset - previousOffset, true);
+				previousOffset = newOffset;
 			}
 
 			ticks++;


### PR DESCRIPTION
Fixes: #9952

The shake was applying cumulative scroll deltas each tick. Since the oscillation periods differ, the final sum usually isn’t zero, leaving a small offset behind.

This change makes the scroll relative to the last applied offset instead of accumulating forever. When all effects end, we scroll back to zero. Also moved effect expiry earlier so the last frame produces no offset.