### PR TITLE
Add STEK offset to RA1 importer

### DIFF
--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertMapCommand.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			var newLoc = new CPos(loc % MapSize, loc / MapSize);
 			var vectorDown = new CVec(0, 1);
 
-			if (input == "tsla" || input == "agun" || input == "gap" || input == "apwr")
+			if (input == "tsla" || input == "agun" || input == "gap" || input == "apwr" || input == "stek")
 				newLoc += vectorDown;
 
 			return newLoc;


### PR DESCRIPTION
Original STEK has [the same foundation and overlap squares](https://github.com/electronicarts/CnC_Red_Alert/blob/0dc09bb1d6188d1ec79ab4765b22a48b75ffee32/CODE/BDATA.CPP#L1047-L1077) as APWR, but the map importer does not give STEK an offset.

<img width="1262" height="687" alt="1_Foundations" src="https://github.com/user-attachments/assets/ba93c868-8f27-41a5-90cd-41813b768e04" />

I probably should have noticed this before in Proving Grounds. It was made more obvious to me by https://github.com/OpenRA/OpenRA/pull/22348, where a center is very close to a coil and SAM.

Original v. ORA bleed import:
<img width="516" height="412" alt="2_allies12_mobius" src="https://github.com/user-attachments/assets/28de0994-801d-4977-b9dd-3793a9f32b50" />
 
<img width="516" height="405" alt="3_allies12_ora" src="https://github.com/user-attachments/assets/1bac323e-7304-4405-affb-e782aee55a5b" />