### PR TITLE
Shuffle, pad allies-05abc Tanya speeches

### DIFF
--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -49,7 +49,8 @@ DogPatrolPath = { DogPatrolRally1.Location, DogPatrolRally2.Location, DogPatrolR
 PatrolAPath = { PatrolRally.Location, PatrolARally1.Location, PatrolARally2.Location, PatrolARally3.Location }
 PatrolBPath = { PatrolBRally1.Location, PatrolBRally2.Location, PatrolBRally3.Location, PatrolRally.Location }
 
-TanyaVoices = { "tuffguy", "bombit", "laugh", "gotit", "lefty", "keepem" }
+TanyaVoices = { "tuffguy", "bombit", "laugh", "keepem" }
+DeathVoices = { "death1", "death2", "death3" }
 SpyVoice = "sking"
 SamSites = { Sam1, Sam2, Sam3, Sam4 }
 
@@ -166,14 +167,28 @@ WarfactoryInfiltrated = function()
 end
 
 MissInfiltrated = function()
-	for i = 0, 5, 1 do
-		local sound = Utils.Random(TanyaVoices)
-		Trigger.AfterDelay(DateTime.Seconds(i), function()
-			Media.PlaySoundNotification(Greece, sound)
+	local taunts = Utils.Shuffle(TanyaVoices)
+	local deathVoices = Utils.Shuffle(DeathVoices)
+	local deaths =
+	{
+		[2] = deathVoices[1],
+		[4] = deathVoices[2]
+	}
+
+	for i = 1, 4, 1 do
+		local taunt = taunts[i]
+		local death = deaths[i]
+
+		Trigger.AfterDelay(i * 30, function()
+			Media.PlaySpeechNotification(Greece, taunt)
+
+			if death then
+				Media.PlaySpeechNotification(Greece, death)
+			end
 		end)
 	end
-	Prison.Attack(Prison)
 
+	Prison.Attack(Prison)
 	Trigger.AfterDelay(DateTime.Seconds(6), FreeTanya)
 end
 
@@ -293,7 +308,7 @@ InitTriggers = function()
 			Spy.DisguiseAsType("e1", USSR)
 			Spy.Move(SpyWaypoint.Location)
 			Spy.Infiltrate(Prison)
-			Media.PlaySoundNotification(Greece, SpyVoice)
+			Media.PlaySpeechNotification(Greece, SpyVoice)
 
 			FollowTruk = false
 

--- a/mods/ra/maps/allies-05a/notifications.yaml
+++ b/mods/ra/maps/allies-05a/notifications.yaml
@@ -1,9 +1,10 @@
-Sounds:
+Speech:
 	Notifications:
 		bombit: bombit1
 		laugh: laugh1
-		gotit: gotit1
-		lefty: lefty1
 		keepem: keepem1
 		tuffguy: tuffguy1
+		death1: dedman5
+		death2: dedman6
+		death3: dedman10
 		sking: sking1

--- a/mods/ra/maps/allies-05b/allies05b.lua
+++ b/mods/ra/maps/allies-05b/allies05b.lua
@@ -37,7 +37,8 @@ CheckpointRifles = { CheckpointRifle1, CheckpointRifle2 }
 BridgePatrol = { CheckpointDog1, CheckpointDog2, CheckpointRifle1, CheckpointRifle2 }
 BridgePatrolPath = { TrukWaypoint4.Location, BridgePatrolWay.Location }
 
-TanyaVoices = { "tuffguy", "bombit", "laugh", "gotit", "lefty", "keepem" }
+TanyaVoices = { "tuffguy", "bombit", "laugh", "keepem" }
+DeathVoices = { "death1", "death2", "death3" }
 SpyVoice = "sking"
 CivVoice = "guyokay"
 DogBark = "dogy"
@@ -71,7 +72,7 @@ ChurchFootprint = function()
 end
 
 ChurchSequence = function()
-	Media.PlaySoundNotification(Greece, CivVoice)
+	Media.PlaySpeechNotification(Greece, CivVoice)
 	Hero = Actor.Create("c1", true, { Owner = GoodGuy, Location = ChurchSpawn.Location })
 	Hero.Attack(TargetBarrel)
 
@@ -174,7 +175,7 @@ WarfactoryInfiltrated = function()
 	Trigger.OnEnteredProximityTrigger(TrukWaypoint4.CenterPosition, WDist.FromCells(1), function(actor, id)
 		if actor.Type == "dog" then
 			Trigger.RemoveProximityTrigger(id)
-			Media.PlaySoundNotification(Greece, DogBark)
+			Media.PlaySpeechNotification(Greece, DogBark)
 			Utils.Do(CheckpointRifles, function(guard)
 				guard.Move(TrukInspect.Location)
 			end)
@@ -193,7 +194,7 @@ WarfactoryInfiltrated = function()
 			Spy.DisguiseAsType("e1", USSR)
 			Spy.Move(TruckWaypoint5.Location)
 			Spy.Infiltrate(Prison)
-			Media.PlaySoundNotification(Greece, SpyVoice)
+			Media.PlaySpeechNotification(Greece, SpyVoice)
 
 			FollowTruk = false
 
@@ -218,14 +219,28 @@ WarfactoryInfiltrated = function()
 end
 
 MissInfiltrated = function()
-	for i = 0, 5, 1 do
-		local sound = Utils.Random(TanyaVoices)
-		Trigger.AfterDelay(DateTime.Seconds(i), function()
-			Media.PlaySoundNotification(Greece, sound)
+	local taunts = Utils.Shuffle(TanyaVoices)
+	local deathVoices = Utils.Shuffle(DeathVoices)
+	local deaths =
+	{
+		[2] = deathVoices[1],
+		[4] = deathVoices[2]
+	}
+
+	for i = 1, 4, 1 do
+		local taunt = taunts[i]
+		local death = deaths[i]
+
+		Trigger.AfterDelay(i * 30, function()
+			Media.PlaySpeechNotification(Greece, taunt)
+
+			if death then
+				Media.PlaySpeechNotification(Greece, death)
+			end
 		end)
 	end
-	Prison.Attack(Prison)
 
+	Prison.Attack(Prison)
 	Trigger.AfterDelay(DateTime.Seconds(6), FreeTanya)
 end
 

--- a/mods/ra/maps/allies-05b/notifications.yaml
+++ b/mods/ra/maps/allies-05b/notifications.yaml
@@ -1,11 +1,12 @@
-Sounds:
+Speech:
 	Notifications:
 		bombit: bombit1
 		laugh: laugh1
-		gotit: gotit1
-		lefty: lefty1
 		keepem: keepem1
 		tuffguy: tuffguy1
+		death1: dedman5
+		death2: dedman6
+		death3: dedman10
 		sking: sking1
 		guyokay: guyokay1
 		dogy: dogy1

--- a/mods/ra/maps/allies-05c/allies05c.lua
+++ b/mods/ra/maps/allies-05c/allies05c.lua
@@ -52,7 +52,8 @@ DogPatrolPath = { DogPatrolRally1.Location, SpyCamera2.Location, DogPatrolRally3
 RiflePath = { RiflePath1.Location, RiflePath2.Location, RiflePath3.Location }
 BasePatrolPath = { BasePatrolPath1.Location, BasePatrolPath2.Location, BasePatrolPath3.Location }
 
-TanyaVoices = { "tuffguy", "bombit", "laugh", "gotit", "lefty", "keepem" }
+TanyaVoices = { "tuffguy", "bombit", "laugh", "keepem" }
+DeathVoices = { "death1", "death2", "death3" }
 SpyVoice = "sking"
 
 SamSites = { Sam1, Sam2, Sam3, Sam4, Sam5, Sam6 }
@@ -165,14 +166,28 @@ WarfactoryInfiltrated = function()
 end
 
 MissInfiltrated = function()
-	for i = 0, 5, 1 do
-		local sound = Utils.Random(TanyaVoices)
-		Trigger.AfterDelay(DateTime.Seconds(i), function()
-			Media.PlaySoundNotification(Greece, sound)
+	local taunts = Utils.Shuffle(TanyaVoices)
+	local deathVoices = Utils.Shuffle(DeathVoices)
+	local deaths =
+	{
+		[2] = deathVoices[1],
+		[4] = deathVoices[2]
+	}
+
+	for i = 1, 4, 1 do
+		local taunt = taunts[i]
+		local death = deaths[i]
+
+		Trigger.AfterDelay(i * 30, function()
+			Media.PlaySpeechNotification(Greece, taunt)
+
+			if death then
+				Media.PlaySpeechNotification(Greece, death)
+			end
 		end)
 	end
-	Prison.Attack(Prison)
 
+	Prison.Attack(Prison)
 	Trigger.AfterDelay(DateTime.Seconds(6), FreeTanya)
 end
 
@@ -267,7 +282,7 @@ InitTriggers = function()
 			Spy.DisguiseAsType("e1", USSR)
 			Spy.Move(SpyWaypoint.Location)
 			Spy.Infiltrate(Prison)
-			Media.PlaySoundNotification(Greece, SpyVoice)
+			Media.PlaySpeechNotification(Greece, SpyVoice)
 
 			FollowTruk = false
 

--- a/mods/ra/maps/allies-05c/notifications.yaml
+++ b/mods/ra/maps/allies-05c/notifications.yaml
@@ -1,9 +1,10 @@
-Sounds:
+Speech:
 	Notifications:
 		bombit: bombit1
 		laugh: laugh1
-		gotit: gotit1
-		lefty: lefty1
 		keepem: keepem1
 		tuffguy: tuffguy1
+		death1: dedman5
+		death2: dedman6
+		death3: dedman10
 		sking: sking1


### PR DESCRIPTION
To reduce overlap and avoid repeats, there's a longer pause between each Tanya notification and the selection goes through a shuffled list, rather than random selection from a pool. Two speeches that are shared by her kill/demolish announcement are removed from the pool.

A pair of infantry yells are also added to Tanya's rampage, as they were in the original A and B maps.