### PR TITLE
Add missing soviet-07 events and reorganize

### DIFF
--- a/mods/ra/fluent/campaign.ftl
+++ b/mods/ra/fluent/campaign.ftl
@@ -41,7 +41,7 @@ actor-5tnk =
 
 actor-5tnk-husk-name = Husk (Super Tank)
 
-## mousetrap, situation-critical
+## mousetrap, situation-critical, soviet-07
 actor-gas-name = Gas
 
 ## sarin-gas-2-down-under

--- a/mods/ra/fluent/lua.ftl
+++ b/mods/ra/fluent/lua.ftl
@@ -195,7 +195,7 @@ chronosphere-explodes-in = Chronosphere explodes in { $time }
 rescue-scientists-extraction-point = Rescue the scientists and escort them back to the
     extraction point.
 
-## in-the-nick-of-time, situation-critical
+## in-the-nick-of-time, situation-critical, soviet-07
 too-late = We're too late!
 
 ## infiltration

--- a/mods/ra/maps/soviet-07/map.yaml
+++ b/mods/ra/maps/soviet-07/map.yaml
@@ -33,7 +33,7 @@ Players:
 		Name: Greece
 		Faction: allies
 		Color: E2E6F5
-		Allies: Soviet
+		Allies: Soviets
 		Enemies: USSR, Creeps
 		Bot: campaign
 	PlayerReference@USSR:
@@ -47,10 +47,10 @@ Players:
 		Color: FE1100
 		LockSpawn: True
 		LockTeam: True
-		Allies: Soviet
+		Allies: Soviets
 		Enemies: Greece, Creeps
-	PlayerReference@Soviet:
-		Name: Soviet
+	PlayerReference@Soviets:
+		Name: Soviets
 		Faction: soviet
 		Color: FE1100
 		Allies: USSR, Greece
@@ -58,8 +58,7 @@ Players:
 	PlayerReference@Spain:
 		Name: Spain
 		Faction: allies
-		Color: 0CBB4A
-		Bot: campaign
+		Color: F6D679
 
 Actors:
 	Actor0: boxes01
@@ -323,7 +322,7 @@ Actors:
 	Actor93: brl3
 		Location: 64,73
 		Owner: Creeps
-	Actor94: barl
+	RocketRetreatTrap: barl
 		Location: 62,73
 		Owner: Creeps
 	Actor95: barl
@@ -344,7 +343,7 @@ Actors:
 	Actor101: barl
 		Location: 45,45
 		Owner: Creeps
-	Actor102: brl3
+	ExecutionBarrel: brl3
 		Location: 47,46
 		Owner: Creeps
 	Actor103: barl
@@ -362,6 +361,18 @@ Actors:
 	Actor107: barl
 		Location: 48,71
 		Owner: Creeps
+	ExecutionWaypoint: waypoint
+		Location:  47,48
+		Owner: Neutral
+	CrateMazeWaypoint1: waypoint
+		Location: 47,63
+		Owner: Neutral
+	CrateMazeWaypoint2: waypoint
+		Location: 48,58
+		Owner: Neutral
+	CrateMazeWaypoint3: waypoint
+		Location: 48,56
+		Owner: Neutral
 	Actor108: brl3
 		Location: 47,72
 		Owner: Creeps
@@ -410,15 +421,15 @@ Actors:
 	Actor125: barl
 		Location: 81,80
 		Owner: Creeps
-	Actor126: brl3
+	PillboxBarrel: brl3
 		Location: 82,80
 		Owner: Creeps
-	Actor127: bio
+	WestLab: bio
 		Location: 65,46
-		Owner: Greece
-	Actor128: bio
+		Owner: Soviets
+	EastLab: bio
 		Location: 87,46
-		Owner: Greece
+		Owner: Soviets
 	Actor130: barl
 		Location: 80,79
 		Owner: Creeps
@@ -443,8 +454,8 @@ Actors:
 	Actor150: e1
 		Location: 84,67
 		Owner: Greece
-		Facing: 768
-		SubCell: 4
+		Facing: 256
+		SubCell: 5
 	Actor172: e1
 		Location: 77,80
 		Owner: Greece
@@ -453,175 +464,190 @@ Actors:
 	Actor214: healcrate
 		Owner: Neutral
 		Location: 88,69
-	Actor227: flare
+	CoolantMarkSouthWest: waypoint
 		Owner: Spain
 		Location: 75,49
-	Actor226: flare
+	CoolantMarkSouthEast: waypoint
 		Owner: Spain
 		Location: 76,49
-	Actor228: flare
+	CoolantMarkNorthWest: waypoint
 		Owner: Spain
 		Location: 75,48
-	Actor229: flare
+	CoolantMarkNorthEast: waypoint
 		Owner: Spain
 		Location: 76,48
 	Actor223: brl3
 		Owner: Creeps
 		Location: 105,53
-	BarlCC: barl
+	SecurityCenterBarrel: barl
 		Location: 83,70
 		Owner: Creeps
-	CameraCC: camera
+	SecurityCenterCamera: camera
 		Owner: Neutral
 		Location: 87,69
-	CameraFTurBottom: camera
+		ScriptTags: Security Control Center
+	CameraFlameTowerSouth: camera
 		Owner: Neutral
 		Location: 62,80
-	CameraFTurLeft: camera
+		ScriptTags: Flame Tower South,Rocket Soldiers
+	CameraFlameTowerWest: camera
 		Owner: Neutral
 		Location: 59,65
-	CameraFTurRight: camera
+		ScriptTags: Flame Tower West
+	CameraFlameTowerEast: camera
 		Owner: Neutral
 		Location: 93,65
+		ScriptTags: Flame Tower East
 	CameraGoalCenter1: camera
 		Owner: Neutral
 		Location: 75,51
+		ScriptTags: Reactor Room
 	CameraGoalCenter2: camera
 		Owner: Neutral
 		Location: 75,55
+		ScriptTags: Reactor Room
 	CameraGoalCenter3: camera
 		Owner: Neutral
 		Location: 75,61
-	CameraGoalLeft1: camera
+		ScriptTags: Reactor Room
+	CameraGoalWest1: camera
 		Owner: Neutral
 		Location: 68,58
-	CameraGoalLeft2: camera
+		ScriptTags: West Coolant Stations
+	CameraGoalWest2: camera
 		Owner: Neutral
 		Location: 68,63
-	CameraGoalRight1: camera
+		ScriptTags: West Coolant Stations
+	CameraGoalEast1: camera
 		Owner: Neutral
 		Location: 84,58
-	CameraGoalRight2: camera
+		ScriptTags: East Coolant Stations
+	CameraGoalEast2: camera
 		Owner: Neutral
 		Location: 84,63
-	CameraRSoldier: camera
+		ScriptTags: East Coolant Stations
+	CameraRocket: camera
 		Owner: Neutral
 		Location: 62,72
-	CameraStart1: camera
+		ScriptTags: Rocket Soldiers,Flame Tower South
+	CameraEntrance1: camera
 		Owner: Neutral
 		Location: 102,48
-	CameraStart2: camera
+		ScriptTags: Entrance
+	CameraEntrance2: camera
 		Owner: Neutral
 		Location: 102,54
-	CameraSoldierTrap2: camera
+		ScriptTags: Entrance
+	CameraCrateMazeTrap: camera
 		Owner: Neutral
 		Location: 47,71
-	CCGuard1: e1
+		ScriptTags: Crate Maze
+	SecurityCenterGuard1: e1
 		Location: 87,67
 		Owner: Greece
-		Facing: 768
-		SubCell: 3
-	CCGuard2: e1
+		Facing: 256
+		SubCell: 4
+	SecurityCenterGuard2: e1
 		Location: 88,67
 		Owner: Greece
-		Facing: 768
-		SubCell: 4
-	CCGuard3: e1
+		Facing: 256
+		SubCell: 5
+	SecurityCenterGuard3: e1
 		Location: 88,68
 		Owner: Greece
-		Facing: 768
+		Facing: 256
 		SubCell: 1
-	CCGuard4: e1
+	SecurityCenterGuard4: e1
 		Location: 87,68
 		Owner: Greece
-		Facing: 768
-		SubCell: 3
+		Facing: 256
+		SubCell: 4
 	Dog1: dog
 		Location: 84,84
-		Owner: Soviet
-		Facing: 896
+		Owner: Soviets
+		Facing: 128
 		SubCell: 1
 	Dog2: dog
-		Owner: Soviet
+		Owner: Soviets
 		Location: 84,83
-		SubCell: 3
-		Facing: 368
+		SubCell: 1
+		Facing: 756
 	Dog3: dog
 		Location: 82,83
-		Owner: Soviet
-		SubCell: 4
+		Owner: Soviets
+		SubCell: 5
 	Dog4: dog
 		Location: 80,83
-		Owner: Soviet
+		Owner: Soviets
 		Facing: 256
 		SubCell: 2
 	Dog5: dog
 		Location: 85,82
-		Owner: Soviet
-		Facing: 896
+		Owner: Soviets
+		Facing: 128
 		SubCell: 1
 	Dog6: dog
 		Location: 85,79
-		Owner: Soviet
-		Facing: 768
-		SubCell: 4
+		Owner: Soviets
+		Facing: 256
+		SubCell: 5
 	Dog7: dog
 		Location: 85,81
-		Owner: Soviet
-		Facing: 768
-		SubCell: 4
+		Owner: Soviets
+		Facing: 256
+		SubCell: 5
 	Dog8: dog
 		Location: 86,83
-		Owner: Soviet
-		Facing: 896
+		Owner: Soviets
+		Facing: 128
 		SubCell: 1
 	Dog9: dog
 		Location: 86,84
-		Owner: Soviet
+		Owner: Soviets
 		SubCell: 0
 	Dog10: dog
 		Location: 86,82
-		Owner: Soviet
-		Facing: 768
+		Owner: Soviets
+		Facing: 256
 		SubCell: 0
 	Dog11: dog
 		Location: 82,84
-		Owner: Soviet
-		Facing: 128
+		Owner: Soviets
+		Facing: 896
 		SubCell: 1
 	Dog12: dog
 		Location: 83,84
-		Owner: Soviet
+		Owner: Soviets
 		SubCell: 1
 	Dog13: dog
 		Location: 86,81
-		Owner: Soviet
+		Owner: Soviets
 		Facing: 128
 		SubCell: 1
 	Dog14: dog
 		Location: 85,83
-		Owner: Soviet
-		SubCell: 3
+		Owner: Soviets
+		SubCell: 4
 	Dog15: dog
 		Location: 81,83
-		Owner: Soviet
-		SubCell: 4
+		Owner: Soviets
+		SubCell: 5
 	Dog16: dog
 		Location: 86,80
-		Owner: Soviet
-		SubCell: 4
+		Owner: Soviets
+		SubCell: 5
 	Dog17: dog
 		Location: 85,84
-		Owner: Soviet
+		Owner: Soviets
 		SubCell: 0
 	Dog18: dog
 		Location: 81,84
-		Owner: Soviet
+		Owner: Soviets
 		SubCell: 1
 	Dog19: dog
 		Location: 86,79
-		Owner: Soviet
-		Facing: 896
+		Owner: Soviets
+		Facing: 128
 		SubCell: 0
 	EntranceGuard1: e1
 		Location: 100,57
@@ -654,91 +680,92 @@ Actors:
 	EntranceGuard8: e1
 		Location: 99,56
 		Owner: Greece
-		SubCell: 3
+		SubCell: 4
 	Tanya: e7
 		Location: 75,54
 		Owner: Greece
 		Facing: 512
 		SubCell: 2
-	GoalGuard1: e1
+	ReactorGuard1: e1
 		Location: 74,54
 		Owner: Greece
 		Facing: 512
 		SubCell: 2
-	GoalGuard2: e1
+	ReactorGuard2: e1
 		Location: 73,54
 		Owner: Greece
 		Facing: 512
 		SubCell: 2
-	GoalGuard3: e1
+	ReactorGuard3: e1
 		Location: 76,54
 		Owner: Greece
 		Facing: 512
 		SubCell: 2
-	GoalGuard4: e1
+	ReactorGuard4: e1
 		Location: 77,54
 		Owner: Greece
 		Facing: 512
 		SubCell: 2
-	FTurBottom: ftur
+	FlameTowerSouth: ftur
 		Location: 62,79
 		Owner: Greece
-	FTur1Goal: waypoint
+	FriendlyTower1Goal: waypoint
 		Owner: Neutral
 		Location: 77,53
-	FTur2Goal: waypoint
+	FriendlyTower2Goal: waypoint
 		Owner: Neutral
 		Location: 74,53
-	FTurLeft: ftur
+	FlameTowerWest: ftur
 		Location: 45,50
 		Owner: Greece
-	FTurPrisoners: ftur
+	FlameTowerPrison: ftur
 		Location: 59,64
 		Owner: Greece
-	FTurRight: ftur
+	FlameTowerEast: ftur
 		Location: 93,64
 		Owner: Greece
-	PBox: pbox
+	Pillbox: pbox
 		Location: 83,81
 		Owner: Greece
-	PBoxBrl: brl3
+	Actor123: brl3
 		Location: 80,80
 		Owner: Creeps
 	Prisoner1: e6
 		Location: 44,46
-		Owner: Soviet
-		Facing: 640
-		SubCell: 4
+		Owner: Soviets
+		Facing: 384
+		SubCell: 5
 	Prisoner2: e6
 		Location: 44,47
-		Owner: Soviet
+		Owner: Soviets
 		Facing: 512
-		SubCell: 4
+		SubCell: 5
 	Prisoner3: e6
 		Location: 46,47
-		Owner: Soviet
-		Facing: 384
+		Owner: Soviets
+		Facing: 640
 		SubCell: 0
 	Prisoner4: e6
 		Location: 45,47
-		Owner: Soviet
-		Facing: 384
+		Owner: Soviets
+		Facing: 640
 		SubCell: 1
 	Prisoner5: e6
 		Location: 46,46
-		Owner: Soviet
+		Owner: Soviets
 		Facing: 512
-		SubCell: 3
+		SubCell: 4
 	Prisoner6: e1
 		Location: 46,46
-		Owner: Soviet
+		Owner: Soviets
 		Health: 51
-		SubCell: 4
-	PrisonEntranceGuard: e1
+		SubCell: 5
+	CrateMazeGuard: e1
 		Location: 46,69
 		Owner: Greece
 		Facing: 512
 		SubCell: 1
+		Stance: Defend
 	PrisonerGuard1: e1
 		Location: 45,48
 		Owner: Greece
@@ -753,43 +780,43 @@ Actors:
 		Owner: Greece
 		Facing: 512
 		SubCell: 0
-	RSoldier1: e3
+	Rocket1: e3
 		Owner: Greece
 		Location: 65,72
-		SubCell: 3
-		Facing: 368
-	RSoldier2: e3
+		SubCell: 4
+		Facing: 768
+	Rocket2: e3
 		Location: 65,74
 		Owner: Greece
-		Facing: 368
+		Facing: 768
 		SubCell: 2
-	RSoldierTrap1: brl3
+	RocketTrap1: brl3
 		Owner: Creeps
 		Location: 68,72
-	RSoldierTrap2: barl
+	RocketTrap2: barl
 		Owner: Creeps
 		Location: 68,74
+	RocketRetreat: waypoint
+		Owner: Neutral
+		Location: 59,73
 	StartingUnitsSpawn: waypoint
 		Location: 102,43
 		Owner: Neutral
-	SoldierTrap1: brl3
+	EntranceTrap: brl3
 		Owner: Creeps
 		Location: 98,50
-	SoldierTrap2: barl
+	CrateMazeTrap: barl
 		Owner: Creeps
 		Location: 46,71
-	SoldierTrap1Waypoint1: waypoint
+	EntranceTrapWaypoint1: waypoint
 		Location: 102,46
 		Owner: Neutral
-	SoldierTrap1Waypoint2: waypoint
+	EntranceTrapWaypoint2: waypoint
 		Owner: Neutral
 		Location: 104,53
-	SoldierTrap1Waypoint3: waypoint
+	EntranceTrapWaypoint3: waypoint
 		Owner: Neutral
 		Location: 93,72
-	SoldierTrap2Waypoint: waypoint
-		Owner: Neutral
-		Location: 45,52
 
 Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -16,6 +16,8 @@ World:
 			normal: options-difficulty.normal
 			hard: options-difficulty.hard
 		Default: normal
+	TimeLimitManager:
+		SkipTimerExpiredNotification: true
 
 Player:
 	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
@@ -25,6 +27,31 @@ Player:
 CAMERA:
 	RevealsShroud:
 		Range: 6c0
+	ScriptTags:
+
+FLARE:
+	RevealsShroud:
+		Range: 2c512
+		ValidRelationships: Ally, Neutral, Enemy
+	Tooltip:
+		Name: actor-gas-name
+
+BIO:
+	ExternalCondition@UNSTABLE:
+		Condition: unstable
+	RevealsShroud:
+		RequiresCondition: unstable
+	RevealOnDeath:
+		Duration: 75
+	ShakeOnDeath:
+		Intensity: 3
+	KillsSelf:
+		RequiresCondition: unstable
+		Delay: 40,60
+		DamageTypes: ExplosionDeath
+	# The purpose of these structures isn't fully clear, so show a generic.
+	Tooltip:
+		GenericVisibility: Ally
 
 FTUR:
 	Valued:

--- a/mods/ra/maps/soviet-07/soviet07.lua
+++ b/mods/ra/maps/soviet-07/soviet07.lua
@@ -6,316 +6,451 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-if Difficulty == "easy" then
-	RemainingTime = DateTime.Minutes(7)
-elseif Difficulty == "normal" then
-	RemainingTime = DateTime.Minutes(6)
-elseif Difficulty == "hard" then
-	RemainingTime = DateTime.Minutes(5)
+
+local USSR = Player.GetPlayer("USSR")
+local Spain = Player.GetPlayer("Spain")
+
+--- The objectives below are delayed and only assigned an ID later.
+
+---@type number Destroy hostile towers from the security center.
+local DeactivateSecurity
+---@type number Free the Soviet dogs.
+local FreeDogs
+---@type number Rescue the guarded Engineers.
+local RescueEngineers
+---@type number Reach all coolant stations with an Engineer.
+local GetEngineersToCoolant
+---@type number Activate friendly towers from the security center.
+local ReprogramSecurity
+---@type number Use the final reactor console.
+local SaveReactor
+
+--- Has either Rocket Soldier reached their fallback position?
+local RocketRetreated = false
+
+local TimeLimits =
+{
+	easy = DateTime.Minutes(7),
+	normal = DateTime.Minutes(6),
+	hard = DateTime.Minutes(5)
+}
+local RemainingTime = TimeLimits[Difficulty]
+local TimerColor = USSR.Color
+local CountdownEnabled = false
+
+local Dogs = { Dog1, Dog2, Dog3, Dog4, Dog5, Dog6, Dog7, Dog8, Dog9, Dog10, Dog11, Dog12, Dog13, Dog14, Dog15, Dog16, Dog17, Dog18, Dog19 }
+local Engineers = { Prisoner1, Prisoner2, Prisoner3, Prisoner4, Prisoner5 }
+local PrisonerGuards = { PrisonerGuard1, PrisonerGuard2, PrisonerGuard3 }
+local EntranceGuards = { EntranceGuard1, EntranceGuard2, EntranceGuard3, EntranceGuard4, EntranceGuard5, EntranceGuard6, EntranceGuard7, EntranceGuard8 }
+local ReactorGuards = { ReactorGuard1, ReactorGuard2, ReactorGuard3, ReactorGuard4 }
+local SecurityCenterGuards = { SecurityCenterGuard1, SecurityCenterGuard2, SecurityCenterGuard3, SecurityCenterGuard4 }
+local StartingUnitsReinforcements = { "e1", "e1", "e1", "e1" }
+
+---@param actor actor
+---@return boolean
+local function IsSoviet(actor)
+	return actor.Owner == USSR
 end
 
-Dogs = { Dog1, Dog2, Dog3, Dog4, Dog5, Dog6, Dog7, Dog8, Dog9, Dog10, Dog11, Dog12, Dog13, Dog14, Dog15, Dog16, Dog17, Dog18, Dog19 }
-Engineers = { Prisoner1, Prisoner2, Prisoner3, Prisoner4, Prisoner5 }
-PrisonerGuards = { PrisonerGuard1, PrisonerGuard2, PrisonerGuard3 }
-EntranceGuards = { EntranceGuard1, EntranceGuard2, EntranceGuard3, EntranceGuard4, EntranceGuard5, EntranceGuard6, EntranceGuard7, EntranceGuard8 }
-GoalGuards = { GoalGuard1, GoalGuard2, GoalGuard3, GoalGuard4 }
-CCGuards = { CCGuard1, CCGuard2, CCGuard3, CCGuard4 }
-StartingUnitsReinforcements = { "e1", "e1", "e1", "e1" }
+---@param actor actor
+---@return boolean
+local function IsSovietHuman(actor)
+	return actor.Owner == USSR and actor.Type ~= "dog"
+end
 
-CameraCCTrigger = { CPos.New(83, 71), CPos.New(84,71) }
-CameraGoalCenterTrigger = { CPos.New(74, 66), CPos.New(75, 66), CPos.New(76, 66), CPos.New(77, 66) }
-CameraGoalLeftTrigger = { CPos.New(62, 59), CPos.New(62, 60), CPos.New(62, 62), CPos.New(62, 63) }
-CameraGoalRightTrigger = { CPos.New(90, 59), CPos.New(90, 60), CPos.New(90, 62), CPos.New(90, 63) }
-ControlCenterTrigger = { CPos.New(87, 67), CPos.New(88, 67) }
-ControlCenterEngineerTrigger = { CPos.New(87, 67), CPos.New(88, 67) }
-FTurBottomTrigger = { CPos.New(67, 82), CPos.New(67, 83) }
-FTurLeftTrigger = { CPos.New(57, 70), CPos.New(58, 70), CPos.New(59, 70), CPos.New(60, 70) }
-FTurRightTrigger = { CPos.New(97, 68), CPos.New(97, 69), CPos.New(97, 70) }
-GoalCenterTrigger = { CPos.New(73, 52), CPos.New(74, 52), CPos.New(75, 52), CPos.New(76, 52), CPos.New(77, 52), CPos.New(78, 52) }
-GoalLeft1Trigger = { CPos.New(65, 58), CPos.New(66, 58), CPos.New(67, 58), CPos.New(65, 59), CPos.New(66, 59), CPos.New(67, 59) }
-GoalLeft2Trigger = { CPos.New(65, 64), CPos.New(66, 64), CPos.New(67, 64), CPos.New(65, 65), CPos.New(66, 65), CPos.New(67, 65) }
-GoalRight1Trigger = { CPos.New(86, 57), CPos.New(87, 57), CPos.New(88, 57), CPos.New(86, 58), CPos.New(87, 58), CPos.New(88, 58) }
-GoalRight2Trigger = { CPos.New(86, 64), CPos.New(87, 64), CPos.New(88, 64), CPos.New(86, 65), CPos.New(87, 65), CPos.New(88, 65) }
-RSoldierTrapTrigger = { CPos.New(72, 72), CPos.New(72,73), CPos.New(72,74) }
-SoldierTrap2Trigger = { CPos.New(51, 73), CPos.New(51, 74) }
+---@param actor actor
+---@return boolean
+local function IsEngineer(actor)
+	return actor.Type == "e6"
+end
 
-Trigger.OnEnteredFootprint(CameraCCTrigger, function(a, id)
-	if not CameraCCTriggered and a.Owner == USSR then
-		CameraCCTriggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraCC.Location })
-	end
-end)
+local function MarkAlliedVictory()
+	DeactivateSecurity = DeactivateSecurity or USSR.AddPrimaryObjective(UserInterface.GetFluentMessage("deactivate-security-system"))
+	local primaries = { DeactivateSecurity, RescueEngineers, GetEngineersToCoolant, SaveReactor }
 
-Trigger.OnEnteredFootprint(CameraGoalCenterTrigger, function(a, id)
-	if not CameraGoalCenterTriggered and a.Owner == USSR then
-		CameraGoalCenterTriggered = true
-		if not ControlCenterEngineerTriggered then
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter1.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter2.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter3.Location })
+	Utils.Do(primaries, function(p)
+		if not USSR.IsObjectiveCompleted(p) then
+			USSR.MarkFailedObjective(p)
 		end
-	end
-end)
+	end)
+end
 
-Trigger.OnEnteredFootprint(CameraGoalLeftTrigger, function(a, id)
-	if not CameraGoalLeftTriggered and a.Owner == USSR then
-		CameraGoalLeftTriggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalLeft1.Location })
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalLeft2.Location })
-	end
-end)
+local function UpdateTimerText()
+	local text = UserInterface.GetFluentMessage("time-until-meltdown", { ["time"] = Utils.FormatTime(RemainingTime) })
+	UserInterface.SetMissionText(text, TimerColor)
+end
 
-Trigger.OnEnteredFootprint(CameraGoalRightTrigger, function(a, id)
-	if not CameraGoalRightTriggered and a.Owner == USSR then
-		CameraGoalRightTriggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalRight1.Location })
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalRight2.Location })
-	end
-end)
+---@param cells cpos[]
+---@param filter fun(actor: actor):boolean
+---@param action fun()
+local function SetBasicFootprint(cells, filter, action)
+	local activated = false
 
-Trigger.OnEnteredFootprint(ControlCenterTrigger, function(a, id)
-	if not ControlCenterTriggered and a.Owner == USSR and a.Type == "e1" then
-		ControlCenterTriggered = true
-		FTurPrisoners.Kill()
-		FTurLeft.Kill()
-		FTurRight.Kill()
-		FTurBottom.Kill()
-		USSR.MarkCompletedObjective(SovietObjective1)
-	end
-end)
-
-Trigger.OnEnteredFootprint(ControlCenterEngineerTrigger, function(a, id)
-	if not ControlCenterEngineerTriggered and a.Owner == USSR and a.Type == "e6" then
-		ControlCenterEngineerTriggered = true
-		local fturA = Actor.Create("ftur", true, { Owner = USSR, Location = FTur1Goal.Location})
-		local fturB = Actor.Create("ftur", true, { Owner = USSR, Location = FTur2Goal.Location})
-		Camera.Position = CameraGoalCenter1.CenterPosition
-
-		if not CameraGoalRightTriggered then
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter1.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter2.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraGoalCenter3.Location })
+	Trigger.OnEnteredFootprint(cells, function(actor, id)
+		if activated or not filter(actor) then
+			return
 		end
 
-		Utils.Do(GoalGuards, function(actor)
-			if not actor.IsDead then
-				actor.AttackMove(FTur1Goal.Location)
-			end
+		activated = true
+		action()
+		Trigger.RemoveFootprintTrigger(id)
+	end)
+end
+
+---@param tag string Tag shared by the cameras.
+local function RevealArea(tag)
+	local cameras = Map.ActorsWithTag(tag)
+	Utils.Do(cameras, function(c)
+		c.Owner = USSR
+	end)
+end
+
+local function PrepareBasicReveals()
+	local securityCenter = { CPos.New(83, 71), CPos.New(84,71) }
+	local reactor = { CPos.New(74, 66), CPos.New(75, 66), CPos.New(76, 66), CPos.New(77, 66) }
+	local westCoolant = { CPos.New(62, 59), CPos.New(62, 60), CPos.New(62, 62), CPos.New(62, 63) }
+	local eastCoolant = { CPos.New(90, 59), CPos.New(90, 60), CPos.New(90, 62), CPos.New(90, 63) }
+	local southFlame = { CPos.New(67, 82), CPos.New(67, 83) }
+	local westFlame = { CPos.New(57, 70), CPos.New(58, 70), CPos.New(59, 70), CPos.New(60, 70) }
+
+	local reveals =
+	{
+		{ cells = securityCenter, tag = "Security Control Center" },
+		{ cells = reactor, tag = "Reactor Room" },
+		{ cells = westCoolant, tag = "West Coolant Stations" },
+		{ cells = eastCoolant, tag = "East Coolant Stations" },
+		{ cells = southFlame, tag = "Flame Tower South" },
+		{ cells = westFlame, tag = "Flame Tower West" },
+	}
+
+	Utils.Do(reveals, function(reveal)
+		SetBasicFootprint(reveal.cells, IsSoviet, function()
+			RevealArea(reveal.tag)
 		end)
+	end)
+end
 
-		if not Tanya.IsDead then
-			Tanya.Demolish(fturA)
-			Tanya.Demolish(fturB)
+local function SpawnFriendlyFlames()
+	local fturA = Actor.Create("ftur", true, { Owner = USSR, Location = FriendlyTower1Goal.Location})
+	local fturB = Actor.Create("ftur", true, { Owner = USSR, Location = FriendlyTower2Goal.Location})
+	Camera.Position = CameraGoalCenter2.CenterPosition
+	RevealArea("Reactor Room")
+
+	Utils.Do(ReactorGuards, function(guard)
+		if not guard.IsDead then
+			guard.AttackMove(FriendlyTower1Goal.Location, 2)
+			guard.AttackMove(CameraGoalCenter2.Location, 2)
 		end
-
-		USSR.MarkCompletedObjective(SovietObjective4)
-	end
-end)
-
-Trigger.OnEnteredFootprint(FTurBottomTrigger, function(a, id)
-	if not FTurBottomTriggered and a.Owner == USSR then
-		FTurBottomTriggered = true
-		if not RSoldierTrapTriggered then
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraRSoldier.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraFTurBottom.Location })
-		end
-	end
-end)
-
-Trigger.OnEnteredFootprint(FTurLeftTrigger, function(a, id)
-	if not FTurLeftTriggered and a.Owner == USSR then
-		FTurLeftTriggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraFTurLeft.Location })
-	end
-end)
-
-Trigger.OnEnteredFootprint(FTurRightTrigger, function(a, id)
-	if not FTurRightTriggered and a.Owner == USSR then
-		FTurRightTriggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraFTurRight.Location })
-	end
-end)
-
-Trigger.OnEnteredFootprint(GoalCenterTrigger, function(a, id)
-	if not GoalCenterTriggered and a.Owner == USSR and a.Type == "e6" then
-		GoalCenterTriggered = true
-		USSR.MarkCompletedObjective(SovietObjective5)
-	end
-end)
-
-Trigger.OnEnteredFootprint(GoalLeft1Trigger, function(a, id)
-	if not GoalLeft1Triggered and a.Owner == USSR and a.Type == "e6" then
-		GoalLeft1Triggered = true
-		Media.PlaySpeechNotification(USSR, "ControlCenterDeactivated")
-	end
-end)
-
-Trigger.OnEnteredFootprint(GoalLeft2Trigger, function(a, id)
-	if not GoalLeft2Triggered and a.Owner == USSR and a.Type == "e6" then
-		GoalLeft2Triggered = true
-		Media.PlaySpeechNotification(USSR, "ControlCenterDeactivated")
-	end
-end)
-
-Trigger.OnEnteredFootprint(GoalRight1Trigger, function(a, id)
-	if not GoalRight1Triggered and a.Owner == USSR and a.Type == "e6" then
-		GoalRight1Triggered = true
-		Media.PlaySpeechNotification(USSR, "ControlCenterDeactivated")
-	end
-end)
-
-Trigger.OnEnteredFootprint(GoalRight2Trigger, function(a, id)
-	if not GoalRight2Triggered and a.Owner == USSR and a.Type == "e6" then
-		GoalRight2Triggered = true
-		Media.PlaySpeechNotification(USSR, "ControlCenterDeactivated")
-	end
-end)
-
-Trigger.OnEnteredFootprint(RSoldierTrapTrigger, function(a, id)
-	if not RSoldierTrapTriggered and a.Owner == USSR then
-		RSoldierTrapTriggered = true
-		if not FTurBottomTriggered then
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraRSoldier.Location })
-			Actor.Create("camera", true, { Owner = USSR, Location = CameraFTurBottom.Location })
-		end
-
-		if not RSoldier1.IsDead and not RSoldierTrap1.IsDead then
-			RSoldier1.Attack(RSoldierTrap1)
-		end
-
-		if not RSoldier2.IsDead and not RSoldierTrap2.IsDead then
-			RSoldier2.Attack(RSoldierTrap2)
-		end
-	end
-end)
-
-Trigger.OnEnteredFootprint(SoldierTrap2Trigger, function(a, id)
-	if not SoldierTrap2Triggered and a.Owner == USSR then
-		SoldierTrap2Triggered = true
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraSoldierTrap2.Location })
-		if not SoldierTrap2.IsDead then
-			PrisonEntranceGuard.Attack(SoldierTrap2)
-		end
-		PrisonEntranceGuard.Move(SoldierTrap2Waypoint.Location)
-	end
-end)
-
-Trigger.OnAllKilled(Engineers, function()
-	Greece.MarkCompletedObjective(AlliedObjective)
-end)
-
-Trigger.OnAllKilled(PrisonerGuards, function()
-	Utils.Do(Engineers, function(actor)
-		actor.Owner = USSR
 	end)
 
-	Prisoner6.Owner = USSR
-	USSR.MarkCompletedObjective(SovietObjective2)
-end)
-
-Trigger.OnKilled(BarlCC, function()
-	if not CameraCCTriggered then
-		Actor.Create("camera", true, { Owner = USSR, Location = CameraCC.Location })
-		CameraCCTriggered = true
+	if not Tanya.IsDead then
+		Tanya.Demolish(fturA)
+		Tanya.Demolish(fturB)
 	end
 
-	Utils.Do(CCGuards, function(actor)
-		if not actor.IsDead then
-			actor.Hunt()
-		end
-	end)
-end)
+	USSR.MarkCompletedObjective(ReprogramSecurity)
+end
 
-Trigger.OnKilled(PBoxBrl, function()
-	PBox.Kill()
-	Utils.Do(Dogs, function(actor)
-		actor.Owner = USSR
-	end)
-	USSR.MarkCompletedObjective(SovietObjective6)
-end)
+local function PrepareSecurityCenter()
+	local cells =  { CPos.New(87, 67), CPos.New(88, 67) }
 
-Trigger.OnKilled(PrisonEntranceGuard, function()
-	if ControlCenterTriggered then
-		Utils.Do(PrisonerGuards, function(actor)
-			if not actor.IsDead then
-				actor.Hunt()
+	Trigger.OnKilled(SecurityCenterBarrel, function()
+		RevealArea("Security Control Center")
+		Utils.Do(SecurityCenterGuards, IdleHunt)
+	end)
+
+	SetBasicFootprint(cells, IsSovietHuman, function()
+		FlameTowerPrison.Kill()
+		FlameTowerWest.Kill()
+		FlameTowerEast.Kill()
+		FlameTowerSouth.Kill()
+		RescueEngineers = RescueEngineers or AddPrimaryObjective(USSR, "rescue-engineers")
+		USSR.MarkCompletedObjective(DeactivateSecurity)
+	end)
+
+	SetBasicFootprint(cells, IsEngineer, SpawnFriendlyFlames)
+end
+
+local function PrepareFinalStation()
+	local cells = { CPos.New(73, 51), CPos.New(74, 51), CPos.New(75, 51), CPos.New(76, 51), CPos.New(77, 51), CPos.New(78, 51) }
+
+	SetBasicFootprint(cells, IsEngineer, function()
+		CountdownEnabled = false
+		TimerColor = HSLColor.LightGreen
+		UpdateTimerText()
+		DateTime.TimeLimit = 0
+		USSR.MarkCompletedObjective(SaveReactor)
+	end)
+end
+
+local function PrepareEngineerStations()
+	local northWestCells = { CPos.New(65, 58), CPos.New(66, 58), CPos.New(67, 58), CPos.New(65, 59), CPos.New(66, 59), CPos.New(67, 59) }
+	local southWestCells = { CPos.New(65, 64), CPos.New(66, 64), CPos.New(67, 64), CPos.New(65, 65), CPos.New(66, 65), CPos.New(67, 65) }
+	local northEastCells = { CPos.New(86, 57), CPos.New(87, 57), CPos.New(88, 57), CPos.New(86, 58), CPos.New(87, 58), CPos.New(88, 58) }
+	local southEastCells = { CPos.New(86, 64), CPos.New(87, 64), CPos.New(88, 64), CPos.New(86, 65), CPos.New(87, 65), CPos.New(88, 65) }
+	local stations = { northWestCells, southWestCells, northEastCells, southEastCells }
+	local coolantMarks = { CoolantMarkNorthWest, CoolantMarkSouthWest, CoolantMarkNorthEast, CoolantMarkSouthEast }
+	local coolantCount = 0
+
+	for i = 1, #stations do
+		SetBasicFootprint(stations[i], IsEngineer, function()
+			Media.PlaySpeechNotification(USSR, "ControlCenterDeactivated")
+			Actor.Create("flare", true, { Owner = Spain, Location = coolantMarks[i].Location })
+			coolantCount = coolantCount + 1
+
+			if coolantCount < #stations then
+				return
 			end
+
+			SaveReactor = AddPrimaryObjective(USSR, "engineer-reactor-core")
+			USSR.MarkCompletedObjective(GetEngineersToCoolant)
+			Trigger.AfterDelay(DateTime.Seconds(2), PrepareFinalStation)
 		end)
 	end
-end)
+end
 
-IntroSequence = function()
-	StartingUnits = Reinforcements.Reinforce(USSR, StartingUnitsReinforcements, { StartingUnitsSpawn.Location, SoldierTrap1Waypoint1.Location }, 0)
+--- Prepare the Rocket Soldiers and their barrel traps.
+--- After the first explosions, they flee to try again at a fallback position.
+local function PrepareRocketSoldiers()
+	local rockets = { Rocket1, Rocket2 }
+	local firstTraps = { RocketTrap1, RocketTrap2 }
+	local trapCells = { CPos.New(72, 72), CPos.New(72,73), CPos.New(72,74) }
+	local retreatTrapCells = { CPos.New(66, 72), CPos.New(66,73), CPos.New(66,74) }
+
+	SetBasicFootprint(trapCells, IsSoviet, function()
+		for i = 1, #rockets do
+			if not rockets[i].IsDead and not firstTraps[i].IsDead then
+				rockets[i].Attack(firstTraps[i])
+			end
+		end
+
+		RevealArea("Rocket Soldiers")
+	end)
+
+	Trigger.OnAnyKilled(firstTraps, function()
+		-- Stay if an attack from the west seems likely.
+		if CrateMazeTrap.IsDead then
+			return
+		end
+
+		Utils.Do(rockets, function(rocket)
+			if rocket.IsDead then
+				return
+			end
+
+			rocket.Move(RocketRetreat.Location)
+		end)
+	end)
+
+	Trigger.OnEnteredProximityTrigger(RocketRetreat.CenterPosition, WDist.FromCells(1), function(a, id)
+		if a.Type == "e3" then
+			RocketRetreated = true
+			Trigger.RemoveProximityTrigger(id)
+		end
+	end)
+
+	Trigger.OnEnteredFootprint(retreatTrapCells, function(a, id)
+		if not RocketRetreated or not IsSoviet(a) then
+			return
+		end
+
+		Utils.Do(rockets, function(rocket)
+			if rocket.IsDead or RocketRetreatTrap.IsDead then
+				return
+			end
+
+			rocket.Attack(RocketRetreatTrap)
+		end)
+
+		Trigger.RemoveFootprintTrigger(id)
+	end)
+
+	Trigger.OnKilled(RocketRetreatTrap, function()
+		Utils.Do(rockets, IdleHunt)
+	end)
+end
+
+--- Prepare a soldier at the maze to fire at a barrel trap and flee.
+--- If they successfully escape, they will blow up the captive Engineers.
+local function PrepareCrateMazeGuard()
+	local trapCells = { CPos.New(51, 73), CPos.New(51, 74) }
+	local moveGoals = { CrateMazeWaypoint1.Location, CrateMazeWaypoint2.Location, CrateMazeWaypoint3.Location, ExecutionWaypoint.Location }
+	local goalCount = 1
+	local waitTime = DateTime.Seconds(6)
+	if Difficulty == "hard" then
+		waitTime = DateTime.Seconds(2)
+	end
+
+	SetBasicFootprint(trapCells, IsSoviet, function()
+		if not CrateMazeTrap.IsDead then
+			CrateMazeGuard.Attack(CrateMazeTrap)
+		end
+
+		CrateMazeGuard.Move(moveGoals[1])
+		RevealArea("Crate Maze")
+	end)
+
+	local proximity = Trigger.OnEnteredProximityTrigger(ExecutionWaypoint.CenterPosition, WDist.New(512), function(a)
+		if a == CrateMazeGuard and not ExecutionBarrel.IsDead then
+			a.Attack(ExecutionBarrel)
+		end
+	end)
+
+	local foot = Trigger.OnEnteredFootprint(moveGoals, function(a)
+		if a ~= CrateMazeGuard then
+			return
+		end
+
+		Trigger.AfterDelay(waitTime, function()
+			if CrateMazeGuard.IsDead then
+				return
+			end
+
+			goalCount = goalCount + 1
+			CrateMazeGuard.Move(moveGoals[goalCount])
+		end)
+	end)
+
+	Trigger.OnKilled(CrateMazeGuard, function()
+		Trigger.RemoveProximityTrigger(proximity)
+		Trigger.RemoveFootprintTrigger(foot)
+	end)
+end
+
+local function PreparePrisonGuards()
+	local towerAndGuards = Utils.Concat({ FlameTowerPrison }, PrisonerGuards)
+
+	Utils.Do(PrisonerGuards, function(guard)
+		Trigger.OnKilled(guard, function()
+			-- Remain behind the tower if possible.
+			if not USSR.IsObjectiveCompleted(DeactivateSecurity) then
+				return
+			end
+
+			Utils.Do(PrisonerGuards, IdleHunt)
+		end)
+	end)
+
+	Trigger.OnAllKilled(towerAndGuards, function()
+		-- Avoid announcing the Engineers' rescue if they're about to burn.
+		if ExecutionBarrel.IsDead then
+			return
+		end
+
+		Utils.Do(Engineers, function(engineer)
+			engineer.Owner = USSR
+		end)
+
+		Prisoner6.Owner = USSR
+		GetEngineersToCoolant = AddPrimaryObjective(USSR, "engineers-coolant-station")
+		ReprogramSecurity = AddSecondaryObjective(USSR, "engineer-reprogram-security")
+		-- Unlikely but possible: guards are dead before security deactivation.
+		RescueEngineers = RescueEngineers or USSR.AddPrimaryObjective(UserInterface.GetFluentMessage("rescue-engineers"))
+		USSR.MarkCompletedObjective(RescueEngineers)
+	end)
+end
+
+--- Set distant lab structures to self-reveal, crumble, and explode.
+--- The original explosions were scheduled for ~291 and ~441 seconds,
+--- but that was on a more lenient time limit of ~600 seconds.
+local function PrepareLabExplosions()
+	-- The time limit changes with difficulty; work backward.
+	Trigger.AfterDelay(RemainingTime - DateTime.Seconds(153), function()
+		EastLab.Health = EastLab.MaxHealth * 0.2
+		EastLab.GrantCondition("unstable")
+	end)
+
+	Trigger.AfterDelay(RemainingTime - DateTime.Seconds(63), function()
+		WestLab.Health = WestLab.MaxHealth * 0.2
+		WestLab.GrantCondition("unstable")
+	end)
+end
+
+--- Start the countdown and entrance encounter.
+local function IntroSequence()
+	local StartingUnits = Reinforcements.Reinforce(USSR, StartingUnitsReinforcements, { StartingUnitsSpawn.Location, EntranceTrapWaypoint1.Location }, 0)
+	local countdownDelay = DateTime.Seconds(5)
+	DateTime.TimeLimit = RemainingTime
+
+	Trigger.AfterDelay(countdownDelay, function()
+		Media.PlaySpeechNotification(USSR, "TimerStarted")
+		RemainingTime = RemainingTime - countdownDelay
+		CountdownEnabled = true
+		UpdateTimerText()
+	end)
+
 	Trigger.AfterDelay(DateTime.Seconds(3), function()
 		Utils.Do(EntranceGuards, function(actor)
-			if not SoldierTrap1.IsDead then
-				actor.Attack(SoldierTrap1)
+			if not EntranceTrap.IsDead then
+				actor.Attack(EntranceTrap)
 			end
-			actor.AttackMove(SoldierTrap1Waypoint1.Location)
-			actor.AttackMove(SoldierTrap1Waypoint2.Location)
-			actor.AttackMove(SoldierTrap1Waypoint3.Location)
+
+			actor.AttackMove(EntranceTrapWaypoint1.Location)
+			actor.AttackMove(EntranceTrapWaypoint2.Location)
+			actor.AttackMove(EntranceTrapWaypoint3.Location)
+			actor.Hunt()
 		end)
-		Media.PlaySpeechNotification(USSR, "TimerStarted")
-		TimerStarted = true
 	end)
 
-	-- Trigger a game over if the player lost all human units before the security system has been deactivated
 	Trigger.OnAllKilled(StartingUnits, function()
-		if not ControlCenterTriggered then
-			Greece.MarkCompletedObjective(AlliedObjective)
+		DeactivateSecurity = DeactivateSecurity or USSR.AddPrimaryObjective(UserInterface.GetFluentMessage("deactivate-security-system"))
+
+		if not USSR.IsObjectiveCompleted(DeactivateSecurity) then
+			MarkAlliedVictory()
 		end
+	end)
+
+	local eastFlameReveal = { CPos.New(97, 68), CPos.New(97, 69), CPos.New(97, 70) }
+	SetBasicFootprint(eastFlameReveal, IsSoviet, function()
+		DeactivateSecurity = AddPrimaryObjective(USSR, "deactivate-security-system")
+		FreeDogs = AddSecondaryObjective(USSR, "free-dogs")
+		RevealArea("Flame Tower East")
 	end)
 end
 
 WorldLoaded = function()
-	USSR = Player.GetPlayer("USSR")
-	Greece = Player.GetPlayer("Greece")
-
-	Camera.Position = SoldierTrap1Waypoint1.CenterPosition
-	Actor.Create("camera", true, { Owner = USSR, Location = CameraStart1.Location })
-	Actor.Create("camera", true, { Owner = USSR, Location = CameraStart2.Location })
+	Camera.Position = EntranceTrapWaypoint1.CenterPosition
+	RevealArea("Entrance")
+	InitObjectives(USSR)
 
 	IntroSequence()
+	PrepareLabExplosions()
+	PrepareBasicReveals()
+	PrepareSecurityCenter()
+	PrepareRocketSoldiers()
+	PrepareCrateMazeGuard()
+	PreparePrisonGuards()
+	PrepareEngineerStations()
 
-	InitObjectives(USSR)
-	AlliedObjective = AddPrimaryObjective(Greece, "")
-	SovietObjective1 = AddPrimaryObjective(USSR, "deactivate-security-system")
-	SovietObjective2 = AddPrimaryObjective(USSR, "rescue-engineers")
-	SovietObjective3 = AddPrimaryObjective(USSR, "engineers-coolant-station")
-	SovietObjective4 = AddPrimaryObjective(USSR, "engineer-reprogram-security")
-	SovietObjective5 = AddPrimaryObjective(USSR, "engineer-reactor-core")
-	SovietObjective6 = AddSecondaryObjective(USSR, "free-dogs")
+	Trigger.OnKilled(PillboxBarrel, function()
+		Pillbox.Kill()
+		Utils.Do(Dogs, function(actor)
+			actor.Owner = USSR
+		end)
+		USSR.MarkCompletedObjective(FreeDogs)
+	end)
+
+	Trigger.OnAllKilled(Engineers, function()
+		-- In case they die before security deactivation.
+		RescueEngineers = RescueEngineers or USSR.AddPrimaryObjective(UserInterface.GetFluentMessage("rescue-engineers"))
+		MarkAlliedVictory()
+	end)
+
+	Trigger.OnTimerExpired(function()
+		UserInterface.SetMissionText(UserInterface.GetFluentMessage("too-late"), TimerColor)
+		MarkAlliedVictory()
+	end)
 end
 
 Tick = function()
-	if USSR.HasNoRequiredUnits() and TimerStarted then
-		Greece.MarkCompletedObjective(AlliedObjective)
+	if USSR.HasNoRequiredUnits() and CountdownEnabled then
+		MarkAlliedVictory()
 	end
 
-	if RemainingTime == DateTime.Minutes(5) and Difficulty ~= "hard" then
-		Media.PlaySpeechNotification(USSR, "WarningFiveMinutesRemaining")
-	elseif RemainingTime == DateTime.Minutes(4) then
-		Media.PlaySpeechNotification(USSR, "WarningFourMinutesRemaining")
-	elseif RemainingTime == DateTime.Minutes(3) then
-		Media.PlaySpeechNotification(USSR, "WarningThreeMinutesRemaining")
-	elseif RemainingTime == DateTime.Minutes(2) then
-		Media.PlaySpeechNotification(USSR, "WarningTwoMinutesRemaining")
-	elseif RemainingTime == DateTime.Minutes(1) then
-		Media.PlaySpeechNotification(USSR, "WarningOneMinuteRemaining")
-	end
-
-	if GoalLeft1Triggered and GoalLeft2Triggered and GoalRight1Triggered and GoalRight2Triggered then
-		USSR.MarkCompletedObjective(SovietObjective3)
-	end
-
-	if RemainingTime > 0 and TimerStarted then
+	if RemainingTime > 0 and CountdownEnabled then
 		if (RemainingTime % DateTime.Seconds(1)) == 0 then
-			Timer = UserInterface.GetFluentMessage("time-until-meltdown", { ["time"] = Utils.FormatTime(RemainingTime) })
-			UserInterface.SetMissionText(Timer, USSR.Color)
+			UpdateTimerText()
 		end
 		RemainingTime = RemainingTime - 1
-	elseif RemainingTime == 0 then
-		UserInterface.SetMissionText("")
-		Greece.MarkCompletedObjective(AlliedObjective)
 	end
 end


### PR DESCRIPTION
This PR aims to add some missing events, spread out objective messages, reorganize the script, and fix some minor oddities.

Added some events from the original:
- Two BIO structures near the north edge can explode as the mission timer progresses. (Triggers `tim3` through `tim6`)
- The Rocket Soldier pair will blow up their barrels as normal, but can also retreat to a second barrel trap to do it again. (Triggers `brlx` and `brl5`)
  - After the second trap is gone, the soldiers will hunt. (Trigger `brl3`)
- If the crate maze guard manages to escape from the player, they can blow up the prisoners with a barrel. (Team `inf9`)
- Each time a coolant station is activated, a flare spawns near the reactor core. (Triggers `set1` through `set4`)
  - I did slightly change this so the NW/SE stations activate NW/SE flares as one might expect.
  - The bleed version simply starts with all flares active.
- Enemies in the starting area will hunt if they are left behind. (Team `inf1`)

Instead of showing every objective at the start, they are added as the mission progresses:
- Escape the starting area, then deactivate security and rescue the dogs.
- After security is down, free the Engineers.
- Once the Engineers are freed, reprogram security and activate the coolant stations.
- Once all coolant stations are done, reach the reactor console.

Other:
- Prisoner guards can hunt if a teammate is killed after security is deactivated.
- The prison tower must be destroyed to trigger the Engineers' rescue.
- The reprogramming objective is secondary. It's easy enough to kill Tanya's group without towers in this version, bleed, or the original.
- TimeLimitManager is used for countdown messages.
- Once the reactor is saved, the countdown is paused rather than erased.
- The Pillbox explodes when the nearest barrel dies, rather than the barrel two cells west of that.
- The final console can be activated by an Engineer that is already nearby. Entering the footprint again is not needed.
- Some infantry subcells are corrected. (https://github.com/OpenRA/OpenRA/pull/21397).
- Greece has their campaign bot added.
- Some added annotations and comments. Renamed actors to be clearer.