### PR TITLE
Adjust allies-07 difficulty, add missing events

### DIFF
--- a/mods/ra/maps/allies-07/allies07-AI.lua
+++ b/mods/ra/maps/allies-07/allies07-AI.lua
@@ -6,115 +6,166 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-IdlingUnits = { }
-AttackGroup = { }
-AttackGroupSize = 10
-BGAttackGroup = { }
-BGAttackGroupSize = 8
-SovietAircraftType = { "yak" }
-Yaks = { }
-SovietInfantry = { "e1", "e2", "e4" }
-SovietVehicles =
+
+--- This mission's human player.
+local Greece = Player.GetPlayer("Greece")
+--- Owner of the main Soviet base and most submarines.
+local USSR = Player.GetPlayer("USSR")
+--- Owner of the radar base, some scattered units, and the Hard battalion.
+local BadGuy = Player.GetPlayer("BadGuy")
+
+local AttackGroup = { }
+local AttackGroupSize = 10
+local BadGuyAttackGroup = { }
+local BadGuyAttackSize = 8
+local BadGuyAttackCount = 0
+
+local SovietAircraftType = { "yak" }
+local Yaks = { }
+local SovietInfantry = { "e1", "e2", "e4" }
+local SovietVehicles =
 {
 	hard = { "3tnk", "3tnk", "v2rl" },
 	normal = { "3tnk" },
 	easy = { "3tnk", "apc" }
 }
 
-ProductionInterval =
+local ProductionIntervals =
 {
-	easy = DateTime.Seconds(30),
+	easy = DateTime.Seconds(20),
 	normal = DateTime.Seconds(15),
-	hard = DateTime.Seconds(5)
+	hard = DateTime.Seconds(10)
 }
 
-ParadropDelay = { DateTime.Seconds(30), DateTime.Minutes(1) }
-ParadropWaves = 6
-ParadropLZs = { ParaLZ1.CenterPosition, ParaLZ2.CenterPosition, ParaLZ3.CenterPosition, ParaLZ4.CenterPosition }
-Paradropped = 0
+local FirstAirDelays =
+{
+	easy = DateTime.Seconds(450),
+	normal = DateTime.Seconds(360),
+	hard = DateTime.Seconds(300)
+}
 
-Paradrop = function()
-	Trigger.AfterDelay(Utils.RandomInteger(ParadropDelay[1], ParadropDelay[2]), function()
-		local aircraft = PowerProxy.TargetParatroopers(Utils.Random(ParadropLZs))
+local MainBaseActivationDelays =
+{
+	easy = DateTime.Seconds(720),
+	normal = DateTime.Seconds(540),
+	hard = DateTime.Seconds(420)
+}
+
+local RadarBaseActivationDelays =
+{
+	easy = DateTime.Seconds(75),
+	normal = DateTime.Seconds(45),
+	hard = DateTime.Seconds(30)
+}
+
+local MainBaseActivated = false
+local RadarBaseActivated = false
+local ParadropIntervals = { DateTime.Seconds(30), DateTime.Seconds(60) }
+local ParadropCount = 0
+local ParadropMax = 6
+local ParadropLZs = { ParaLZ1.CenterPosition, ParaLZ2.CenterPosition, ParaLZ3.CenterPosition, ParaLZ4.CenterPosition }
+
+--- Schedule paratroopers, loosely based on RA1 teams "para" and "tm05".
+local function Paradrop()
+	Trigger.AfterDelay(Utils.RandomInteger(ParadropIntervals[1], ParadropIntervals[2]), function()
+		local aircraft = ParaProxy.TargetParatroopers(Utils.Random(ParadropLZs))
 		Utils.Do(aircraft, function(a)
 			Trigger.OnPassengerExited(a, function(t, p)
 				IdleHunt(p)
 			end)
 		end)
 
-		Paradropped = Paradropped + 1
-		if Paradropped <= ParadropWaves then
+		ParadropCount = ParadropCount + 1
+		if ParadropCount <= ParadropMax then
 			Paradrop()
 		end
 	end)
 end
 
-SendBGAttackGroup = function()
-	if #BGAttackGroup < BGAttackGroupSize then
-		return
-	end
+--- Form a small tank team from BadGuy's starting units for a hunt.
+--- Based on the RA1 trigger "tm15".
+local function SendBadGuyTank()
+	local path = { RadarDefenseLanding.Location, ParaLZ4.Location, ParaLZ3.Location }
+	local tank = BadGuy.GetActorsByType("3tnk")[1]
+	local eastFlames = Utils.Where(BadGuy.GetActorsByType("e4"), function(flame)
+		return flame.Location.X > ParaLZ2.Location.X
+	end)
 
-	Utils.Do(BGAttackGroup, function(unit)
-		if not unit.IsDead then
-			Trigger.OnIdle(unit, unit.Hunt)
+	Utils.Do(eastFlames, function(flame)
+		flame.Patrol(path)
+		IdleHunt(flame)
+
+		if tank then
+			tank.Guard(flame)
 		end
 	end)
 
-	BGAttackGroup = { }
+	if tank then
+		IdleHunt(tank)
+	end
 end
 
-ProduceBadGuyInfantry = function()
+local function SendBadGuyAttackGroup()
+	if #BadGuyAttackGroup < BadGuyAttackSize then
+		return
+	end
+
+	Utils.Do(BadGuyAttackGroup, IdleHunt)
+	BadGuyAttackGroup = { }
+	BadGuyAttackCount = BadGuyAttackCount + 1
+
+	if BadGuyAttackCount == 2 then
+		SendBadGuyTank()
+	end
+end
+
+local function ProduceBadGuyInfantry()
 	if BadGuyRax.IsDead or BadGuyRax.Owner ~= BadGuy then
 		return
 	end
 
 	BadGuy.Build({ Utils.Random(SovietInfantry) }, function(units)
-		table.insert(BGAttackGroup, units[1])
-		SendBGAttackGroup()
-		Trigger.AfterDelay(ProductionInterval[Difficulty], ProduceBadGuyInfantry)
+		BadGuyAttackGroup[#BadGuyAttackGroup + 1] = units[1]
+		SendBadGuyAttackGroup()
+		Trigger.AfterDelay(ProductionIntervals[Difficulty], ProduceBadGuyInfantry)
 	end)
 end
 
-SendAttackGroup = function()
+local function SendAttackGroup()
 	if #AttackGroup < AttackGroupSize then
 		return
 	end
 
-	Utils.Do(AttackGroup, function(unit)
-		if not unit.IsDead then
-			Trigger.OnIdle(unit, unit.Hunt)
-		end
-	end)
-
+	Utils.Do(AttackGroup, IdleHunt)
 	AttackGroup = { }
 end
 
-ProduceUSSRInfantry = function()
+local function ProduceUSSRInfantry()
 	if USSRRax.IsDead or USSRRax.Owner ~= USSR then
 		return
 	end
 
 	USSR.Build({ Utils.Random(SovietInfantry) }, function(units)
-		table.insert(AttackGroup, units[1])
+		AttackGroup[#AttackGroup + 1] = units[1]
 		SendAttackGroup()
-		Trigger.AfterDelay(ProductionInterval[Difficulty], ProduceUSSRInfantry)
+		Trigger.AfterDelay(ProductionIntervals[Difficulty], ProduceUSSRInfantry)
 	end)
 end
 
-ProduceVehicles = function()
+local function ProduceVehicles()
 	if USSRWarFactory.IsDead or USSRWarFactory.Owner ~= USSR then
 		return
 	end
 
-	USSR.Build({ Utils.Random(SovietVehicles) }, function(units)
-		table.insert(AttackGroup, units[1])
+	USSR.Build({ Utils.Random(SovietVehicles[Difficulty]) }, function(units)
+		AttackGroup[#AttackGroup + 1] = units[1]
 		SendAttackGroup()
-		Trigger.AfterDelay(ProductionInterval[Difficulty], ProduceVehicles)
+		Trigger.AfterDelay(ProductionIntervals[Difficulty], ProduceVehicles)
 	end)
 end
 
-ProduceAircraft = function()
-	if (Airfield1.IsDead or Airfield1.Owner ~= USSR) and (Airfield2.IsDead or Airfield2.Owner ~= USSR) and (Airfield3.IsDead or Airfield3.Owner ~= USSR) and (Airfield4.IsDead or Airfield4.Owner ~= USSR) then
+local function ProduceAircraft()
+	if not USSR.HasPrerequisites({ "afld" }) then
 		return
 	end
 
@@ -126,28 +177,55 @@ ProduceAircraft = function()
 
 		local alive = Utils.Where(Yaks, function(y) return not y.IsDead end)
 		if #alive < 2 then
-			Trigger.AfterDelay(DateTime.Seconds(ProductionInterval[Difficulty] / 2), ProduceAircraft)
+			Trigger.AfterDelay(DateTime.Seconds(ProductionIntervals[Difficulty] / 2), ProduceAircraft)
 		end
 
 		InitializeAttackAircraft(yak, Greece)
 	end)
 end
 
-ActivateAI = function()
-	SovietVehicles = SovietVehicles[Difficulty]
+local function ActivateRadarBase()
+	if RadarBaseActivated then
+		return
+	end
 
-	local buildings = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == USSR and self.HasProperty("StartBuildingRepairs") end)
+	RadarBaseActivated = true
+	ProduceBadGuyInfantry()
+end
+
+local function ActivateMainBase()
+	if MainBaseActivated then
+		return
+	end
+
+	MainBaseActivated = true
+	ProduceUSSRInfantry()
+	ProduceVehicles()
+end
+
+ActivateAI = function()
+	local buildings = Utils.Where(USSR.GetActors(), function(self) return self.HasProperty("StartBuildingRepairs") end)
 	Utils.Do(buildings, function(actor)
 		Trigger.OnDamaged(actor, function(building)
-			if building.Owner == USSR and building.Health < building.MaxHealth * 3/4 then
+			if building.Owner == USSR and building.Health < building.MaxHealth * 0.75 then
 				building.StartBuildingRepairs()
+				ActivateMainBase()
 			end
 		end)
 	end)
 
-	Paradrop()
-	ProduceBadGuyInfantry()
-	ProduceUSSRInfantry()
-	ProduceVehicles()
-	ProduceAircraft()
+	Trigger.AfterDelay(DateTime.Seconds(60), Paradrop)
+	Trigger.AfterDelay(MainBaseActivationDelays[Difficulty], ActivateMainBase)
+	Trigger.AfterDelay(FirstAirDelays[Difficulty], ProduceAircraft)
+	Trigger.AfterDelay(RadarBaseActivationDelays[Difficulty], ActivateRadarBase)
+
+	-- Based on RA1 trigger "bact".
+	Trigger.OnEnteredProximityTrigger(RadarDefenseProximity.CenterPosition, WDist.FromCells(10), function(actor, id)
+		if actor.Owner ~= Greece then
+			return
+		end
+
+		Trigger.RemoveProximityTrigger(id)
+		ActivateRadarBase()
+	end)
 end

--- a/mods/ra/maps/allies-07/allies07.lua
+++ b/mods/ra/maps/allies-07/allies07.lua
@@ -6,142 +6,299 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
-DestroySubPensTriggerActivator = { Spen1, Spen2, Spen3, Spen4, Spen5 }
-ClearSubActivityTriggerActivator = { Sub1, Sub2, Sub3, Sub4, Sub5, Sub6, Sub7, Sub8, Sub9, Sub10, Sub11, Sub12, Sub13, Sub14, Sub15, Sub16, Sub17 }
-AlliedGunboats = { "pt", "pt", "pt" }
-BeachRifles = { BeachRifle1, BeachRifle2, BeachRifle3, BeachRifle4 }
 
-LstReinforcements =
+--- This mission's human player.
+local Greece = Player.GetPlayer("Greece")
+--- Owner of the main Soviet base and most submarines.
+local USSR = Player.GetPlayer("USSR")
+--- Owner of the radar base, some scattered units, and the Hard battalion.
+local BadGuy = Player.GetPlayer("BadGuy")
+
+local CaptureRadarDome = AddPrimaryObjective(Greece, "capture-radar-dome")
+local DestroySubPens = AddPrimaryObjective(Greece, "destroy-all-soviet-sub-pens")
+local ClearSubActivity = AddSecondaryObjective(Greece, "clear-area-all-subs")
+local PlayerVictoryStarted = false
+local RadarCaptured = false
+local PensDestroyed = false
+local BoatRaidsStarted = false
+
+local DestroySubPensTriggerActivator = { Spen1, Spen2, Spen3, Spen4, Spen5 }
+local ClearSubActivityTriggerActivator = { Sub1, Sub2, Sub3, Sub4, Sub5, Sub6, Sub7, Sub8, Sub9, Sub10, Sub11, Sub12, Sub13, Sub14, Sub15, Sub16, Sub17 }
+local BeachRifles = { BeachRifle1, BeachRifle2, BeachRifle3, BeachRifle4 }
+
+--- Greece's reinforcements, based on RA1 teams "mcvlst" and "renf".
+local LstReinforcements =
 {
 	first =
 	{
 		actors = { "mcv", "jeep", "2tnk", "2tnk" },
-		entryPath = { AlliedMCVEntry.Location, Unload1.Location },
+		entryPath = { AlliedMCVEntry.Location, waypoint1.Location, AlliedLanding.Location },
 		exitPath = { AlliedMCVEntry.Location }
 	},
 	second =
 	{
 		actors = { "jeep", "2tnk", "e1", "e1", "e1" },
-		entryPath = { AlliedMCVEntry.Location, Unload1.Location },
+		entryPath = { AlliedMCVEntry.Location, waypoint1.Location, AlliedLanding.Location },
 		exitPath = { AlliedMCVEntry.Location }
 	}
 }
 
-if Difficulty == "easy" then
-	ActivateAIDelay = DateTime.Minutes(1)
-else
-	ActivateAIDelay = DateTime.Seconds(30)
+local RaidingParties =
+{
+	easy = { "e1", "e1", "e2", "e2", "e2" },
+	normal = { "3tnk", "e2", "e2", "e2", "e2" },
+	hard = { "3tnk", "3tnk", "v2rl", "e1", "e2" }
+}
+local BoatRaidDelay1 = { DateTime.Minutes(1), DateTime.Minutes(2) }
+local BoatRaidDelay2 = { DateTime.Minutes(3), DateTime.Minutes(4) }
+local RaidOnePath = { RaidOneEntry.Location, RaidOneLanding.Location }
+local RaidTwoPath = { RaidTwoEntry.Location, RaidTwoLanding.Location }
+
+local TimerEnabled = false
+local TimerColor = USSR.Color
+local TimerTicks = DateTime.Minutes(10)
+local StartTimerDelay = DateTime.Minutes(5)
+
+---@param objective integer
+---@param speech string
+---@param markDelay? integer
+---@param speechDelay? integer
+local function CompleteObjectiveWithSpeech(objective, speech, markDelay, speechDelay)
+	Trigger.AfterDelay(markDelay or 0, function()
+		Greece.MarkCompletedObjective(objective)
+	end)
+
+	Trigger.AfterDelay(speechDelay or 0, function()
+		Media.PlaySpeechNotification(Greece, speech)
+	end)
 end
 
-RaidingParty = { "3tnk", "3tnk", "v2rl", "e1", "e2"}
-BaseRaidDelay1 = { DateTime.Minutes(1), DateTime.Minutes(2) }
-BaseRaidDelay2 = { DateTime.Minutes(3), DateTime.Minutes(4) }
-RaidOnePath = { RaidOneEntry.Location, RaidOneLanding.Location }
-RaidTwoPath = { RaidTwoEntry.Location, RaidTwoLanding.Location }
+local function MarkDefeat()
+	local mainObjectives = { CaptureRadarDome, DestroySubPens }
 
-StartTimer = false
-TimerColor = Player.GetPlayer("USSR").Color
-TimerTicks = DateTime.Minutes(10)
-Ticked = TimerTicks
-StartTimerDelay = DateTime.Minutes(5)
+	Utils.Do(mainObjectives, function(mo)
+		if not Greece.IsObjectiveCompleted(mo) then
+			Greece.MarkFailedObjective(mo)
+		end
+	end)
+end
 
-InitialAlliedReinforcements = function()
+--- Send the MCV and its escort, based on RA1 trigger "set1".
+local function InitialAlliedReinforcements()
+	local gunboats = { "pt", "pt", "pt" }
+
 	Trigger.AfterDelay(DateTime.Seconds(1), function()
-		Reinforcements.Reinforce(Greece, AlliedGunboats, { GunboatEntry.Location, waypoint42.Location }, 2)
+		Reinforcements.Reinforce(Greece, gunboats, { GunboatEntry.Location, waypoint1.Location, waypoint42.Location }, 15)
 		Media.PlaySpeechNotification(Greece, "ReinforcementsArrived")
 		local reinforcement = LstReinforcements.first
 		Reinforcements.ReinforceWithTransport(Greece, "lst.reinforcement", reinforcement.actors, reinforcement.entryPath, reinforcement.exitPath)
 	end)
 end
 
-BeachRunners = function()
+--- Order some infantry to flee for help as others investigate.
+--- The RA1 triggers were "flee" and "chek".
+local function BeachRunners()
+	local grenadiers = { BeachScout1, BeachScout2 }
+
 	Trigger.AfterDelay(DateTime.Seconds(7), function()
 		Utils.Do(BeachRifles, function(actor)
-			actor.Move(BeachRifleDestination.Location)
+			if actor.IsDead then
+				return
+			end
+
+			actor.Move(MainBaseGate.Location)
+		end)
+	end)
+
+	Trigger.AfterDelay(DateTime.Seconds(52), function()
+		Utils.Do(grenadiers, function(actor)
+			if actor.IsDead then
+				return
+			end
+
+			actor.Move(AlliedLanding.Location, 2)
+			actor.Hunt()
+		end)
+	end)
+
+	Utils.Do(grenadiers, function(actor)
+		Trigger.OnDamaged(actor, function(_, attacker)
+			if actor.IsDead or attacker.IsDead then
+				return
+			end
+
+			Trigger.Clear(actor, "OnDamaged")
+			actor.Stop()
+			actor.Attack(attacker)
+			IdleHunt(actor)
 		end)
 	end)
 end
 
-SecondAlliedLanding = function()
-	Trigger.AfterDelay(DateTime.Minutes(1), function()
+--- Prepare a V2 to follow runners on their return hunt.
+--- The RA1 trigger was "attk", where the V2 was ordered to attack on its own.
+local function PrepareRunnerLauncher()
+	local path = { RadarDefenseLanding.Location, waypoint29.Location, ParaLZ4.Location, ParaLZ3.Location }
+
+	local foot = Trigger.OnEnteredFootprint({ MainBaseGate.Location }, function(a, id)
+		if a.Owner ~= BadGuy then
+			return
+		end
+
+		Trigger.RemoveFootprintTrigger(id)
+		local liveRifles = Utils.Where(BeachRifles, function(br)
+			return not br.IsDead
+		end)
+
+		Utils.Do(liveRifles, function(rifle)
+			rifle.Patrol(path)
+			IdleHunt(rifle)
+
+			if not BadGuyLauncherEast.IsDead then
+				BadGuyLauncherEast.Guard(rifle)
+			end
+		end)
+
+		Trigger.OnAllKilled(liveRifles, function()
+			IdleHunt(BadGuyLauncherEast)
+		end)
+	end)
+
+	Trigger.OnAllKilled(BeachRifles, function()
+		if foot then
+			Trigger.RemoveFootprintTrigger(foot)
+		end
+	end)
+end
+
+--- Send Greece's follow-up reinforcement LST.
+--- The RA1 trigger was "renf" and activated by Greece's first refinery.
+local function SecondAlliedLanding()
+	Trigger.AfterDelay(DateTime.Seconds(90), function()
 		Media.PlaySpeechNotification(Greece, "ReinforcementsArrived")
 		local reinforcement = LstReinforcements.second
 		Reinforcements.ReinforceWithTransport(Greece, "lst.reinforcement", reinforcement.actors, reinforcement.entryPath, reinforcement.exitPath)
 	end)
 end
 
-CaptureRadarDome = function()
+--- Set up the radar objective, based on RA1 triggers "win" and "xp".
+local function PrepareRadarDome()
 	Trigger.OnKilled(RadarDome, function()
-		Greece.MarkFailedObjective(CaptureRadarDomeObj)
+		if RadarCaptured then
+			return
+		end
+
+		Media.PlaySpeechNotification(Greece, "ObjectiveNotMet")
+
+		Trigger.AfterDelay(50, function()
+			Greece.MarkFailedObjective(CaptureRadarDome)
+		end)
 	end)
 
 	Trigger.OnCapture(RadarDome, function()
-		Greece.MarkCompletedObjective(CaptureRadarDomeObj)
-		BaseRaids()
+		RadarCaptured = true
+		PlayerVictoryStarted = RadarCaptured and PensDestroyed
+		CompleteObjectiveWithSpeech(CaptureRadarDome, "FirstObjectiveMet", 50, 36)
 	end)
 end
 
-BaseRaids = function()
-	if Difficulty == "easy" then
-		return
-	else
-		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay1[1], BaseRaidDelay1[2]), function()
-			local raiders = Reinforcements.ReinforceWithTransport(USSR, "lst", RaidingParty, RaidOnePath, { RaidOneEntry.Location })[2]
-			Utils.Do(raiders, function(a)
-				Trigger.OnAddedToWorld(a, function()
-					a.AttackMove(PlayerBase.Location)
-					IdleHunt(a)
-				end)
-			end)
-		end)
+--- Set up defensive paratroopers for BadGuy, based on the RA1 trigger "atkd".
+local function PrepareRadarDefenseDrop()
+	local done = false
+	local buildings = { BadGuyFlameTower, BadGuyRax, RadarDome }
 
-		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay2[1], BaseRaidDelay2[2]), function()
-			local raiders = Reinforcements.ReinforceWithTransport(USSR, "lst", RaidingParty, RaidTwoPath, { RaidTwoEntry.Location })[2]
-			Utils.Do(raiders, function(a)
-				Trigger.OnAddedToWorld(a, function()
-					a.AttackMove(PlayerBase.Location)
-					IdleHunt(a)
-				end)
+	Utils.Do(buildings, function(wsb)
+		Trigger.OnDamaged(wsb, function(_, attacker)
+			if done or attacker.Owner ~= Greece then
+				return
+			end
+
+			done = true
+			local proxy = Actor.Create("powerproxy.badguydrop", false, { Owner = BadGuy })
+			local plane = proxy.TargetParatroopers(RadarDefenseLanding.CenterPosition, Angle.West)[1]
+			proxy.Destroy()
+
+			Trigger.OnPassengerExited(plane, function(_, passenger)
+				IdleHunt(passenger)
 			end)
 		end)
-	end
+	end)
 end
 
-StartTimerFunction = function()
+--- Schedule LSTs to unload attackers near the Allied start area.
+--- This is loosely based on the RA1 triggers "navl" and "tm09".
+local function StartBoatRaids()
+	Trigger.AfterDelay(Utils.RandomInteger(BoatRaidDelay1[1], BoatRaidDelay1[2]), function()
+		local raiders = Reinforcements.ReinforceWithTransport(USSR, "lst", RaidingParties[Difficulty], RaidOnePath, { RaidOneEntry.Location })[2]
+		Utils.Do(raiders, function(a)
+			Trigger.OnAddedToWorld(a, function()
+				a.AttackMove(PlayerBase.Location)
+				IdleHunt(a)
+			end)
+		end)
+	end)
+
+	Trigger.AfterDelay(Utils.RandomInteger(BoatRaidDelay2[1], BoatRaidDelay2[2]), function()
+		local raiders = Reinforcements.ReinforceWithTransport(USSR, "lst", RaidingParties[Difficulty], RaidTwoPath, { RaidTwoEntry.Location })[2]
+		Utils.Do(raiders, function(a)
+			Trigger.OnAddedToWorld(a, function()
+				a.AttackMove(PlayerBase.Location)
+				IdleHunt(a)
+			end)
+		end)
+	end)
+end
+
+--- Check if the Allied base has progressed enough to trigger LST raids.
+--- Based on the RA1 trigger "navl", which only checks for a Naval Yard.
+local function PrepareBoatRaids()
+	Trigger.OnBuildingPlaced(Greece, function()
+		if BoatRaidsStarted or not Greece.HasPrerequisites({ "proc", "syrd", "weap" }) then
+			return
+		end
+
+		BoatRaidsStarted = true
+		StartBoatRaids()
+	end)
+end
+
+local function StartTimer()
 	if Difficulty == "hard" then
-		StartTimer = true
+		TimerEnabled = true
 		Media.PlaySpeechNotification(Greece, "TimerStarted")
 	end
 end
 
-EnemyApproaching = UserInterface.GetFluentMessage("enemy-approaching")
-FinishTimer = function()
+local function FinishTimer()
+	local enemyApproaching = UserInterface.GetFluentMessage("enemy-approaching")
+
 	for i = 0, 5, 1 do
 		local c = TimerColor
 		if i % 2 == 0 then
 			c = HSLColor.White
 		end
 
-		Trigger.AfterDelay(DateTime.Seconds(i), function() UserInterface.SetMissionText(EnemyApproaching, c) end)
+		Trigger.AfterDelay(DateTime.Seconds(i), function() UserInterface.SetMissionText(enemyApproaching, c) end)
 	end
 	Trigger.AfterDelay(DateTime.Seconds(6), function() UserInterface.SetMissionText("") end)
 end
 
-BattalionWays =
-{
-	{ HardEntry1.Location, HardLanding1.Location },
-	{ HardEntry2.Location, HardLanding2.Location },
-	{ HardEntry3.Location, HardLanding3.Location },
-	{ HardEntry4.Location, HardLanding4.Location },
-	{ HardEntry5.Location, HardLanding5.Location },
-	{ HardEntry6.Location, HardLanding6.Location }
-}
+local function SendArmoredBattalion()
+	local boatPaths =
+	{
+		{ HardEntry1.Location, HardLanding1.Location },
+		{ HardEntry2.Location, HardLanding2.Location },
+		{ HardEntry3.Location, HardLanding3.Location },
+		{ HardEntry4.Location, HardLanding4.Location },
+		{ HardEntry5.Location, HardLanding5.Location },
+		{ HardEntry6.Location, HardLanding6.Location }
+	}
 
-SendArmoredBattalion = function()
 	Media.PlaySpeechNotification(Greece, "EnemyUnitsApproaching")
-	Utils.Do(BattalionWays, function(way)
+	Utils.Do(boatPaths, function(way)
 		local units = { "3tnk", "3tnk", "3tnk", "4tnk", "4tnk" }
-		local armor = Reinforcements.ReinforceWithTransport(USSR, "lst", units , way, { way[2], way[1] })[2]
+		local armor = Reinforcements.ReinforceWithTransport(BadGuy, "lst", units , way, { way[2], way[1] })[2]
+
 		Utils.Do(armor, function(a)
 			Trigger.OnAddedToWorld(a, function()
 				a.AttackMove(PlayerBase.Location)
@@ -151,58 +308,60 @@ SendArmoredBattalion = function()
 	end)
 end
 
-DestroySubPensCompleted = function()
-	Greece.MarkCompletedObjective(DestroySubPens)
+local function DestroySubPensCompleted()
+	PensDestroyed = true
+	PlayerVictoryStarted = RadarCaptured and PensDestroyed
+	CompleteObjectiveWithSpeech(DestroySubPens, "SecondObjectiveMet", 50)
 end
 
-ClearSubActivityCompleted = function()
-	Greece.MarkCompletedObjective(ClearSubActivity)
+local function ClearSubActivityCompleted()
+	CompleteObjectiveWithSpeech(ClearSubActivity, "ObjectiveMet")
 end
 
 Tick = function()
 	USSR.Cash = 5000
 	BadGuy.Cash = 500
 
-	if StartTimer then
-		if Ticked > 0 then
-			if (Ticked % DateTime.Seconds(1)) == 0 then
-				Timer = UserInterface.GetFluentMessage("soviet-armored-battalion-arrives-in", { ["time"] = Utils.FormatTime(Ticked) })
-				UserInterface.SetMissionText(Timer, TimerColor)
-			end
-			Ticked = Ticked - 1
-		elseif Ticked == 0 then
-			FinishTimer()
-			SendArmoredBattalion()
-			Ticked = Ticked - 1
-		end
+	if Greece.HasNoRequiredUnits() and not PlayerVictoryStarted then
+		MarkDefeat()
 	end
 
-	if Greece.HasNoRequiredUnits() then
-		USSR.MarkCompletedObjective(BeatAllies)
+	if not TimerEnabled then
+		return
+	end
+
+	if TimerTicks > 0 then
+		if (TimerTicks % DateTime.Seconds(1)) == 0 then
+			Timer = UserInterface.GetFluentMessage("soviet-armored-battalion-arrives-in", { ["time"] = Utils.FormatTime(TimerTicks) })
+			UserInterface.SetMissionText(Timer, TimerColor)
+		end
+		TimerTicks = TimerTicks - 1
+	else
+		FinishTimer()
+		SendArmoredBattalion()
+		TimerEnabled = false
 	end
 end
 
 WorldLoaded = function()
-	Greece = Player.GetPlayer("Greece")
-	USSR = Player.GetPlayer("USSR")
-	BadGuy = Player.GetPlayer("BadGuy")
+	local englandAttackers = { EnglandRifle1, EnglandRifle2, EnglandRifle3, EnglandRanger }
 
 	Camera.Position = DefaultCameraPosition.CenterPosition
-
 	InitObjectives(Greece)
-	CaptureRadarDomeObj = AddPrimaryObjective(Greece, "capture-radar-dome")
-	DestroySubPens = AddPrimaryObjective(Greece, "destroy-all-soviet-sub-pens")
-	ClearSubActivity = AddSecondaryObjective(Greece, "clear-area-all-subs")
-	BeatAllies = AddPrimaryObjective(USSR, "")
-
-	PowerProxy = Actor.Create("powerproxy.paratroopers", false, { Owner = USSR })
 
 	InitialAlliedReinforcements()
 	SecondAlliedLanding()
 	BeachRunners()
-	CaptureRadarDome()
-	Trigger.AfterDelay(ActivateAIDelay, ActivateAI)
-	Trigger.AfterDelay(StartTimerDelay, StartTimerFunction)
+	PrepareRunnerLauncher()
+	PrepareRadarDome()
+	PrepareRadarDefenseDrop()
+	PrepareBoatRaids()
+	ActivateAI()
+	Trigger.AfterDelay(StartTimerDelay, StartTimer)
+
+	Trigger.OnAnyKilled(englandAttackers, function()
+		Utils.Do(englandAttackers, IdleHunt)
+	end)
 
 	Trigger.OnAllKilledOrCaptured(DestroySubPensTriggerActivator, DestroySubPensCompleted)
 	Trigger.OnAllRemovedFromWorld(ClearSubActivityTriggerActivator, ClearSubActivityCompleted)

--- a/mods/ra/maps/allies-07/map.yaml
+++ b/mods/ra/maps/allies-07/map.yaml
@@ -358,7 +358,7 @@ Actors:
 	Actor97: apwr
 		Location: 73,81
 		Owner: USSR
-	BGFlameTower: ftur
+	BadGuyFlameTower: ftur
 		Location: 46,78
 		Owner: BadGuy
 	Actor99: powr
@@ -388,109 +388,111 @@ Actors:
 	Actor107: v2rl
 		Location: 95,60
 		Owner: USSR
-		Facing: 764
+		Facing: 768
 	Actor108: v2rl
 		Location: 87,56
 		Owner: USSR
-		Facing: 892
+		Facing: 896
 	Actor109: v2rl
 		Location: 78,54
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Actor110: v2rl
 		Location: 78,67
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor111: v2rl
 		Location: 78,62
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor112: 3tnk
 		Location: 87,69
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Actor113: 3tnk
 		Location: 84,71
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Actor114: v2rl
 		Location: 94,68
 		Owner: USSR
-		Facing: 636
-	Actor115: jeep
+		Facing: 640
+	EnglandRanger: jeep
 		Location: 27,58
 		Owner: England
 		Health: 7
-		Facing: 636
+		Facing: 640
+		Stance: ReturnFire
 	Actor116: 3tnk
 		Location: 72,67
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	Actor117: 3tnk
 		Location: 63,66
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	Actor118: 3tnk
 		Location: 43,79
 		Owner: BadGuy
-		Facing: 124
+		Facing: 128
 	Actor119: 3tnk
 		Location: 47,55
 		Owner: USSR
-		Facing: 636
-	Actor120: v2rl
+		Facing: 640
+	BadGuyLauncherEast: v2rl
 		Location: 89,71
 		Owner: BadGuy
-		Facing: 124
-	Actor121: v2rl
+		Facing: 128
+	BadGuyLauncherWest: v2rl
 		Location: 48,80
 		Owner: BadGuy
-		Facing: 124
+		Facing: 128
+		Stance: Defend
 	Actor122: 3tnk
 		Location: 65,69
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor123: 3tnk
 		Location: 69,69
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor124: 3tnk
 		Location: 53,56
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	Actor125: 3tnk
 		Location: 67,71
 		Owner: BadGuy
-		Facing: 124
+		Facing: 128
 	Actor126: e1
 		Location: 79,64
 		Owner: USSR
-		Facing: 380
-		SubCell: 4
+		Facing: 384
+		SubCell: 5
 	Actor127: e1
 		Location: 78,63
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 0
 	Actor128: e1
 		Location: 82,62
 		Owner: USSR
-		Facing: 636
+		Facing: 640
 		SubCell: 0
 	Actor129: e1
 		Location: 95,59
 		Owner: USSR
-		Facing: 892
+		Facing: 896
 		SubCell: 2
 	Actor130: e1
 		Location: 94,60
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 2
 	Actor131: e1
 		Location: 96,61
 		Owner: USSR
-		Facing: 636
+		Facing: 640
 		SubCell: 1
 	Actor132: e2
 		Location: 77,66
@@ -499,7 +501,7 @@ Actors:
 	Actor133: e2
 		Location: 79,61
 		Owner: USSR
-		SubCell: 4
+		SubCell: 5
 	Actor134: e2
 		Location: 80,67
 		Owner: USSR
@@ -507,28 +509,28 @@ Actors:
 	Actor135: e2
 		Location: 59,70
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 2
 	Actor136: e2
 		Location: 60,71
 		Owner: USSR
-		Facing: 636
-		SubCell: 4
+		Facing: 640
+		SubCell: 5
 	Actor137: e2
 		Location: 58,71
 		Owner: USSR
-		Facing: 508
-		SubCell: 4
+		Facing: 512
+		SubCell: 5
 	Actor138: e2
 		Location: 71,62
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 0
 	Actor139: e2
 		Location: 70,63
 		Owner: USSR
-		Facing: 636
-		SubCell: 4
+		Facing: 640
+		SubCell: 5
 	Actor140: e1
 		Location: 82,74
 		Owner: USSR
@@ -536,140 +538,140 @@ Actors:
 	Actor141: e1
 		Location: 80,72
 		Owner: USSR
-		Facing: 380
-		SubCell: 4
+		Facing: 384
+		SubCell: 5
 	Actor142: e1
 		Location: 81,76
 		Owner: USSR
-		Facing: 892
-		SubCell: 3
+		Facing: 896
+		SubCell: 4
 	Actor143: e1
 		Location: 80,77
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Actor144: e2
 		Location: 84,74
 		Owner: USSR
-		Facing: 892
-		SubCell: 4
+		Facing: 896
+		SubCell: 5
 	Actor145: e2
 		Location: 81,77
 		Owner: USSR
-		Facing: 636
-		SubCell: 4
+		Facing: 640
+		SubCell: 5
 	Actor146: e2
 		Location: 81,75
 		Owner: USSR
-		Facing: 764
+		Facing: 768
 		SubCell: 1
 	Actor147: e4
 		Location: 30,61
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 0
 	Actor148: e4
 		Location: 30,59
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 		SubCell: 0
-	Actor149: e1
+	EnglandRifle2: e1
 		Location: 26,58
 		Owner: England
 		Health: 61
-		Facing: 764
+		Facing: 768
 		SubCell: 0
-	Actor150: e1
+	EnglandRifle1: e1
 		Location: 27,57
 		Owner: England
 		Health: 43
-		Facing: 636
+		Facing: 640
 		SubCell: 0
-	Actor151: e1
+	EnglandRifle3: e1
 		Location: 26,59
 		Owner: England
 		Health: 55
-		Facing: 636
-		SubCell: 4
+		Facing: 640
+		SubCell: 5
 	BeachRifle1: e1
 		Location: 35,55
 		Owner: BadGuy
-		Facing: 252
-		SubCell: 3
+		Facing: 256
+		SubCell: 4
 	BeachRifle2: e1
 		Location: 33,55
 		Owner: BadGuy
-		Facing: 380
-		SubCell: 4
+		Facing: 384
+		SubCell: 5
 	BeachRifle3: e1
 		Location: 34,55
 		Owner: BadGuy
-		Facing: 124
+		Facing: 128
 		SubCell: 1
 	BeachRifle4: e1
 		Location: 34,56
 		Owner: BadGuy
-		Facing: 636
-		SubCell: 4
+		Facing: 640
+		SubCell: 5
 	Actor156: dog
 		Location: 82,65
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 1
 	Actor157: dog
 		Location: 86,62
 		Owner: USSR
-		Facing: 252
-		SubCell: 4
+		Facing: 256
+		SubCell: 5
 	Actor158: dog
 		Location: 80,69
 		Owner: USSR
-		Facing: 892
-		SubCell: 3
-	Actor159: e2
+		Facing: 896
+		SubCell: 4
+	BeachScout1: e2
 		Location: 40,74
 		Owner: BadGuy
-		Facing: 380
+		Facing: 384
 		SubCell: 0
-	Actor160: e2
+	BeachScout2: e2
 		Location: 40,73
 		Owner: BadGuy
-		Facing: 892
-		SubCell: 4
+		Facing: 896
+		SubCell: 5
 	Actor161: e1
 		Location: 46,74
 		Owner: BadGuy
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Actor162: e1
 		Location: 45,75
 		Owner: BadGuy
-		Facing: 380
+		Facing: 384
 		SubCell: 2
 	Actor163: e1
 		Location: 47,74
 		Owner: BadGuy
-		Facing: 636
+		Facing: 640
 		SubCell: 1
 	Actor164: e1
 		Location: 67,66
 		Owner: USSR
-		Facing: 380
-		SubCell: 4
+		Facing: 384
+		SubCell: 5
 	Actor165: e1
 		Location: 68,70
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Actor166: e1
 		Location: 66,68
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 1
 	Actor167: e1
 		Location: 66,66
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Actor168: e1
 		Location: 45,81
@@ -686,75 +688,75 @@ Actors:
 	Actor171: e4
 		Location: 43,81
 		Owner: BadGuy
-		SubCell: 4
+		SubCell: 5
 	Actor172: e4
 		Location: 45,77
 		Owner: BadGuy
-		Facing: 892
+		Facing: 896
 		SubCell: 0
 	Actor173: e4
 		Location: 31,60
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Actor174: dog
 		Location: 60,80
 		Owner: USSR
-		Facing: 892
+		Facing: 896
 		SubCell: 0
 	Actor175: e4
 		Location: 61,63
 		Owner: BadGuy
-		Facing: 508
-		SubCell: 3
+		Facing: 512
+		SubCell: 4
 	Actor176: e4
 		Location: 66,72
 		Owner: BadGuy
-		SubCell: 3
+		SubCell: 4
 	Actor177: e4
 		Location: 62,67
 		Owner: BadGuy
-		Facing: 380
-		SubCell: 3
+		Facing: 384
+		SubCell: 4
 	Actor178: pt
 		Location: 13,51
 		Owner: Greece
-		Facing: 764
+		Facing: 768
 	Actor179: pt
 		Location: 13,55
 		Owner: Greece
-		Facing: 764
+		Facing: 768
 	Sub1: ss
 		Location: 43,52
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Sub2: ss
 		Location: 39,52
 		Owner: USSR
-		Facing: 764
+		Facing: 768
 	Sub3: ss
 		Location: 21,53
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Sub4: ss
 		Location: 13,70
 		Owner: USSR
 	Sub5: ss
 		Location: 16,75
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Sub6: ss
 		Location: 66,58
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Sub7: ss
 		Location: 71,54
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Sub8: ss
 		Location: 65,50
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	Sub9: ss
 		Location: 103,75
 		Owner: USSR
@@ -767,27 +769,27 @@ Actors:
 	Sub12: ss
 		Location: 95,78
 		Owner: USSR
-		Facing: 764
+		Facing: 768
 	Sub13: ss
 		Location: 86,46
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Sub14: ss
 		Location: 93,51
 		Owner: USSR
-		Facing: 124
+		Facing: 128
 	Sub15: ss
 		Location: 101,50
 		Owner: BadGuy
-		Facing: 636
+		Facing: 640
 	Sub16: ss
 		Location: 99,51
 		Owner: BadGuy
-		Facing: 252
+		Facing: 256
 	Sub17: ss
 		Location: 99,48
 		Owner: BadGuy
-		Facing: 380
+		Facing: 384
 	AlliedMCVEntry: waypoint
 		Location: 10,53
 		Owner: Neutral
@@ -809,8 +811,11 @@ Actors:
 	ParaLZ2: waypoint
 		Location: 49,64
 		Owner: Neutral
-	BeachRifleDestination: waypoint
-		Location: 44,78
+	RadarDefenseProximity: waypoint
+		Location: 46,79
+		Owner: Neutral
+	RadarDefenseLanding: waypoint
+		Location: 43,77
 		Owner: Neutral
 	RaidTwoEntry: waypoint
 		Location: 10,75
@@ -824,14 +829,17 @@ Actors:
 	ParaLZ1: waypoint
 		Location: 39,63
 		Owner: Neutral
-	Unload1: waypoint
+	AlliedLanding: waypoint
 		Location: 24,57
 		Owner: Neutral
 	GunboatEntry: waypoint
 		Owner: Neutral
 		Location: 10,54
 	waypoint42: waypoint
-		Location: 19,54
+		Location: 20,50
+		Owner: Neutral
+	waypoint29: waypoint
+		Location: 53,75
 		Owner: Neutral
 	DefaultCameraPosition: waypoint
 		Location: 13,53
@@ -875,6 +883,12 @@ Actors:
 	SovCamera: camera
 		Owner: USSR
 		Location: 33,62
+	MainBaseGate: waypoint
+		Location: 76,64
+		Owner: Neutral
+	ParaProxy: powerproxy.paratroopers
+		Location: 5,5
+		Owner: USSR
 
 Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/ra/maps/allies-07/rules.yaml
+++ b/mods/ra/maps/allies-07/rules.yaml
@@ -33,6 +33,16 @@ powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
 
+powerproxy.badguydrop:
+	ParatroopersPower:
+		DropItems: E1,E1,E2,E4,E4
+
+BARR:
+	ProvidesPrerequisite@FTUR:
+		Prerequisite: ftur
+		Factions: soviet
+		ResetOnOwnerChange: true
+
 FTRK:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
Outside of Easy, the difficulty on this map is an outlier. Part of that difficulty spike comes from rushes with Flamethrowers, tanks, and V2 launchers before the player's first refinery can be set up. The biggest change of this PR is added delays for different parts of Soviet production. There should be a noticeable escalation from scouts to infantry, air raids, and eventually tank groups.

Other, smaller changes bring this a little closer to the RA1 map, but I've skipped some details like the bomber, BadGuy submarines, and MiGs to avoid getting more carried away (and doing more playtesting) than I already have. The script also has annotations and most vars or functions are now local for https://github.com/OpenRA/OpenRA/issues/20632.

Specifics:
- Add separate delays for Yaks, the radar base's barracks, and the main Soviet base.
  - The radar base can be activated early by approaching it.
  - The main base can be activated early by damaging it enough to trigger repairs.
- Add orders to England's beach team.
- Add orders for nearby Grenadiers to investigate the beach, prior to the radar base's first infantry attack.
- Add RA1's `baddrp` paratroopers, which drop near the radar base once it is damaged.
- Add a Heavy Tank/Flamethrower team that attacks before the main Soviet base begins production.
- Change the production interval on Hard to be longer (5s -> 10s), since the battallion timer already adds a lot of pressure. Easy's interval is shortened (30s -> 20s).
- Change the LST raids so they are not scheduled after the radar objective is completed. Instead, this is done after Greece gains a refinery, War Factory, and Naval Yard.
  - This is similar to the RA1 `NAVL` trigger.
- Change the LST raids to have different teams for each difficulty.
  - These raids are no longer skipped on Easy.
  - The Normal units are from the `tm09` team. The Easy ones are from `landy`.
- Change the radar base's V2 launcher to hold its position.
- Change the radar objective so that it can not be failed after the dome has been captured.
  - This matches its behavior in RA1, and other current missions like `soviet-05` or `allies-06ab`.
- Change the second Allied landing to be a bit more delayed (60s -> 90s). This originally happens when the Allied refinery is built, and roughly coincides with the first V2 launcher attack.
- Change the beach runners so they summon a V2 launcher from the main base. Unlike RA1, the V2 will follow the runners as they return for a hunt, instead of attacking alone.
- Add a death check to the beach runners before their move orders, just in case.
- Fix infantry production being stopped if all Flame Towers are destroyed.
- Fix some infantry subcells. (#21397)