### PR TITLE
Fix mentions of LaysTerrain & MPStartUnits

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnStartingUnits.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[TraitLocation(SystemActors.World)]
 	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. " +
-		"Both are defined at MPStartUnits. Attach this to the world actor.")]
+		"Both are defined at `" + nameof(StartingUnits) + "`. Attach this to the world actor.")]
 	public class SpawnStartingUnitsInfo : TraitInfo, Requires<StartingUnitsInfo>, NotBefore<PathFinderInfo>, ILobbyOptions
 	{
 		public readonly string StartingUnitsClass = "none";

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -14,12 +14,13 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.D2k.Traits.Buildings;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	[Desc("Attach this to the world actor. Required for LaysTerrain to work.")]
+	[Desc("Attach this to the world actor. Required for `" + nameof(D2kBuilding) + "` to work.")]
 	[TraitLocation(SystemActors.World)]
 	public class BuildableTerrainLayerInfo : TraitInfo, Requires<ITiledTerrainRendererInfo>
 	{


### PR DESCRIPTION
[The docs mention](https://docs.openra.net/en/bleed/traits/#buildableterrainlayer) LaysTerrain in BuildableTerrainLayer, but this was folded into D2kBuilding by https://github.com/OpenRA/OpenRA/pull/18685.

MPStartUnits was renamed to MapStartingUnits the same year in https://github.com/OpenRA/OpenRA/pull/18836, and eventually became just StartingUnits.