### PR TITLE
Trim D2k repair pad text from factory upgrade

### DIFF
--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -339,7 +339,6 @@ actor-upgrade-heavy =
     .name = Heavy Factory Upgrade
     .description =
     Unlocks additional construction options:
-    - Repair Pad
     - IX Research Center
 
     Unlocks additional heavy units:


### PR DESCRIPTION
A small follow-up to https://github.com/OpenRA/OpenRA/pull/21930, where the factory was removed as a pad prerequisite.