### PR TITLE
Adjust allies-06b difficulty

### DIFF
--- a/mods/ra/maps/allies-06b/allies06b-AI.lua
+++ b/mods/ra/maps/allies-06b/allies06b-AI.lua
@@ -7,6 +7,8 @@
    information, see COPYING.
 ]]
 
+SovietsActivated = false
+
 WTransWays =
 {
 	{ WaterUnloadEntry1.Location, WaterUnload1.Location },
@@ -23,23 +25,23 @@ WTransUnits =
 
 WTransDelays =
 {
-	easy = 4,
-	normal = 3,
-	hard = 1
+	easy = DateTime.Seconds(240),
+	normal = DateTime.Seconds(180),
+	hard = DateTime.Seconds(140)
+}
+
+FirstAirDelays =
+{
+	easy = { DateTime.Seconds(180), DateTime.Seconds(270) },
+	normal = { DateTime.Seconds(120), DateTime.Seconds(180) },
+	hard = { DateTime.Seconds(90), DateTime.Seconds(135) }
 }
 
 BuildDelays =
 {
-	easy = 90,
-	normal = 60,
-	hard = 30
-}
-
-WaterAttacks =
-{
-	easy = 1,
-	normal = 2,
-	hard = 3
+	easy = DateTime.Seconds(90),
+	normal = DateTime.Seconds(60),
+	hard = DateTime.Seconds(30)
 }
 
 WaterAttackTypes =
@@ -53,9 +55,9 @@ VehicleTypes = { "v2rl", "3tnk", "3tnk", "3tnk", "3tnk", "harv" }
 
 InfTypes =
 {
-	{ "e1", "e1", "e1", "e1", "e1"},
-	{ "e2", "e2", "e1", "e1", "e1"},
-	{ "e4", "e4", "e4", "e1", "e1"}
+	{ "e1", "e1", "e1" },
+	{ "e2", "e2", "e1" },
+	{ "e4", "e4", "e1" }
 }
 
 AttackRallyPoints =
@@ -65,49 +67,39 @@ AttackRallyPoints =
 	{ SovietSideAttack2.Location, SovietBaseAttack.Location }
 }
 
-ImportantBuildings = { WarFactory, Airfield1, Airfield2, Radar2, Refinery, SovietConyard }
+ImportantBuildings = { WarFactory, Airfield1, Airfield2, NorthRadarDome, Refinery, SovietConyard }
 SovietAircraftType = { "yak" }
-Yaks = { }
-IdlingUnits = { }
 IdlingTanks = { tank1, tank2, tank3, tank4, tank5, tank6, tank7 }
 IdlingNavalUnits = { }
 
 InitialiseAttack = function()
 	Utils.Do(ImportantBuildings, function(a)
 		Trigger.OnDamaged(a, function()
-			Utils.Do(IdlingTanks, function(unit)
-				if not unit.IsDead then
-					IdleHunt(unit)
-				end
-			end)
+			Utils.Do(IdlingTanks, IdleHunt)
 		end)
 		Trigger.OnCapture(a, function()
-			Utils.Do(IdlingTanks, function(unit)
-				if not unit.IsDead then
-					IdleHunt(unit)
-				end
-			end)
+			Utils.Do(IdlingTanks, IdleHunt)
 		end)
 	end)
 end
 
-Attack = 0
+InfantryWave = 0
 ProduceInfantry = function()
 	if SovietBarracks.IsDead or SovietBarracks.Owner ~= USSR then
 		return
 	end
 
-	Attack = Attack + 1
+	InfantryWave = InfantryWave + 1
 	local toBuild = Utils.Random(InfTypes)
 	USSR.Build(toBuild, function(units)
-		if Attack == 2 and not AttackTank1.IsDead then
+		if InfantryWave == 2 and not AttackTank1.IsDead then
 			units[#units + 1] = AttackTank1
-		elseif Attack == 4 and not AttackTank2.IsDead then
+		elseif InfantryWave == 4 and not AttackTank2.IsDead then
 			units[#units + 1] = AttackTank2
 		end
 
 		SendAttack(units, Utils.Random(AttackRallyPoints))
-		Trigger.AfterDelay(DateTime.Seconds(BuildDelays), ProduceInfantry)
+		Trigger.AfterDelay(BuildDelays[Difficulty], ProduceInfantry)
 	end)
 end
 
@@ -125,48 +117,42 @@ ProduceVehicles = function()
 end
 
 ProduceNaval = function()
+	if not Greece.HasPrerequisites({ "syrd" }) then
+		Trigger.AfterDelay(DateTime.Seconds(60), ProduceNaval)
+		return
+	end
+
 	if SubPen.IsDead or SubPen.Owner ~= USSR then
 		return
 	end
 
-	if not ShouldProduce and #Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == Greece and self.Type == "syrd" end) < 1 then
-		Trigger.AfterDelay(DateTime.Minutes(1), ProduceNaval)
-		return
-	end
-
-	ShouldProduce = true
-
-	USSR.Build(WaterAttackTypes, function(units)
+	USSR.Build(WaterAttackTypes[Difficulty], function(units)
 		Utils.Do(units, function(unit)
 			IdlingNavalUnits[#IdlingNavalUnits + 1] = unit
 		end)
 
 		Trigger.AfterDelay(DateTime.Minutes(1) + DateTime.Seconds(40), ProduceNaval)
-		if #IdlingNavalUnits >= WaterAttacks then
+		if #IdlingNavalUnits >= #WaterAttackTypes[Difficulty] then
 			Trigger.AfterDelay(DateTime.Seconds(20), function()
-				SendAttack(SetupNavalAttackGroup(), { SubPatrol1_2.Location })
+				SendAttack(SetupNavalAttackGroup(), { Harbor.Location })
 			end)
 		end
 	end)
 end
 
 ProduceAircraft = function()
-	if (Airfield1.IsDead or Airfield1.Owner ~= USSR) and (Airfield2.IsDead or Airfield2.Owner ~= USSR) then
+	if not USSR.HasPrerequisites({ "afld" }) then
 		return
 	end
 
 	USSR.Build(SovietAircraftType, function(units)
-		local yak = units[1]
-		Yaks[#Yaks + 1] = yak
+		Utils.Do(units, function(yak)
+			InitializeAttackAircraft(yak, Greece)
 
-		Trigger.OnKilled(yak, ProduceAircraft)
-
-		local alive = Utils.Where(Yaks, function(y) return not y.IsDead end)
-		if #alive < 2 then
-			Trigger.AfterDelay(DateTime.Seconds(BuildDelays / 2), ProduceAircraft)
-		end
-
-		InitializeAttackAircraft(yak, Greece)
+			Trigger.OnKilled(yak, function()
+				Trigger.AfterDelay(BuildDelays[Difficulty], ProduceAircraft)
+			end)
+		end)
 	end)
 end
 
@@ -179,7 +165,7 @@ end
 
 SetupNavalAttackGroup = function()
 	local units = { }
-	for i = 0, 3 do
+	for i = 1, 3 do
 		if #IdlingNavalUnits == 0 then
 			return units
 		end
@@ -196,7 +182,7 @@ end
 
 WTransWaves = function()
 	local way = Utils.Random(WTransWays)
-	local units = Utils.Random(WTransUnits)
+	local units = Utils.Random(WTransUnits[Difficulty])
 	local attackUnits = Reinforcements.ReinforceWithTransport(USSR, "lst", units , way, { way[2], way[1] })[2]
 	Utils.Do(attackUnits, function(a)
 		Trigger.OnAddedToWorld(a, function()
@@ -205,22 +191,24 @@ WTransWaves = function()
 		end)
 	end)
 
-	Trigger.AfterDelay(DateTime.Minutes(WTransDelays), WTransWaves)
+	Trigger.AfterDelay(WTransDelays[Difficulty], WTransWaves)
 end
 
 ActivateAI = function()
-	WaterAttackTypes = WaterAttackTypes[Difficulty]
-	WaterAttacks = WaterAttacks[Difficulty]
-	WTransUnits = WTransUnits[Difficulty]
-	WTransDelays = WTransDelays[Difficulty]
-	BuildDelays = BuildDelays[Difficulty]
+	if SovietsActivated then
+		return
+	end
+	SovietsActivated = true
 
 	InitialiseAttack()
 	Trigger.AfterDelay(DateTime.Seconds(40), ProduceInfantry)
-	Trigger.AfterDelay(DateTime.Minutes(1) + DateTime.Seconds(10), ProduceAircraft)
 	Trigger.AfterDelay(DateTime.Minutes(2) + DateTime.Seconds(10), ProduceVehicles)
 
+	Utils.Do(FirstAirDelays[Difficulty], function(delay)
+		Trigger.AfterDelay(delay, ProduceAircraft)
+	end)
+
 	WarFactory.RallyPoint = WeaponMeetPoint.Location
-	Trigger.AfterDelay(DateTime.Minutes(4) + DateTime.Seconds(10), ProduceNaval)
-	Trigger.AfterDelay(DateTime.Minutes(WTransDelays + 1) + DateTime.Seconds(30), WTransWaves)
+	Trigger.AfterDelay(WTransDelays[Difficulty] + DateTime.Seconds(150), WTransWaves)
+	Trigger.OnAnyKilled(USSR.GetActorsByType("ss"), ProduceNaval)
 end

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -6,8 +6,9 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+
 AlliedReinforcementsA = { "e1", "e1", "e1", "e1", "e1" }
-AlliedReinforcementsB = { "e1", "e1", "e3", "e3", "e3" }
+AlliedReinforcementsB = { "e3", "e3", "e3", "e3", "e3" }
 AlliedBoatReinforcements = { "pt", "pt" }
 BadGuys = { BadGuy1, BadGuy2, BadGuy3, BadGuy4 }
 
@@ -39,9 +40,7 @@ SovietMammothPaths =
 SubPaths = {
 	{ SubPatrol1_1.Location, SubPatrol1_2.Location },
 	{ SubPatrol2_1.Location, SubPatrol2_2.Location },
-	{ SubPatrol3_1.Location, SubPatrol3_2.Location },
-	{ SubPatrol4_1.Location, SubPatrol4_2.Location },
-	{ SubPatrol5_1.Location, SubPatrol5_2.Location }
+	{ SubPatrol3_1.Location, SubPatrol3_2.Location }
 }
 
 ParadropWaypoints =
@@ -63,7 +62,7 @@ GroupPatrol = function(units, waypoints, delay)
 				return
 			end
 			if unit.Location == waypoints[i] then
-				local bool = Utils.All(units, function(actor) return actor.IsIdle end)
+				local bool = Utils.All(units, function(actor) return actor.IsIdle or actor.IsDead end)
 				if bool then
 					stop = true
 					i = i + 1
@@ -99,8 +98,43 @@ InitialSovietPatrols = function()
 	Patrol1Sub.Patrol(SubPaths[1])
 	Patrol2Sub.Patrol(SubPaths[2])
 	Patrol3Sub.Patrol(SubPaths[3])
-	Patrol4Sub.Patrol(SubPaths[4])
-	Patrol5Sub.Patrol(SubPaths[5])
+end
+
+MarkNavalObjective = function()
+	Trigger.AfterDelay(DateTime.Seconds(2), function()
+		InfiltrateTechCenterObj = InfiltrateTechCenterObj or AddPrimaryObjective(Greece, "infiltrate-tech-center-spy")
+		Greece.MarkCompletedObjective(NavalYardObj)
+		Media.PlaySpeechNotification(Greece, "FirstObjectiveMet")
+	end)
+end
+
+--- Once Greece is secure with a ship yard, send subs to investigate the coast.
+--- Any sub's death will trigger production of more subs, if not yet started.
+CheckNavalObjective = function()
+	if Greece.IsObjectiveCompleted(NavalYardObj) or not Greece.HasPrerequisites({ "syrd" }) then
+		return
+	end
+
+	local eastBase = { EastFlame1, EastFlame2, SovietBarracks }
+	local eastBaseDefeated = Utils.All(eastBase, function(building)
+		return building.IsDead or building.Owner ~= USSR
+	end)
+
+	if not eastBaseDefeated then
+		return
+	end
+
+	MarkNavalObjective()
+
+	if not ScoutSub1.IsDead then
+		-- NE and NW corners of the middle island, then back to NE.
+		local path = { SubPatrol3_2.Location, SubPatrol3_1.Location, Harbor.Location }
+		ScoutSub1.Patrol(path, false)
+	end
+
+	Trigger.AfterDelay(DateTime.Seconds(150), function()
+		IdleHunt(ScoutSub2)
+	end)
 end
 
 InitialAlliedReinforcements = function()
@@ -108,17 +142,22 @@ InitialAlliedReinforcements = function()
 	Trigger.AfterDelay(DateTime.Seconds(30), camera.Destroy)
 
 	Trigger.AfterDelay(DateTime.Seconds(1), function()
-	Reinforcements.Reinforce(Greece, AlliedReinforcementsA, { AlliedEntry3.Location, UnitCStopLocation.Location }, 2)
+		Reinforcements.Reinforce(Greece, AlliedReinforcementsA, { AlliedEntry3.Location, UnitCStopLocation.Location }, 2)
 		Reinforcements.Reinforce(Greece, AlliedReinforcementsB, { AlliedEntry2.Location, UnitAStopLocation.Location }, 2)
 	end)
 	Trigger.AfterDelay(DateTime.Seconds(3), function()
-		Reinforcements.Reinforce(Greece, { "mcv" }, { AlliedEntry1.Location, UnitBStopLocation.Location })
+		local mcv = Reinforcements.Reinforce(Greece, { "mcv" }, { AlliedEntry1.Location, UnitBStopLocation.Location })[1]
+		Trigger.OnRemovedFromWorld(mcv, ActivateAI)
 		Reinforcements.Reinforce(Greece, AlliedBoatReinforcements, { AlliedBoatEntry.Location, AlliedBoatStop.Location })
 	end)
 end
 
 CaptureRadarDome = function()
 	Trigger.OnKilled(RadarDome, function()
+		if Greece.IsObjectiveCompleted(CaptureRadarDomeObj) then
+			return
+		end
+
 		Greece.MarkFailedObjective(CaptureRadarDomeObj)
 	end)
 
@@ -144,39 +183,93 @@ CaptureRadarDome = function()
 	end)
 end
 
+FailTechCenter = function(killed)
+	local speechDelay = 0
+
+	if not killed then
+		-- Let the capture speech play first.
+		speechDelay = 36
+	end
+
+	Trigger.AfterDelay(speechDelay, function()
+		Media.PlaySpeechNotification(Greece, "ObjectiveNotMet")
+	end)
+
+	Trigger.AfterDelay(speechDelay + DateTime.Seconds(1), function()
+		InfiltrateTechCenterObj = InfiltrateTechCenterObj or AddPrimaryObjective(Greece, "infiltrate-tech-center-spy")
+		Greece.MarkFailedObjective(InfiltrateTechCenterObj)
+	end)
+end
+
 InfiltrateTechCenter = function()
+	local infiltrated = false
+	local allKilled = false
+
 	Utils.Do(SovietTechLabs, function(a)
 		Trigger.OnInfiltrated(a, function()
-			if Infiltrated then
+			if infiltrated then
 				return
 			end
-			Infiltrated = true
-			DestroySovietsObj = AddPrimaryObjective(Greece, "destroy-soviet-buildings-units")
-			Greece.MarkCompletedObjective(InfiltrateTechCenterObj)
+
+			infiltrated = true
+			InfiltrateTechCenterObj = InfiltrateTechCenterObj or AddPrimaryObjective(Greece, "infiltrate-tech-center-spy")
+
+			-- Let the infiltration speech play first.
+			Trigger.AfterDelay(38, function()
+				Media.PlaySpeechNotification(Greece, "SecondObjectiveMet")
+				DestroySovietsObj = AddPrimaryObjective(Greece, "destroy-soviet-buildings-units")
+				Greece.MarkCompletedObjective(InfiltrateTechCenterObj)
+
+				local proxy = Actor.Create("powerproxy.paratroopers", false, { Owner = USSR })
+				Utils.Do(ParadropWaypoints[Difficulty], function(waypoint)
+					local plane = proxy.TargetParatroopers(waypoint.CenterPosition, Angle.South)[1]
+					Trigger.OnPassengerExited(plane, function(_, passenger)
+						IdleHunt(passenger)
+					end)
+				end)
+				proxy.Destroy()
+			end)
 		end)
 
 		Trigger.OnCapture(a, function()
-			if not Infiltrated then
+			if not infiltrated then
+				Media.PlaySoundNotification(Greece, "AlertBleep")
 				Media.DisplayMessage(UserInterface.GetFluentMessage("do-not-capture-tech-centers"))
 			end
 		end)
 	end)
 
+	Trigger.OnAllKilled(SovietTechLabs, function()
+		allKilled = true
+	end)
+
 	Trigger.OnAllKilledOrCaptured(SovietTechLabs, function()
-		if not Greece.IsObjectiveCompleted(InfiltrateTechCenterObj) then
-			Greece.MarkFailedObjective(InfiltrateTechCenterObj)
+		if infiltrated then
+			return
 		end
+
+		Trigger.AfterDelay(1, function()
+			FailTechCenter(allKilled)
+		end)
 	end)
 end
 
 Tick = function()
-	if Greece.HasNoRequiredUnits() then
-		Greece.MarkFailedObjective(InfiltrateTechCenterObj)
-	end
-
 	if DestroySovietsObj and USSR.HasNoRequiredUnits() then
 		Greece.MarkCompletedObjective(DestroySovietsObj)
 	end
+
+	if not Greece.HasNoRequiredUnits() then
+		return
+	end
+
+	Utils.Do({ NavalYardObj, InfiltrateTechCenterObj, DestroySovietsObj }, function(objective)
+		if Greece.IsObjectiveCompleted(objective) then
+			return
+		end
+
+		Greece.MarkFailedObjective(objective)
+	end)
 end
 
 WorldLoaded = function()
@@ -185,59 +278,80 @@ WorldLoaded = function()
 
 	InitObjectives(Greece)
 
-	InfiltrateTechCenterObj = AddPrimaryObjective(Greece, "infiltrate-tech-center-spy")
+	NavalYardObj = AddPrimaryObjective(Greece, "build-naval-yard-redeploy-mcv")
 	CaptureRadarDomeObj = AddSecondaryObjective(Greece, "capture-radar-shore")
 
 	Camera.Position = DefaultCameraPosition.CenterPosition
 
-	if Difficulty == "easy" then
-		Trigger.OnEnteredProximityTrigger(SovietDefenseCam.CenterPosition, WDist.New(1024 * 7), function(a, id)
-			if a.Owner == Greece then
-				Trigger.RemoveProximityTrigger(id)
-				local cam1 = Actor.Create("TECH.CAM", true, { Owner = Greece, Location = SovietDefenseCam.Location })
-				Trigger.AfterDelay(DateTime.Seconds(15), cam1.Destroy)
-				if not DefenseFlame1.IsDead then
-					local cam2 = Actor.Create("TECH.CAM", true, { Owner = Greece, Location = DefenseFlame1.Location })
-					Trigger.AfterDelay(DateTime.Seconds(15), cam2.Destroy)
-				end
-				if not DefenseFlame2.IsDead then
-					local cam3 = Actor.Create("TECH.CAM", true, { Owner = Greece, Location = DefenseFlame2.Location })
-					Trigger.AfterDelay(DateTime.Seconds(15), cam3.Destroy)
-				end
-			end
-		end)
-	end
+	Trigger.OnEnteredProximityTrigger(SovietDefenseCam.CenterPosition, WDist.FromCells(7), function(a, id)
+		if a.Owner ~= Greece then
+			return
+		end
 
-	if Difficulty ~= "hard" then
-		Trigger.OnKilled(DefBrl1, function(a, b)
-			if not DefenseFlame1.IsDead then
-				DefenseFlame1.Kill()
-			end
-		end)
-		Trigger.OnKilled(DefBrl2, function(a, b)
-			if not DefenseFlame2.IsDead then
-				DefenseFlame2.Kill()
-			end
-		end)
-	end
+		Trigger.RemoveProximityTrigger(id)
+		local revealTargets = { SovietDefenseCam, StartFlame1, StartFlame2 }
 
-	Utils.Do(BadGuys, function(a)
-		a.AttackMove(UnitCStopLocation.Location)
+		Utils.Do(revealTargets, function(target)
+			if not target.IsInWorld then
+				return
+			end
+
+			local reveal = Actor.Create("TECH.CAM", true, { Owner = Greece, Location = target.Location })
+			Trigger.AfterDelay(DateTime.Seconds(20), reveal.Destroy)
+		end)
+	end)
+
+	Utils.Do(BadGuys, function(bg)
+		if bg == BadGuy3 or bg == BadGuy4 then
+			bg.AttackMove(UnitCStopLocation.Location)
+			IdleHunt(bg)
+			return
+		end
+
+		Trigger.OnEnteredProximityTrigger(bg.CenterPosition, WDist.FromCells(7), function(a, id)
+			if a.Owner ~= Greece or a.Type == "pt" or a.Type == "camera" then
+				return
+			end
+
+			Trigger.RemoveProximityTrigger(id)
+			IdleHunt(bg)
+		end)
+
+		Trigger.OnDamaged(bg, function()
+			if bg.IsIdle then
+				IdleHunt(bg)
+			end
+		end)
+	end)
+
+	Trigger.OnKilled(StartBarrel1, function()
+		if not StartFlame1.IsDead then
+			StartFlame1.Kill()
+		end
+	end)
+	Trigger.OnKilled(StartBarrel2, function()
+		if not StartFlame2.IsDead then
+			StartFlame2.Kill()
+		end
 	end)
 
 	InitialAlliedReinforcements()
-	Trigger.AfterDelay(DateTime.Seconds(1), function()
-		InitialSovietPatrols()
+	Trigger.AfterDelay(DateTime.Seconds(1), InitialSovietPatrols)
+
+	Trigger.OnEnteredProximityTrigger(SovietMiniBaseCam.CenterPosition, WDist.FromCells(14), function(a, id)
+		if a.Owner ~= Greece or a.Type == "pt" or a.Type == "lst" then
+			return
+		end
+
+		Trigger.RemoveProximityTrigger(id)
+		local cam = Actor.Create("Camera", true, { Owner = Greece, Location = SovietMiniBaseCam.Location })
+		Trigger.AfterDelay(DateTime.Seconds(15), cam.Destroy)
 	end)
 
-	Trigger.OnEnteredProximityTrigger(SovietMiniBaseCam.CenterPosition, WDist.New(1024 * 14), function(a, id)
-		if a.Owner == Greece then
-			Trigger.RemoveProximityTrigger(id)
-			local cam = Actor.Create("Camera", true, { Owner = Greece, Location = SovietMiniBaseCam.Location })
-			Trigger.AfterDelay(DateTime.Seconds(15), cam.Destroy)
-		end
-	end)
 	CaptureRadarDome()
 	InfiltrateTechCenter()
-	Trigger.AfterDelay(0, ActivateAI)
+	Trigger.OnBuildingPlaced(Greece, CheckNavalObjective)
+	Trigger.OnAllKilledOrCaptured({ EastFlame1, EastFlame2, SovietBarracks }, CheckNavalObjective)
+	-- Prepare Soviet attacks if Greece still has not deployed the MCV.
+	Trigger.AfterDelay(DateTime.Seconds(90), ActivateAI)
 end

--- a/mods/ra/maps/allies-06b/map.yaml
+++ b/mods/ra/maps/allies-06b/map.yaml
@@ -42,198 +42,198 @@ Players:
 		LockFaction: True
 		Faction: allies
 		LockColor: True
-		Color: E2E6F6
+		Color: ABB7E4
 		LockSpawn: True
 		LockTeam: True
 		Enemies: USSR
 
 Actors:
 	Actor245: sbag
-		Owner: Neutral
+		Owner: USSR
 		Location: 69,83
 	Actor0: sbag
 		Location: 69,80
-		Owner: Neutral
+		Owner: USSR
 	Actor1: sbag
 		Location: 70,80
-		Owner: Neutral
+		Owner: USSR
 	Actor2: sbag
 		Location: 71,80
-		Owner: Neutral
+		Owner: USSR
 	Actor3: sbag
 		Location: 72,80
-		Owner: Neutral
+		Owner: USSR
 	Actor4: sbag
 		Location: 73,80
-		Owner: Neutral
+		Owner: USSR
 	Actor5: sbag
 		Location: 74,80
-		Owner: Neutral
+		Owner: USSR
 	Actor6: sbag
 		Location: 75,80
-		Owner: Neutral
+		Owner: USSR
 	Actor7: sbag
 		Location: 76,80
-		Owner: Neutral
+		Owner: USSR
 	Actor8: sbag
 		Location: 77,80
-		Owner: Neutral
+		Owner: USSR
 	Actor9: sbag
 		Location: 69,81
-		Owner: Neutral
+		Owner: USSR
 	Actor10: sbag
 		Location: 75,81
-		Owner: Neutral
+		Owner: USSR
 	Actor11: sbag
 		Location: 77,81
-		Owner: Neutral
+		Owner: USSR
 	Actor12: sbag
 		Location: 69,82
-		Owner: Neutral
+		Owner: USSR
 	Actor13: sbag
 		Location: 75,82
-		Owner: Neutral
+		Owner: USSR
 	Actor14: sbag
 		Location: 76,82
-		Owner: Neutral
+		Owner: USSR
 	Actor15: sbag
 		Location: 77,82
-		Owner: Neutral
+		Owner: USSR
 	Actor17: sbag
 		Location: 69,84
-		Owner: Neutral
+		Owner: USSR
 	Actor18: sbag
 		Location: 85,84
-		Owner: Neutral
+		Owner: USSR
 	Actor19: sbag
 		Location: 86,84
-		Owner: Neutral
+		Owner: USSR
 	Actor20: sbag
 		Location: 87,84
-		Owner: Neutral
+		Owner: USSR
 	Actor21: sbag
 		Location: 85,85
-		Owner: Neutral
+		Owner: USSR
 	Actor22: sbag
 		Location: 87,85
-		Owner: Neutral
+		Owner: USSR
 	Actor23: sbag
 		Location: 85,86
-		Owner: Neutral
+		Owner: USSR
 	Actor24: sbag
 		Location: 86,86
-		Owner: Neutral
+		Owner: USSR
 	Actor25: sbag
 		Location: 87,86
-		Owner: Neutral
+		Owner: USSR
 	Actor26: sbag
 		Location: 87,87
-		Owner: Neutral
+		Owner: USSR
 	Actor27: sbag
 		Location: 87,88
-		Owner: Neutral
+		Owner: USSR
 	Actor28: sbag
 		Location: 87,89
-		Owner: Neutral
+		Owner: USSR
 	Actor29: sbag
 		Location: 69,90
-		Owner: Neutral
+		Owner: USSR
 	Actor30: sbag
 		Location: 87,90
-		Owner: Neutral
+		Owner: USSR
 	Actor31: sbag
 		Location: 69,91
-		Owner: Neutral
+		Owner: USSR
 	Actor32: sbag
 		Location: 87,91
-		Owner: Neutral
+		Owner: USSR
 	Actor33: sbag
 		Location: 69,92
-		Owner: Neutral
+		Owner: USSR
 	Actor34: sbag
 		Location: 74,92
-		Owner: Neutral
+		Owner: USSR
 	Actor35: sbag
 		Location: 75,92
-		Owner: Neutral
+		Owner: USSR
 	Actor36: sbag
 		Location: 76,92
-		Owner: Neutral
+		Owner: USSR
 	Actor37: sbag
 		Location: 81,92
-		Owner: Neutral
+		Owner: USSR
 	Actor38: sbag
 		Location: 82,92
-		Owner: Neutral
+		Owner: USSR
 	Actor39: sbag
 		Location: 83,92
-		Owner: Neutral
+		Owner: USSR
 	Actor40: sbag
 		Location: 87,92
-		Owner: Neutral
+		Owner: USSR
 	Actor41: sbag
 		Location: 69,93
-		Owner: Neutral
+		Owner: USSR
 	Actor42: sbag
 		Location: 74,93
-		Owner: Neutral
+		Owner: USSR
 	Actor43: sbag
 		Location: 76,93
-		Owner: Neutral
+		Owner: USSR
 	Actor44: sbag
 		Location: 81,93
-		Owner: Neutral
+		Owner: USSR
 	Actor45: sbag
 		Location: 83,93
-		Owner: Neutral
+		Owner: USSR
 	Actor46: sbag
 		Location: 87,93
-		Owner: Neutral
+		Owner: USSR
 	Actor47: sbag
 		Location: 69,94
-		Owner: Neutral
+		Owner: USSR
 	Actor48: sbag
 		Location: 70,94
-		Owner: Neutral
+		Owner: USSR
 	Actor49: sbag
 		Location: 71,94
-		Owner: Neutral
+		Owner: USSR
 	Actor50: sbag
 		Location: 72,94
-		Owner: Neutral
+		Owner: USSR
 	Actor51: sbag
 		Location: 73,94
-		Owner: Neutral
+		Owner: USSR
 	Actor52: sbag
 		Location: 74,94
-		Owner: Neutral
+		Owner: USSR
 	Actor53: sbag
 		Location: 75,94
-		Owner: Neutral
+		Owner: USSR
 	Actor54: sbag
 		Location: 76,94
-		Owner: Neutral
+		Owner: USSR
 	Actor55: sbag
 		Location: 81,94
-		Owner: Neutral
+		Owner: USSR
 	Actor56: sbag
 		Location: 82,94
-		Owner: Neutral
+		Owner: USSR
 	Actor57: sbag
 		Location: 83,94
-		Owner: Neutral
+		Owner: USSR
 	Actor58: sbag
 		Location: 84,94
-		Owner: Neutral
+		Owner: USSR
 	Actor59: sbag
 		Location: 85,94
-		Owner: Neutral
+		Owner: USSR
 	Actor60: sbag
 		Location: 86,94
-		Owner: Neutral
+		Owner: USSR
 	Actor61: sbag
 		Location: 87,94
-		Owner: Neutral
+		Owner: USSR
 	Actor62: tc05
 		Location: 54,109
 		Owner: Neutral
@@ -363,10 +363,10 @@ Actors:
 	Actor104: mine
 		Location: 31,108
 		Owner: Neutral
-	Actor106: ftur
+	EastFlame2: ftur
 		Location: 69,89
 		Owner: USSR
-	Actor107: ftur
+	EastFlame1: ftur
 		Location: 69,85
 		Owner: USSR
 	Actor108: powr
@@ -447,23 +447,24 @@ Actors:
 	Actor148: 3tnk
 		Location: 49,91
 		Owner: USSR
-		Facing: 508
+		Facing: 512
+		Stance: Defend
 	Actor158: harv
 		Location: 78,37
 		Owner: USSR
-		Facing: 892
+		Facing: 896
 	Actor161: v2rl
 		Location: 85,55
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Actor165: e1
 		Location: 75,93
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	Actor166: e1
 		Location: 82,93
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	Actor167: e1
 		Location: 86,85
 		Owner: USSR
@@ -483,11 +484,11 @@ Actors:
 	Actor171: e2
 		Location: 86,85
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	Actor172: e2
 		Location: 76,81
 		Owner: USSR
-		SubCell: 3
+		SubCell: 4
 	Actor182: e1
 		Location: 54,105
 		Owner: Greece
@@ -500,12 +501,12 @@ Actors:
 	Actor184: e1
 		Location: 55,105
 		Owner: Greece
-		Facing: 892
-		SubCell: 4
+		Facing: 896
+		SubCell: 5
 	Actor186: ss
 		Location: 67,62
 		Owner: USSR
-		Facing: 508
+		Facing: 512
 	Actor236: mine
 		Owner: Neutral
 		Location: 88,35
@@ -530,11 +531,11 @@ Actors:
 	AttackTank1: 3tnk
 		Location: 71,87
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	AttackTank2: 3tnk
 		Location: 80,84
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	AlliedEntry1: waypoint
 		Location: 49,111
 		Owner: Neutral
@@ -548,10 +549,10 @@ Actors:
 		Location: 60,111
 		Owner: Neutral
 	UnitAStopLocation: waypoint
-		Location: 49,108
+		Location: 47,108
 		Owner: Neutral
 	UnitBStopLocation: waypoint
-		Location: 47,108
+		Location: 49,108
 		Owner: Neutral
 	UnitCStopLocation: waypoint
 		Location: 51,108
@@ -616,7 +617,7 @@ Actors:
 	RadarDome: dome
 		Location: 75,86
 		Owner: USSR
-	Radar2: dome
+	NorthRadarDome: dome
 		Location: 59,44
 		Owner: USSR
 	SovietBarracks: barr
@@ -628,85 +629,79 @@ Actors:
 	BadGuy1: e1
 		Location: 48,95
 		Owner: USSR
-		Facing: 380
-		SubCell: 4
+		SubCell: 5
+		Facing: 384
 	BadGuy2: e1
-		Location: 50,98
-		Owner: USSR
-		Facing: 380
-		SubCell: 1
-	BadGuy3: e1
 		Location: 50,96
 		Owner: USSR
-		Facing: 380
 		SubCell: 1
-	BadGuy4: e1
+		Facing: 384
+	BadGuy3: e1
 		Location: 48,97
 		Owner: USSR
-		Facing: 380
-		SubCell: 4
-	Patrol1Sub: ss
+		SubCell: 5
+		Facing: 384
+	BadGuy4: e1
+		Location: 50,98
+		Owner: USSR
+		SubCell: 1
+		Facing: 384
+	ScoutSub2: ss
 		Location: 96,58
 		Owner: USSR
-		Facing: 508
-	SubPatrol1_1: waypoint
-		Location: 96,58
-		Owner: Neutral
-	SubPatrol1_2: waypoint
+		Facing: 512
+	Harbor: waypoint
 		Location: 86,77
 		Owner: Neutral
-	Patrol2Sub: ss
+	Patrol1Sub: ss
 		Location: 39,70
 		Owner: USSR
-		Facing: 380
-	SubPatrol2_1: waypoint
+		Facing: 384
+	SubPatrol1_1: waypoint
 		Location: 42,63
 		Owner: Neutral
-	SubPatrol2_2: waypoint
+	SubPatrol1_2: waypoint
 		Location: 22,72
 		Owner: Neutral
-	Patrol3Sub: ss
+	Patrol2Sub: ss
 		Location: 22,64
 		Owner: USSR
-		Facing: 764
-	SubPatrol3_1: waypoint
+		Facing: 768
+	SubPatrol2_1: waypoint
 		Location: 41,75
 		Owner: Neutral
-	SubPatrol3_2: waypoint
+	SubPatrol2_2: waypoint
 		Location: 22,64
 		Owner: Neutral
-	Patrol4Sub: ss
+	ScoutSub1: ss
 		Location: 79,51
 		Owner: USSR
-		Facing: 764
-	SubPatrol4_1: waypoint
-		Location: 79,51
-		Owner: Neutral
-	SubPatrol4_2: waypoint
+		Facing: 768
+	WaterUnloadEntry4: waypoint
 		Location: 102,51
 		Owner: Neutral
-	Patrol5Sub: ss
+	Patrol3Sub: ss
 		Owner: USSR
 		Location: 94,75
-		Facing: 500
-	SubPatrol5_1: waypoint
+		Facing: 512
+	SubPatrol3_1: waypoint
 		Location: 94,94
 		Owner: Neutral
-	SubPatrol5_2: waypoint
+	SubPatrol3_2: waypoint
 		Location: 94,75
 		Owner: Neutral
 	Mammoth1: 4tnk
 		Location: 69,43
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Mammoth2: 4tnk
 		Location: 43,40
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	Mammoth3: 4tnk
 		Location: 54,37
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 	TnkPatrol1: waypoint
 		Location: 69,43
 		Owner: Neutral
@@ -725,58 +720,58 @@ Actors:
 	TnkPatrol6: waypoint
 		Location: 62,37
 		Owner: Neutral
-	DefenseFlame1: ftur
+	StartFlame1: ftur
 		Location: 51,91
 		Owner: USSR
-	DefenseFlame2: ftur
+	StartFlame2: ftur
 		Location: 47,91
 		Owner: USSR
-	DefBrl1: brl3
+	StartBarrel1: brl3
 		Location: 51,90
 		Owner: USSR
-	DefBrl2: brl3
+	StartBarrel2: brl3
 		Location: 46,89
 		Owner: USSR
 	Patrol_1_e1: e1
 		Location: 40,44
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Patrol_1_dog: dog
 		Location: 40,43
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Patrol_2_e1: e1
 		Location: 41,37
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 1
 	Patrol_2_dog: dog
 		Location: 41,37
 		Owner: USSR
-		Facing: 252
-		SubCell: 3
+		Facing: 256
+		SubCell: 4
 	Patrol_3_e1: e1
 		Location: 84,43
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 2
 	Patrol_3_dog: dog
 		Location: 86,43
 		Owner: USSR
-		Facing: 252
+		Facing: 256
 		SubCell: 0
 	Patrol_4_e1: e1
 		Location: 67,51
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 1
 	Patrol_4_dog: dog
 		Location: 66,50
 		Owner: USSR
-		Facing: 380
-		SubCell: 3
+		Facing: 384
+		SubCell: 4
 	Patrol1: waypoint
 		Location: 85,43
 		Owner: Neutral
@@ -804,34 +799,34 @@ Actors:
 	tank1: 3tnk
 		Location: 81,56
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	tank2: 3tnk
 		Location: 77,54
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	tank3: 3tnk
 		Location: 64,43
 		Owner: USSR
-		Facing: 636
+		Facing: 640
 	tank4: 3tnk
 		Location: 45,43
 		Owner: USSR
-		Facing: 508
+		Facing: 512
 	tank5: 3tnk
 		Location: 51,56
 		Owner: USSR
 	tank6: v2rl
 		Location: 46,41
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 	tank7: v2rl
 		Location: 62,42
 		Owner: USSR
-		Facing: 636
+		Facing: 640
 	BeachDog: dog
 		Location: 75,54
 		Owner: USSR
-		Facing: 380
+		Facing: 384
 		SubCell: 1
 	BeachPatrol1: waypoint
 		Owner: Neutral
@@ -842,6 +837,51 @@ Actors:
 	BeachPatrol3: waypoint
 		Location: 77,58
 		Owner: Neutral
+	Actor246: fenc
+		Location: 66,34
+		Owner: USSR
+	Actor247: fenc
+		Location: 73,34
+		Owner: USSR
+	Actor248: fenc
+		Location: 66,35
+		Owner: USSR
+	Actor249: fenc
+		Location: 73,35
+		Owner: USSR
+	Actor250: fenc
+		Location: 66,36
+		Owner: USSR
+	Actor251: fenc
+		Location: 67,36
+		Owner: USSR
+	Actor252: fenc
+		Location: 73,36
+		Owner: USSR
+	Actor253: fenc
+		Location: 72,37
+		Owner: USSR
+	Actor254: fenc
+		Location: 73,37
+		Owner: USSR
+	Actor255: fenc
+		Location: 70,49
+		Owner: USSR
+	Actor256: fenc
+		Location: 71,49
+		Owner: USSR
+	Actor257: fenc
+		Location: 72,49
+		Owner: USSR
+	Actor258: fenc
+		Location: 73,50
+		Owner: USSR
+	Actor259: fenc
+		Location: 73,51
+		Owner: USSR
+	Actor260: fenc
+		Location: 73,52
+		Owner: USSR
 
 Rules: ra|rules/campaign-rules.yaml, ra|rules/campaign-tooltips.yaml, ra|rules/campaign-palettes.yaml, rules.yaml
 

--- a/mods/ra/maps/allies-06b/rules.yaml
+++ b/mods/ra/maps/allies-06b/rules.yaml
@@ -1,6 +1,6 @@
 Player:
 	PlayerResources:
-		DefaultCash: 5000
+		DefaultCash: 8500
 
 World:
 	LuaScript:


### PR DESCRIPTION
A _very_ late follow-up to https://github.com/OpenRA/OpenRA/pull/21401.

Shared with 06a:
- Add Yak delay.
- Change Greece's death check so they can be defeated if they're somehow wiped out after the spy objective is done.
- Change Greece's starting cash to 8500 (from 5000).
- Change dog patrols to stop waiting on dead team members.
- Add an alert bleep to the tech capture message.
- Add the "scout" sub that triggers sub production when killed.
- Add Naval Yard objective, with the sub stacking check.
- Add "objective met" notifications, with some delays so speech should not overlap (at least on normal speed).
- Fix missing wire fencing at Soviet bases. (#21373)
- Fix some infantry subcells. (#21397)

Specific to this B map:
- Add a 90s grace period before Soviet infantry production, reinforcement timers, and so on are started. This grace period ends when Greece deploys or loses their MCV, but it should help with early pressure. 06a uses 30s.
- Start barrels will detonate start towers on Hard -> any difficulty.
- Start barrels and start Flame Towers are revealed on Easy -> any difficulty when approached.
- Add a second scout sub, triggered by the Naval Yard after a delay.
- Add separate delay for the second Yak.
- 4 -> 2 of the Soviet infantry are ordered to attack at the start. The others should mimic their original Area Guard orders.
- Set Defend stance for start tank to mimic Sticky orders.
- Change ownership of Soviet sandbags to Neutral to USSR.
- Change eastern Soviet base reveal trigger to ignore Patrol Boats.
- Change the infantry teams to be one unit smaller. (5 -> 4. 06a has only 3 per team.)
- Correct the MCV/Rifle Infantry rallies that were swapped.
- Two of the starting Rocket Soldiers were swapped to Rifle Infantry. Unsure why but considering how easy it is for them to die from Yaks (or Yak crashes), I've reverted that change.