### PR TITLE
AI showcase (Complete AI for RA&CNC&D2K&TS)

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/BotModules/BotModuleLogic/UnitAttackOptions.cs
+++ b/OpenRA.Mods.Cnc/Traits/BotModules/BotModuleLogic/UnitAttackOptions.cs
@@ -1,0 +1,54 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Flags]
+	public enum AttackRequires
+	{
+		None = 0,
+		CargoLoaded = 1,
+		Disguised = 2,
+	}
+
+	[Desc("Adds metadata for the " + nameof(SendUnitToAttackBotModule) + ".")]
+	public sealed class UnitAttackOptions
+	{
+		[Desc("Base desire provided for attack desire for each of this unit.",
+			"When desire reach 100, AI will send them to attack")]
+		public readonly int AttackDesireOfEach = 20;
+
+		[Desc("Order used for closing in the target before attack. Left empty for attack directly.")]
+		public readonly string MoveToOrderName = null;
+
+		[Desc("Attack order name. Used for actor to attack target.")]
+		public readonly string AttackOrderName = "Attack";
+
+		[Desc("Order used for moving the unit back to where it was after attack. Left empty for no return.")]
+		public readonly string MoveBackOrderName = null;
+
+		[Desc("Disguise before attack, if possible.")]
+		public readonly bool TryDisguise = false;
+
+		[Desc("Repaired before attack, if possible.")]
+		public readonly bool TryGetHealed = true;
+
+		[Desc("Filters units don't meet the requirements. Possible values are None, CargoLoaded, MustDisguised.")]
+		public readonly AttackRequires AttackRequires = AttackRequires.None;
+
+		public UnitAttackOptions(MiniYaml yaml)
+		{
+			FieldLoader.Load(this, yaml);
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
+++ b/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
@@ -21,14 +21,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	[Flags]
-	public enum TargetDistance
-	{
-		Closest = 0,
-		Furthest = 1,
-		Random = 2
-	}
-
 	[TraitLocation(SystemActors.Player)]
 	[Desc("Bot logic for units that should not be sent with a regular squad, like suicide or subterranean units.")]
 	public sealed class SendUnitToAttackBotModuleInfo : ConditionalTraitInfo

--- a/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
+++ b/OpenRA.Mods.Cnc/Traits/BotModules/SendUnitToAttackBotModule.cs
@@ -1,0 +1,376 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Flags]
+	public enum TargetDistance
+	{
+		Closest = 0,
+		Furthest = 1,
+		Random = 2
+	}
+
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Bot logic for units that should not be sent with a regular squad, like suicide or subterranean units.")]
+	public sealed class SendUnitToAttackBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Actors used for attack, and their options on attacking.")]
+		[FieldLoader.LoadUsing(nameof(LoadOptions))]
+		public readonly FrozenDictionary<string, UnitAttackOptions> ActorTypesAndAttackOptions = default;
+
+		[Desc("Target types that can be targeted.")]
+		public readonly BitSet<TargetableType> ValidTargets = new("Structure");
+
+		[Desc("Target types that can't be targeted.")]
+		public readonly BitSet<TargetableType> InvalidTargets;
+
+		[Desc("Player relationships that will be targeted.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Enemy;
+
+		[Desc("Should attack the furthest or closest target. Possible values are Closest, Furthest, Random",
+			"Multiple values mean the distance randomizes between them")]
+		public readonly TargetDistance[] TargetDistances = [TargetDistance.Closest];
+
+		[Desc("Prepare unit, disguise unit and try attack target in this interval.")]
+		public readonly int ScanTick = 463;
+
+		[Desc("The total attack desire increases by this amount per scan",
+			"Note: When there is no attack unit, the total attack desire will return to 0.")]
+		public readonly int AttackDesireIncreasedPerScan = 10;
+
+		static object LoadOptions(MiniYaml yaml)
+		{
+			var ret = new Dictionary<string, UnitAttackOptions>();
+			var options = yaml.Nodes.FirstOrDefault(n => n.Key == "ActorTypesAndAttackOptions");
+			if (options != null)
+				foreach (var d in options.Value.Nodes)
+				{
+					ret.Add(d.Key, new UnitAttackOptions(d.Value));
+				}
+
+			return ret.ToFrozenDictionary();
+		}
+
+		public override object Create(ActorInitializer init) { return new SendUnitToAttackBotModule(init.Self, this); }
+	}
+
+	public class SendUnitToAttackBotModule : ConditionalTrait<SendUnitToAttackBotModuleInfo>, IBotTick
+	{
+		const PlayerRelationship ValidDisguiseRelationship = PlayerRelationship.Ally | PlayerRelationship.Neutral;
+
+		readonly World world;
+		readonly Player player;
+		PathFinder pathfinder;
+
+		readonly Predicate<Actor> unitCannotBeOrdered;
+		readonly Predicate<Actor> unitCannotBeOrderedOrIsBusy;
+		readonly Predicate<Actor> isInvalidActor;
+
+		readonly List<TraitPair<Disguise>> disguisePairs = [];
+		BitSet<TargetableType> disguiseTypes;
+		List<Actor> attackActors = [];
+
+		int prepareAttackTicks;
+		int disguiseDelayTicks;
+		int assignAttackTicks;
+
+		Player targetPlayer;
+		int desireIncreased;
+
+		public SendUnitToAttackBotModule(Actor self, SendUnitToAttackBotModuleInfo info)
+		: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			isInvalidActor = a => a == null || a.IsDead || !a.IsInWorld;
+			unitCannotBeOrdered = a => isInvalidActor(a) || a.Owner != player;
+			unitCannotBeOrderedOrIsBusy = a => unitCannotBeOrdered(a) || !(a.IsIdle || a.CurrentActivity is FlyIdle);
+			desireIncreased = 0;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query player traits from self, which refers
+			// for bot modules always to the Player actor.
+			pathfinder = world.WorldActor.Trait<PathFinder>();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			// and we divide preparing stage, disguising stage and attacking stage for PERF.
+			prepareAttackTicks = world.LocalRandom.Next(0, Info.ScanTick);
+			disguiseDelayTicks = prepareAttackTicks + Info.ScanTick / 3;
+			assignAttackTicks = disguiseDelayTicks + Info.ScanTick / 3;
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (--prepareAttackTicks <= 0)
+			{
+				prepareAttackTicks = Info.ScanTick;
+				PrepareAttackTick(bot);
+			}
+
+			if (--disguiseDelayTicks < 0)
+			{
+				disguiseDelayTicks = Info.ScanTick;
+				if (targetPlayer.WinState != WinState.Lost)
+					DisguiseTicks(bot);
+			}
+
+			if (--assignAttackTicks <= 0)
+			{
+				assignAttackTicks = Info.ScanTick;
+				if (targetPlayer.WinState != WinState.Lost)
+					AttackTicks(bot);
+			}
+		}
+
+		void PrepareAttackTick(IBot bot)
+		{
+			// Randomly choose target player to attack
+			var targetPlayers = world.Players.Where(p => p.WinState != WinState.Lost && Info.ValidRelationships.HasRelationship(p.RelationshipWith(player))).ToList();
+			if (targetPlayers.Count == 0)
+				return;
+			targetPlayer = targetPlayers.Random(world.LocalRandom);
+
+			attackActors = world.ActorsHavingTrait<IPositionable>().Where(a =>
+			{
+				if (!unitCannotBeOrderedOrIsBusy(a) && Info.ActorTypesAndAttackOptions.TryGetValue(a.Info.Name, out var option))
+				{
+					if (option.TryGetHealed && TryGetHeal(bot, a))
+						return false;
+
+					if (option.AttackRequires.HasFlag(AttackRequires.CargoLoaded) && a.TraitsImplementing<Cargo>().FirstOrDefault(t => !t.IsTraitDisabled) is Cargo cargo
+						&& cargo.IsEmpty())
+						return false;
+
+					if (option.TryDisguise && a.TraitOrDefault<Disguise>() is Disguise disguise && !disguise.Disguised)
+					{
+						disguisePairs.Add(new TraitPair<Disguise>(a, disguise));
+						disguiseTypes = disguiseTypes.Union(disguise.Info.TargetTypes);
+						if (option.AttackRequires.HasFlag(AttackRequires.Disguised))
+							return false;
+					}
+
+					return true;
+				}
+
+				return false;
+			}).ToList();
+		}
+
+		void DisguiseTicks(IBot bot)
+		{
+			var invalidActors = new HashSet<Actor>();
+			foreach (var p in disguisePairs)
+			{
+				if (isInvalidActor(p.Actor))
+					invalidActors.Add(p.Actor);
+			}
+
+			disguisePairs.RemoveAll(p => invalidActors.Contains(p.Actor));
+
+			if (disguisePairs.Count <= 0)
+				return;
+
+			var targets = world.Actors.Where(a =>
+			{
+				if (isInvalidActor(a) || !ValidDisguiseRelationship.HasRelationship(a.Owner.RelationshipWith(targetPlayer)) || a.Info.HasTraitInfo<DisguiseInfo>())
+					return false;
+
+				var t = a.GetEnabledTargetTypes();
+
+				if (!disguiseTypes.Overlaps(t))
+					return false;
+
+				var hasModifier = false;
+				var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+				foreach (var v in visModifiers)
+				{
+					if (v.IsVisible(a, player))
+						return true;
+
+					hasModifier = true;
+				}
+
+				return !hasModifier;
+			});
+
+			foreach (var t in targets)
+			{
+				invalidActors.Clear();
+				foreach (var p in disguisePairs)
+				{
+					if (!p.Trait.Info.TargetTypes.Overlaps(t.GetEnabledTargetTypes()))
+						continue;
+
+					bot.QueueOrder(new Order("Disguise", p.Actor, Target.FromActor(t), true));
+					invalidActors.Add(p.Actor);
+					attackActors.Add(p.Actor);
+				}
+
+				disguisePairs.RemoveAll(p => invalidActors.Contains(p.Actor));
+				if (disguisePairs.Count == 0)
+					break;
+			}
+
+			disguisePairs.Clear();
+		}
+
+		void AttackTicks(IBot bot)
+		{
+			var attackdesire = 0;
+
+			var invalidActors = new HashSet<Actor>();
+			foreach (var a in attackActors)
+			{
+				if (unitCannotBeOrderedOrIsBusy(a))
+					invalidActors.Add(a);
+				else
+					attackdesire += Info.ActorTypesAndAttackOptions[a.Info.Name].AttackDesireOfEach;
+			}
+
+			attackActors.RemoveAll(invalidActors.Contains);
+			invalidActors.Clear();
+
+			if (attackActors.Count == 0)
+			{
+				desireIncreased = 0;
+				return;
+			}
+
+			desireIncreased += Info.AttackDesireIncreasedPerScan;
+			if (desireIncreased + attackdesire < 100)
+				return;
+
+			var targets = world.Actors.Where(a =>
+			{
+				if (isInvalidActor(a) || a.Owner != targetPlayer)
+					return false;
+
+				var t = a.GetEnabledTargetTypes();
+
+				if (!Info.ValidTargets.Overlaps(t) || Info.InvalidTargets.Overlaps(t))
+					return false;
+
+				var hasModifier = false;
+				var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+				foreach (var v in visModifiers)
+				{
+					if (v.IsVisible(a, player))
+						return true;
+
+					hasModifier = true;
+				}
+
+				return !hasModifier;
+			});
+
+			var targetDistance = Info.TargetDistances.Random(world.LocalRandom);
+			switch (targetDistance)
+			{
+				case TargetDistance.Closest:
+					targets = targets.OrderBy(a => (a.CenterPosition - attackActors[0].CenterPosition).HorizontalLengthSquared);
+					break;
+				case TargetDistance.Furthest:
+					targets = targets.OrderByDescending(a => (a.CenterPosition - attackActors[0].CenterPosition).HorizontalLengthSquared);
+					break;
+				case TargetDistance.Random:
+					targets = targets.Shuffle(world.LocalRandom);
+					break;
+			}
+
+			foreach (var t in targets)
+			{
+				foreach (var a in attackActors)
+				{
+					if (!a.Info.HasTraitInfo<IMoveInfo>())
+						continue;
+
+					var mobile = a.TraitOrDefault<Mobile>();
+					if (mobile != null && !pathfinder.PathMightExistForLocomotorBlockedByImmovable(mobile.Locomotor, a.Location, t.Location))
+						continue;
+
+					AssignAttackOrders(bot, a, t);
+					invalidActors.Add(a);
+				}
+
+				attackActors.RemoveAll(invalidActors.Contains);
+				invalidActors.Clear();
+
+				if (attackActors.Count == 0)
+					break;
+			}
+
+			attackActors.Clear();
+		}
+
+		void AssignAttackOrders(IBot bot, Actor attacker, Actor victim)
+		{
+			var option = Info.ActorTypesAndAttackOptions[attacker.Info.Name];
+			if (option.MoveToOrderName != null)
+				bot.QueueOrder(new Order(option.MoveToOrderName, attacker, Target.FromCell(world, victim.Location), true));
+
+			bot.QueueOrder(new Order(option.AttackOrderName, attacker, Target.FromActor(victim), true));
+
+			if (option.MoveBackOrderName != null)
+				bot.QueueOrder(new Order(option.MoveBackOrderName, attacker, Target.FromCell(world, attacker.Location), true));
+		}
+
+		protected static bool TryGetHeal(IBot bot, Actor unit)
+		{
+			var health = unit.TraitOrDefault<IHealth>();
+
+			if (health != null && health.DamageState > DamageState.Undamaged)
+			{
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+				var repairable = unit.TraitOrDefault<Repairable>();
+				if (repairable != null)
+					repairBuilding = repairable.FindRepairBuilding(unit);
+				else
+				{
+					var repairableNear = unit.TraitOrDefault<RepairableNear>();
+					if (repairableNear != null)
+					{
+						orderId = "RepairNear";
+						repairBuilding = repairableNear.FindRepairBuilding(unit);
+					}
+				}
+
+				if (repairBuilding != null)
+				{
+					bot.QueueOrder(new Order(orderId, unit, Target.FromActor(repairBuilding), true));
+					return true;
+				}
+
+				return false;
+			}
+			else
+				return false;
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		public bool Disguised => AsPlayer != null;
 		public Player Owner => AsPlayer;
 
+		public readonly DisguiseInfo Info;
 		readonly Actor self;
-		readonly DisguiseInfo info;
 
 		int disguisedToken = Actor.InvalidConditionToken;
 		int disguisedAsToken = Actor.InvalidConditionToken;
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public Disguise(Actor self, DisguiseInfo info)
 		{
 			this.self = self;
-			this.info = info;
+			Info = info;
 
 			AsActor = self.Info;
 		}
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			get
 			{
-				yield return new DisguiseOrderTargeter(info);
+				yield return new DisguiseOrderTargeter(Info);
 			}
 		}
 
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
-			return order.OrderString == "Disguise" ? info.Voice : null;
+			return order.OrderString == "Disguise" ? Info.Voice : null;
 		}
 
 		public void DisguiseAs(Actor target)
@@ -238,7 +238,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (Disguised != oldDisguiseSetting)
 			{
 				if (Disguised && disguisedToken == Actor.InvalidConditionToken)
-					disguisedToken = self.GrantCondition(info.DisguisedCondition);
+					disguisedToken = self.GrantCondition(Info.DisguisedCondition);
 				else if (!Disguised && disguisedToken != Actor.InvalidConditionToken)
 					disguisedToken = self.RevokeCondition(disguisedToken);
 			}
@@ -248,7 +248,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (disguisedAsToken != Actor.InvalidConditionToken)
 					disguisedAsToken = self.RevokeCondition(disguisedAsToken);
 
-				if (info.DisguisedAsConditions.TryGetValue(AsActor.Name, out var disguisedAsCondition))
+				if (Info.DisguisedAsConditions.TryGetValue(AsActor.Name, out var disguisedAsCondition))
 					disguisedAsToken = self.GrantCondition(disguisedAsCondition);
 			}
 		}
@@ -257,43 +257,43 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Attack))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Attack))
 				DisguiseAs(null);
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Damaged) && e.Damage.Value > 0)
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Damaged) && e.Damage.Value > 0)
 				DisguiseAs(null);
 		}
 
 		void INotifyLoadCargo.Loading(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Load))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Load))
 				DisguiseAs(null);
 		}
 
 		void INotifyUnloadCargo.Unloading(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Unload))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Unload))
 				DisguiseAs(null);
 		}
 
 		void INotifyDemolition.Demolishing(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Demolish))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Demolish))
 				DisguiseAs(null);
 		}
 
 		void INotifyInfiltration.Infiltrating(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Infiltrate))
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Infiltrate))
 				DisguiseAs(null);
 		}
 
 		void ITick.Tick(Actor self)
 		{
-			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Move) && lastPos != null && lastPos.Value != self.Location)
+			if (Info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Move) && lastPos != null && lastPos.Value != self.Location)
 				DisguiseAs(null);
 
 			lastPos = self.Location;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				var targetCell = target.Location + targetDelta;
 
-				if (self.Owner.Shroud.IsExplored(targetCell) && cs.CanChronoshiftTo(target, targetCell))
+				if ((self.Owner.Shroud.IsExplored(targetCell) || self.Owner.IsBot) && cs.CanChronoshiftTo(target, targetCell))
 					cs.Teleport(target, targetCell, info.Duration, info.KillCargo, self);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -9,13 +9,19 @@
  */
 #endregion
 
+using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public enum BotSupportPowerTriggerMode { Periodically, OnAttacked }
+
+	public enum BotSupportPowerTargetLocationMode { CheckCenter, ActorLocation, ActorCenter, CellCanBeEnteredByTargetedActor }
+
 	[Desc("Adds metadata for the AI bots.")]
 	public class SupportPowerDecision
 	{
@@ -24,11 +30,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("What support power does this decision apply to?")]
 		public readonly string OrderName = "AirstrikePowerInfoOrder";
-
 		[Desc(
 			"What is the coarse scan radius of this power?",
-			"For finding the general target area, before doing a detail scan",
-			"Should be 10 or more to avoid lag")]
+			$"For finding the general target area, before doing a detail scan when {nameof(DecisionMode)} is Periodically",
+			$"For picking the area around attacked actor, before doing a detail scan when {nameof(DecisionMode)} is OnAttacked",
+			$"Should be 10 or more to avoid lag, when {nameof(DecisionMode)} is Periodically")]
 		public readonly int CoarseScanRadius = 20;
 
 		[Desc(
@@ -39,13 +45,32 @@ namespace OpenRA.Mods.Common.Traits
 
 		[FieldLoader.LoadUsing(nameof(LoadConsiderations))]
 		[Desc("The decisions associated with this power")]
-		public readonly ImmutableArray<Consideration> Considerations = [];
+		public readonly FrozenDictionary<string, SupportPowerStrategy> Considerations = FrozenDictionary<string, SupportPowerStrategy>.Empty;
 
 		[Desc("Minimum ticks to wait until next Decision scan attempt.")]
 		public readonly int MinimumScanTimeInterval = 250;
 
 		[Desc("Maximum ticks to wait until next Decision scan attempt.")]
 		public readonly int MaximumScanTimeInterval = 262;
+
+		[Desc("Extra data that put into support power order.")]
+		public readonly uint ExtraData = uint.MaxValue;
+
+		[Desc("The way of triggering the order.")]
+		public readonly BotSupportPowerTriggerMode DecisionMode = BotSupportPowerTriggerMode.Periodically;
+
+		[Desc("What kind of the location should the bot find as target?")]
+		public readonly BotSupportPowerTargetLocationMode TargetLocationMode = BotSupportPowerTargetLocationMode.CheckCenter;
+
+		[Desc("What kind of the location should the bot find as extra location?", "Extra location is used for support power act like Chronoshift.")]
+		public readonly BotSupportPowerTargetLocationMode ExtraLocationMode = BotSupportPowerTargetLocationMode.CheckCenter;
+
+		[Desc("When set to true, the bot will find target location earlier than extra location, and vice versa",
+			"when earlier check is ActorLocation or ActorCenter and later check is CellCanBeEnteredByTargetedActor, the targetted actor will be passed from early check to later check.")]
+		public readonly bool CheckTargetLocationFirst = true;
+
+		[Desc("Visibility check")]
+		public readonly bool VisibilityCheck = true;
 
 		public SupportPowerDecision(MiniYaml yaml)
 		{
@@ -54,31 +79,79 @@ namespace OpenRA.Mods.Common.Traits
 
 		static object LoadConsiderations(MiniYaml yaml)
 		{
-			var ret = new List<Consideration>();
+			var ret = new Dictionary<string, SupportPowerStrategy>();
 			foreach (var d in yaml.Nodes)
+			{
 				if (d.Key.Split('@')[0] == "Consideration")
-					ret.Add(new Consideration(d.Value));
+				{
+					var consideration = new Consideration(d.Value);
+					if (!ret.ContainsKey(consideration.StrategyName))
+						ret.Add(consideration.StrategyName, new SupportPowerStrategy());
 
-			return ret.ToImmutableArray();
+					var strategy = ret[consideration.StrategyName];
+					if (consideration.AsExtraLocation)
+						strategy.ExtraPositionConsiderations.Add(consideration);
+					else
+						strategy.TargetPositionConsiderations.Add(consideration);
+				}
+			}
+
+			return ret.ToFrozenDictionary();
+		}
+
+		/// <summary>Get a random strategy consists of a set considerations.</summary>
+		public string GetRandomStrategy(int randomNumber)
+		{
+			randomNumber = Math.Abs(randomNumber);
+			var names = Considerations.Keys.ToList();
+			if (names.Count == 0)
+				return null;
+			return names[randomNumber % names.Count];
+		}
+
+		public bool NeedsConsiderTargetPosition(string strategyName)
+		{
+			return strategyName != null && Considerations.TryGetValue(strategyName, out var strategy) && strategy.TargetPositionConsiderations.Count > 0;
+		}
+
+		public bool NeedsConsiderExtraLocation(string strategyName)
+		{
+			return strategyName != null && Considerations.TryGetValue(strategyName, out var strategy) && strategy.ExtraPositionConsiderations.Count > 0;
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>
-		public int GetAttractiveness(WPos pos, Player firedBy)
+		public (int Attractiveness, Actor TargetActor) GetAttractiveness(
+			WPos pos,
+			Player firedBy,
+			string considerationName,
+			bool asExtraPos = false)
 		{
 			var answer = 0;
 			var world = firedBy.World;
 			var targetTile = world.Map.CellContaining(pos);
 
-			if (!world.Map.Contains(targetTile))
-				return 0;
+			if (!Considerations.TryGetValue(considerationName, out var strategy) && !world.Map.Contains(targetTile))
+				return (0, null);
 
-			foreach (var consideration in Considerations)
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+			var goodActors = new List<Actor>();
+			foreach (var consideration in considerations)
 			{
 				var radiusToUse = new WDist(consideration.CheckRadius.Length);
 
 				var checkActors = world.FindActorsInCircle(pos, radiusToUse);
 				foreach (var scrutinized in checkActors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner), firedBy);
+				{
+					var attractiveness = consideration.GetAttractiveness(scrutinized, firedBy, VisibilityCheck);
+
+					if (attractiveness > 0)
+						goodActors.Add(scrutinized);
+
+					answer += attractiveness;
+				}
+
+				if (!VisibilityCheck)
+					continue;
 
 				var delta = new WVec(radiusToUse, radiusToUse, WDist.Zero);
 				var tl = world.Map.CellContaining(pos - delta);
@@ -87,53 +160,109 @@ namespace OpenRA.Mods.Common.Traits
 
 				// IsValid check filters out Frozen Actors that have not initialized their Owner
 				foreach (var scrutinized in checkFrozen)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner));
+					answer += consideration.GetAttractiveness(scrutinized, firedBy);
 			}
+
+			return (answer, goodActors.RandomOrDefault(world.LocalRandom));
+		}
+
+		/// <summary>Evaluates the attractiveness of an actor according to all considerations.</summary>
+		public int GetAttractiveness(Actor actor, Player firedBy, string strategyName, bool asExtraPos = false)
+		{
+			var answer = 0;
+
+			if (!Considerations.TryGetValue(strategyName, out var strategy))
+				return 0;
+
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+
+			foreach (var consideration in considerations)
+				answer += consideration.GetAttractiveness(actor, firedBy, VisibilityCheck);
 
 			return answer;
 		}
 
 		/// <summary>Evaluates the attractiveness of a group of actors according to all considerations.</summary>
-		public int GetAttractiveness(IEnumerable<Actor> actors, Player firedBy)
+		public int GetAttractiveness(IEnumerable<Actor> actors, Player firedBy, string considerationName, bool asExtraPos = false)
 		{
 			var answer = 0;
 
-			foreach (var consideration in Considerations)
+			if (!Considerations.TryGetValue(considerationName, out var strategy))
+				return 0;
+
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+
+			foreach (var consideration in considerations)
 				foreach (var scrutinized in actors)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner), firedBy);
+					answer += consideration.GetAttractiveness(scrutinized, firedBy, VisibilityCheck);
 
 			return answer;
 		}
 
-		public int GetAttractiveness(IEnumerable<FrozenActor> frozenActors, Player firedBy)
+		public int GetAttractiveness(IEnumerable<FrozenActor> frozenActors, Player firedBy, string considerationName, bool asExtraPos = false)
 		{
+			if (!VisibilityCheck)
+				return 0;
+
+			if (!Considerations.TryGetValue(considerationName, out var strategy))
+				return 0;
+
 			var answer = 0;
 
-			foreach (var consideration in Considerations)
+			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
+			foreach (var consideration in considerations)
 				foreach (var scrutinized in frozenActors)
 					if (scrutinized.IsValid && scrutinized.Visible)
-						answer += consideration.GetAttractiveness(scrutinized, firedBy.RelationshipWith(scrutinized.Owner));
+						answer += consideration.GetAttractiveness(scrutinized, firedBy);
 
 			return answer;
 		}
 
-		public int GetNextScanTime(World world) { return world.LocalRandom.Next(MinimumScanTimeInterval, MaximumScanTimeInterval); }
+		public int GetNextScanTime(World world, int minScanTime)
+		{
+			return Math.Max(world.LocalRandom.Next(MinimumScanTimeInterval, MaximumScanTimeInterval), minScanTime);
+		}
+
+		public class SupportPowerStrategy
+		{
+			public string Name;
+			public List<Consideration> TargetPositionConsiderations = [];
+			public List<Consideration> ExtraPositionConsiderations = [];
+		}
 
 		/// <summary>Makes up part of a decision, describing how to evaluate a target.</summary>
 		public class Consideration
 		{
-			public enum DecisionMetric { Health, Value, None }
+			public enum DecisionMetric { Health, HealthLoss, Value, None }
 
-			[Desc("Against whom should this power be used?", "Allowed keywords: Ally, Neutral, Enemy")]
+			[Desc("The strategy name of the consideration", "Considerations of the same strategy will be considered together in one check run.")]
+			public readonly string StrategyName = "primary";
+
+			[Desc("This consideration is used as extra location in order", "Used for support power needs extra location.")]
+			public readonly bool AsExtraLocation = false;
+
+			[Desc("Against whom should this power be used?", "Allowed keywords: Ally, Neutral, Enemy.")]
 			public readonly PlayerRelationship Against = PlayerRelationship.Enemy;
 
-			[Desc("What types should the desired targets of this power be?")]
-			public readonly BitSet<TargetableType> Types = new("Air", "Ground", "Water");
+			[Desc("Only target actors belongs to this bot.")]
+			public readonly bool AgainstOwnActors = false;
+
+			[Desc("What target types should the desired targets of this power be?")]
+			public readonly BitSet<TargetableType> ValidTargetTypes = [];
+
+			[Desc("What target types should the undesired targets of this power be?")]
+			public readonly BitSet<TargetableType> InvalidTargetTypes = [];
+
+			[Desc("What types of actor should the desired targets of this power be?")]
+			public readonly FrozenSet<string> ValidActorTypes = FrozenSet<string>.Empty;
+
+			[Desc("What types of actor should the undesired targets of this power be?")]
+			public readonly FrozenSet<string> InvalidActorTypes = FrozenSet<string>.Empty;
 
 			[Desc("How attractive are these types of targets?")]
 			public readonly int Attractiveness = 100;
 
-			[Desc("Weight the target attractiveness by this property", "Allowed keywords: Health, Value, None")]
+			[Desc("Weight the target attractiveness by this property", "Allowed keywords: Health, HealthLoss, Value, None")]
 			public readonly DecisionMetric TargetMetric = DecisionMetric.None;
 
 			[Desc("What is the check radius of this decision?")]
@@ -145,18 +274,25 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			/// <summary>Evaluates a single actor according to the rules defined in this consideration.</summary>
-			public int GetAttractiveness(Actor a, PlayerRelationship stance, Player firedBy)
+			public int GetAttractiveness(Actor a, Player firedBy, bool visibilityCheck = true)
 			{
-				if (stance != Against)
+				if (a == null || a.IsDead)
 					return 0;
 
-				if (a == null)
+				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(a.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(a.Info.Name)))
 					return 0;
 
-				if (!a.IsTargetableBy(firedBy.PlayerActor) || !a.CanBeViewedByPlayer(firedBy))
+				if ((AgainstOwnActors && a.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(a.Owner))))
 					return 0;
 
-				if (Types.Overlaps(a.GetEnabledTargetTypes()))
+				if (visibilityCheck && !a.CanBeViewedByPlayer(firedBy))
+					return 0;
+
+				if ((!a.IsTargetableBy(firedBy.PlayerActor)) && ((!ValidTargetTypes.IsEmpty) || !InvalidTargetTypes.IsEmpty))
+					return 0;
+
+				if ((ValidTargetTypes.IsEmpty || ValidTargetTypes.Overlaps(a.GetEnabledTargetTypes())) &&
+					(InvalidTargetTypes.IsEmpty || !InvalidTargetTypes.Overlaps(a.GetEnabledTargetTypes())))
 				{
 					switch (TargetMetric)
 					{
@@ -165,13 +301,17 @@ namespace OpenRA.Mods.Common.Traits
 							return (valueInfo != null) ? valueInfo.Cost * Attractiveness : 0;
 
 						case DecisionMetric.Health:
+						case DecisionMetric.HealthLoss:
+
 							var health = a.TraitOrDefault<IHealth>();
 
 							if (health == null)
 								return 0;
 
+							var healthneed = TargetMetric == DecisionMetric.Health ? health.HP : (health.MaxHP - health.HP);
+
 							// Cast to long to avoid overflow when multiplying by the health
-							return (int)((long)health.HP * Attractiveness / health.MaxHP);
+							return (int)((long)healthneed * Attractiveness / health.MaxHP);
 
 						default:
 							return Attractiveness;
@@ -181,15 +321,18 @@ namespace OpenRA.Mods.Common.Traits
 				return 0;
 			}
 
-			public int GetAttractiveness(FrozenActor fa, PlayerRelationship stance)
+			public int GetAttractiveness(FrozenActor fa, Player firedBy)
 			{
-				if (stance != Against)
+				if ((AgainstOwnActors && fa.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(fa.Owner))))
 					return 0;
 
 				if (fa == null || !fa.IsValid || !fa.Visible)
 					return 0;
 
-				if (Types.Overlaps(fa.TargetTypes))
+				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(fa.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(fa.Info.Name)))
+					return 0;
+
+				if ((ValidTargetTypes.IsEmpty || ValidTargetTypes.Overlaps(fa.TargetTypes)) && (InvalidTargetTypes.IsEmpty || !InvalidTargetTypes.Overlaps(fa.TargetTypes)))
 				{
 					switch (TargetMetric)
 					{

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>
-		public (int Attractiveness, Actor TargetActor) GetAttractiveness(
+		public (int Attractiveness, Actor TargetActor, FrozenActor FrozenActor) GetAttractiveness(
 			WPos pos,
 			Player firedBy,
 			string considerationName,
@@ -131,10 +131,11 @@ namespace OpenRA.Mods.Common.Traits
 			var targetTile = world.Map.CellContaining(pos);
 
 			if (!Considerations.TryGetValue(considerationName, out var strategy) && !world.Map.Contains(targetTile))
-				return (0, null);
+				return (0, null, null);
 
 			var considerations = asExtraPos ? strategy.ExtraPositionConsiderations : strategy.TargetPositionConsiderations;
 			var goodActors = new List<Actor>();
+			var goodFrozenActors = new List<FrozenActor>();
 			foreach (var consideration in considerations)
 			{
 				var radiusToUse = new WDist(consideration.CheckRadius.Length);
@@ -156,14 +157,21 @@ namespace OpenRA.Mods.Common.Traits
 				var delta = new WVec(radiusToUse, radiusToUse, WDist.Zero);
 				var tl = world.Map.CellContaining(pos - delta);
 				var br = world.Map.CellContaining(pos + delta);
-				var checkFrozen = firedBy.FrozenActorLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
 
-				// IsValid check filters out Frozen Actors that have not initialized their Owner
+				var checkFrozen = firedBy.FrozenActorLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
 				foreach (var scrutinized in checkFrozen)
-					answer += consideration.GetAttractiveness(scrutinized, firedBy);
+				{
+					// IsValid check filters out Frozen Actors that have not initialized their Owner
+					var attractiveness = consideration.GetAttractiveness(scrutinized, firedBy);
+
+					if (attractiveness > 0)
+						goodFrozenActors.Add(scrutinized);
+
+					answer += attractiveness;
+				}
 			}
 
-			return (answer, goodActors.RandomOrDefault(world.LocalRandom));
+			return (answer, goodActors.RandomOrDefault(world.LocalRandom), goodFrozenActors.RandomOrDefault(world.LocalRandom));
 		}
 
 		/// <summary>Evaluates the attractiveness of an actor according to all considerations.</summary>
@@ -233,7 +241,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>Makes up part of a decision, describing how to evaluate a target.</summary>
 		public class Consideration
 		{
-			public enum DecisionMetric { Health, HealthLoss, Value, None }
+			public enum DecisionMetric { Health, HealthLoss, Value, Undetected, None }
 
 			[Desc("The strategy name of the consideration", "Considerations of the same strategy will be considered together in one check run.")]
 			public readonly string StrategyName = "primary";
@@ -276,7 +284,7 @@ namespace OpenRA.Mods.Common.Traits
 			/// <summary>Evaluates a single actor according to the rules defined in this consideration.</summary>
 			public int GetAttractiveness(Actor a, Player firedBy, bool visibilityCheck = true)
 			{
-				if (a == null || a.IsDead)
+				if (a == null || a.IsDead || !a.IsInWorld)
 					return 0;
 
 				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(a.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(a.Info.Name)))
@@ -285,7 +293,8 @@ namespace OpenRA.Mods.Common.Traits
 				if ((AgainstOwnActors && a.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(a.Owner))))
 					return 0;
 
-				if (visibilityCheck && !a.CanBeViewedByPlayer(firedBy))
+				var canbeview = a.CanBeViewedByPlayer(firedBy);
+				if (TargetMetric != DecisionMetric.Undetected && visibilityCheck && !canbeview)
 					return 0;
 
 				if ((!a.IsTargetableBy(firedBy.PlayerActor)) && ((!ValidTargetTypes.IsEmpty) || !InvalidTargetTypes.IsEmpty))
@@ -313,6 +322,17 @@ namespace OpenRA.Mods.Common.Traits
 							// Cast to long to avoid overflow when multiplying by the health
 							return (int)((long)healthneed * Attractiveness / health.MaxHP);
 
+						case DecisionMetric.Undetected:
+							if (canbeview)
+								return 0;
+
+							// we consider visible frozen actor can be regard as detected actor for this bot module.
+							var frozen = a.TraitOrDefault<FrozenUnderFog>();
+							if (frozen != null && frozen.IsVisible(a, firedBy))
+								return 0;
+
+							return Attractiveness;
+
 						default:
 							return Attractiveness;
 					}
@@ -326,7 +346,7 @@ namespace OpenRA.Mods.Common.Traits
 				if ((AgainstOwnActors && fa.Owner != firedBy) || (!AgainstOwnActors && !Against.HasRelationship(firedBy.RelationshipWith(fa.Owner))))
 					return 0;
 
-				if (fa == null || !fa.IsValid || !fa.Visible)
+				if (fa == null || !fa.IsValid || !fa.Visible || TargetMetric == DecisionMetric.Undetected)
 					return 0;
 
 				if ((ValidActorTypes.Count > 0 && !ValidActorTypes.Contains(fa.Info.Name)) || (InvalidActorTypes.Count > 0 && InvalidActorTypes.Contains(fa.Info.Name)))

--- a/OpenRA.Mods.Common/Traits/BotModules/ExternalBotOrdersManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/ExternalBotOrdersManager.cs
@@ -1,0 +1,150 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Allows the player to issue the orders from actors with " + nameof(IssueOrderToBot) + ". etc")]
+	public class ExternalBotOrdersManagerInfo : ConditionalTraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new ExternalBotOrdersManager(init.Self, this); }
+	}
+
+	public class ExternalBotOrdersManager : ConditionalTrait<ExternalBotOrdersManagerInfo>, IBotTick
+	{
+		readonly Dictionary<Actor, (Order Order, int Chance)> directEntries = [];
+		readonly Dictionary<Actor, IssueOrderToBotInfo> issueOrderToBotEntries = [];
+		readonly World world;
+		readonly Player player;
+
+		public bool ManagerRunning { get; private set; }
+
+		public ExternalBotOrdersManager(Actor self, ExternalBotOrdersManagerInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+			ManagerRunning = false;
+		}
+
+		// Use for proactive targeting.
+		public bool IsPreferredTarget(Actor self, Actor a,
+			PlayerRelationship validRelationships, BitSet<TargetableType> validTargets, BitSet<TargetableType> invalidTargets)
+		{
+			if (a == self || a == null || a.IsDead || !a.IsInWorld || !validRelationships.HasRelationship(self.Owner.RelationshipWith(a.Owner)))
+				return false;
+
+			var targetTypes = a.GetEnabledTargetTypes();
+			return !targetTypes.IsEmpty && validTargets.Overlaps(targetTypes) && !invalidTargets.Overlaps(targetTypes);
+		}
+
+		public bool IsNotHiddenUnit(Actor self, Actor a)
+		{
+			var hasModifier = false;
+			var visModifiers = a.TraitsImplementing<IVisibilityModifier>();
+			foreach (var v in visModifiers)
+			{
+				if (v.IsVisible(a, self.Owner))
+					return true;
+
+				hasModifier = true;
+			}
+
+			return !hasModifier;
+		}
+
+		public void AddEntry(Actor issuer, Order order, int chance)
+		{
+			directEntries[issuer] = (order, chance);
+		}
+
+		public void AddEntryFromIssueOrderToBot(Actor issuer, IssueOrderToBotInfo info)
+		{
+			issueOrderToBotEntries[issuer] = info;
+		}
+
+		public Order PhraseEntryFromIssueOrderToBot(Actor issuer, IssueOrderToBotInfo info)
+		{
+			if (issuer.IsDead || !issuer.IsInWorld || issuer.Owner != player || world.LocalRandom.Next(100) > info.OrderChance)
+				return null;
+
+			var subject = info.IsIssuerOwner ? issuer.Owner.PlayerActor : issuer;
+			Order order = null;
+
+			if (info.TargetRangeInCell > 0)
+			{
+				var validActors = world.FindActorsInCircle(issuer.CenterPosition, WDist.FromCells(info.TargetRangeInCell))
+					.Where(a => IsPreferredTarget(issuer, a, info.ValidRelationships, info.ValidTargets, info.InvalidTargets) && IsNotHiddenUnit(issuer, a));
+
+				Actor validActor = null;
+
+				switch (info.TargetDistance)
+				{
+					case TargetDistance.Closest:
+						validActor = validActors.ClosestToIgnoringPath(issuer);
+						break;
+					case TargetDistance.Furthest:
+						validActor = validActors.OrderByDescending(a => (a.Location - issuer.Location).LengthSquared).FirstOrDefault();
+						break;
+					case TargetDistance.Random:
+						validActor = validActors.RandomOrDefault(world.LocalRandom);
+						break;
+				}
+
+				if (validActor == null)
+					return null;
+
+				var target = Target.Invalid;
+				if (info.UseTargetLocation)
+					order = new Order(info.OrderName, subject, Target.FromCell(world, validActor.Location), false);
+				else
+					order = new Order(info.OrderName, subject, Target.FromActor(validActor), false);
+			}
+
+			return order ??= new Order(info.OrderName, subject, false);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			// "ManagerRunning = true" means IBotTick is running, and the game is
+			// 1. not a replay
+			// 2. not saved game still loading
+			// 3. the game running on the host where AI is enabled
+			ManagerRunning = true;
+
+			foreach (var entry in directEntries)
+			{
+				if (entry.Key.IsDead || !entry.Key.IsInWorld || entry.Key.Owner != player)
+					continue;
+
+				if (world.LocalRandom.Next(100) > entry.Value.Chance)
+					continue;
+
+				bot.QueueOrder(entry.Value.Order);
+			}
+
+			directEntries.Clear();
+
+			foreach (var entry in issueOrderToBotEntries)
+			{
+				var order = PhraseEntryFromIssueOrderToBot(entry.Key, entry.Value);
+				if (order != null)
+					bot.QueueOrder(order);
+			}
+
+			issueOrderToBotEntries.Clear();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/LoadCargoBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/LoadCargoBotModule.cs
@@ -1,0 +1,157 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Flags]
+	public enum LoadRequirement
+	{
+		All = 0,
+		IdleUnit = 1,
+	}
+
+	[Flags]
+	public enum TransportOwner
+	{
+		Self = 0,
+		AlliedBot = 1,
+		Allies = 2
+	}
+
+	[TraitLocation(SystemActors.Player)]
+	[Desc("Manages AI load unit related with " + nameof(Cargo) + " and " + nameof(Passenger) + " traits.")]
+	public class LoadCargoBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Actor types that can be targeted for load, must have " + nameof(Cargo) + ".",
+			"The flag represents if this transport only requires idle unit. Possible values are: All, IdleUnit")]
+		public readonly FrozenDictionary<string, LoadRequirement> TransportTypesAndLoadRequirement = default;
+
+		[Desc("Actor types that used for loading, must have " + nameof(Passenger) + ".")]
+		public readonly FrozenSet<string> PassengerTypes = default;
+
+		[Desc("The type of relationship that can be targeted for load. Possible values are: Self, AlliedBot and Allies",
+			"AlliedBot means AI will load transport for another allied bot player.")]
+		public readonly TransportOwner ValidTransportOwner = TransportOwner.Self;
+
+		[Desc("Scan suitable actors and target in this interval.")]
+		public readonly int ScanTick = 317;
+
+		[Desc("Don't load passengers to this actor if damage state is worse than this.")]
+		public readonly DamageState ValidDamageState = DamageState.Heavy;
+
+		[Desc("Don't load passengers that are further than this distance to this actor.")]
+		public readonly WDist MaxDistance = WDist.FromCells(20);
+
+		public override object Create(ActorInitializer init) { return new LoadCargoBotModule(init.Self, this); }
+	}
+
+	public class LoadCargoBotModule : ConditionalTrait<LoadCargoBotModuleInfo>, IBotTick
+	{
+		readonly World world;
+		readonly Player player;
+		readonly Predicate<Actor> unitCannotBeOrdered;
+		readonly Predicate<Actor> unitCannotBeOrderedOrIsBusy;
+		readonly Predicate<Actor> invalidTransport;
+
+		int minAssignRoleDelayTicks;
+
+		public LoadCargoBotModule(Actor self, LoadCargoBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+
+			switch (info.ValidTransportOwner)
+			{
+				case TransportOwner.Self:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || a.Owner != player;
+					break;
+				case TransportOwner.AlliedBot:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || !a.Owner.IsBot || a.Owner.RelationshipWith(player) != PlayerRelationship.Ally;
+					break;
+				case TransportOwner.Allies:
+					invalidTransport = a => a == null || a.IsDead || !a.IsInWorld || a.Owner.RelationshipWith(player) != PlayerRelationship.Ally;
+					break;
+			}
+
+			unitCannotBeOrdered = a => a == null || a.IsDead || !a.IsInWorld || a.Owner != player;
+			unitCannotBeOrderedOrIsBusy = a => unitCannotBeOrdered(a) || (!a.IsIdle && a.CurrentActivity is not FlyIdle);
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			// Avoid all AIs reevaluating assignments on the same tick, randomize their initial evaluation delay.
+			minAssignRoleDelayTicks = world.LocalRandom.Next(0, Info.ScanTick);
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			if (--minAssignRoleDelayTicks <= 0)
+			{
+				minAssignRoleDelayTicks = Info.ScanTick;
+
+				var transporters = world.ActorsWithTrait<Cargo>().Where(at =>
+				{
+					var health = at.Actor.TraitOrDefault<IHealth>()?.DamageState;
+					return Info.TransportTypesAndLoadRequirement.ContainsKey(at.Actor.Info.Name) && !invalidTransport(at.Actor)
+					&& !at.Trait.IsTraitDisabled && at.Trait.HasSpace(1) && (health == null || health < Info.ValidDamageState);
+				}).ToArray();
+
+				if (transporters.Length == 0)
+					return;
+
+				var transporter = transporters.Random(world.LocalRandom);
+				var cargo = transporter.Trait;
+				var transport = transporter.Actor;
+				var spaceTaken = 0;
+
+				Predicate<Actor> invalidPassenger;
+				if (Info.TransportTypesAndLoadRequirement[transport.Info.Name] == LoadRequirement.IdleUnit)
+					invalidPassenger = unitCannotBeOrderedOrIsBusy;
+				else
+					invalidPassenger = unitCannotBeOrdered;
+
+				var passengers = world.ActorsWithTrait<Passenger>().Where(at => Info.PassengerTypes.Contains(at.Actor.Info.Name) && !invalidPassenger(at.Actor)
+					&& cargo.HasSpace(at.Trait.Info.Weight)
+					&& (at.Actor.CenterPosition - transport.CenterPosition).HorizontalLengthSquared <= Info.MaxDistance.LengthSquared)
+					.OrderBy(at => (at.Actor.CenterPosition - transport.CenterPosition).HorizontalLengthSquared);
+
+				var orderedActors = new List<Actor>();
+
+				foreach (var p in passengers)
+				{
+					var mobile = p.Actor.TraitOrDefault<Mobile>();
+					if (mobile == null || !mobile.PathFinder.PathExistsForLocomotor(mobile.Locomotor, p.Actor.Location, transport.Location))
+						continue;
+
+					if (cargo.HasSpace(spaceTaken + p.Trait.Info.Weight))
+					{
+						spaceTaken += p.Trait.Info.Weight;
+						orderedActors.Add(p.Actor);
+					}
+
+					if (!cargo.HasSpace(spaceTaken + 1))
+						break;
+				}
+
+				if (orderedActors.Count > 0)
+					bot.QueueOrder(new Order("EnterTransport", null, Target.FromActor(transport), false, groupedActors: orderedActors.ToArray()));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits.BotModules.Squads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -151,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 			World = self.World;
 			Player = self.Owner;
 
-			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld;
+			unitCannotBeOrdered = a => a == null || a.Owner != Player || a.IsDead || !a.IsInWorld || a.CurrentActivity is Enter;
 			constructionYardBuildings = new ActorIndex.NamesAndTrait<BuildingInfo>(World, info.ConstructionYardTypes);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -119,18 +119,17 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 				var wpos = map.CenterOfCell(pos);
 
-				if (CountAntiAirUnits(owner, owner.World.FindActorsOnLine(position, wpos, WDist.FromCells(dangerRadius)).ToList()) * MissileUnitMultiplier
-					< owner.Units.Count)
+				// check the targets along the flight path, pick a random safe target to engage.
+				var actors = owner.World.FindActorsOnLine(position, wpos, WDist.FromCells(dangerRadius)).Where(owner.SquadManager.IsPreferredEnemyUnit).ToList();
+				if (CountAntiAirUnits(owner, actors) * MissileUnitMultiplier > owner.Units.Count)
 					continue;
 
-				if (NearToPosSafely(owner, wpos, out var detectedEnemyTarget))
-				{
-					if (detectedEnemyTarget == null)
-						continue;
+				var detectedEnemyTarget = actors.RandomOrDefault(owner.World.LocalRandom);
+				if (detectedEnemyTarget == null)
+					continue;
 
-					checkedIndex = owner.World.LocalRandom.Next(airStrikeCheckIndices.Length);
-					return detectedEnemyTarget;
-				}
+				checkedIndex = owner.World.LocalRandom.Next(airStrikeCheckIndices.Length);
+				return detectedEnemyTarget;
 			}
 
 			return null;

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -434,7 +434,7 @@ namespace OpenRA.Mods.Common.Traits
 					var pos = world.Map.CenterOfCell(new CPos(x, y));
 					var consideredAttractiveness = 0;
 
-					var (attractiveness, targetActor) = powerDecision.GetAttractiveness(pos, player, strategyName, asExtraPos);
+					var (attractiveness, targetActor, frozenTarget) = powerDecision.GetAttractiveness(pos, player, strategyName, asExtraPos);
 
 					consideredAttractiveness += attractiveness;
 
@@ -447,19 +447,33 @@ namespace OpenRA.Mods.Common.Traits
 						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorLocation && !asExtraPos))
 					{
 						if (targetActor == null)
-							continue;
+						{
+							if (frozenTarget == null)
+								continue;
 
-						bestPos = world.Map.CenterOfCell(targetActor.Location);
-						bestActor = targetActor;
+							bestPos = frozenTarget.CenterPosition;
+						}
+						else
+						{
+							bestPos = world.Map.CenterOfCell(targetActor.Location);
+							bestActor = targetActor;
+						}
 					}
 					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && asExtraPos)
 						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && !asExtraPos))
 					{
 						if (targetActor == null)
-							continue;
+						{
+							if (frozenTarget == null)
+								continue;
 
-						bestPos = targetActor.CenterPosition;
-						bestActor = targetActor;
+							bestPos = frozenTarget.CenterPosition;
+						}
+						else
+						{
+							bestPos = targetActor.CenterPosition;
+							bestActor = targetActor;
+						}
 					}
 					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && asExtraPos)
 						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && !asExtraPos))

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.LoadUsing(nameof(LoadDecisions))]
 		public readonly ImmutableArray<SupportPowerDecision> Decisions = [];
 
+		[Desc("The interval of checking support powers when attacked.")]
+		public int RespondToAttackCoolDown = 31;
+
 		static object LoadDecisions(MiniYaml yaml)
 		{
 			var ret = new List<SupportPowerDecision>();
@@ -38,14 +41,16 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new SupportPowerBotModule(init.Self, this); }
 	}
 
-	public class SupportPowerBotModule : ConditionalTrait<SupportPowerBotModuleInfo>, IBotTick, IGameSaveTraitData
+	public class SupportPowerBotModule : ConditionalTrait<SupportPowerBotModuleInfo>, IBotTick, IBotRespondToAttack, IGameSaveTraitData
 	{
 		readonly World world;
 		readonly Player player;
 		readonly Dictionary<SupportPowerInstance, int> waitingPowers = [];
 		readonly Dictionary<string, SupportPowerDecision> powerDecisions = [];
+		readonly Dictionary<string, SupportPowerDecision> powerDecisionsWhenAttacked = [];
 		readonly List<SupportPowerInstance> stalePowers = [];
 		SupportPowerManager supportPowerManager;
+		int attackedcooldown;
 
 		public SupportPowerBotModule(Actor self, SupportPowerBotModuleInfo info)
 			: base(info)
@@ -62,11 +67,30 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self)
 		{
 			foreach (var decision in Info.Decisions)
-				powerDecisions.Add(decision.OrderName, decision);
+			{
+				switch (decision.DecisionMode)
+				{
+					case BotSupportPowerTriggerMode.OnAttacked:
+						powerDecisionsWhenAttacked.Add(decision.OrderName, decision);
+						break;
+
+					case BotSupportPowerTriggerMode.Periodically:
+						powerDecisions.Add(decision.OrderName, decision);
+						break;
+
+					default:
+						break;
+				}
+			}
 		}
 
 		void IBotTick.BotTick(IBot bot)
 		{
+			attackedcooldown--;
+
+			// We only check one support power per tick, as the support power check here is expensive,
+			// which will go through all map cells in coarse and fine scans.
+			var supportPowerNotChecked = true;
 			foreach (var sp in supportPowerManager.Powers.Values)
 			{
 				if (sp.Disabled)
@@ -74,47 +98,138 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Add power to dictionary if not in delay dictionary yet
 				waitingPowers.TryAdd(sp, 0);
-
 				if (waitingPowers[sp] > 0)
 					waitingPowers[sp]--;
 
 				// If we have recently tried and failed to find a use location for a power, then do not try again until later
-				var isDelayed = waitingPowers[sp] > 0;
-				if (sp.Ready && !isDelayed && powerDecisions.TryGetValue(sp.Info.OrderName, out var powerDecision))
+				if (supportPowerNotChecked && sp.Ready && waitingPowers[sp] <= 0 && powerDecisions.TryGetValue(sp.Info.OrderName, out var powerDecision))
 				{
-					if (powerDecision == null)
+					var strategyName = powerDecision.GetRandomStrategy(world.LocalRandom.Next());
+
+					WPos? targetPosition = null;
+					WPos? extraPosition = null;
+					Actor actorNeedsPosition = null;
+					supportPowerNotChecked = false;
+					waitingPowers[sp] += powerDecision.GetNextScanTime(world, Info.Decisions.Length);
+
+					if (powerDecision.CheckTargetLocationFirst)
 					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {sp.Info.OrderName}");
-						continue;
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							var targetLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, false);
+							if (targetLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(targetPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, targetLocation.Value, strategyName, false);
+							if (targetPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
+
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							if (actorNeedsPosition == null && powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+							{
+								AIUtils.BotDebug(
+									$"{player.ResolvedPlayerName} can't find suitable target location actor for extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							var extraLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, true);
+							if (extraLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(extraPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, extraLocation.Value, strategyName, true, actorNeedsPosition);
+							if (extraPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 					}
-
-					var attackLocation = FindCoarseAttackLocationToSupportPower(sp);
-					if (attackLocation == null)
+					else
 					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse attack location for support power {sp.Info.OrderName}. Delaying rescan.");
-						waitingPowers[sp] += powerDecision.GetNextScanTime(world);
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							var extraLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, true);
+							if (extraLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
 
-						continue;
-					}
+							// Found a target location, check for precise target
+							(extraPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, extraLocation.Value, strategyName, true);
+							if (extraPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 
-					// Found a target location, check for precise target
-					attackLocation = FindFineAttackLocationToSupportPower(sp, (CPos)attackLocation);
-					if (attackLocation == null)
-					{
-						AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final attack location for support power {sp.Info.OrderName}. Delaying rescan.");
-						waitingPowers[sp] += powerDecision.GetNextScanTime(world);
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							if (actorNeedsPosition == null && powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+							{
+								AIUtils.BotDebug(
+									$"{player.ResolvedPlayerName} can't find suitable extra location actor for target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
 
-						continue;
+							var targetLocation = FindCoarseAttackLocationToSupportPower(powerDecision, strategyName, false);
+							if (targetLocation == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable coarse target location for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+
+							// Found a target location, check for precise target
+							(targetPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, targetLocation.Value, strategyName, false, actorNeedsPosition);
+							if (targetPosition == null)
+							{
+								AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+								continue;
+							}
+						}
 					}
 
 					// Valid target found, delay by a few ticks to avoid rescanning before power fires via order
-					AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target location {attackLocation} for support power {sp.Info.OrderName}.");
-					waitingPowers[sp] += 10;
+					AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target position {(targetPosition != null ? targetPosition.Value.ToString() : "null")}" +
+						$"and extra location {(extraPosition != null ? extraPosition.Value.ToString() : "null")} for support power {sp.Info.OrderName}.");
+
+					var order = new Order(sp.Key, supportPowerManager.Self, false);
+
+					if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+					{
+						if (targetPosition != null)
+							order = new Order(sp.Key, supportPowerManager.Self, Target.FromPos(targetPosition.Value), false);
+						else
+							continue;
+					}
+
+					order.SuppressVisualFeedback = true;
+					order.ExtraData = powerDecision.ExtraData;
+
+					if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+					{
+						if (extraPosition != null)
+							order.ExtraLocation = world.Map.CellContaining(extraPosition.Value);
+						else
+							continue;
+					}
 
 					// Note: SelectDirectionalTarget uses uint.MaxValue in ExtraData to indicate that the player did not pick a direction.
-					bot.QueueOrder(
-						new Order(sp.Key, supportPowerManager.Self, Target.FromCell(world, attackLocation.Value), false)
-						{ SuppressVisualFeedback = true, ExtraData = uint.MaxValue });
+					bot.QueueOrder(order);
 				}
 			}
 
@@ -126,15 +241,130 @@ namespace OpenRA.Mods.Common.Traits
 			stalePowers.Clear();
 		}
 
-		/// <summary>Scans the map in chunks, evaluating all actors in each.</summary>
-		CPos? FindCoarseAttackLocationToSupportPower(SupportPowerInstance readyPower)
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
-			var powerDecision = powerDecisions[readyPower.Info.OrderName];
-			if (powerDecision == null)
+			// Only consider enmey attack
+			if (attackedcooldown < 0 && self != null && !self.IsDead && self.IsInWorld && e.Attacker.AppearsHostileTo(self))
 			{
-				AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {readyPower.Info.OrderName}");
-				return null;
+				attackedcooldown = Info.RespondToAttackCoolDown;
+				foreach (var sp in supportPowerManager.Powers.Values)
+				{
+					// Note: We only check one support power per tick, as the support power check here may be expensive
+					if (!sp.Disabled && sp.Ready && waitingPowers[sp] <= 0 && powerDecisionsWhenAttacked.TryGetValue(sp.Info.OrderName, out var powerDecision))
+					{
+						// Add power to dictionary if not in delay dictionary yet
+						waitingPowers.TryAdd(sp, 0);
+
+						var strategyName = powerDecision.GetRandomStrategy(world.LocalRandom.Next());
+
+						if (strategyName != null && powerDecision.GetAttractiveness(self, player, strategyName) <= 0)
+							continue;
+
+						waitingPowers[sp] += powerDecision.GetNextScanTime(world, Info.Decisions.Length);
+
+						WPos? targetPosition = null;
+						WPos? extraPosition = null;
+						Actor actorNeedsPosition = null;
+
+						// Found a target location, check for precise target
+						if (powerDecision.CheckTargetLocationFirst)
+						{
+							if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+							{
+								(targetPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, false);
+								if (targetPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+
+							if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+							{
+								if (actorNeedsPosition == null && powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+								{
+									AIUtils.BotDebug(
+										$"{player.ResolvedPlayerName} can't find suitable target location actor for extra location for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+
+								(extraPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, true, actorNeedsPosition);
+								if (extraPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+						}
+						else
+						{
+							if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+							{
+								(extraPosition, actorNeedsPosition) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, true);
+								if (extraPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final extra position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+
+							if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+							{
+								if (actorNeedsPosition == null && powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor)
+								{
+									AIUtils.BotDebug(
+										$"{player.ResolvedPlayerName} can't find suitable extra location actor for target location for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+
+								(targetPosition, _) = FindFineAttackPositionToSupportPower(powerDecision, self.Location, strategyName, false, actorNeedsPosition);
+								if (targetPosition == null)
+								{
+									AIUtils.BotDebug($"{player.ResolvedPlayerName} can't find suitable final target position for support power {sp.Info.OrderName}. Delaying rescan.");
+									break;
+								}
+							}
+						}
+
+						// Valid target found, delay by a few ticks to avoid rescanning before power fires via order
+						AIUtils.BotDebug($"{player.ResolvedPlayerName} found new target position {(targetPosition != null ? targetPosition.Value.ToString() : "null")}" +
+							$"and extra location {(extraPosition != null ? extraPosition.Value.ToString() : "null")} for support power {sp.Info.OrderName}.");
+
+						var order = new Order(sp.Key, supportPowerManager.Self, false);
+
+						if (powerDecision.NeedsConsiderTargetPosition(strategyName))
+						{
+							if (targetPosition != null)
+								order = new Order(sp.Key, supportPowerManager.Self, Target.FromPos(targetPosition.Value), false);
+							else
+								continue;
+						}
+
+						order.SuppressVisualFeedback = true;
+						order.ExtraData = powerDecision.ExtraData;
+
+						if (powerDecision.NeedsConsiderExtraLocation(strategyName))
+						{
+							if (extraPosition != null)
+								order.ExtraLocation = world.Map.CellContaining(extraPosition.Value);
+							else
+								continue;
+						}
+
+						// Note: SelectDirectionalTarget uses uint.MaxValue in ExtraData to indicate that the player did not pick a direction.
+						bot.QueueOrder(order);
+						break;
+					}
+				}
 			}
+		}
+
+		/// <summary>Scans the map in chunks, evaluating all actors in each.</summary>
+		CPos? FindCoarseAttackLocationToSupportPower(SupportPowerDecision powerDecision, string strategyName, bool asExtraPos)
+		{
+			if ((asExtraPos && powerDecision.Considerations[strategyName].ExtraPositionConsiderations.Count == 0)
+				|| (!asExtraPos && powerDecision.Considerations[strategyName].TargetPositionConsiderations.Count == 0))
+				return null;
 
 			var map = world.Map;
 			var checkRadius = powerDecision.CoarseScanRadius;
@@ -155,7 +385,8 @@ namespace OpenRA.Mods.Common.Traits
 					var targets = world.ActorMap.ActorsInBox(wtl, wbr);
 
 					var frozenTargets = player.FrozenActorLayer != null ? player.FrozenActorLayer.FrozenActorsInRegion(region) : [];
-					var consideredAttractiveness = powerDecision.GetAttractiveness(targets, player) + powerDecision.GetAttractiveness(frozenTargets, player);
+					var consideredAttractiveness = powerDecision.GetAttractiveness(targets, player, strategyName, asExtraPos)
+						+ powerDecision.GetAttractiveness(frozenTargets, player, strategyName, asExtraPos);
 					if (consideredAttractiveness < powerDecision.MinimumAttractiveness)
 						continue;
 
@@ -175,17 +406,22 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		/// <summary>Detail scans an area, evaluating positions.</summary>
-		CPos? FindFineAttackLocationToSupportPower(SupportPowerInstance readyPower, CPos checkPos, int extendedRange = 1)
+		(WPos? BestPos, Actor BestActor) FindFineAttackPositionToSupportPower(
+			SupportPowerDecision powerDecision,
+			CPos checkPos,
+			string strategyName,
+			bool asExtraPos,
+			Actor actorNeedsPlace = null,
+			int extendedRange = 1)
 		{
-			CPos? bestLocation = null;
-			var bestAttractiveness = 0;
-			var powerDecision = powerDecisions[readyPower.Info.OrderName];
-			if (powerDecision == null)
-			{
-				AIUtils.BotDebug($"{player.ResolvedPlayerName} couldn't find powerDecision for {readyPower.Info.OrderName}");
-				return null;
-			}
+			if ((asExtraPos && powerDecision.Considerations[strategyName].ExtraPositionConsiderations.Count == 0)
+				|| (!asExtraPos && powerDecision.Considerations[strategyName].TargetPositionConsiderations.Count == 0))
+				return (null, null);
 
+			WPos? bestPos = null;
+			Actor bestActor = null;
+
+			var bestAttractiveness = powerDecision.MinimumAttractiveness;
 			var checkRadius = powerDecision.CoarseScanRadius;
 			var fineCheck = powerDecision.FineScanRadius;
 			for (var i = 0 - extendedRange; i <= checkRadius + extendedRange; i += fineCheck)
@@ -197,17 +433,51 @@ namespace OpenRA.Mods.Common.Traits
 					var y = checkPos.Y + j;
 					var pos = world.Map.CenterOfCell(new CPos(x, y));
 					var consideredAttractiveness = 0;
-					consideredAttractiveness += powerDecision.GetAttractiveness(pos, player);
 
-					if (consideredAttractiveness <= bestAttractiveness || consideredAttractiveness < powerDecision.MinimumAttractiveness)
+					var (attractiveness, targetActor) = powerDecision.GetAttractiveness(pos, player, strategyName, asExtraPos);
+
+					consideredAttractiveness += attractiveness;
+
+					if (consideredAttractiveness < bestAttractiveness)
 						continue;
 
 					bestAttractiveness = consideredAttractiveness;
-					bestLocation = new CPos(x, y);
+
+					if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.ActorLocation && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorLocation && !asExtraPos))
+					{
+						if (targetActor == null)
+							continue;
+
+						bestPos = world.Map.CenterOfCell(targetActor.Location);
+						bestActor = targetActor;
+					}
+					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.ActorCenter && !asExtraPos))
+					{
+						if (targetActor == null)
+							continue;
+
+						bestPos = targetActor.CenterPosition;
+						bestActor = targetActor;
+					}
+					else if ((powerDecision.ExtraLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && asExtraPos)
+						|| (powerDecision.TargetLocationMode == BotSupportPowerTargetLocationMode.CellCanBeEnteredByTargetedActor && !asExtraPos))
+					{
+						var cell = world.Map.FindTilesInAnnulus(new CPos(x, y), 0, fineCheck).Shuffle(world.LocalRandom)
+							.FirstOrDefault(c => actorNeedsPlace?.TraitOrDefault<IPositionable>()?.CanEnterCell(c) ?? false);
+
+						if (cell == CPos.Zero)
+							continue;
+
+						bestPos = world.Map.CenterOfCell(cell);
+					}
+					else
+						bestPos = world.Map.CenterOfCell(new CPos(x, y));
 				}
 			}
 
-			return bestLocation;
+			return (bestPos, bestActor);
 		}
 
 		List<MiniYamlNode> IGameSaveTraitData.IssueTraitData(Actor self)

--- a/OpenRA.Mods.Common/Traits/IssueOrderToBot.cs
+++ b/OpenRA.Mods.Common/Traits/IssueOrderToBot.cs
@@ -1,0 +1,147 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Flags]
+	public enum TargetDistance
+	{
+		Closest = 0,
+		Furthest = 1,
+		Random = 2
+	}
+
+	[Flags]
+	public enum OrderTriggers
+	{
+		None = 0,
+		Attack = 1,
+		Damage = 2,
+		Heal = 4,
+		Periodically = 8,
+		BecomingIdle = 16
+	}
+
+	[Desc("Allow this actor to automatically issue orders to bot player and processed by " + nameof(ExternalBotOrdersManager))]
+	public class IssueOrderToBotInfo : ConditionalTraitInfo
+	{
+		[Desc("Events leading to the actor issue order. Possible values are: None, Attack, Damage, Heal, Periodically, BecomingIdle.")]
+		public readonly OrderTriggers OrderTrigger = OrderTriggers.Attack | OrderTriggers.Damage;
+
+		[FieldLoader.Require]
+		[Desc("Order name to issue.")]
+		public readonly string OrderName = null;
+
+		[Desc("Chance of the order take effect.")]
+		public readonly int OrderChance = 50;
+
+		[Desc("Order's target range. <0 means disable targeting.")]
+		public readonly int TargetRangeInCell = -1;
+
+		[Desc("Should the player be the subject of the order. It is the actor by default.", "Can use this to issue support power order.")]
+		public readonly bool IsIssuerOwner = false;
+
+		[Desc("What player relationships are affected.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Enemy;
+
+		[Desc("What types of targets are affected.")]
+		public readonly BitSet<TargetableType> ValidTargets;
+
+		[Desc("What types of targets are unaffected.", "Overrules ValidTargets.")]
+		public readonly BitSet<TargetableType> InvalidTargets;
+
+		[Desc("Use Target's Location.")]
+		public readonly bool UseTargetLocation = true;
+
+		[Desc("Delay between two successful issued orders.")]
+		public readonly int OrderInterval = 2500;
+
+		[Desc("Should attack the furthest or closest target. Possible values are Closest, Furthest, Random",
+			"Multiple values mean the distance randomizes between them")]
+		public readonly TargetDistance TargetDistance = TargetDistance.Closest;
+
+		public override object Create(ActorInitializer init) { return new IssueOrderToBot(this); }
+	}
+
+	public class IssueOrderToBot : ConditionalTrait<IssueOrderToBotInfo>, INotifyAttack, ITick, INotifyDamage,
+		INotifyCreated, INotifyOwnerChanged, INotifyBecomingIdle
+	{
+		int orderTicks;
+		ExternalBotOrdersManager orderManager;
+
+		public IssueOrderToBot(IssueOrderToBotInfo info)
+			: base(info) { }
+
+		protected override void Created(Actor self)
+		{
+			orderManager = self.Owner.PlayerActor.Trait<ExternalBotOrdersManager>();
+		}
+
+		void TryIssueOrder(Actor self)
+		{
+			if (!orderManager.ManagerRunning || orderTicks > 0 || orderManager.IsTraitDisabled)
+				return;
+
+			orderManager.AddEntryFromIssueOrderToBot(self, Info);
+			orderTicks = Info.OrderInterval;
+		}
+
+		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (Info.OrderTrigger.HasFlag(OrderTriggers.Attack))
+				TryIssueOrder(self);
+		}
+
+		void INotifyAttack.PreparingAttack(Actor self, in Target target, Armament a, Barrel barrel) { }
+
+		void ITick.Tick(Actor self)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (--orderTicks < 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Periodically))
+				TryIssueOrder(self);
+		}
+
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (e.Damage.Value > 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Damage))
+				TryIssueOrder(self);
+
+			if (e.Damage.Value < 0 && Info.OrderTrigger.HasFlag(OrderTriggers.Heal))
+				TryIssueOrder(self);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			orderManager = newOwner.PlayerActor.Trait<ExternalBotOrdersManager>();
+		}
+
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
+		{
+			if (!orderManager.ManagerRunning || IsTraitDisabled || orderManager.IsTraitDisabled)
+				return;
+
+			if (Info.OrderTrigger.HasFlag(OrderTriggers.BecomingIdle))
+				TryIssueOrder(self);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Excess orders remain queued for subsequent ticks.")]
 		public readonly int MinOrderQuotientPerTick = 5;
 
+		[Desc("Those orders will be issued immediately.", "Used for orders that is very sensitive to delays.")]
+		public readonly HashSet<string> HighPriorityOrders = [];
+
 		string IBotInfo.Type => Type;
 
 		string IBotInfo.Name => Name;
@@ -47,6 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly ModularBotInfo info;
 		readonly World world;
 		readonly Queue<Order> orders = [];
+		readonly List<Order> highPriorityOrders = [];
 
 		Player player;
 
@@ -80,7 +84,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBot.QueueOrder(Order order)
 		{
-			orders.Enqueue(order);
+			if (info.HighPriorityOrders.Contains(order.OrderString))
+				highPriorityOrders.Add(order);
+			else
+				orders.Enqueue(order);
 		}
 
 		void ITick.Tick(Actor self)
@@ -97,6 +104,10 @@ namespace OpenRA.Mods.Common.Traits
 							t.BotTick(this);
 				});
 			}
+
+			foreach (var order in highPriorityOrders)
+				world.IssueOrder(order);
+			highPriorityOrders.Clear();
 
 			var ordersToIssueThisTick = Math.Min((orders.Count + info.MinOrderQuotientPerTick - 1) / info.MinOrderQuotientPerTick, orders.Count);
 			for (var i = 0; i < ordersToIssueThisTick; i++)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RenameTypesUnderConsiderations.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RenameTypesUnderConsiderations.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	sealed class RenameTypesUnderConsiderations : UpdateRule
+	{
+		public override string Name => "Rename Types to ValidTargetTypes under Considerations.";
+
+		public override string Description => "Types -> ValidTargetTypes";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var spbm in actorNode.ChildrenMatching("SupportPowerBotModule"))
+			{
+				foreach (var decision in spbm.ChildrenMatching("Decisions"))
+				{
+					foreach (var sp in decision.Value.Nodes)
+					{
+						foreach (var consideration in sp.ChildrenMatching("Consideration"))
+						{
+							consideration.RenameChildrenMatching("Types", "ValidTargetTypes");
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new EditorMarkerTileLabels(),
 				new RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule(),
 				new RemoveAlwaysVisible(),
+				new RenameTypesUnderConsiderations(),
 				new RemoveAndRenameDefenseRadiusInBaseBuilderBotModule(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -20,6 +20,8 @@ Player:
 	GrantConditionOnBotOwner@hal9001:
 		Condition: enable-hal9001-ai
 		Bots: hal9001
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	SupportPowerBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		Decisions:
@@ -283,6 +285,7 @@ Player:
 			e3: 40
 			e4: 15
 			e5: 15
+			rmbo: 1
 			harv: 10
 			bggy: 5
 			bike: 40
@@ -301,6 +304,8 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+		UnitDelays:
+			bike: 2000
 	McvExpansionManagerBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		McvTypes: mcv
@@ -331,6 +336,7 @@ Player:
 			e3: 40
 			e4: 30
 			e5: 30
+			rmbo: 1
 			harv: 10
 			bggy: 10
 			ftnk: 10
@@ -348,6 +354,8 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 2
+		UnitDelays:
+			bike: 2000
 	SquadManagerBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		SquadSize: 15
@@ -367,6 +375,7 @@ Player:
 			e3: 40
 			e4: 50
 			e5: 50
+			rmbo: 1
 			harv: 16
 			bggy: 10
 			bike: 10
@@ -385,3 +394,5 @@ Player:
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+		UnitDelays:
+			bike: 2000

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -96,6 +96,13 @@ Player:
 		HarvesterTypes: harv
 		RefineryTypes: proc
 		EnemyBaseBuildingTypes: fact,pyle,hand,weap,afld,gtwr,gun,atwr,obli,hpad,nuke,nuk2,proc
+	LoadCargoBotModule:
+		RequiresCondition: enable-hal9001-ai || enable-cabal-ai || enable-watson-ai
+		TransportTypesAndLoadRequirement:
+			apc: IdleUnit
+			tran: IdleUnit
+		ValidTransportOwner: AlliedBot
+		PassengerTypes: e1, e2, e3, e4, e5, rmbo
 	BaseBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		BuildingQueues: Building.Nod, Building.GDI
@@ -266,7 +273,7 @@ Player:
 	SquadManagerBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		SquadSize: 50
-		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs, tran
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
@@ -301,11 +308,14 @@ Player:
 			heli: 5
 			orca: 5
 			mlrs: 1
+			tran: 1
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+			tran: 1
 		UnitDelays:
 			bike: 2000
+			tran: 6000
 	McvExpansionManagerBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		McvTypes: mcv
@@ -322,7 +332,7 @@ Player:
 	SquadManagerBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		SquadSize: 15
-		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs, tran
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
@@ -351,15 +361,18 @@ Player:
 			jeep: 20
 			mtnk: 50
 			mlrs: 1
+			tran: 1
 		UnitLimits:
 			harv: 8
 			mlrs: 2
+			tran: 1
 		UnitDelays:
 			bike: 2000
+			tran: 5000
 	SquadManagerBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		SquadSize: 15
-		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs
+		ExcludeFromSquadsTypes: harv, mcv, a10, mlrs, tran
 		ConstructionYardTypes: fact
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
@@ -391,8 +404,23 @@ Player:
 			msam: 50
 			htnk: 50
 			orca: 10
+			tran: 1
 		UnitLimits:
 			harv: 8
 			mlrs: 3
+			tran: 1
 		UnitDelays:
 			bike: 2000
+			tran: 5000
+	SendUnitToAttackBotModule@AirTransport:
+		RequiresCondition: enable-hal9001-ai || enable-cabal-ai || enable-watson-ai
+		ActorTypesAndAttackOptions:
+			tran:
+				AttackDesireOfEach: 80
+				MoveToOrderName: Move
+				AttackOrderName: Unload
+				MoveBackOrderName: Move
+				AttackRequires: CargoLoaded
+		ValidTargets: Structure
+		InvalidTargets: Water, Support
+		TargetDistances: Random

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -2,12 +2,15 @@ Player:
 	ModularBot@Cabal:
 		Name: bot-cabal.name
 		Type: cabal
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Watson:
 		Name: bot-watson.name
 		Type: watson
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@HAL9001:
 		Name: bot-hal9001.name
 		Type: hal9001
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@cabal:
 		Condition: enable-cabal-ai
 		Bots: cabal

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -23,21 +23,22 @@ Player:
 			Airstrike:
 				OrderName: AirstrikePowerInfoOrder
 				MinimumAttractiveness: 2000
+				TargetLocationMode: ActorCenter
 				Consideration@1:
 					Against: Enemy
-					Types: Vehicle, Infantry
+					ValidTargetTypes: Vehicle, Infantry
 					Attractiveness: 3
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@2:
 					Against: Ally
-					Types: Ground, Water
+					ValidTargetTypes: Ground, Water
 					Attractiveness: -20
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@3:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 2c0
@@ -47,19 +48,19 @@ Player:
 				FineScanRadius: 2
 				Consideration@1:
 					Against: Enemy
-					Types: Air, Tank, Vehicle, Infantry, Water
+					ValidTargetTypes: Air, Tank, Vehicle, Infantry, Water
 					Attractiveness: 2
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@2:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 2c0
 				Consideration@3:
 					Against: Ally
-					Types: Ground, Water
+					ValidTargetTypes: Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 3c0
@@ -68,13 +69,13 @@ Player:
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground, Water
+					ValidTargetTypes: Air, Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -282,6 +282,7 @@ Player:
 		MinimumAttackForceDelay: 1000
 		ProtectUnitScanRadius: 30
 		ProtectionScanRadius: 12
+		DangerScanRadius: 18
 	UnitBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		ProductionMinCashRequirement: 750
@@ -337,6 +338,7 @@ Player:
 		AirUnitsTypes: heli, orca
 		ProtectionTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, silo, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, gun, sam, obli, gtwr, atwr, mcv, harv, miss
 		IgnoredEnemyTargetTypes: Air
+		DangerScanRadius: 15
 	UnitBuilderBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
@@ -379,6 +381,7 @@ Player:
 		IgnoredEnemyTargetTypes: Air
 		ProtectUnitScanRadius: 15
 		ProtectionScanRadius: 12
+		DangerScanRadius: 18
 	UnitBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -50,10 +50,26 @@ TRAN:
 		MaxWeight: 10
 		UnloadVoice: Unload
 		AfterUnloadDelay: 40
+		LoadedCondition: loaded
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	Selectable:
 		DecorationBounds: 1749, 1749
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 76
+	IssueOrderToBot@AI2: # find infantry to load
+		RequiresCondition: !loaded
+		OrderTrigger: Periodically
+		OrderName: Move
+		OrderChance: 100
+		OrderInterval: 2000
+		TargetRangeInCell: 200
+		ValidTargets: Infantry
+		ValidRelationships: Ally
+		TargetDistance: Random
 
 HELI:
 	Inherits: ^Helicopter

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -304,6 +304,26 @@ RMBO:
 	AnnounceOnKill:
 	Voiced:
 		VoiceSet: CommandoVoice
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## c4
+		OrderName: C4
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 4
+		ValidTargets: C4
+		InvalidTargets: Water
+		ValidRelationships: Enemy
+		TargetDistance: Closest
 
 PVICE:
 	Inherits: ^Viceroid

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -190,6 +190,7 @@ APC:
 		MaxWeight: 5
 		UnloadVoice: Unload
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeBig
 		EmptyWeapon: UnitExplodeBig
@@ -197,6 +198,11 @@ APC:
 		Actor: APC.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 ARTY:
 	Inherits: ^Tank

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -354,6 +354,15 @@ BGGY:
 		Actor: BGGY.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 BIKE:
 	Inherits: ^Vehicle
@@ -402,6 +411,15 @@ BIKE:
 		Actor: BIKE.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 JEEP:
 	Inherits: ^Vehicle
@@ -453,6 +471,15 @@ JEEP:
 		Actor: JEEP.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 LTNK:
 	Inherits: ^Tank
@@ -816,7 +843,6 @@ STNK:
 		Voice: Attack
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	FireWarheadsOnDeath:
 		Weapon: UnitExplodeStealthTank
 		EmptyWeapon: UnitExplodeStealthTank
@@ -825,6 +851,15 @@ STNK:
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	-MustBeDestroyed:
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 MHQ:
 	Inherits: ^Vehicle

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -28,25 +28,25 @@ Player:
 				MinimumAttractiveness: 2500
 				Consideration@1:
 					Against: Enemy
-					Types: Vehicle, Tank, Infantry
+					ValidTargetTypes: Vehicle, Tank, Infantry
 					Attractiveness: 2
 					TargetMetric: Value
 					CheckRadius: 3c0
 				Consideration@2:
 					Against: Enemy
-					Types: Structure, Defense
+					ValidTargetTypes: Structure, Defense
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@3:
 					Against: Ally
-					Types: Ground
+					ValidTargetTypes: Ground
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 4c0
 				Consideration@4:
 					Against: Enemy
-					Types: Defense
+					ValidTargetTypes: Defense
 					Attractiveness: 6
 					TargetMetric: Value
 					CheckRadius: 4c0
@@ -55,26 +55,26 @@ Player:
 				MinimumAttractiveness: 3500
 				Consideration@1:
 					Against: Enemy
-					Types: Structure, Defense
+					ValidTargetTypes: Structure, Defense
 					Attractiveness: 10
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@3:
 					Against: Enemy
-					Types: Infantry, Vehicle, Tank, Defense
+					ValidTargetTypes: Infantry, Vehicle, Tank, Defense
 					Attractiveness: 5
 					TargetMetric: Value
 					CheckRadius: 4c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground
+					ValidTargetTypes: Air, Ground
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
 			Fremen:
 				OrderName: ProduceActorPower.Fremen
-				Consideration@1:
-					Against: Ally
+				MinimumAttractiveness: -1
+
 	HarvesterBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 		HarvesterTypes: harvester

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -20,6 +20,8 @@ Player:
 	GrantConditionOnBotOwner@gladius:
 		Condition: enable-gladius-ai
 		Bots: gladius
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 	ProvidesPrerequisite@autoConcreteForBots:
 		Prerequisite: global-auto-concrete
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
@@ -76,6 +78,9 @@ Player:
 					CheckRadius: 7c0
 			Fremen:
 				OrderName: ProduceActorPower.Fremen
+				MinimumAttractiveness: -1
+			Saboteur:
+				OrderName: ProduceActorPower.Saboteur
 				MinimumAttractiveness: -1
 
 	HarvesterBotModule:
@@ -269,7 +274,7 @@ Player:
 		RequiresCondition: enable-omnius-ai
 		SquadSize: 8
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter, saboteur, thumper
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep, Air, Cliff
 		ProtectionTypes: mcv, harvester, construction_yard, conyard.atreides, conyard.harkonnen, conyard.ordos, wind_trap, barracks, refinery, silo, light_factory, heavy_factory, outpost, starport, medium_gun_turret, large_gun_turret, repair_pad, high_tech_factory, research_centre, palace, mcv.starport, harvester.starport
@@ -282,6 +287,7 @@ Player:
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
+			thumper: 1
 			harvester: 1
 			trike.starport: 5
 			quad.starport: 7
@@ -305,6 +311,7 @@ Player:
 		UnitLimits:
 			harvester: 15
 			carryall: 8
+			thumper: 1
 	McvManagerBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 		McvTypes: mcv
@@ -314,7 +321,7 @@ Player:
 		RequiresCondition: enable-vidious-ai
 		SquadSize: 6
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter, saboteur, thumper
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep, Air, Cliff
 		ProtectionTypes: mcv, harvester, construction_yard, conyard.atreides, conyard.harkonnen, conyard.ordos, wind_trap, barracks, refinery, silo, light_factory, heavy_factory, outpost, starport, medium_gun_turret, large_gun_turret, repair_pad, high_tech_factory, research_centre, palace, mcv.starport, harvester.starport
@@ -327,6 +334,7 @@ Player:
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
+			thumper: 1
 			harvester: 1
 			trike.starport: 7
 			quad.starport: 12
@@ -350,11 +358,12 @@ Player:
 		UnitLimits:
 			harvester: 15
 			carryall: 8
+			thumper: 1
 	SquadManagerBotModule@gladius:
 		RequiresCondition: enable-gladius-ai
 		SquadSize: 10
 		MaxBaseRadius: 40
-		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter
+		ExcludeFromSquadsTypes: harvester, mcv, carryall, carryall.reinforce, ornithopter, saboteur, thumper
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep, Air, Cliff
 		ProtectionTypes: mcv, harvester, construction_yard, conyard.atreides, conyard.harkonnen, conyard.ordos, wind_trap, barracks, refinery, silo, light_factory, heavy_factory, outpost, starport, medium_gun_turret, large_gun_turret, repair_pad, high_tech_factory, research_centre, palace, mcv.starport, harvester.starport
@@ -367,6 +376,7 @@ Player:
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
+			thumper: 1
 			harvester: 1
 			trike.starport: 5
 			quad.starport: 7
@@ -390,3 +400,27 @@ Player:
 		UnitLimits:
 			harvester: 15
 			carryall: 8
+			thumper: 1
+	SendUnitToAttackBotModule@saboteur:
+		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+		ActorTypesAndAttackOptions:
+			saboteur:
+				AttackDesireOfEach: 100
+				MoveToOrderName: Move
+				AttackOrderName: C4
+				MoveBackOrderName: Move
+				TryGetHealed: False
+		ValidTargets: C4
+		InvalidTargets: Air, Vehicle, CapturedUnit
+		TargetDistances: Random
+	SendUnitToAttackBotModule@trumper:
+		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+		ActorTypesAndAttackOptions:
+			thumper:
+				AttackDesireOfEach: 100
+				MoveToOrderName: Move
+				AttackOrderName: GrantConditionOnDeploy
+				TryGetHealed: False
+		ScanTick: 1200
+		ValidTargets: Harvester
+		TargetDistances: Closest

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -2,12 +2,15 @@ Player:
 	ModularBot@Omnius:
 		Name: bot-omnius.name
 		Type: omnius
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Vidius:
 		Name: bot-vidius.name
 		Type: vidious
+		HighPriorityOrders: PlaceBuilding
 	ModularBot@Gladius:
 		Name: bot-gladius.name
 		Type: gladius
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@omnius:
 		Condition: enable-omnius-ai
 		Bots: omnius

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -368,6 +368,17 @@ saboteur:
 		Sequence: prone-stand
 		RequiresCondition: triggered
 	-AttackFrontal:
+	GrantConditionOnDamageState@AI:
+		ValidDamageStates: Heavy, Critical, Medium
+		Condition: bot-suicide
+	IssueOrderToBot@AI: ### Hack: activate halfway only when there is valid hostile enemy and damaged
+		RequiresCondition: bot-suicide && !triggered
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderInterval: 60
+		TargetRangeInCell: 7
+		ValidTargets: Infantry, Vehicle, Structure
+		ValidRelationships: Enemy
 
 nsfremen:
 	Inherits: fremen

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -124,6 +124,8 @@ harvester:
 		Pieces: 1, 3
 		Range: 1c0, 5c0
 		RequiresCondition: !harvester-empty
+	Targetable@Harvester:
+		TargetTypes: Harvester
 
 trike:
 	Inherits: ^Vehicle

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -150,7 +150,7 @@ Player:
 				Consideration@ally-structure-assualt-target1:
 					StrategyName: structure-assualt-magic
 					Against: Enemy
-					ValidActorTypes: mcv, harv
+					ValidTargetTypes: Structure
 					Attractiveness: 100
 					TargetMetric: Value
 					CheckRadius: 4c0
@@ -269,7 +269,7 @@ Player:
 				Consideration@ally-structure-assualt-target1:
 					StrategyName: structure-assualt-magic
 					Against: Enemy
-					ValidActorTypes: mcv, harv
+					ValidTargetTypes: Structure
 					Attractiveness: 100
 					TargetMetric: Value
 					CheckRadius: 4c0
@@ -319,14 +319,15 @@ Player:
 				VisibilityCheck: false
 				Consideration@1:
 					Against: Enemy
-					Attractiveness: 1
-					TargetMetric: None
+					Attractiveness: 1100
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					TargetMetric: Undetected
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Enemy
+					Attractiveness: 1
 					ValidTargetTypes: Structure
-					Attractiveness: 100
-					TargetMetric: None
+					TargetMetric: Value
 					CheckRadius: 5c0
 			paratroopers:
 				OrderName: SovietParatroopers
@@ -392,7 +393,7 @@ Player:
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Ally
-					ValidTargetTypes: Air, Ground, Water
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -33,51 +33,350 @@ Player:
 	SupportPowerBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		Decisions:
+			ioncurtain:
+				OrderName: ironcurtain
+				DecisionMode: OnAttacked
+				TargetLocationMode: ActorCenter
+				VisibilityCheck: false
+				CoarseScanRadius: 8 ##triggered by OnAttacked
+				MinimumAttractiveness: 100
+				Consideration@1:
+					AgainstOwnActors: true
+					ValidTargetTypes: Structure, Vehicle
+					InvalidActorTypes: dtrk
+					Attractiveness: 150
+					TargetMetric: HealthLoss
+					CheckRadius: 1c512
+				Consideration@2:
+					Against: Ally
+					ValidTargetTypes: Infantry
+					Attractiveness: -20
+					TargetMetric: None
+					CheckRadius: 1c512
+				Consideration@4:
+					Against: Enemy
+					ValidTargetTypes: Structure, Vehicle
+					Attractiveness: -40
+					CheckRadius: 1c512
+			chronoshift:
+				OrderName: Chronoshift
+				CheckTargetLocationFirst: false
+				TargetLocationMode: CellCanBeEnteredByTargetedActor
+				ExtraLocationMode: ActorLocation
+				MinimumAttractiveness: 10000
+				VisibilityCheck: false
+				FineScanRadius: 4
+				## steal enemy harvester\mcv
+				Consideration@enemy-harvester-extraloc1:
+					StrategyName: harvester-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@enemy-harvester-target1:
+					StrategyName: harvester-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## steal enemy vehicles
+				Consideration@enemy-vehicles-extraloc1:
+					StrategyName: vehicles-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidTargetTypes: Vehicle
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@enemy-vehicles-target1:
+					StrategyName: vehicles-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 50
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## teleport vehicles to attack weak spot (harv)
+				Consideration@ally-harv-assualt-extraloc1:
+					StrategyName: harv-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@ally-harv-assualt-target1:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-harv-assualt-target2:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport vehicles to attack weak spot (structure)
+				Consideration@ally-structure-assualt-extraloc1:
+					StrategyName: structure-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk, v2rl, arty, msub,ca
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 1c512
+				Consideration@ally-structure-assualt-target1:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-structure-assualt-target2:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport mcv for expansion
+				Consideration@ally-mcv-expansion-extraloc1:
+					StrategyName: ally-expansion-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: mcv
+					Attractiveness: 14000 ## Teleport will kill conyard HP below 50%
+					TargetMetric: Health
+					CheckRadius: 1c512
+				Consideration@ally-mcv-expansion-target1:
+					StrategyName: ally-expansion-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					InvalidActorTypes: harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target2:
+					StrategyName: ally-expansion-magic
+					Against: Ally
+					ValidActorTypes: mcv, proc, fact
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target3:
+					StrategyName: ally-expansion-magic
+					Against: Ally, Neutral, Enemy
+					ValidActorTypes: mine, gmine
+					Attractiveness: 10001
+					TargetMetric: None
+					CheckRadius: 8c0
+			advancedchronoshift:
+				OrderName: AdvancedChronoshift
+				CheckTargetLocationFirst: false
+				TargetLocationMode: CellCanBeEnteredByTargetedActor
+				ExtraLocationMode: ActorLocation
+				VisibilityCheck: false
+				MinimumAttractiveness: 10000
+				FineScanRadius: 4
+				## steal enemy harvester\mcv
+				Consideration@enemy-harvester-extraloc1:
+					StrategyName: harvester-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@enemy-harvester-target1:
+					StrategyName: harvester-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## steal enemy vehicles
+				Consideration@enemy-vehicles-extraloc1:
+					StrategyName: vehicles-magic
+					AsExtraLocation: true
+					Against: Enemy
+					ValidTargetTypes: Vehicle
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@enemy-vehicles-target1:
+					StrategyName: vehicles-magic
+					Against: Ally
+					ValidActorTypes: e3, e3r1, shok, tsla, gun, 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 50
+					TargetMetric: Value
+					CheckRadius: 4c0
+				## teleport vehicles to attack weak spot (harv)
+				Consideration@ally-harv-assualt-extraloc1:
+					StrategyName: harv-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@ally-harv-assualt-target1:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-harv-assualt-target2:
+					StrategyName: harv-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport vehicles to attack weak spot (structure)
+				Consideration@ally-structure-assualt-extraloc1:
+					StrategyName: structure-assualt-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: 1tnk, 2tnk, 3tnk, 4tnk, ttnk, v2rl, arty, msub,ca
+					Attractiveness: 200
+					TargetMetric: Value
+					CheckRadius: 2c512
+				Consideration@ally-structure-assualt-target1:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidActorTypes: mcv, harv
+					Attractiveness: 100
+					TargetMetric: Value
+					CheckRadius: 4c0
+				Consideration@ally-structure-assualt-target2:
+					StrategyName: structure-assualt-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 8c0
+				## teleport mcv for expansion
+				Consideration@ally-mcv-expansion-extraloc1:
+					StrategyName: ally-expansion-magic
+					AsExtraLocation: true
+					AgainstOwnActors: true
+					ValidActorTypes: mcv
+					Attractiveness: 14000 ## Teleport will kill conyard HP below 50%
+					TargetMetric: Health
+					CheckRadius: 2c512
+				Consideration@ally-mcv-expansion-target1:
+					StrategyName: ally-expansion-magic
+					Against: Enemy
+					ValidTargetTypes: Vehicle, Infantry, Structure, Water
+					InvalidActorTypes: harv, gap
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target2:
+					StrategyName: ally-expansion-magic
+					Against: Ally
+					ValidActorTypes: mcv, proc, fact
+					Attractiveness: -800
+					TargetMetric: Value
+					CheckRadius: 16c0
+				Consideration@ally-mcv-expansion-target3:
+					StrategyName: ally-expansion-magic
+					Against: Ally, Neutral, Enemy
+					ValidActorTypes: mine, gmine
+					Attractiveness: 100001
+					TargetMetric: None
+					CheckRadius: 8c0
 			spyplane:
 				OrderName: SovietSpyPlane
 				MinimumAttractiveness: 1
+				TargetLocationMode: ActorCenter
+				VisibilityCheck: false
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
 					Attractiveness: 1
+					TargetMetric: None
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 100
 					TargetMetric: None
 					CheckRadius: 5c0
 			paratroopers:
 				OrderName: SovietParatroopers
-				MinimumAttractiveness: 5
-				Consideration@1:
+				MinimumAttractiveness: 3
+				VisibilityCheck: false
+				FineScanRadius: 4
+				## paratroopers attack weak spot (structure)
+				Consideration@assualt1:
+					StrategyName: structure-assualt
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
+					InvalidActorTypes: ftur, pbox, hbox, tsla
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 8c0
-				Consideration@2:
+				Consideration@assualt2:
+					StrategyName: structure-assualt
 					Against: Enemy
-					Types: Water
+					ValidTargetTypes: Water, Vehicle, Defense, Infantry
+					InvalidActorTypes: mcv, harv, gap
 					Attractiveness: -5
+					TargetMetric: None
+					CheckRadius: 8c0
+				## paratroopers reinforce the expansion
+				Consideration@reinforce1:
+					StrategyName: reinforce-expansion
+					Against: Ally
+					ValidActorTypes: proc, fact
+					Attractiveness: 2
+					TargetMetric: None
+					CheckRadius: 8c0
+				Consideration@reinforce2:
+					StrategyName: reinforce-expansion
+					Against: Ally
+					ValidTargetTypes: Vehicle, Infantry
+					InvalidActorTypes: mcv, harv
+					Attractiveness: -3
 					TargetMetric: None
 					CheckRadius: 8c0
 			parabombs:
 				OrderName: UkraineParabombs
-				MinimumAttractiveness: 1
+				TargetLocationMode: ActorCenter
+				MinimumAttractiveness: 4000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
 					Attractiveness: 1
-					TargetMetric: None
+					TargetMetric: Value
+					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					ValidTargetTypes: Structure
+					Attractiveness: 2
+					TargetMetric: Value
 					CheckRadius: 5c0
 			nukepower:
 				OrderName: NukePowerInfoOrder
 				MinimumAttractiveness: 3000
 				Consideration@1:
 					Against: Enemy
-					Types: Structure
+					ValidTargetTypes: Structure
 					Attractiveness: 1
 					TargetMetric: Value
 					CheckRadius: 5c0
 				Consideration@2:
 					Against: Ally
-					Types: Air, Ground, Water
+					ValidTargetTypes: Air, Ground, Water
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
@@ -115,6 +414,9 @@ Player:
 			kenn: 1
 			dome: 1
 			weap: 4
+			hpad: 1
+			afld: 1
+			afld.ukraine: 1
 			atek: 1
 			stek: 1
 			fix: 1
@@ -125,6 +427,9 @@ Player:
 			kenn: 1
 			tent: 3
 			weap: 4
+			hpad: 1
+			afld: 1
+			afld.ukraine: 1
 			pbox: 3
 			gun: 3
 			tsla: 3
@@ -137,6 +442,8 @@ Player:
 			fix: 1
 			dome: 10
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 7000
 			fix: 3000
@@ -202,6 +509,8 @@ Player:
 			atek: 1
 			stek: 1
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 6000
 			fix: 3000
@@ -267,6 +576,8 @@ Player:
 			atek: 1
 			stek: 1
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 5000
 			atek: 7000
@@ -322,6 +633,8 @@ Player:
 			agun: 5
 			sam: 5
 			mslo: 1
+			iron: 1
+			pdox: 1
 		BuildingDelays:
 			dome: 3000
 			fix: 20000
@@ -329,7 +642,7 @@ Player:
 			kenn: 4000
 	PowerDownBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
-		PowerDownTypes: dome,tsla,mslo,agun,sam
+		PowerDownTypes: dome,tsla,mslo,agun,sam, gap, iron, pdox
 	BuildingRepairBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 	SquadManagerBotModule@rush:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -38,7 +38,7 @@ Player:
 			hbox: All
 			pbox: All
 		ValidTransportOwner: AlliedBot
-		PassengerTypes: e1, e1r1, e2, e3, e3r1, e4, e7, shok
+		PassengerTypes: e1, e1r1, e2, e3, e3r1, e4, e7, shok, thf
 	ResourceMapBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai
 		ResourceCreatorTypes: mine, gmine
@@ -666,7 +666,7 @@ Player:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england, thf, tran
 		ConstructionYardTypes: fact
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
@@ -712,6 +712,7 @@ Player:
 			shok: 15
 			spy: 2
 			spy.england: 2
+			thf: 1
 			harv: 10
 			apc: 30
 			jeep: 20
@@ -740,7 +741,7 @@ Player:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england, thf, tran
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -764,6 +765,7 @@ Player:
 			harv: 15
 			spy: 2
 			spy.england: 2
+			thf: 1
 			apc: 30
 			jeep: 20
 			arty: 15
@@ -802,7 +804,7 @@ Player:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly, dtrk, qtnk, spy, spy.england
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly, dtrk, qtnk, spy, spy.england, thf, tran
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -827,6 +829,7 @@ Player:
 			shok: 15
 			spy: 2
 			spy.england: 2
+			thf: 1
 			harv: 15
 			apc: 30
 			jeep: 20
@@ -874,7 +877,7 @@ Player:
 	SquadManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		SquadSize: 1
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england, thf, tran
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
@@ -887,6 +890,7 @@ Player:
 		UnitsToBuild:
 			spy: 2
 			spy.england: 2
+			thf: 1
 			harv: 1
 			ftrk: 40
 			arty: 40
@@ -941,5 +945,17 @@ Player:
 				AttackRequires: Disguised
 				AttackOrderName: Infiltrate
 		ValidTargets: SpyInfiltrate
+		InvalidTargets: WaterActor
+		TargetDistances: Random
+
+	SendUnitToAttackBotModule@SendTheif:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		ActorTypesAndAttackOptions:
+			thf:
+				AttackDesireOfEach: 100
+				TryGetHealed: False
+				AttackRequires: Disguised
+				AttackOrderName: Infiltrate
+		ValidTargets: ThiefInfiltrate
 		InvalidTargets: WaterActor
 		TargetDistances: Random

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -425,7 +425,7 @@ Player:
 		ProductionTypes: barr,tent,weap
 		NewProductionCashThreshold: 7000
 		SiloTypes: silo
-		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		BuildingLimits:
 			barr: 7
 			tent: 7
@@ -462,6 +462,18 @@ Player:
 			mslo: 1
 			iron: 1
 			pdox: 1
+			fpwr: 1
+			tenf: 1
+			syrf: 1
+			spef: 1
+			weaf: 1
+			domf: 1
+			fixf: 1
+			fapw: 1
+			atef: 1
+			pdof: 1
+			mslf: 1
+			facf: 1
 		BuildingDelays:
 			dome: 7000
 			fix: 3000
@@ -472,6 +484,18 @@ Player:
 			kenn: 9000
 			atek: 11000
 			stek: 11000
+			fpwr: 6000
+			tenf: 7000
+			syrf: 8000
+			spef: 9000
+			weaf: 9000
+			domf: 10000
+			fixf: 10000
+			fapw: 10000
+			atef: 14000
+			pdof: 14000
+			mslf: 14000
+			facf: 6000
 	BaseBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		MinimumExcessPower: 0
@@ -489,7 +513,7 @@ Player:
 		NewProductionCashThreshold: 8000
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
-		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		BuildingLimits:
 			barr: 7
 			tent: 7
@@ -529,6 +553,18 @@ Player:
 			mslo: 1
 			iron: 1
 			pdox: 1
+			fpwr: 1
+			tenf: 1
+			syrf: 1
+			spef: 1
+			weaf: 1
+			domf: 1
+			fixf: 1
+			fapw: 1
+			atef: 1
+			pdof: 1
+			mslf: 1
+			facf: 1
 		BuildingDelays:
 			dome: 6000
 			fix: 3000
@@ -541,6 +577,18 @@ Player:
 			syrd: 6000
 			atek: 9000
 			stek: 9000
+			fpwr: 6000
+			tenf: 7000
+			syrf: 8000
+			spef: 9000
+			weaf: 9000
+			domf: 10000
+			fixf: 10000
+			fapw: 10000
+			atef: 14000
+			pdof: 14000
+			mslf: 14000
+			facf: 6000
 	BaseBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinimumExcessPower: 20
@@ -555,7 +603,7 @@ Player:
 		ProductionTypes: barr,tent,weap
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
-		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		BuildingLimits:
 			barr: 1
 			tent: 1
@@ -596,11 +644,35 @@ Player:
 			mslo: 1
 			iron: 1
 			pdox: 1
+			fpwr: 1
+			tenf: 1
+			syrf: 1
+			spef: 1
+			weaf: 1
+			domf: 1
+			fixf: 1
+			fapw: 1
+			atef: 1
+			pdof: 1
+			mslf: 1
+			facf: 1
 		BuildingDelays:
 			dome: 5000
 			atek: 7000
 			stek: 7000
 			kenn: 8000
+			fpwr: 6000
+			tenf: 7000
+			syrf: 8000
+			spef: 9000
+			weaf: 9000
+			domf: 10000
+			fixf: 10000
+			fapw: 10000
+			atef: 14000
+			pdof: 14000
+			mslf: 14000
+			facf: 6000
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		MinimumExcessPower: 0
@@ -616,7 +688,7 @@ Player:
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen, syrd
 		SiloTypes: silo
-		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam
+		DefenseTypes: hbox,pbox,gun,ftur,tsla,agun,sam,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		BuildingLimits:
 			proc: 3
 			dome: 1
@@ -671,7 +743,7 @@ Player:
 		ConstructionYardTypes: fact
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
-		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
+		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		IgnoredEnemyTargetTypes: AirborneActor
 		DangerScanRadius: 18
 	McvManagerBotModule@naval:
@@ -752,7 +824,7 @@ Player:
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
-		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
+		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		IgnoredEnemyTargetTypes: AirborneActor
 		ProtectUnitScanRadius: 15
 		ProtectionScanRadius: 12
@@ -819,7 +891,7 @@ Player:
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
-		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
+		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		IgnoredEnemyTargetTypes: AirborneActor
 		RushInterval: 100000
 		MinimumAttackForceDelay: 100000
@@ -894,7 +966,7 @@ Player:
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
-		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
+		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf,fpwr,tenf,syrf,spef,weaf,domf,fixf,fapw,atef,pdof,mslf,facf
 		IgnoredEnemyTargetTypes: AirborneActor
 	UnitBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -37,6 +37,7 @@ Player:
 			stnk: IdleUnit
 			hbox: All
 			pbox: All
+			tran: IdleUnit
 		ValidTransportOwner: AlliedBot
 		PassengerTypes: e1, e1r1, e2, e3, e3r1, e4, e7, shok, thf
 	ResourceMapBotModule:
@@ -729,6 +730,7 @@ Player:
 			mrj: 1
 			dtrk: 1
 			qtnk: 1
+			tran: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
@@ -737,6 +739,9 @@ Player:
 			mrj: 1
 			dtrk: 1
 			qtnk: 1
+			tran: 1
+		UnitDelays:
+			tran: 9000
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
@@ -790,16 +795,19 @@ Player:
 			mrj: 1
 			dtrk: 1
 			qtnk: 1
+			tran: 1
 		UnitLimits:
 			dog: 4
 			medi: 3
 			mech: 3
 			harv: 8
 			jeep: 4
-			ftrk: 4
-			mrj: 1
 			dtrk: 1
 			qtnk: 1
+			mrj: 1
+			tran: 1
+		UnitDelays:
+			tran: 8000
 	SquadManagerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
@@ -907,6 +915,7 @@ Player:
 			pt: 10
 			ctnk: 3
 			mrj: 1
+			tran: 1
 		UnitLimits:
 			harv: 4
 			ftrk: 3
@@ -914,6 +923,7 @@ Player:
 			v2rl: 1
 			jeep: 1
 			mrj: 1
+			tran: 1
 		UnitDelays:
 			harv: 10000
 	SendUnitToAttackBotModule@Mad:
@@ -944,6 +954,12 @@ Player:
 				TryGetHealed: False
 				AttackRequires: Disguised
 				AttackOrderName: Infiltrate
+			tran:
+				AttackDesireOfEach: 80
+				MoveToOrderName: Move
+				AttackOrderName: Unload
+				MoveBackOrderName: Move
+				AttackRequires: CargoLoaded
 		ValidTargets: SpyInfiltrate
 		InvalidTargets: WaterActor
 		TargetDistances: Random

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -705,6 +705,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 1
+			mech: 1
 			dog: 15
 			shok: 15
 			spy: 2
@@ -722,6 +724,7 @@ Player:
 			ttnk: 25
 			stnk: 5
 			ctnk: 3
+			mrj: 1
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
@@ -729,6 +732,7 @@ Player:
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			mrj: 1
 			dtrk: 1
 			qtnk: 1
 	SquadManagerBotModule@normal:
@@ -752,6 +756,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 2
+			mech: 2
 			dog: 15
 			shok: 15
 			harv: 15
@@ -778,13 +784,17 @@ Player:
 			ca: 10
 			pt: 10
 			ctnk: 3
+			mrj: 1
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
 			dog: 4
+			medi: 3
+			mech: 3
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			mrj: 1
 			dtrk: 1
 			qtnk: 1
 	SquadManagerBotModule@turtle:
@@ -810,6 +820,8 @@ Player:
 			e3: 30
 			e4: 15
 			e7: 1
+			medi: 3
+			mech: 3
 			dog: 15
 			shok: 15
 			spy: 2
@@ -837,14 +849,18 @@ Player:
 			pt: 10
 			mnly: 2
 			ctnk: 3
+			mrj: 1
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
 			dog: 3
+			medi: 3
+			mech: 3
 			harv: 8
 			jeep: 2
 			ftrk: 4
 			mnly: 2
+			mrj: 2
 			dtrk: 1
 			qtnk: 1
 	MinelayerBotModule@turtle:
@@ -885,12 +901,14 @@ Player:
 			ca: 20
 			pt: 10
 			ctnk: 3
+			mrj: 1
 		UnitLimits:
 			harv: 4
 			ftrk: 3
 			arty: 1
 			v2rl: 1
 			jeep: 1
+			mrj: 1
 		UnitDelays:
 			harv: 10000
 	SendUnitToAttackBotModule@Mad:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -2,15 +2,19 @@ Player:
 	ModularBot@RushAI:
 		Name: bot-rush-ai.name
 		Type: rush
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@NormalAI:
 		Name: bot-normal-ai.name
 		Type: normal
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@TurtleAI:
 		Name: bot-turtle-ai.name
 		Type: turtle
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	ModularBot@NavalAI:
 		Name: bot-naval-ai.name
 		Type: naval
+		HighPriorityOrders: AdvancedChronoshift, Chronoshift, ironcurtain, PlaceBuilding
 	GrantConditionOnBotOwner@rush:
 		Condition: enable-rush-ai
 		Bots: rush

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -721,6 +721,7 @@ Player:
 			4tnk: 25
 			ttnk: 25
 			stnk: 5
+			ctnk: 3
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
@@ -776,6 +777,7 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
+			ctnk: 3
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
@@ -834,6 +836,7 @@ Player:
 			ca: 10
 			pt: 10
 			mnly: 2
+			ctnk: 3
 			dtrk: 1
 			qtnk: 1
 		UnitLimits:
@@ -881,6 +884,7 @@ Player:
 			dd: 30
 			ca: 20
 			pt: 10
+			ctnk: 3
 		UnitLimits:
 			harv: 4
 			ftrk: 3

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -27,6 +27,18 @@ Player:
 	GrantConditionOnBotOwner@naval:
 		Condition: enable-naval-ai
 		Bots: naval
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	LoadCargoBotModule:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		TransportTypesAndLoadRequirement:
+			jeep: IdleUnit
+			apc: IdleUnit
+			stnk: IdleUnit
+			hbox: All
+			pbox: All
+		ValidTransportOwner: AlliedBot
+		PassengerTypes: e1, e1r1, e2, e3, e3r1, e4, e7, shok
 	ResourceMapBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai
 		ResourceCreatorTypes: mine, gmine

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -673,6 +673,7 @@ Player:
 		AircraftTargetType: AirborneActor
 		ProtectionTypes: harv, mcv, mslo, gap, spen, syrd, iron, pdox, tsla, agun, dome, pbox, hbox, gun, ftur, sam, atek, weap, fact, proc, silo, hpad, afld, afld.ukraine, powr, apwr, stek, barr, kenn, tent, fix, fpwr, tenf, syrf, spef, weaf, domf, fixf, fapw, atef, pdof, mslf, facf
 		IgnoredEnemyTargetTypes: AirborneActor
+		DangerScanRadius: 18
 	McvManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		McvTypes: mcv
@@ -755,6 +756,7 @@ Player:
 		IgnoredEnemyTargetTypes: AirborneActor
 		ProtectUnitScanRadius: 15
 		ProtectionScanRadius: 12
+		DangerScanRadius: 18
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		UnitsToBuild:
@@ -823,6 +825,7 @@ Player:
 		MinimumAttackForceDelay: 100000
 		ProtectUnitScanRadius: 30
 		ProtectionScanRadius: 15
+		DangerScanRadius: 18
 	UnitBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		UnitsToBuild:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -653,7 +653,7 @@ Player:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		AirUnitsTypes: mig, yak, heli, hind, mh60
 		AircraftTargetType: AirborneActor
@@ -695,6 +695,8 @@ Player:
 			e7: 1
 			dog: 15
 			shok: 15
+			spy: 2
+			spy.england: 2
 			harv: 10
 			apc: 30
 			jeep: 20
@@ -707,16 +709,20 @@ Player:
 			4tnk: 25
 			ttnk: 25
 			stnk: 5
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			dtrk: 1
+			qtnk: 1
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -736,6 +742,8 @@ Player:
 			dog: 15
 			shok: 15
 			harv: 15
+			spy: 2
+			spy.england: 2
 			apc: 30
 			jeep: 20
 			arty: 15
@@ -756,16 +764,20 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 4
 			harv: 8
 			jeep: 4
 			ftrk: 4
+			dtrk: 1
+			qtnk: 1
 	SquadManagerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, mnly, dtrk, qtnk, spy, spy.england
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
 		AirUnitsTypes: mig, yak, heli, hind, mh60
@@ -786,6 +798,8 @@ Player:
 			e7: 1
 			dog: 15
 			shok: 15
+			spy: 2
+			spy.england: 2
 			harv: 15
 			apc: 30
 			jeep: 20
@@ -808,12 +822,16 @@ Player:
 			ca: 10
 			pt: 10
 			mnly: 2
+			dtrk: 1
+			qtnk: 1
 		UnitLimits:
 			dog: 3
 			harv: 8
 			jeep: 2
 			ftrk: 4
 			mnly: 2
+			dtrk: 1
+			qtnk: 1
 	MinelayerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinelayingActorTypes: mnly
@@ -824,7 +842,7 @@ Player:
 	SquadManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		SquadSize: 1
-		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2
+		ExcludeFromSquadsTypes: harv, mcv, dog, badr.bomber, u2, dtrk, qtnk, spy, spy.england
 		NavalUnitsTypes: ss, msub, dd, ca, lst, pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen, syrd
@@ -835,6 +853,8 @@ Player:
 	UnitBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		UnitsToBuild:
+			spy: 2
+			spy.england: 2
 			harv: 1
 			ftrk: 40
 			arty: 40
@@ -857,3 +877,34 @@ Player:
 			jeep: 1
 		UnitDelays:
 			harv: 10000
+	SendUnitToAttackBotModule@Mad:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		ActorTypesAndAttackOptions:
+			dtrk:
+				AttackDesireOfEach: 100
+				MoveToOrderName: AssaultMove
+				MoveBackOrderName: AssaultMove
+			qtnk:
+				AttackDesireOfEach: 100
+				AttackOrderName: DetonateAttack
+				MoveBackOrderName: Detonate
+		ValidTargets: Structure
+		InvalidTargets: WaterActor
+	SendUnitToAttackBotModule@SendSpy:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		ActorTypesAndAttackOptions:
+			spy:
+				AttackDesireOfEach: 100
+				TryDisguise: True
+				TryGetHealed: False
+				AttackRequires: Disguised
+				AttackOrderName: Infiltrate
+			spy.england:
+				AttackDesireOfEach: 100
+				TryDisguise: True
+				TryGetHealed: False
+				AttackRequires: Disguised
+				AttackOrderName: Infiltrate
+		ValidTargets: SpyInfiltrate
+		InvalidTargets: WaterActor
+		TargetDistances: Random

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -265,10 +265,26 @@ TRAN:
 		Types: Infantry
 		MaxWeight: 8
 		AfterUnloadDelay: 40
+		LoadedCondition: loaded
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	Selectable:
 		DecorationBounds: 1706, 1536
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 76
+	IssueOrderToBot@AI2: # find infantry to load
+		RequiresCondition: !loaded
+		OrderTrigger: Periodically
+		OrderName: Move
+		OrderChance: 100
+		OrderInterval: 2000
+		TargetRangeInCell: 200
+		ValidTargets: Infantry
+		ValidRelationships: Ally
+		TargetDistance: Random
 
 HELI:
 	Inherits: ^Helicopter

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -880,6 +880,11 @@
 	-MustBeDestroyed:
 	MapEditorData:
 		Categories: Fake
+	IssueOrderToBot@AI: ## sell to put at frontline
+		OrderName: Sell
+		OrderTrigger: Periodically
+		OrderChance: 60
+		OrderInterval: 7000
 
 ^InfiltratableFake:
 	Targetable:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -67,6 +67,16 @@ DOG:
 	Voiced:
 		VoiceSet: DogVoice
 	-TakeCover:
+	IssueOrderToBot@AI: ## patrol
+		OrderName: AttackMove
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 2500
+		TargetRangeInCell: 50
+		ValidTargets: SpyInfiltrate
+		InvalidTargets: WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Random
 
 E1:
 	Inherits: ^Soldier

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -731,6 +731,17 @@ THF:
 		Voice: Move
 		Speed: 72
 	-AttackFrontal:
+	IssueOrderToBot@AI: ## capture vehicle
+		OrderName: CaptureActor
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 7
+		ValidTargets: Vehicle
+		InvalidTargets: Air, Water
+		ValidRelationships: Enemy, Neutral
+		TargetDistance: Closest
 
 SHOK:
 	Inherits: ^Soldier

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -456,6 +456,26 @@ E7:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: barracks.upgraded
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## c4
+		OrderName: C4
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 4
+		ValidTargets: C4
+		InvalidTargets: WaterActor
+		ValidRelationships: Enemy
+		TargetDistance: Closest
 
 MEDI:
 	Inherits: ^Soldier
@@ -499,6 +519,15 @@ MEDI:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Infantry
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 MECH:
 	Inherits: ^Soldier
@@ -555,6 +584,26 @@ MECH:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Vehicle, Ship
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
+	IssueOrderToBot@AI2: ## capture husk
+		OrderName: CaptureActor
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 7
+		ValidTargets: Husk
+		InvalidTargets: AirActor, WaterActor
+		ValidRelationships: Ally, Enemy, Neutral
+		TargetDistance: Closest
 
 EINSTEIN:
 	Inherits: ^CivInfantry

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -431,6 +431,7 @@ IRON:
 		HasMinibib: true
 	GrantExternalConditionPower@IRONCURTAIN:
 		PauseOnCondition: disabled
+		OrderName: ironcurtain
 		Icon: invuln
 		ChargeInterval: 3000
 		Name: actor-iron.grantexternalconditionpower-ironcurtain-name

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -750,6 +750,7 @@ PBOX:
 		Types: Infantry
 		MaxWeight: 1
 		InitialUnits: e1
+		LoadedCondition: loaded
 		PassengerConditions:
 			e3: RocketSoldier
 	WithRangeCircle@ROCKETSOLDIER:
@@ -769,6 +770,15 @@ PBOX:
 		Amount: -20
 	DetectCloaked:
 		Range: 6c0
+	GrantConditionOnDamageState@CriticalDamaged:
+		Condition: CriticalDamaged
+		ValidDamageStates: Critical
+	IssueOrderToBot:
+		RequiresCondition: loaded && CriticalDamaged
+		OrderName: Unload
+		OrderChance: 100
+		OrderTrigger: Periodically
+		OrderInterval: 20
 
 HBOX:
 	Inherits: ^Defense
@@ -817,6 +827,7 @@ HBOX:
 		Types: Infantry
 		MaxWeight: 1
 		InitialUnits: e1
+		LoadedCondition: loaded
 	-SpawnActorsOnSell:
 	DetectCloaked:
 		Range: 6c0
@@ -830,6 +841,12 @@ HBOX:
 		PortCones: 88, 88, 88, 88, 88, 88
 	Power:
 		Amount: -20
+	IssueOrderToBot:
+		RequiresCondition: loaded && cloak-force-disabled
+		OrderName: Unload
+		OrderChance: 100
+		OrderTrigger: Periodically
+		OrderInterval: 20
 	-MustBeDestroyed:
 
 GUN:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -918,6 +918,19 @@ QTNK:
 		TargetTypes: GroundActor, MADTank, Vehicle
 	Selectable:
 		DecorationBounds: 1877, 1621, 0, -170
+	GrantConditionOnDamageState@AI:
+		ValidDamageStates: Heavy, Critical, Medium
+		Condition: bot-suicide
+	IssueOrderToBot@AI: ## Hack: activate halfway only when there is valid hostile enemy and damaged
+		RequiresCondition: !deployed && !being-captured && bot-suicide
+		OrderTrigger: Damage
+		OrderName: Detonate
+		OrderChance: 100
+		OrderInterval: 150
+		TargetRangeInCell: 6
+		ValidTargets: Vehicle, Structure
+		ValidRelationships: Enemy
+
 
 STNK:
 	Inherits: ^Vehicle

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -842,6 +842,15 @@ CTNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		OrderName: PortableChronoTeleport
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 265
+		TargetRangeInCell: 12
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally, Neutral
+		TargetDistance: Furthest
 
 QTNK:
 	Inherits: ^TrackedVehicle

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -663,6 +663,15 @@ MRJ:
 		Range: 5c0
 		DeflectionRelationships: Neutral, Enemy
 	RenderJammerCircle:
+	IssueOrderToBot@AI: ## retreat To safety
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 7
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 TTNK:
 	Inherits: ^TrackedVehicle
@@ -706,6 +715,15 @@ TTNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 7
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 FTRK:
 	Inherits: ^Vehicle
@@ -758,6 +776,15 @@ FTRK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 DTRK:
 	Inherits: ^Vehicle
@@ -924,7 +951,6 @@ STNK:
 		Range: 4c0
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	Armament:
 		Weapon: APTusk.stnk
 		LocalOffset: 192,0,176
@@ -955,6 +981,16 @@ STNK:
 		Prerequisites: vehicles.upgraded
 	IssueOrderToBot@AI:
 		RequiresCondition: loaded
+		OrderTrigger: Attack
 		OrderName: Unload
 		OrderChance: 100
 		OrderInterval: 45
+	IssueOrderToBot@AI2: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: GroundActor, AirActor, WaterActor
+		ValidRelationships: Ally
+		TargetDistance: Furthest

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -451,11 +451,17 @@ JEEP:
 		Types: Infantry
 		MaxWeight: 1
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 APC:
 	Inherits: ^TrackedVehicle
@@ -497,11 +503,17 @@ APC:
 		Types: Infantry
 		MaxWeight: 5
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 MNLY:
 	Inherits: ^TrackedVehicle
@@ -915,6 +927,7 @@ STNK:
 		Types: Infantry
 		MaxWeight: 5
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 175
@@ -931,3 +944,8 @@ STNK:
 	WithProductionIconOverlay:
 		Types: Veterancy
 		Prerequisites: vehicles.upgraded
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -14,7 +14,7 @@ Player:
 		RefineryTypes: proc
 	PowerDownBotModule:
 		RequiresCondition: enable-test-ai
-		PowerDownTypes: garadr, naradr, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		PowerDownTypes: garadr, naradr, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam,napuls
 	ResourceMapBotModule:
 		RequiresCondition: enable-test-ai
 		ResourceCreatorTypes: tibtre01, tibtre02, tibtre03, bigblue, bigblue3
@@ -29,12 +29,14 @@ Player:
 		ExcessPowerIncrement: 30
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: gacnst
+		BuildingQueues: Building
+		DefenseQueues: Support
 		RefineryTypes: proc
 		PowerTypes: gapowr, gapowrup, napowr, naapwr
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
 		TechTypes: garadr, naradr, gahpad, nahpad, gatech, natech
 		SiloTypes: gasilo
-		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam,napuls
 		SellRefineryNoResourceDistance: 18
 		BuildingLimits:
 			proc: 4
@@ -59,6 +61,7 @@ Player:
 			naobel: 2
 			nalasr: 8
 			nasam: 4
+			napuls: 1
 		BuildingFractions:
 			proc: 30
 			gapile: 1
@@ -79,6 +82,7 @@ Player:
 			gactwr: 18
 			nasam: 6
 			naobel: 3
+			napuls: 1
 	BuildingRepairBotModule:
 		RequiresCondition: enable-test-ai
 	SquadManagerBotModule@test:

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -2,6 +2,7 @@ Player:
 	ModularBot@bot-test-ai:
 		Name: bot-test-ai.name
 		Type: test
+		HighPriorityOrders: PlaceBuilding
 	GrantConditionOnBotOwner@test:
 		Condition: enable-test-ai
 		Bots: test

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -82,7 +82,7 @@ Player:
 	SquadManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter
+		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, subtank
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
@@ -122,3 +122,13 @@ Player:
 		ConstructionYardTypes: gacnst
 		McvFactoryTypes: gaweap, naweap
 		MinimumConstructionYardCount: 2
+	SendUnitToAttackBotModule@test:
+		RequiresCondition: enable-test-ai
+		ActorTypesAndAttackOptions:
+			subtank:
+				AttackDesireOfEach: 10
+				MoveToOrderName: Move
+				MoveBackOrderName: Move
+		ValidTargets: Building
+		InvalidTargets: Defense
+		TargetDistances: Furthest, Random

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -21,7 +21,7 @@ Player:
 		ValuableResourceTypes: Tiberium, BlueTiberium
 		HarvesterTypes: harv
 		RefineryTypes: proc
-		EnemyBaseBuildingTypes: gacnst, gapowr, gapowrup, napowr, naapwr, gapile, nahand, gaweap, naweap,garadr, naradr, gahpad, nahpad, gatech, natech, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam
+		EnemyBaseBuildingTypes: gacnst, gapowr, gapowrup, napowr, naapwr, gapile, nahand, gaweap, naweap,garadr, naradr, gahpad, nahpad, gatech, natech, gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam, napuls
 	BaseBuilderBotModule@test:
 		RequiresCondition: enable-test-ai
 		MinimumExcessPower: 30
@@ -39,14 +39,10 @@ Player:
 		DefenseTypes: gavulc,garock,gacsam,gactwr,naobel,nalasr,nasam,napuls
 		SellRefineryNoResourceDistance: 18
 		BuildingLimits:
-			proc: 4
-			gasilo: 2
-			gapowr: 8
-			napowr: 8
-			gapile: 1
-			nahand: 1
-			gaweap: 1
-			naweap: 1
+			gapile: 7
+			nahand: 7
+			gaweap: 4
+			naweap: 4
 			garadr: 1
 			naradr: 1
 			gatech: 1
@@ -54,41 +50,39 @@ Player:
 			nastlh: 1
 			gahpad: 3
 			nahpad: 3
-			gavulc: 8
-			garock: 2
-			gacsam: 4
-			gactwr: 14
-			naobel: 2
-			nalasr: 8
-			nasam: 4
+			natmpl: 1
 			napuls: 1
 		BuildingFractions:
-			proc: 30
-			gapile: 1
-			nahand: 1
-			gaweap: 1
-			naweap: 1
+			proc: 25
+			gapile: 4
+			nahand: 4
+			gaweap: 4
+			naweap: 4
 			garadr: 1
 			naradr: 1
 			gatech: 1
 			natech: 1
+			natmpl: 1
 			nastlh: 1
 			gahpad: 1
 			nahpad: 1
-			nalasr: 10
-			gavulc: 10
+			nalasr: 8
+			gavulc: 7
 			garock: 3
 			gacsam: 6
-			gactwr: 18
+			gactwr: 14
 			nasam: 6
-			naobel: 3
+			naobel: 5
 			napuls: 1
+		BuildingDelays:
+			garadr: 8000
+			naradr: 8000
 	BuildingRepairBotModule:
 		RequiresCondition: enable-test-ai
 	SquadManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, lpst, subtank
+		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, lpst, subtank, sapc, mhijack
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
@@ -102,21 +96,29 @@ Player:
 			e3: 25
 			cyborg: 15
 			jumpjet: 15
+			cyc2: 1
+			ghost: 1
+			mhijack: 1
+			apc: 1
 			repair: 2
 			medic: 2
 			harv: 10
 			mmch: 15
 			ttnk: 15
 			smech: 25
-			bggy: 25
+			bggy: 10
 			hvr: 20
-			bike: 20
-			subtank: 10
+			bike: 10
+			subtank: 1
 			sonic: 10
 			stnk: 8
-			art2: 5
-			jugg: 5
-			lpst: 5
+			sapc: 1
+			art2: 50
+			jugg: 6
+			lpst: 1
+			hmec: 1
+			mobilemp: 1
+			sgen: 1
 			orca: 5
 			orcab: 4
 			apache: 5
@@ -126,19 +128,44 @@ Player:
 			medic: 3
 			repair: 3
 			lpst: 1
+			mobilemp: 1
+			apc: 1
+			sapc: 1
+			sgen: 1
 	McvExpansionManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		McvTypes: mcv
 		ConstructionYardTypes: gacnst
 		McvFactoryTypes: gaweap, naweap
 		MinimumConstructionYardCount: 2
-	SendUnitToAttackBotModule@test:
+	SendUnitToAttackBotModule@backline:
 		RequiresCondition: enable-test-ai
 		ActorTypesAndAttackOptions:
 			subtank:
-				AttackDesireOfEach: 10
+				AttackDesireOfEach: 100
+				MoveBackOrderName: AssualtMove
+			sapc:
+				AttackDesireOfEach: 100
 				MoveToOrderName: Move
+				AttackOrderName: Unload
 				MoveBackOrderName: Move
-		ValidTargets: Building
-		InvalidTargets: Defense
+				AttackRequires: CargoLoaded
+		ValidTargets: Infantry, Building
+		InvalidTargets: Support, Water, Air
 		TargetDistances: Furthest, Random
+	SendUnitToAttackBotModule@hijack:
+		RequiresCondition: enable-test-ai
+		ActorTypesAndAttackOptions:
+			mhijack:
+				AttackDesireOfEach: 100
+				AttackOrderName: CaptureActor
+		ValidTargets: Vehicle
+		InvalidTargets: Water, Air
+		TargetDistances: Closest
+	LoadCargoBotModule:
+		RequiresCondition: enable-test-ai
+		TransportTypesAndLoadRequirement:
+			apc: IdleUnit
+			sapc: IdleUnit
+		PassengerTypes: e1, jumpjet, e2, e3, cyborg, cyc2, ghost, mhijack
+		ValidTransportOwner: AlliedBot

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -6,6 +6,8 @@ Player:
 	GrantConditionOnBotOwner@test:
 		Condition: enable-test-ai
 		Bots: test
+	ExternalBotOrdersManager:
+		RequiresCondition: enable-test-ai
 	HarvesterBotModule:
 		RequiresCondition: enable-test-ai
 		HarvesterTypes: harv

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -87,6 +87,7 @@ Player:
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
 		IgnoredEnemyTargetTypes: Air
+		DangerScanRadius: 18
 	UnitBuilderBotModule@test:
 		RequiresCondition: enable-test-ai
 		UnitQueues: Vehicle, Infantry, Air

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -84,7 +84,7 @@ Player:
 	SquadManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, subtank
+		ExcludeFromSquadsTypes: harv, mcv, dpod, hunter, lpst, subtank
 		ConstructionYardTypes: gacnst
 		AirUnitsTypes: orca, orcab, scrin, apache, jumpjet
 		ProtectionTypes: gapowr, gapile, gaweap, gahpad, gadept, garadr, gatech, gaplug, gagate_a, gagate_b, gactwr, napowr, naapwr, nahand, naweap, nahpad, naradr, natech, nastlh, natmpl, namisl, nawast, nagate_a, nagate_b, nalasr, naobel, nasam, weed, gacnst, proc, gasilo, napuls, mcv, harv
@@ -110,6 +110,9 @@ Player:
 			subtank: 10
 			sonic: 10
 			stnk: 8
+			art2: 5
+			jugg: 5
+			lpst: 5
 			orca: 5
 			orcab: 4
 			apache: 5
@@ -118,6 +121,7 @@ Player:
 			harv: 12
 			medic: 3
 			repair: 3
+			lpst: 1
 	McvExpansionManagerBotModule@test:
 		RequiresCondition: enable-test-ai
 		McvTypes: mcv

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -85,6 +85,11 @@
 		BlinkPatterns:
 			hospitalheal: On, Off
 
+^BotOwner:
+	GrantConditionOnBotOwner@BotOwner:
+		Condition: bot-owner
+		Bots: test
+
 ^CrateStatModifiers:
 	FirepowerMultiplier@CRATES:
 		RequiresCondition: crate-firepower

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -86,6 +86,15 @@ MEDIC:
 		Delay: 60
 	Passenger:
 		CustomPipType: red
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 JUMPJET:
 	Inherits: ^Soldier
@@ -264,3 +273,14 @@ GHOST:
 		DefaultAttackSequence: attack
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
+	IssueOrderToBot@AI2: ## c4
+		OrderName: C4
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 4
+		ValidTargets: C4
+		InvalidTargets: WaterActor
+		ValidRelationships: Enemy
+		TargetDistance: Closest

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -31,6 +31,7 @@ APC:
 		MaxWeight: 5
 		UnloadVoice: Unload
 		LoadingCondition: loading
+		LoadedCondition: loaded
 		EjectOnDeath: true
 	GrantConditionOnTerrain:
 		Condition: inwater
@@ -47,6 +48,11 @@ APC:
 		TerrainTypes: Water
 		StationaryInterval: 18
 		MovingInterval: 6
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 HVR:
 	Inherits: ^Vehicle
@@ -104,6 +110,15 @@ HVR:
 		MovingInterval: 6
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 SMECH:
 	Inherits: ^Vehicle
@@ -460,8 +475,27 @@ MOBILEMP:
 	GrantChargedConditionOnToggle:
 		Voice: Move
 		ChargeDuration: 750
+		ChargedCondition: charged
 		ActivatedCondition: triggered
 		PauseOnCondition: empdisable
 	FireWarheads:
 		Weapons: MEMPulse
 		RequiresCondition: triggered && !empdisable
+	IssueOrderToBot@AI:
+		RequiresCondition: charged
+		OrderName: ActivateCondition
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		TargetRangeInCell: 3
+		ValidTargets: Vehicle, Support
+		ValidRelationships: Enemy
+	IssueOrderToBot@AI-getcloser:
+		RequiresCondition: charged
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 100
+		TargetRangeInCell: 10
+		ValidTargets: Vehicle, Support
+		ValidRelationships: Enemy

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -318,6 +318,7 @@ JUGG:
 	Inherits@SPRITES: ^SpriteActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -342,7 +343,7 @@ JUGG:
 		TurnSpeed: 20
 		AlwaysTurnInPlace: true
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 		TerrainOrientationAdjustmentMargin: -1
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
@@ -421,6 +422,15 @@ JUGG:
 		ArmamentNames: deployed
 	Selectable:
 		DecorationBounds: 1448, 2413, 0, -482
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 45
+		TargetRangeInCell: 17
+		ValidTargets: Ground, Water
+		ValidRelationships: Enemy
 
 MOBILEMP:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -141,3 +141,14 @@ MHIJACK:
 		PlayerExperience: 10
 	RevealsShroud:
 		Range: 6c0
+	IssueOrderToBot@AI: ## capture vehicle
+		OrderName: CaptureActor
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 100
+		UseTargetLocation: False
+		TargetRangeInCell: 7
+		ValidTargets: Vehicle
+		InvalidTargets: Air, Water
+		ValidRelationships: Enemy, Neutral
+		TargetDistance: Closest

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -86,6 +86,7 @@ TTNK:
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -105,7 +106,7 @@ TTNK:
 		TurnSpeed: 20
 		Speed: 85
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	Health:
 		HP: 35000
 	Armor:
@@ -203,6 +204,12 @@ TTNK:
 		ArmamentNames: primary, deployed
 	RenderVoxels:
 		Scale: 11.5
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderTrigger: Attack
+		OrderInterval: 35
 
 ART2:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -216,6 +216,7 @@ ART2:
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@BOT: ^BotOwner
 	Valued:
 		Cost: 975
 	Tooltip:
@@ -239,7 +240,7 @@ ART2:
 		Speed: 71
 		TurnSpeed: 8
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 9c0
@@ -306,6 +307,15 @@ ART2:
 	WithMuzzleOverlay:
 	RevealOnFire:
 		ArmamentNames: deployed
+	IssueOrderToBot@AI:
+		RequiresCondition: undeployed
+		OrderName: GrantConditionOnDeploy
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 45
+		TargetRangeInCell: 17
+		ValidTargets: Ground, Water
+		ValidRelationships: Enemy
 
 REPAIR:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -80,6 +80,15 @@ BIKE:
 		RequiresCondition: !inside-tunnel && !rank-elite
 	LeavesTrails@VEINS:
 		RequiresCondition: !inside-tunnel && !rank-elite
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 TTNK:
 	Inherits: ^Tank
@@ -209,7 +218,7 @@ TTNK:
 		OrderName: GrantConditionOnDeploy
 		OrderChance: 100
 		OrderTrigger: Attack
-		OrderInterval: 35
+		OrderInterval: 40
 
 ART2:
 	Inherits: ^Tank
@@ -355,6 +364,15 @@ REPAIR:
 		InitialStance: AttackAnything
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Vehicle
+	IssueOrderToBot@AI: ## retreat to safty
+		OrderName: AttackMove
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 70
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 WEED:
 	Inherits: ^Tank
@@ -443,6 +461,7 @@ SAPC:
 		MaxWeight: 5
 		UnloadVoice: Unload
 		LoadingCondition: loading
+		LoadedCondition: loaded
 		EjectOnDeath: true
 	WithVoxelBody:
 		RequiresCondition: !submerged
@@ -460,6 +479,11 @@ SAPC:
 		RequiresCondition: !submerged
 	WithDecoration@UNDERGROUND:
 		RequiresCondition: inside-tunnel || submerged
+	IssueOrderToBot@AI:
+		RequiresCondition: loaded
+		OrderName: Unload
+		OrderChance: 100
+		OrderInterval: 45
 
 SUBTANK:
 	Inherits: ^Tank
@@ -567,6 +591,15 @@ STNK:
 	FireWarheadsOnDeath@ELITE:
 		RequiresCondition: rank-elite
 		Weapon: UnitExplode
+	IssueOrderToBot@AI: ## hit and run
+		OrderName: Move
+		OrderTrigger: Damage
+		OrderChance: 100
+		OrderInterval: 80
+		TargetRangeInCell: 9
+		ValidTargets: Ground
+		ValidRelationships: Ally
+		TargetDistance: Furthest
 
 SGEN:
 	Inherits: ^Tank
@@ -653,3 +686,9 @@ SGEN:
 		Range: 6c0
 		Type: cloakgenerator
 		RequiresCondition: deployed && !empdisable
+	IssueOrderToBot@AI:
+		OrderTrigger: BecomingIdle, Periodically
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderInterval: 40
+		RequiresCondition: undeployed

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -50,9 +50,22 @@ NAPULS:
 		Cursor: emp
 		Icon: emp
 		ChargeInterval: 3375
+		OrderName: EmpCannonAttack
 		Name: actor-napuls.attackorderpower-name
 		Description: actor-napuls.attackorderpower-description
 		EndChargeSpeechNotification: EmPulseCannonReady
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeTextNotification: notification-emp-cannon-ready
 		SelectTargetTextNotification: notification-select-target
+	IssueOrderToBot@AI:
+		RequiresCondition: !empdisable && !disabled
+		OrderName: EmpCannonAttack
+		OrderTrigger: Periodically
+		OrderChance: 100
+		OrderInterval: 675
+		IsIssuerOwner: True
+		TargetRangeInCell: 38
+		ValidTargets: Vehicle
+		InvalidTargets: Air
+		ValidRelationships: Enemy
+		TargetDistance: Random

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -118,6 +118,7 @@ LPST:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@selection: ^SelectableSupportUnit
+	Inherits@BOT: ^BotOwner
 	-AppearsOnRadar:
 	Buildable:
 		Queue: Vehicle
@@ -140,7 +141,7 @@ LPST:
 		Speed: 85
 		TurnSpeed: 20
 		ImmovableCondition: !undeployed
-		RequireForceMoveCondition: !undeployed
+		RequireForceMoveCondition: !undeployed && !bot-owner
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel && undeployed
 		Range: 10c0
@@ -196,3 +197,9 @@ LPST:
 		TrailCount: 3
 	RenderVoxels:
 		Scale: 11.5
+	IssueOrderToBot@AI:
+		OrderTrigger: BecomingIdle, Periodically
+		OrderName: GrantConditionOnDeploy
+		OrderChance: 100
+		OrderInterval: 40
+		RequiresCondition: undeployed


### PR DESCRIPTION
This PR is a showcase of combination of my 3 PR related with bot:
#22177 provide AI to use chronoshift and ironcurtain. -> all support power can be used now


#21060 make AI can send squad consist units not suitable (suicide unit) or special (no normal attack behaivior), which enable spy, madtank, air transport.

#21062 make AI can load unit and micro unit -> ai can do some micro management on unit, such as hit&run (buggy and bike), teleport, deploy in time.
![AI_chrono](https://github.com/user-attachments/assets/9533ea6c-c53a-4c3b-9c46-10aae53af683)

With all 3 PR, I add remmaining units in mods for bot player (except engineer which should use the `CaptureManagerBotModule`)



