### PR TITLE
Enhance the Load Game and Save Game UIs

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -221,6 +221,9 @@ namespace OpenRA.Network
 			// 120ms network frame interval for 40ms local tick
 			public int NetFrameInterval = 3;
 
+			// Timestep in milliseconds used for converting frame count to game duration
+			public int GameTimestep = 0;
+
 			[FieldLoader.Ignore]
 			public Dictionary<string, LobbyOptionState> LobbyOptions = [];
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1398,6 +1398,8 @@ namespace OpenRA.Server
 				if (IsMultiplayer)
 					OrderLatency = gameSpeed.OrderLatency;
 
+				LobbyInfo.GlobalSettings.GameTimestep = gameSpeed.Timestep;
+
 				if (GameSave == null && LobbyInfo.GlobalSettings.EnableGameSaves)
 					GameSave = new GameSave();
 

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -255,8 +255,8 @@ namespace OpenRA
 		public static string ReadLengthPrefixedString(this Stream s, Encoding encoding, int maxLength)
 		{
 			var length = s.ReadInt32();
-			if (length > maxLength)
-				throw new InvalidOperationException($"The length of the string ({length}) is longer than the maximum allowed ({maxLength}).");
+			if (length < 0 || length > maxLength)
+				throw new InvalidOperationException($"The length of the string ({length}) is outside the allowed range (0..{maxLength}).");
 
 			var buffer = length < 128 ? stackalloc byte[length] : new byte[length];
 			s.ReadBytes(buffer);

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -10,15 +10,19 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using OpenRA.Network;
+using OpenRA.Primitives;
+using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
+	[IncludeStaticFluentReferences(typeof(GameSaveUtils))]
 	public class GameSaveBrowserLogic : ChromeLogic
 	{
 		[FluentReference]
@@ -60,29 +64,50 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string OverwriteSaveAccept = "dialog-overwrite-save.confirm";
 
+		[FluentReference]
+		const string NoSaveSelected = "label-gamesave-browser-panel-no-save-selected";
+
+		[FluentReference("name", "number")]
+		const string EnumeratedBotName = "enumerated-bot-name";
+
+		[FluentReference]
+		const string HumanPlayer = "label-load-game-browser-panel-human-player";
+
+		[FluentReference]
+		const string Players = "label-players";
+
+		[FluentReference("team")]
+		const string TeamNumber = "label-team-name";
+
+		[FluentReference]
+		const string NoTeam = "label-no-team";
+
 		readonly Widget panel;
 		readonly ScrollPanelWidget gameList;
 		readonly TextFieldWidget saveTextField;
 		readonly List<string> games = [];
-		readonly Action onStart;
 		readonly Action onExit;
 		readonly ModData modData;
-		readonly bool isSavePanel;
 		readonly string baseSavePath;
+
+		readonly ScrollPanelWidget playerList;
+		readonly ScrollItemWidget playerHeader;
+		readonly ScrollItemWidget playerTemplate;
+		MapPreview map;
 
 		readonly string defaultSaveFilename;
 		string selectedPath;
 		GameSave selectedSave;
+		readonly World world;
 
 		[ObjectCreator.UseCtor]
-		public GameSaveBrowserLogic(Widget widget, ModData modData, Action onExit, Action onStart, bool isSavePanel, World world)
+		public GameSaveBrowserLogic(Widget widget, ModData modData, Action onExit, Action onStart, World world)
 		{
 			panel = widget;
 
 			this.modData = modData;
-			this.onStart = onStart;
 			this.onExit = onExit;
-			this.isSavePanel = isSavePanel;
+			this.world = world;
 			Game.BeforeGameStart += OnGameStart;
 
 			var cancelButton = panel.Get<ButtonWidget>("CANCEL_BUTTON");
@@ -94,52 +119,112 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			gameList = panel.Get<ScrollPanelWidget>("GAME_LIST");
 			var gameTemplate = panel.Get<ScrollItemWidget>("GAME_TEMPLATE");
-			var newTemplate = panel.Get<ScrollItemWidget>("NEW_TEMPLATE");
+			var dateHeaderTemplate = panel.Get<ScrollItemWidget>("DATE_HEADER");
 
 			var mod = modData.Manifest;
 			baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
 
-			// Avoid filename conflicts when creating new saves
-			if (isSavePanel)
+			panel.Get("SAVE_TITLE").IsVisible = () => true;
+
+			defaultSaveFilename = world.Map.Title;
+			var filenameAttempt = 0;
+			while (File.Exists(Path.Combine(baseSavePath, defaultSaveFilename + ".orasav")))
+				defaultSaveFilename = world.Map.Title + $" ({++filenameAttempt})";
+
+			var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
+			saveButton.IsDisabled = () => string.IsNullOrWhiteSpace(saveTextField.Text);
+			saveButton.OnClick = () => Save(world);
+			saveButton.IsVisible = () => true;
+
+			var saveWidgets = panel.Get("SAVE_WIDGETS");
+			gameList.Bounds.Height -= saveWidgets.Bounds.Height;
+			saveWidgets.IsVisible = () => true;
+
+			saveTextField = saveWidgets.Get<TextFieldWidget>("SAVE_TEXTFIELD");
+			saveTextField.OnEnterKey = saveButton.HandleKeyPress;
+			saveTextField.OnEscKey = cancelButton.HandleKeyPress;
+			saveTextField.OnTextEdited = () =>
 			{
-				panel.Get("SAVE_TITLE").IsVisible = () => true;
-
-				defaultSaveFilename = world.Map.Title;
-				var filenameAttempt = 0;
-				while (File.Exists(Path.Combine(baseSavePath, defaultSaveFilename + ".orasav")))
-					defaultSaveFilename = world.Map.Title + $" ({++filenameAttempt})";
-
-				var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
-				saveButton.IsDisabled = () => string.IsNullOrWhiteSpace(saveTextField.Text);
-				saveButton.OnClick = () => Save(world);
-				saveButton.IsVisible = () => true;
-
-				var saveWidgets = panel.Get("SAVE_WIDGETS");
-				gameList.Bounds.Height -= saveWidgets.Bounds.Height;
-				saveWidgets.IsVisible = () => true;
-
-				saveTextField = saveWidgets.Get<TextFieldWidget>("SAVE_TEXTFIELD");
-				saveTextField.OnEnterKey = saveButton.HandleKeyPress;
-				saveTextField.OnEscKey = cancelButton.HandleKeyPress;
-			}
-			else
-			{
-				panel.Get("LOAD_TITLE").IsVisible = () => true;
-				var loadButton = panel.Get<ButtonWidget>("LOAD_BUTTON");
-				loadButton.IsVisible = () => true;
-				loadButton.IsDisabled = () => selectedSave == null || modData.MapCache[selectedSave.GlobalSettings.Map].Status != MapStatus.Available;
-				loadButton.OnClick = Load;
-			}
+				if (string.IsNullOrEmpty(saveTextField.Text))
+				{
+					selectedPath = null;
+					selectedSave = null;
+					map = modData.MapCache[world.Map.Uid];
+					UpdatePlayerList();
+				}
+			};
 
 			if (Directory.Exists(baseSavePath))
-				LoadGames(gameTemplate, newTemplate, world);
+				LoadGames(gameTemplate, dateHeaderTemplate, world);
+
+			map = modData.MapCache[world.Map.Uid];
+
+			var mapPreviewRoot = panel.Get("MAP_PREVIEW_ROOT");
+
+			var saveInfo = panel.Get("SAVE_INFO");
+
+			var noSaveSelectedLabel = saveInfo.Get<LabelWidget>("NO_SAVE_SELECTED_LABEL");
+			noSaveSelectedLabel.GetText = () => FluentProvider.GetMessage(NoSaveSelected);
+			noSaveSelectedLabel.IsVisible = () => false;
+
+			var incompatibleTitleLabel = saveInfo.Get<LabelWidget>("INCOMPATIBLE_TITLE_LABEL");
+			incompatibleTitleLabel.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var incompatibleLabelA = saveInfo.Get<LabelWidget>("INCOMPATIBLE_LABEL_A");
+			incompatibleLabelA.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var incompatibleLabelB = saveInfo.Get<LabelWidget>("INCOMPATIBLE_LABEL_B");
+			incompatibleLabelB.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var savegameInfoDate = saveInfo.GetOrNull<LabelWidget>("SAVEGAME_INFO_DATE");
+			if (savegameInfoDate != null)
+			{
+				savegameInfoDate.GetText = () => selectedSave != null && selectedPath != null
+					? "Date created: " + File.GetCreationTime(selectedPath).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+					: string.Empty;
+				savegameInfoDate.IsVisible = () => selectedSave != null;
+			}
+
+			var savegameInfoDuration = saveInfo.GetOrNull<LabelWidget>("SAVEGAME_INFO_DURATION");
+			if (savegameInfoDuration != null)
+			{
+				savegameInfoDuration.GetText = () =>
+				{
+					if (selectedSave != null && selectedSave.GlobalSettings.GameTimestep > 0 && selectedSave.LastOrdersFrame >= 0)
+					{
+						var duration = TimeSpan.FromMilliseconds((long)selectedSave.LastOrdersFrame * selectedSave.GlobalSettings.GameTimestep);
+						return "Duration: " + duration.ToString(@"hh\:mm\:ss", CultureInfo.InvariantCulture);
+					}
+
+					return "Duration: ?";
+				};
+				savegameInfoDuration.IsVisible = () => selectedSave != null;
+			}
+
+			playerList = saveInfo.Get<ScrollPanelWidget>("PLAYER_LIST");
+			playerHeader = playerList.Get<ScrollItemWidget>("HEADER");
+			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
+			playerList.RemoveChildren();
+
+			var spawnOccupants = new CachedTransform<GameSave, Dictionary<int, SpawnOccupant>>(_ => GetSpawnOccupants());
+
+			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
+			{
+				{ "orderManager", null },
+				{ "getMap", (Func<(MapPreview, Session.MapStatus)>)(() => (map, Session.MapStatus.Playable)) },
+				{ "onMouseDown", null },
+				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedSave)) },
+				{ "getDisabledSpawnPoints", () => FrozenSet<int>.Empty },
+				{ "showUnoccupiedSpawnpoints", false },
+				{ "mapUpdatesEnabled", false },
+				{ "onMapUpdate", (Action<string>)(_ => { }) },
+			});
 
 			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
 			renameButton.IsDisabled = () => selectedSave == null;
 			renameButton.OnClick = () =>
 			{
 				var initialName = Path.GetFileNameWithoutExtension(selectedPath);
-				var invalidChars = Path.GetInvalidFileNameChars();
 
 				ConfirmationDialogs.TextInputPrompt(modData,
 					RenameSaveTitle,
@@ -149,22 +234,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onCancel: null,
 					acceptText: RenameSaveAccept,
 					cancelText: null,
-					inputValidator: newName =>
-					{
-						if (newName == initialName)
-							return false;
-
-						if (string.IsNullOrWhiteSpace(newName))
-							return false;
-
-						if (newName.IndexOfAny(invalidChars) >= 0)
-							return false;
-
-						if (File.Exists(Path.Combine(baseSavePath, newName)))
-							return false;
-
-						return true;
-					});
+					inputValidator: newName => GameSaveUtils.IsValidNewSaveName(newName, initialName, baseSavePath));
 			};
 
 			var deleteButton = panel.Get<ButtonWidget>("DELETE_BUTTON");
@@ -178,14 +248,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onConfirm: () =>
 					{
 						Delete(selectedPath);
-
-						if (games.Count == 0 && !isSavePanel)
-						{
-							Ui.CloseWindow();
-							onExit();
-						}
-						else
-							SelectFirstVisible();
+						SelectFirstVisible();
 					},
 					confirmText: DeleteSaveAccept,
 					onCancel: () => { });
@@ -214,56 +277,80 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SelectFirstVisible();
 		}
 
-		void LoadGames(ScrollItemWidget gameTemplate, ScrollItemWidget newTemplate, World world)
+		void LoadGames(ScrollItemWidget gameTemplate, ScrollItemWidget dateHeaderTemplate, World world)
 		{
 			gameList.RemoveChildren();
-			if (isSavePanel)
-			{
-				var item = ScrollItemWidget.Setup(newTemplate,
-					() => selectedSave == null,
-					() => Select(null),
-					() => { });
-				gameList.AddChild(item);
-			}
 
 			var savePaths = Directory.GetFiles(baseSavePath, "*.orasav", SearchOption.AllDirectories)
 				.OrderByDescending(File.GetLastWriteTime)
 				.ToList();
 
-			foreach (var savePath in savePaths)
+			var byDate = savePaths
+				.GroupBy(p => File.GetLastWriteTime(p).Date)
+				.OrderByDescending(g => g.Key);
+
+			foreach (var group in byDate)
 			{
-				games.Add(savePath);
+				var dateLabel = group.Key.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+				var header = ScrollItemWidget.Setup(dateHeaderTemplate, () => false, () => { });
+				header.Get<LabelWidget>("LABEL").GetText = () => dateLabel;
+				header.IsVisible = () => true;
+				gameList.AddChild(header);
 
-				// Create the item manually so the click handlers can refer to itself
-				// This simplifies the rename handling (only needs to update ItemKey)
-				var item = gameTemplate.Clone();
-				item.ItemKey = savePath;
-				item.IsVisible = () => true;
-				item.IsSelected = () => selectedPath == item.ItemKey;
-				item.OnClick = () => Select(item.ItemKey);
+				foreach (var savePath in group)
+				{
+					games.Add(savePath);
 
-				if (isSavePanel)
-					item.OnDoubleClick = () => Save(world);
-				else
-					item.OnDoubleClick = Load;
+					GameSave save = null;
+					try
+					{
+						save = new GameSave(savePath);
+					}
+					catch
+					{
+					}
 
-				var title = Path.GetFileNameWithoutExtension(savePath);
-				var label = item.Get<LabelWithTooltipWidget>("TITLE");
-				WidgetUtils.TruncateLabelToTooltip(label, title);
+					// Create the item manually so the click handlers can refer to itself.
+					// This simplifies the rename handling (only needs to update ItemKey).
+					var gameItem = gameTemplate.Clone();
+					gameItem.ItemKey = savePath;
+					gameItem.IsVisible = () => true;
+					gameItem.IsSelected = () => selectedPath == gameItem.ItemKey;
+					gameItem.OnClick = () => Select(gameItem.ItemKey);
+					gameItem.OnDoubleClick = () => Save(world);
 
-				var date = File.GetLastWriteTime(savePath).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.CurrentCulture);
-				item.Get<LabelWidget>("DATE").GetText = () => date;
+					var title = Path.GetFileNameWithoutExtension(savePath);
+					var label = gameItem.Get<LabelWithTooltipWidget>("TITLE");
+					WidgetUtils.TruncateLabelToTooltip(label, title);
+					var tooltipText = GameSaveUtils.BuildSaveTooltipText(savePath, save, modData);
+					label.GetTooltipText = () => tooltipText;
 
-				gameList.AddChild(item);
+					var creationTime = File.GetCreationTime(savePath);
+					var creationTimeLabel = gameItem.GetOrNull<LabelWidget>("CREATION_TIME");
+					if (creationTimeLabel != null)
+					{
+						creationTimeLabel.GetText = () => creationTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+						creationTimeLabel.IsVisible = () => gameItem.IsSelected();
+					}
+
+					gameList.AddChild(gameItem);
+				}
 			}
 		}
 
 		void Rename(string oldName, string newName)
 		{
+			var oldPath = Path.Combine(baseSavePath, oldName + ".orasav");
+
+			var uniqueName = newName;
+			var attempt = 1;
+			while (File.Exists(Path.Combine(baseSavePath, uniqueName + ".orasav")))
+				uniqueName = newName + $" ({attempt++})";
+
+			var newPath = Path.Combine(baseSavePath, uniqueName + ".orasav");
+
 			try
 			{
-				var oldPath = Path.Combine(baseSavePath, oldName + ".orasav");
-				var newPath = Path.Combine(baseSavePath, newName + ".orasav");
 				File.Move(oldPath, newPath);
 
 				games[games.IndexOf(oldPath)] = newPath;
@@ -273,7 +360,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						continue;
 
 					item.ItemKey = newPath;
-					item.Get<LabelWidget>("TITLE").GetText = () => newName;
+					item.Get<LabelWidget>("TITLE").GetText = () => uniqueName;
 				}
 
 				if (selectedPath == oldPath)
@@ -312,12 +399,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void SelectFirstVisible()
 		{
-			Select(isSavePanel ? null : games.FirstOrDefault());
-			if (isSavePanel)
-			{
-				saveTextField.TakeKeyboardFocus();
-				saveTextField.CursorPosition = saveTextField.Text.Length;
-			}
+			Select(null);
+			saveTextField.TakeKeyboardFocus();
+			saveTextField.CursorPosition = saveTextField.Text.Length;
 		}
 
 		void Select(string savePath)
@@ -326,43 +410,141 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (savePath != null)
 			{
-				selectedSave = new GameSave(savePath);
-				var preview = modData.MapCache[selectedSave.GlobalSettings.Map];
-				if (preview.Status != MapStatus.Available && selectedSave.MapGenerationArgs != null)
+				try
 				{
-					// Add to the MapCache so the server will accept the map
-					preview.UpdateFromGenerationArgs(selectedSave.MapGenerationArgs);
-					preview.Generate();
+					selectedSave = new GameSave(savePath);
+					var preview = modData.MapCache[selectedSave.GlobalSettings.Map];
+					if (preview.Status != MapStatus.Available && selectedSave.MapGenerationArgs != null)
+					{
+						// Add to the MapCache so the server will accept the map.
+						preview.UpdateFromGenerationArgs(selectedSave.MapGenerationArgs);
+						preview.Generate();
+					}
+
+					map = preview;
 				}
+				catch
+				{
+					selectedSave = null;
+					map = MapCache.UnknownMap;
+				}
+
+				UpdatePlayerList();
 			}
 			else
-				selectedSave = null;
-
-			if (isSavePanel)
 			{
-				saveTextField.Text = savePath == null ? defaultSaveFilename : Path.GetFileNameWithoutExtension(savePath);
-				saveTextField.CursorPosition = saveTextField.Text.Length;
+				selectedSave = null;
+				map = modData.MapCache[world.Map.Uid];
+				UpdatePlayerList();
 			}
+
+			saveTextField.Text = savePath == null ? defaultSaveFilename : Path.GetFileNameWithoutExtension(savePath);
+			saveTextField.CursorPosition = saveTextField.Text.Length;
 		}
 
-		void Load()
+		Dictionary<string, SlotClient> GetWorldSlotClients()
 		{
-			if (selectedSave == null)
-				return;
+			var result = new Dictionary<string, SlotClient>();
+			foreach (var client in world.LobbyInfo.Clients)
+				if (client.Slot != null)
+					result[client.Slot] = new SlotClient(client);
+			return result;
+		}
 
-			var map = modData.MapCache[selectedSave.GlobalSettings.Map];
-			if (map.Status != MapStatus.Available)
-				return;
+		Dictionary<int, SpawnOccupant> GetSpawnOccupants()
+		{
+			var slotClients = selectedSave?.SlotClients ?? (selectedPath == null ? GetWorldSlotClients() : null);
+			if (slotClients == null)
+				return [];
 
-			Ui.CloseWindow();
-
-			var orders = new List<Order>()
+			var occupants = new Dictionary<int, SpawnOccupant>();
+			foreach (var (_, slotClient) in slotClients)
 			{
-				Order.FromTargetString("LoadGameSave", Path.GetFileName(selectedPath), true),
-				Order.Command($"state {Session.ClientState.Ready}")
-			};
+				if (slotClient.SpawnPoint == 0)
+					continue;
 
-			Game.CreateAndStartLocalServer(map.Uid, orders);
+				var client = new Session.Client
+				{
+					Color = slotClient.Color,
+					Faction = slotClient.Faction,
+					SpawnPoint = slotClient.SpawnPoint,
+					Team = slotClient.Team,
+					Bot = slotClient.Bot,
+					Name = slotClient.Bot != null ? FluentProvider.GetMessage(slotClient.BotName) : string.Empty
+				};
+
+				occupants[slotClient.SpawnPoint] = new SpawnOccupant(client);
+			}
+
+			return occupants;
+		}
+
+		void UpdatePlayerList()
+		{
+			playerList.RemoveChildren();
+
+			Dictionary<string, SlotClient> slotClients;
+			if (selectedSave != null)
+				slotClients = selectedSave.SlotClients;
+			else if (selectedPath == null)
+				slotClients = GetWorldSlotClients();
+			else
+				return;
+
+			var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
+
+			var botOrdinals = slotClients
+				.Where(kv => kv.Value.Bot != null)
+				.GroupBy(kv => kv.Value.Bot)
+				.SelectMany(g => g.Select((kv, i) => (SlotKey: kv.Key, Ordinal: i + 1)))
+				.ToFrozenDictionary(x => x.SlotKey, x => x.Ordinal);
+
+			var slotClientsByTeam = slotClients
+				.GroupBy(kv => kv.Value.Team)
+				.OrderBy(g => g.Key)
+				.ToList();
+
+			var noTeams = slotClientsByTeam.Count == 1;
+
+			foreach (var teamGroup in slotClientsByTeam)
+			{
+				var team = teamGroup.Key;
+				var label = noTeams ? FluentProvider.GetMessage(Players) : team > 0
+					? FluentProvider.GetMessage(TeamNumber, "team", team)
+					: FluentProvider.GetMessage(NoTeam);
+
+				if (label.Length > 0)
+				{
+					var header = ScrollItemWidget.Setup(playerHeader, () => false, () => { });
+					header.Get<LabelWidget>("LABEL").GetText = () => label;
+					playerList.AddChild(header);
+				}
+
+				foreach (var (slotKey, slotClient) in teamGroup)
+				{
+					var displayName = slotClient.Bot != null
+						? FluentProvider.GetMessage(EnumeratedBotName,
+							"name", FluentProvider.GetMessage(slotClient.BotName),
+							"number", botOrdinals[slotKey])
+						: FluentProvider.GetMessage(HumanPlayer);
+
+					var color = slotClient.Color;
+					var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+
+					var nameLabel = item.Get<LabelWidget>("LABEL");
+					var font = Game.Renderer.Fonts[nameLabel.Font];
+					var name = WidgetUtils.TruncateText(displayName, nameLabel.Bounds.Width, font);
+					nameLabel.GetText = () => name;
+					nameLabel.GetColor = () => color;
+
+					var flag = item.Get<ImageWidget>("FLAG");
+					flag.GetImageCollection = () => "flags";
+					var faction = slotClient.Faction;
+					flag.GetImageName = () => factionInfo != null && factionInfo.Any(f => f.InternalName == faction) ? faction : "Random";
+
+					playerList.AddChild(item);
+				}
+			}
 		}
 
 		void Save(World world)
@@ -399,7 +581,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OnGameStart()
 		{
 			Ui.CloseWindow();
-			onStart();
+			onExit();
 		}
 
 		bool disposed;
@@ -412,15 +594,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			base.Dispose(disposing);
-		}
-
-		public static bool IsLoadPanelEnabled(Manifest mod)
-		{
-			var baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
-			if (!Directory.Exists(baseSavePath))
-				return false;
-
-			return Directory.GetFiles(baseSavePath, "*.orasav", SearchOption.AllDirectories).Length > 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveUtils.cs
@@ -1,0 +1,82 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Globalization;
+using System.IO;
+using OpenRA.Network;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public static class GameSaveUtils
+	{
+		[FluentReference]
+		const string TooltipSavegameDateCreated = "tooltip-savegame-date-created";
+
+		[FluentReference]
+		const string TooltipSavegameMap = "tooltip-savegame-map";
+
+		[FluentReference]
+		const string TooltipSavegameDuration = "tooltip-savegame-duration";
+
+		[FluentReference]
+		const string TooltipSavegamePlayers = "tooltip-savegame-players";
+
+		public static TimeSpan? GetGameDuration(GameSave save)
+		{
+			if (save == null || save.GlobalSettings.GameTimestep <= 0 || save.LastOrdersFrame < 0)
+				return null;
+
+			return TimeSpan.FromMilliseconds((long)save.LastOrdersFrame * save.GlobalSettings.GameTimestep);
+		}
+
+		public static string FormatGameDuration(TimeSpan? duration)
+		{
+			if (!duration.HasValue)
+				return "?";
+
+			var d = duration.Value;
+			return $"{(int)d.TotalHours:D2}:{d.Minutes:D2}:{d.Seconds:D2}";
+		}
+
+		public static string BuildSaveTooltipText(string savePath, GameSave save, ModData modData)
+		{
+			var mapTitle = save != null ? modData.MapCache[save.GlobalSettings.Map].Title : null;
+			var creationDate = File.GetCreationTime(savePath).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+			var durationText = FormatGameDuration(GetGameDuration(save));
+			var lines = new[]
+			{
+				$"{FluentProvider.GetMessage(TooltipSavegameDateCreated)}: {creationDate}",
+				$"{FluentProvider.GetMessage(TooltipSavegameMap)}: {mapTitle ?? "?"}",
+				$"{FluentProvider.GetMessage(TooltipSavegameDuration)}: {durationText}",
+				$"{FluentProvider.GetMessage(TooltipSavegamePlayers)}: {save?.SlotClients.Count ?? 0}"
+			};
+			return string.Join("\n", lines);
+		}
+
+		public static bool IsValidNewSaveName(string newName, string initialName, string directory)
+		{
+			if (newName == initialName)
+				return false;
+
+			if (string.IsNullOrWhiteSpace(newName))
+				return false;
+
+			if (newName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+				return false;
+
+			if (File.Exists(Path.Combine(directory, newName)))
+				return false;
+
+			return true;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -405,16 +405,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 
 			var button = AddButton("LOAD_GAME", LoadGameButton);
-			button.IsDisabled = () => leaving || !GameSaveBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
+			button.IsDisabled = () => leaving || !LoadGameBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
 			button.OnClick = () =>
 			{
 				hideMenu = true;
-				Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+				Ui.OpenWindow("LOAD_GAME_BROWSER_PANEL", new WidgetArgs
 				{
 					{ "onExit", () => hideMenu = false },
 					{ "onStart", CloseMenu },
-					{ "isSavePanel", false },
-					{ "world", null }
 				});
 			};
 		}
@@ -433,7 +431,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					{ "onExit", () => hideMenu = false },
 					{ "onStart", () => { } },
-					{ "isSavePanel", true },
 					{ "world", world }
 				});
 			};

--- a/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
@@ -1,0 +1,1029 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using OpenRA.Network;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	[IncludeStaticFluentReferences(typeof(GameSaveUtils))]
+	public class LoadGameBrowserLogic : ChromeLogic
+	{
+		enum SaveType
+		{
+			Any,
+			Autosave,
+			Manual
+		}
+
+		enum DateType
+		{
+			Any,
+			Today,
+			LastWeek,
+			LastFortnight,
+			LastMonth
+		}
+
+		enum DurationType
+		{
+			Any,
+			VeryShort,
+			Short,
+			Medium,
+			Long
+		}
+
+		sealed class SaveEntry
+		{
+			public string Path;
+			public DateTime LastWrite;
+			public DateTime CreationTime;
+			public TimeSpan? Duration;
+			public string MapTitle;
+			public IReadOnlyList<string> Factions = [];
+			public bool Visible = true;
+			public ScrollItemWidget Item;
+		}
+
+		sealed class Filter
+		{
+			public SaveType Type;
+			public DateType Date;
+			public DurationType Duration;
+			public string SaveName;
+			public string MapName;
+			public string Faction;
+
+			public bool IsEmpty =>
+				Type == default
+				&& Date == default
+				&& Duration == default
+				&& string.IsNullOrEmpty(SaveName)
+				&& string.IsNullOrEmpty(MapName)
+				&& string.IsNullOrEmpty(Faction);
+		}
+
+		[FluentReference]
+		const string RenameSaveTitle = "dialog-rename-save.title";
+
+		[FluentReference]
+		const string RenameSavePrompt = "dialog-rename-save.prompt";
+
+		[FluentReference]
+		const string RenameSaveAccept = "dialog-rename-save.confirm";
+
+		[FluentReference]
+		const string DeleteSaveTitle = "dialog-delete-save.title";
+
+		[FluentReference("save")]
+		const string DeleteSavePrompt = "dialog-delete-save.prompt";
+
+		[FluentReference]
+		const string DeleteSaveAccept = "dialog-delete-save.confirm";
+
+		[FluentReference]
+		const string DeleteAllSavesTitle = "dialog-delete-all-saves.title";
+
+		[FluentReference("count")]
+		const string DeleteAllSavesPrompt = "dialog-delete-all-saves.prompt";
+
+		[FluentReference]
+		const string DeleteAllSavesAccept = "dialog-delete-all-saves.confirm";
+
+		[FluentReference("savePath")]
+		const string SaveDeletionFailed = "notification-save-deletion-failed";
+
+		[FluentReference]
+		const string Players = "label-players";
+
+		[FluentReference("team")]
+		const string TeamNumber = "label-team-name";
+
+		[FluentReference]
+		const string NoTeam = "label-no-team";
+
+		[FluentReference]
+		const string SaveTypeAutosave = "options-save-type.autosave";
+
+		[FluentReference]
+		const string SaveTypeManual = "options-save-type.manual";
+
+		[FluentReference]
+		const string Today = "options-replay-date.today";
+
+		[FluentReference]
+		const string LastWeek = "options-replay-date.last-week";
+
+		[FluentReference]
+		const string LastFortnight = "options-replay-date.last-fortnight";
+
+		[FluentReference]
+		const string LastMonth = "options-replay-date.last-month";
+
+		[FluentReference]
+		const string SaveDurationVeryShort = "options-replay-duration.very-short";
+
+		[FluentReference]
+		const string SaveDurationShort = "options-replay-duration.short";
+
+		[FluentReference]
+		const string SaveDurationMedium = "options-replay-duration.medium";
+
+		[FluentReference]
+		const string SaveDurationLong = "options-replay-duration.long";
+
+		[FluentReference("name", "number")]
+		const string EnumeratedBotName = "enumerated-bot-name";
+
+		[FluentReference]
+		const string HumanPlayer = "label-load-game-browser-panel-human-player";
+
+		static Filter filter = new();
+
+		readonly Widget panel;
+		readonly ScrollPanelWidget gameList;
+		readonly ScrollPanelWidget playerList;
+		readonly ScrollItemWidget playerTemplate;
+		readonly ScrollItemWidget playerHeader;
+		readonly ScrollItemWidget gameTemplate;
+		readonly ScrollItemWidget dateHeaderTemplate;
+		readonly List<SaveEntry> saves = [];
+		readonly Action onStart;
+		readonly ModData modData;
+		readonly string baseSavePath;
+
+		MapPreview map;
+		string selectedPath;
+		GameSave selectedSave;
+		bool filtersVisible;
+
+		[ObjectCreator.UseCtor]
+		public LoadGameBrowserLogic(Widget widget, ModData modData, Action onExit, Action onStart)
+		{
+			// Reset filters to their neutral state every time the panel opens.
+			filter = new Filter();
+
+			map = MapCache.UnknownMap;
+			panel = widget;
+
+			this.modData = modData;
+			this.onStart = onStart;
+			Game.BeforeGameStart += OnGameStart;
+
+			var mod = modData.Manifest;
+			baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () =>
+			{
+				Ui.CloseWindow();
+				onExit();
+			};
+
+			playerList = panel.Get<ScrollPanelWidget>("PLAYER_LIST");
+			playerHeader = playerList.Get<ScrollItemWidget>("HEADER");
+			playerTemplate = playerList.Get<ScrollItemWidget>("TEMPLATE");
+			playerList.RemoveChildren();
+
+			var loadButton = panel.Get<ButtonWidget>("LOAD_BUTTON");
+			loadButton.IsDisabled = () => selectedSave == null || modData.MapCache[selectedSave.GlobalSettings.Map].Status != MapStatus.Available;
+			loadButton.OnClick = Load;
+
+			var mapPreviewRoot = panel.Get("MAP_PREVIEW_ROOT");
+			mapPreviewRoot.IsVisible = () => selectedPath != null;
+			var saveInfo = panel.Get("SAVE_INFO");
+			saveInfo.IsVisible = () => selectedPath != null;
+
+			var incompatibleTitleLabel = saveInfo.Get<LabelWidget>("INCOMPATIBLE_TITLE_LABEL");
+			incompatibleTitleLabel.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var incompatibleLabelA = saveInfo.Get<LabelWidget>("INCOMPATIBLE_LABEL_A");
+			incompatibleLabelA.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var incompatibleLabelB = saveInfo.Get<LabelWidget>("INCOMPATIBLE_LABEL_B");
+			incompatibleLabelB.IsVisible = () => selectedPath != null && selectedSave == null;
+
+			var savegameInfoDate = saveInfo.GetOrNull<LabelWidget>("SAVEGAME_INFO_DATE");
+			if (savegameInfoDate != null)
+			{
+				savegameInfoDate.GetText = () => selectedSave != null && selectedPath != null
+					? "Date created: " + File.GetCreationTime(selectedPath).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+					: string.Empty;
+				savegameInfoDate.IsVisible = () => selectedSave != null;
+			}
+
+			var savegameInfoDuration = saveInfo.GetOrNull<LabelWidget>("SAVEGAME_INFO_DURATION");
+			if (savegameInfoDuration != null)
+			{
+				savegameInfoDuration.GetText = () => "Duration: " + GameSaveUtils.FormatGameDuration(GameSaveUtils.GetGameDuration(selectedSave));
+				savegameInfoDuration.IsVisible = () => selectedSave != null;
+			}
+
+			var playerListWidget = saveInfo.Get<ScrollPanelWidget>("PLAYER_LIST");
+			playerListWidget.IsVisible = () => selectedPath != null;
+
+			var spawnOccupants = new CachedTransform<GameSave, Dictionary<int, SpawnOccupant>>(_ => GetSpawnOccupants());
+
+			Ui.LoadWidget("MAP_PREVIEW", mapPreviewRoot, new WidgetArgs
+			{
+				{ "orderManager", null },
+				{ "getMap", (Func<(MapPreview, Session.MapStatus)>)(() => (map, Session.MapStatus.Playable)) },
+				{ "onMouseDown", null },
+				{ "getSpawnOccupants", (Func<Dictionary<int, SpawnOccupant>>)(() => spawnOccupants.Update(selectedSave)) },
+				{ "getDisabledSpawnPoints", () => FrozenSet<int>.Empty },
+				{ "showUnoccupiedSpawnpoints", false },
+				{ "mapUpdatesEnabled", false },
+				{ "onMapUpdate", (Action<string>)(_ => { }) },
+			});
+
+			gameList = panel.Get<ScrollPanelWidget>("GAME_LIST");
+			gameTemplate = panel.Get<ScrollItemWidget>("GAME_TEMPLATE");
+			dateHeaderTemplate = panel.Get<ScrollItemWidget>("DATE_HEADER");
+
+			SetupFilters();
+			SetupManagement(onExit);
+
+			if (Directory.Exists(baseSavePath))
+				LoadGames(gameTemplate, dateHeaderTemplate);
+
+			SetupSaveDependentFilters();
+			ApplyFilter();
+		}
+
+		void LoadGames(ScrollItemWidget gameTemplate, ScrollItemWidget dateHeaderTemplate)
+		{
+			gameList.RemoveChildren();
+
+			var savePaths = Directory.GetFiles(baseSavePath, "*.orasav")
+				.OrderByDescending(File.GetLastWriteTime)
+				.ToList();
+
+			var byDate = savePaths
+				.GroupBy(p => File.GetLastWriteTime(p).Date)
+				.OrderByDescending(g => g.Key);
+
+			foreach (var group in byDate)
+			{
+				var dateLabel = group.Key.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+				var header = ScrollItemWidget.Setup(dateHeaderTemplate, () => false, () => { });
+				header.Get<LabelWidget>("LABEL").GetText = () => dateLabel;
+
+				// The header is visible only if at least one save in this group is visible.
+				// Assigned after all entries in the group are created.
+				var groupEntries = new List<SaveEntry>();
+				header.IsVisible = () => groupEntries.Any(e => e.Visible);
+				gameList.AddChild(header);
+
+				foreach (var savePath in group)
+				{
+					GameSave save = null;
+					try
+					{
+						save = new GameSave(savePath);
+					}
+					catch
+					{
+					}
+
+					var lastWrite = File.GetLastWriteTime(savePath);
+					var creationTime = File.GetCreationTime(savePath);
+					var entry = new SaveEntry
+					{
+						Path = savePath,
+						LastWrite = lastWrite,
+						CreationTime = creationTime,
+						Duration = GameSaveUtils.GetGameDuration(save),
+						MapTitle = save != null ? modData.MapCache[save.GlobalSettings.Map].Title : null,
+						Factions = save?.SlotClients.Values
+							.Select(sc => sc.Faction)
+							.Where(f => !string.IsNullOrEmpty(f))
+							.ToList() ?? []
+					};
+
+					saves.Add(entry);
+					groupEntries.Add(entry);
+
+					var item = gameTemplate.Clone();
+					item.ItemKey = savePath;
+					item.IsSelected = () => selectedPath == item.ItemKey;
+					item.OnClick = () => SelectSave(item.ItemKey);
+					item.OnDoubleClick = Load;
+
+					var title = Path.GetFileNameWithoutExtension(savePath);
+					var label = item.Get<LabelWithTooltipWidget>("TITLE");
+					WidgetUtils.TruncateLabelToTooltip(label, title);
+					var tooltipText = GameSaveUtils.BuildSaveTooltipText(savePath, save, modData);
+					label.GetTooltipText = () => tooltipText;
+
+					var creationTimeLabel = item.GetOrNull<LabelWidget>("CREATION_TIME");
+					if (creationTimeLabel != null)
+					{
+						creationTimeLabel.GetText = () => entry.CreationTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture);
+						creationTimeLabel.IsVisible = () => item.IsSelected();
+					}
+
+					entry.Item = item;
+					item.IsVisible = () => entry.Visible;
+
+					gameList.AddChild(item);
+				}
+			}
+		}
+
+		void SetupFilters()
+		{
+			TextFieldWidget nameInput = null;
+
+			// Save name
+			{
+				nameInput = panel.GetOrNull<TextFieldWidget>("FLT_NAME_INPUT");
+				if (nameInput != null)
+				{
+					nameInput.Text = filter.SaveName ?? string.Empty;
+					nameInput.OnEscKey = _ =>
+					{
+						filter.SaveName = nameInput.Text = null;
+						ApplyFilter();
+						return true;
+					};
+					nameInput.OnTextEdited = () =>
+					{
+						filter.SaveName = string.IsNullOrEmpty(nameInput.Text) ? null : nameInput.Text;
+						ApplyFilter();
+					};
+				}
+			}
+
+			// Save type
+			{
+				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_TYPE_DROPDOWNBUTTON");
+				if (ddb != null)
+				{
+					(SaveType SaveType, string Text)[] options =
+					[
+						(SaveType.Any, ddb.GetText()),
+						(SaveType.Autosave, FluentProvider.GetMessage(SaveTypeAutosave)),
+						(SaveType.Manual, FluentProvider.GetMessage(SaveTypeManual))
+					];
+
+					var lookup = options.ToFrozenDictionary(kvp => kvp.SaveType, kvp => kvp.Text);
+
+					ddb.GetText = () => lookup[filter.Type];
+					ddb.OnMouseDown = _ =>
+					{
+						ScrollItemWidget SetupItem((SaveType SaveType, string Text) option, ScrollItemWidget tpl)
+						{
+							var item = ScrollItemWidget.Setup(
+								tpl,
+								() => filter.Type == option.SaveType,
+								() => { filter.Type = option.SaveType; ApplyFilter(); });
+							item.Get<LabelWidget>("LABEL").GetText = () => option.Text;
+							return item;
+						}
+
+						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+					};
+				}
+			}
+
+			// Date
+			{
+				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_DATE_DROPDOWNBUTTON");
+				if (ddb != null)
+				{
+					(DateType DateType, string Text)[] options =
+					[
+						(DateType.Any, ddb.GetText()),
+						(DateType.Today, FluentProvider.GetMessage(Today)),
+						(DateType.LastWeek, FluentProvider.GetMessage(LastWeek)),
+						(DateType.LastFortnight, FluentProvider.GetMessage(LastFortnight)),
+						(DateType.LastMonth, FluentProvider.GetMessage(LastMonth))
+					];
+
+					var lookup = options.ToFrozenDictionary(kvp => kvp.DateType, kvp => kvp.Text);
+
+					ddb.GetText = () => lookup[filter.Date];
+					ddb.OnMouseDown = _ =>
+					{
+						ScrollItemWidget SetupItem((DateType DateType, string Text) option, ScrollItemWidget tpl)
+						{
+							var item = ScrollItemWidget.Setup(
+								tpl,
+								() => filter.Date == option.DateType,
+								() => { filter.Date = option.DateType; ApplyFilter(); });
+							item.Get<LabelWidget>("LABEL").GetText = () => option.Text;
+							return item;
+						}
+
+						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+					};
+				}
+			}
+
+			// Duration
+			{
+				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_DURATION_DROPDOWNBUTTON");
+				if (ddb != null)
+				{
+					(DurationType DurationType, string Text)[] options =
+					[
+						(DurationType.Any, ddb.GetText()),
+						(DurationType.VeryShort, FluentProvider.GetMessage(SaveDurationVeryShort)),
+						(DurationType.Short, FluentProvider.GetMessage(SaveDurationShort)),
+						(DurationType.Medium, FluentProvider.GetMessage(SaveDurationMedium)),
+						(DurationType.Long, FluentProvider.GetMessage(SaveDurationLong))
+					];
+
+					var lookup = options.ToFrozenDictionary(kvp => kvp.DurationType, kvp => kvp.Text);
+
+					ddb.GetText = () => lookup[filter.Duration];
+					ddb.OnMouseDown = _ =>
+					{
+						ScrollItemWidget SetupItem((DurationType DurationType, string Text) option, ScrollItemWidget tpl)
+						{
+							var item = ScrollItemWidget.Setup(
+								tpl,
+								() => filter.Duration == option.DurationType,
+								() => { filter.Duration = option.DurationType; ApplyFilter(); });
+							item.Get<LabelWidget>("LABEL").GetText = () => option.Text;
+							return item;
+						}
+
+						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, options, SetupItem);
+					};
+				}
+			}
+
+			// Reset
+			{
+				var button = panel.Get<ButtonWidget>("FLT_RESET_BUTTON");
+				button.IsDisabled = () => filter.IsEmpty;
+				button.OnClick = () =>
+				{
+					filter = new Filter();
+					if (nameInput != null)
+						nameInput.Text = string.Empty;
+					SetupSaveDependentFilters();
+					ApplyFilter();
+				};
+			}
+		}
+
+		void SetupSaveDependentFilters()
+		{
+			// Map name
+			{
+				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_MAPNAME_DROPDOWNBUTTON");
+				if (ddb != null)
+				{
+					var mapNames = saves
+						.Select(s => s.MapTitle)
+						.Where(t => t != null)
+						.Distinct(StringComparer.OrdinalIgnoreCase)
+						.OrderBy(t => t, StringComparer.OrdinalIgnoreCase)
+						.ToList();
+
+					mapNames.Insert(0, null);
+
+					var anyText = ddb.GetText();
+					ddb.GetText = () => string.IsNullOrEmpty(filter.MapName) ? anyText : filter.MapName;
+					ddb.OnMouseDown = _ =>
+					{
+						ScrollItemWidget SetupItem(string option, ScrollItemWidget tpl)
+						{
+							var item = ScrollItemWidget.Setup(
+								tpl,
+								() => string.Equals(filter.MapName, option, StringComparison.CurrentCultureIgnoreCase),
+								() => { filter.MapName = option; ApplyFilter(); });
+							item.Get<LabelWidget>("LABEL").GetText = () => option ?? anyText;
+							return item;
+						}
+
+						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, mapNames, SetupItem);
+					};
+				}
+			}
+
+			// Faction
+			{
+				var ddb = panel.GetOrNull<DropDownButtonWidget>("FLT_FACTION_DROPDOWNBUTTON");
+				if (ddb != null)
+				{
+					var factions = saves
+						.SelectMany(s => s.Factions)
+						.Distinct(StringComparer.OrdinalIgnoreCase)
+						.OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+						.ToList();
+
+					factions.Insert(0, null);
+
+					var anyText = ddb.GetText();
+					ddb.GetText = () => string.IsNullOrEmpty(filter.Faction) ? anyText : FluentProvider.GetMessage(filter.Faction);
+					ddb.OnMouseDown = _ =>
+					{
+						ScrollItemWidget SetupItem(string option, ScrollItemWidget tpl)
+						{
+							var item = ScrollItemWidget.Setup(
+								tpl,
+								() => string.Equals(filter.Faction, option, StringComparison.CurrentCultureIgnoreCase),
+								() => { filter.Faction = option; ApplyFilter(); });
+							item.Get<LabelWidget>("LABEL").GetText = () => option != null ? FluentProvider.GetMessage(option) : anyText;
+							return item;
+						}
+
+						ddb.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 330, factions, SetupItem);
+					};
+				}
+			}
+		}
+
+		static bool EvaluateSaveVisibility(SaveEntry entry)
+		{
+			// Save type
+			if (filter.Type != SaveType.Any)
+			{
+				var isAutosave = Path.GetFileNameWithoutExtension(entry.Path)
+					.StartsWith("autosave", StringComparison.OrdinalIgnoreCase);
+
+				if (filter.Type == SaveType.Autosave && !isAutosave)
+					return false;
+
+				if (filter.Type == SaveType.Manual && isAutosave)
+					return false;
+			}
+
+			// Date
+			if (filter.Date != DateType.Any)
+			{
+				TimeSpan t;
+				switch (filter.Date)
+				{
+					case DateType.Today:
+						t = TimeSpan.FromDays(1d);
+						break;
+
+					case DateType.LastWeek:
+						t = TimeSpan.FromDays(7d);
+						break;
+
+					case DateType.LastFortnight:
+						t = TimeSpan.FromDays(14d);
+						break;
+
+					case DateType.LastMonth:
+					default:
+						t = TimeSpan.FromDays(30d);
+						break;
+				}
+
+				if (entry.LastWrite < DateTime.Now - t)
+					return false;
+			}
+
+			// Duration
+			if (filter.Duration != DurationType.Any)
+			{
+				if (!entry.Duration.HasValue)
+					return true;
+
+				var minutes = entry.Duration.Value.TotalMinutes;
+				switch (filter.Duration)
+				{
+					case DurationType.VeryShort:
+						if (minutes >= 5)
+							return false;
+						break;
+
+					case DurationType.Short:
+						if (minutes < 5 || minutes >= 20)
+							return false;
+						break;
+
+					case DurationType.Medium:
+						if (minutes < 20 || minutes >= 60)
+							return false;
+						break;
+
+					case DurationType.Long:
+						if (minutes < 60)
+							return false;
+						break;
+				}
+			}
+
+			// Save name
+			if (!string.IsNullOrEmpty(filter.SaveName))
+			{
+				var saveName = Path.GetFileNameWithoutExtension(entry.Path);
+				if (!saveName.Contains(filter.SaveName, StringComparison.OrdinalIgnoreCase))
+					return false;
+			}
+
+			// Map name
+			if (!string.IsNullOrEmpty(filter.MapName) &&
+				!string.Equals(filter.MapName, entry.MapTitle, StringComparison.CurrentCultureIgnoreCase))
+				return false;
+
+			// Faction
+			if (!string.IsNullOrEmpty(filter.Faction) &&
+				!entry.Factions.Any(f => string.Equals(filter.Faction, f, StringComparison.CurrentCultureIgnoreCase)))
+				return false;
+
+			return true;
+		}
+
+		void ApplyFilter()
+		{
+			foreach (var entry in saves)
+				entry.Visible = EvaluateSaveVisibility(entry);
+
+			if (selectedPath == null)
+				SelectFirstVisible();
+			else if (saves.All(s => s.Path != selectedPath || !s.Visible))
+			{
+				var firstVisible = saves.FirstOrDefault(s => s.Visible);
+				if (firstVisible != null)
+					SelectSave(firstVisible.Path);
+			}
+
+			gameList.Layout.AdjustChildren();
+			gameList.ScrollToSelectedItem();
+		}
+
+		void SetupFiltersToggle()
+		{
+			var filtersToggle = panel.GetOrNull<CheckboxWidget>("FILTERS_TOGGLE");
+			if (filtersToggle == null)
+				return;
+
+			var filterContainer = panel.GetOrNull("FILTER_AND_MANAGE_CONTAINER") ?? panel.GetOrNull("FILTERS");
+			var saveListContainer = panel.GetOrNull("SAVE_LIST_CONTAINER");
+			if (filterContainer == null || saveListContainer == null)
+				return;
+
+			filterContainer.IsVisible = () => filtersVisible;
+			filtersToggle.IsChecked = () => filtersVisible;
+
+			// The YAML lays the save list out as if the filter panel were visible.
+			var saveListNormalBounds = saveListContainer.Bounds;
+			var expandedX = filterContainer.Bounds.X;
+			var expandedWidth = saveListNormalBounds.Right - expandedX;
+
+			void ApplyFiltersVisibility(bool reloadGames)
+			{
+				var newX = filtersVisible ? saveListNormalBounds.X : expandedX;
+				var newWidth = filtersVisible ? saveListNormalBounds.Width : expandedWidth;
+				var widthDelta = newWidth - saveListContainer.Bounds.Width;
+
+				saveListContainer.Bounds = new WidgetBounds(newX, saveListNormalBounds.Y, newWidth, saveListNormalBounds.Height);
+
+				var saveListLabel = saveListContainer.GetOrNull<LabelWidget>("SAVE_LIST_LABEL");
+				if (saveListLabel != null)
+					saveListLabel.Bounds.Width += widthDelta;
+
+				gameList.Bounds.Width += widthDelta;
+
+				gameTemplate.Bounds.Width += widthDelta;
+				foreach (var child in gameTemplate.Children)
+					child.Bounds.Width += widthDelta;
+
+				dateHeaderTemplate.Bounds.Width += widthDelta;
+				foreach (var child in dateHeaderTemplate.Children)
+					child.Bounds.Width += widthDelta;
+
+				if (reloadGames)
+				{
+					LoadGames(gameTemplate, dateHeaderTemplate);
+					ApplyFilter();
+				}
+			}
+
+			filtersToggle.OnClick = () =>
+			{
+				filtersVisible = !filtersVisible;
+				ApplyFiltersVisibility(reloadGames: true);
+			};
+
+			// Filters are hidden by default, so widen the save list to fill the freed space.
+			if (!filtersVisible)
+				ApplyFiltersVisibility(reloadGames: false);
+		}
+
+		void SetupManagement(Action onExit)
+		{
+			SetupFiltersToggle();
+
+			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
+			renameButton.IsDisabled = () => selectedPath == null;
+			renameButton.OnClick = () =>
+			{
+				var initialName = Path.GetFileNameWithoutExtension(selectedPath);
+
+				ConfirmationDialogs.TextInputPrompt(modData,
+					RenameSaveTitle,
+					RenameSavePrompt,
+					initialName,
+					onAccept: newName => Rename(initialName, newName),
+					onCancel: null,
+					acceptText: RenameSaveAccept,
+					cancelText: null,
+					inputValidator: newName => GameSaveUtils.IsValidNewSaveName(newName, initialName, baseSavePath));
+			};
+
+			var deleteButton = panel.Get<ButtonWidget>("DELETE_BUTTON");
+			deleteButton.IsDisabled = () => selectedPath == null;
+			deleteButton.OnClick = () =>
+			{
+				ConfirmationDialogs.ButtonPrompt(modData,
+					title: DeleteSaveTitle,
+					text: DeleteSavePrompt,
+					textArguments: ["save", Path.GetFileNameWithoutExtension(selectedPath)],
+					onConfirm: () =>
+					{
+						Delete(selectedPath);
+
+						if (!saves.Any(s => s.Visible))
+						{
+							Ui.CloseWindow();
+							onExit();
+						}
+						else
+							SelectFirstVisible();
+					},
+					confirmText: DeleteSaveAccept,
+					onCancel: () => { });
+			};
+
+			var deleteAllButton = panel.Get<ButtonWidget>("DELETE_ALL_BUTTON");
+			deleteAllButton.IsDisabled = () => !saves.Any(s => s.Visible);
+			deleteAllButton.OnClick = () =>
+			{
+				var visible = saves.Where(s => s.Visible).ToList();
+
+				ConfirmationDialogs.ButtonPrompt(modData,
+					title: DeleteAllSavesTitle,
+					text: DeleteAllSavesPrompt,
+					textArguments: ["count", visible.Count],
+					onConfirm: () =>
+					{
+						foreach (var s in visible)
+							Delete(s.Path);
+
+						if (!saves.Any(s => s.Visible))
+						{
+							Ui.CloseWindow();
+							onExit();
+						}
+					},
+					confirmText: DeleteAllSavesAccept,
+					onCancel: () => { });
+			};
+		}
+
+		void Rename(string oldName, string newName)
+		{
+			try
+			{
+				var oldPath = Path.Combine(baseSavePath, oldName + ".orasav");
+				var newPath = Path.Combine(baseSavePath, newName + ".orasav");
+				File.Move(oldPath, newPath);
+
+				var entry = saves.First(s => s.Path == oldPath);
+				entry.Path = newPath;
+
+				foreach (var c in gameList.Children)
+				{
+					if (c is not ScrollItemWidget item || item.ItemKey != oldPath)
+						continue;
+
+					item.ItemKey = newPath;
+					item.Get<LabelWidget>("TITLE").GetText = () => newName;
+				}
+
+				if (selectedPath == oldPath)
+					selectedPath = newPath;
+			}
+			catch (Exception ex)
+			{
+				Log.Write("debug", ex.ToString());
+			}
+		}
+
+		void Delete(string savePath)
+		{
+			try
+			{
+				File.Delete(savePath);
+			}
+			catch (Exception ex)
+			{
+				TextNotificationsManager.Debug(FluentProvider.GetMessage(SaveDeletionFailed, "savePath", savePath));
+				Log.Write("debug", ex.ToString());
+			}
+
+			if (File.Exists(savePath))
+				return;
+
+			if (savePath == selectedPath)
+				SelectSave(null);
+
+			var entry = saves.First(s => s.Path == savePath);
+			gameList.RemoveChild(entry.Item);
+			saves.Remove(entry);
+		}
+
+		void SelectFirstVisible()
+		{
+			SelectSave(saves.FirstOrDefault(s => s.Visible)?.Path);
+		}
+
+		void SelectSave(string savePath)
+		{
+			selectedPath = savePath;
+			playerList.RemoveChildren();
+
+			if (savePath == null)
+			{
+				selectedSave = null;
+				map = MapCache.UnknownMap;
+				return;
+			}
+
+			try
+			{
+				selectedSave = new GameSave(savePath);
+			}
+			catch (Exception ex)
+			{
+				Log.Write("debug", $"Failed to load save file '{savePath}': {ex}");
+				selectedSave = null;
+				map = MapCache.UnknownMap;
+				return;
+			}
+
+			var preview = modData.MapCache[selectedSave.GlobalSettings.Map];
+			if (preview.Status != MapStatus.Available && selectedSave.MapGenerationArgs != null)
+			{
+				preview.UpdateFromGenerationArgs(selectedSave.MapGenerationArgs);
+				preview.Generate();
+			}
+
+			map = preview;
+
+			UpdatePlayerList();
+		}
+
+		Dictionary<int, SpawnOccupant> GetSpawnOccupants()
+		{
+			if (selectedSave == null)
+				return [];
+
+			var occupants = new Dictionary<int, SpawnOccupant>();
+			foreach (var (_, slotClient) in selectedSave.SlotClients)
+			{
+				if (slotClient.SpawnPoint == 0)
+					continue;
+
+				var client = new Session.Client
+				{
+					Color = slotClient.Color,
+					Faction = slotClient.Faction,
+					SpawnPoint = slotClient.SpawnPoint,
+					Team = slotClient.Team,
+					Bot = slotClient.Bot,
+					Name = slotClient.Bot != null ? slotClient.BotName : string.Empty
+				};
+
+				occupants[slotClient.SpawnPoint] = new SpawnOccupant(client);
+			}
+
+			return occupants;
+		}
+
+		void UpdatePlayerList()
+		{
+			playerList.RemoveChildren();
+
+			if (selectedSave == null)
+				return;
+
+			var factionInfo = modData.DefaultRules.Actors[SystemActors.World].TraitInfos<FactionInfo>();
+
+			var botOrdinals = selectedSave.SlotClients
+				.Where(kv => kv.Value.Bot != null)
+				.GroupBy(kv => kv.Value.Bot)
+				.SelectMany(g => g.Select((kv, i) => (SlotKey: kv.Key, Ordinal: i + 1)))
+				.ToFrozenDictionary(x => x.SlotKey, x => x.Ordinal);
+
+			var slotClientsByTeam = selectedSave.SlotClients
+				.GroupBy(kv => kv.Value.Team)
+				.OrderBy(g => g.Key)
+				.ToList();
+
+			var noTeams = slotClientsByTeam.Count == 1;
+
+			foreach (var teamGroup in slotClientsByTeam)
+			{
+				var team = teamGroup.Key;
+				var label = noTeams ? FluentProvider.GetMessage(Players) : team > 0
+					? FluentProvider.GetMessage(TeamNumber, "team", team)
+					: FluentProvider.GetMessage(NoTeam);
+
+				if (label.Length > 0)
+				{
+					var header = ScrollItemWidget.Setup(playerHeader, () => false, () => { });
+					header.Get<LabelWidget>("LABEL").GetText = () => label;
+					playerList.AddChild(header);
+				}
+
+				foreach (var (slotKey, slotClient) in teamGroup)
+				{
+					var displayName = slotClient.Bot != null
+						? FluentProvider.GetMessage(EnumeratedBotName,
+							"name", FluentProvider.GetMessage(slotClient.BotName),
+							"number", botOrdinals[slotKey])
+						: FluentProvider.GetMessage(HumanPlayer);
+
+					var color = slotClient.Color;
+					var item = ScrollItemWidget.Setup(playerTemplate, () => false, () => { });
+
+					var nameLabel = item.Get<LabelWidget>("LABEL");
+					var font = Game.Renderer.Fonts[nameLabel.Font];
+					var name = WidgetUtils.TruncateText(displayName, nameLabel.Bounds.Width, font);
+					nameLabel.GetText = () => name;
+					nameLabel.GetColor = () => color;
+
+					var flag = item.Get<ImageWidget>("FLAG");
+					flag.GetImageCollection = () => "flags";
+					var faction = slotClient.Faction;
+					flag.GetImageName = () => factionInfo != null && factionInfo.Any(f => f.InternalName == faction) ? faction : "Random";
+
+					playerList.AddChild(item);
+				}
+			}
+		}
+
+		void Load()
+		{
+			if (selectedSave == null)
+				return;
+
+			var mapPreview = modData.MapCache[selectedSave.GlobalSettings.Map];
+			if (mapPreview.Status != MapStatus.Available)
+				return;
+
+			Ui.CloseWindow();
+
+			var orders = new List<Order>
+			{
+				Order.FromTargetString("LoadGameSave", Path.GetFileName(selectedPath), true),
+				Order.Command($"state {Session.ClientState.Ready}")
+			};
+
+			Game.CreateAndStartLocalServer(mapPreview.Uid, orders);
+		}
+
+		void OnGameStart()
+		{
+			Ui.CloseWindow();
+			onStart();
+		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				Game.BeforeGameStart -= OnGameStart;
+			}
+
+			base.Dispose(disposing);
+		}
+
+		public static bool IsLoadPanelEnabled(Manifest mod)
+		{
+			var baseSavePath = Path.Combine(Platform.SupportDir, "Saves", mod.Id, mod.Metadata.Version);
+			if (!Directory.Exists(baseSavePath))
+				return false;
+
+			return Directory.GetFiles(baseSavePath, "*.orasav").Length > 0;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -218,10 +218,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			previewWidgets[PreviewStatus.DownloadError] =
 				[previewSmall, widget.Get("MAP_ERROR"), retryButton];
 
-			// Hide all widgets.
+			// Hide all widgets, then show the correct ones for the initial state.
 			foreach (var preview in previewWidgets)
 				foreach (var p in preview.Value)
 					p.IsVisible = () => false;
+
+			UpdateVisibility();
 		}
 
 		Widget[] visibleWidgets = [];

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			skirmishButton.Disabled = !hasMaps;
 
 			var loadButton = singleplayerMenu.Get<ButtonWidget>("LOAD_BUTTON");
-			loadButton.IsDisabled = () => !GameSaveBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
+			loadButton.IsDisabled = () => !LoadGameBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
 			loadButton.OnClick = OpenGameSaveBrowserPanel;
 
 			var encyclopediaButton = singleplayerMenu.GetOrNull<ButtonWidget>("ENCYCLOPEDIA_BUTTON");
@@ -512,12 +512,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void OpenGameSaveBrowserPanel()
 		{
 			SwitchMenu(MenuType.None);
-			Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+			Ui.OpenWindow("LOAD_GAME_BROWSER_PANEL", new WidgetArgs
 			{
 				{ "onExit", () => SwitchMenu(MenuType.Singleplayer) },
 				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.GameSaves; } },
-				{ "isSavePanel", false },
-				{ "world", null }
 			});
 		}
 

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -2,8 +2,8 @@ Container@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
 	X: (WINDOW_WIDTH - WIDTH) / 2
 	Y: (WINDOW_HEIGHT - HEIGHT) / 2
-	Width: 716
-	Height: 435
+	Width: 900
+	Height: 540
 	Children:
 		Label@LOAD_TITLE:
 			Width: PARENT_WIDTH
@@ -30,21 +30,23 @@ Container@GAMESAVE_BROWSER_PANEL:
 			Children:
 				ScrollPanel@GAME_LIST:
 					X: 15
-					Y: 15
-					Width: PARENT_WIDTH - 30
-					Height: PARENT_HEIGHT - 30
+					Y: 13
+					Width: PARENT_WIDTH - 219
+					Height: PARENT_HEIGHT - 36
 					Children:
-						ScrollItem@NEW_TEMPLATE:
+						ScrollItem@DATE_HEADER:
+							Background: scrollheader
 							Width: PARENT_WIDTH - 27
-							Height: 25
+							Height: 13
 							X: 2
+							Y: 0
 							Visible: false
 							Children:
-								Label@TITLE:
+								Label@LABEL:
+									Font: TinyBold
 									Width: PARENT_WIDTH
-									Height: PARENT_HEIGHT
+									Height: 13
 									Align: Center
-									Text: label-bg-title
 						ScrollItem@GAME_TEMPLATE:
 							Width: PARENT_WIDTH - 27
 							Height: 25
@@ -54,24 +56,113 @@ Container@GAMESAVE_BROWSER_PANEL:
 							Children:
 								LabelWithTooltip@TITLE:
 									X: 10
-									Width: PARENT_WIDTH - 200 - 10
+									Width: PARENT_WIDTH - 10
 									Height: 25
 									TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
-								Label@DATE:
-									X: PARENT_WIDTH - WIDTH - 10
-									Width: 200
+				Container@MAP_PREVIEW_ROOT:
+					X: PARENT_WIDTH - WIDTH - 15
+					Y: 13
+					Width: 174
+					Height: 250
+				Container@SAVE_INFO:
+					X: PARENT_WIDTH - WIDTH - 15
+					Y: 263
+					Width: 174
+					Height: PARENT_HEIGHT - 240
+					Children:
+						Label@NO_SAVE_SELECTED_LABEL:
+							Y: -75
+							Width: PARENT_WIDTH
+							Height: 65
+							Font: Tiny
+							Align: Center
+							WordWrap: True
+							Text: label-gamesave-browser-panel-no-save-selected
+							Visible: False
+						Label@INCOMPATIBLE_TITLE_LABEL:
+							Y: -61
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: Bold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-title
+							Visible: False
+						Label@INCOMPATIBLE_LABEL_A:
+							Y: -46
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: TinyBold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-a
+						Label@INCOMPATIBLE_LABEL_B:
+							Y: -33
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: TinyBold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-b
+						Label@SAVEGAME_INFO_DATE:
+							X: 5
+							Y: -27
+							Width: PARENT_WIDTH
+							Height: 16
+							Font: TinyBold
+							Align: Left
+							Visible: False
+						Label@SAVEGAME_INFO_DURATION:
+							X: 5
+							Y: -11
+							Width: PARENT_WIDTH
+							Height: 16
+							Font: TinyBold
+							Align: Left
+							Visible: False
+						ScrollPanel@PLAYER_LIST:
+							Y: 8
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 46
+							IgnoreChildMouseOver: true
+							Children:
+								ScrollItem@HEADER:
+									Background: scrollheader
+									Width: PARENT_WIDTH - 27
+									Height: 13
+									X: 2
+									Y: 0
+									Visible: false
+									Children:
+										Label@LABEL:
+											Font: TinyBold
+											Width: PARENT_WIDTH
+											Height: 13
+											Align: Center
+								ScrollItem@TEMPLATE:
+									Width: PARENT_WIDTH - 27
 									Height: 25
-									Align: Right
+									X: 2
+									Y: 0
+									Visible: false
+									Children:
+										Image@FLAG:
+											X: 4
+											Y: 6
+											Width: 32
+											Height: 16
+										Label@LABEL:
+											X: 40
+											Width: PARENT_WIDTH - 50
+											Height: 25
+											Shadow: True
 				Container@SAVE_WIDGETS:
 					X: 15
 					Y: PARENT_HEIGHT - 40
-					Width: PARENT_WIDTH - 30
-					Height: 30
+					Width: PARENT_WIDTH - 219
+					Height: 25
 					Visible: False
 					Children:
 						TextField@SAVE_TEXTFIELD:
-							Width: PARENT_WIDTH
+							Width: PARENT_WIDTH - 1
 							Height: 25
 							Type: Filename
 				Button@CANCEL_BUTTON:

--- a/mods/cnc/chrome/load-game-browser.yaml
+++ b/mods/cnc/chrome/load-game-browser.yaml
@@ -1,0 +1,295 @@
+﻿Container@LOAD_GAME_BROWSER_PANEL:
+	Logic: LoadGameBrowserLogic
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
+	Width: 900
+	Height: 540
+	Children:
+		Label@TITLE:
+			Width: PARENT_WIDTH
+			Height: 25
+			Y: 0 - 34
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: label-load-game-browser-panel-title
+		Background@bg:
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Background: panel-black
+			Children:
+				Background@FILTERS:
+					X: 17
+					Y: 30
+					Width: 278
+					Height: 231
+					Background: panel-gray
+					Children:
+						Label@FILTERS_TITLE:
+							Y: 0 - 24
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: Bold
+							Align: Center
+							Text: label-filters-title
+						Label@FLT_NAME_DESC:
+							X: 0
+							Y: 8
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-name-desc
+							Align: Right
+						TextField@FLT_NAME_INPUT:
+							X: 85
+							Y: 8
+							Width: PARENT_WIDTH - 93
+							Height: 25
+						Label@FLT_TYPE_DESC:
+							X: 0
+							Y: 38
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-gametype-desc
+							Align: Right
+						DropDownButton@FLT_TYPE_DROPDOWNBUTTON:
+							X: 85
+							Y: 38
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_DATE_DESC:
+							X: 0
+							Y: 68
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-date-desc
+							Align: Right
+						DropDownButton@FLT_DATE_DROPDOWNBUTTON:
+							X: 85
+							Y: 68
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_DURATION_DESC:
+							X: 0
+							Y: 98
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-duration-desc
+							Align: Right
+						DropDownButton@FLT_DURATION_DROPDOWNBUTTON:
+							X: 85
+							Y: 98
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_MAPNAME_DESC:
+							X: 0
+							Y: 128
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-mapname-desc
+							Align: Right
+						DropDownButton@FLT_MAPNAME_DROPDOWNBUTTON:
+							X: 85
+							Y: 128
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_FACTION_DESC:
+							X: 0
+							Y: 158
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-faction-desc
+							Align: Right
+						DropDownButton@FLT_FACTION_DROPDOWNBUTTON:
+							X: 85
+							Y: 158
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Button@FLT_RESET_BUTTON:
+							X: 85
+							Y: 198
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: button-filters-flt-reset
+							Font: Bold
+				Container@SAVE_LIST_CONTAINER:
+					X: 304
+					Y: 15
+					Width: PARENT_WIDTH - 508
+					Height: PARENT_HEIGHT - 33
+					Children:
+						Label@SAVE_LIST_LABEL:
+							Y: 0 - 9
+							Width: PARENT_WIDTH
+							Height: 25
+							Text: label-load-game-browser-panel-choose-save
+							Align: Center
+							Font: Bold
+						ScrollPanel@GAME_LIST:
+							X: 0
+							Y: 15
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 15
+							CollapseHiddenChildren: True
+							Children:
+								ScrollItem@DATE_HEADER:
+									Background: scrollheader
+									Width: PARENT_WIDTH - 27
+									Height: 13
+									X: 2
+									Y: 0
+									Visible: false
+									Children:
+										Label@LABEL:
+											Font: TinyBold
+											Width: PARENT_WIDTH
+											Height: 13
+											Align: Center
+								ScrollItem@GAME_TEMPLATE:
+									Width: PARENT_WIDTH - 27
+									Height: 25
+									X: 2
+									Visible: false
+									EnableChildMouseOver: True
+									Children:
+										LabelWithTooltip@TITLE:
+											X: 10
+											Width: PARENT_WIDTH - 10
+											Height: 25
+											TooltipContainer: LOAD_GAME_TITLE_TOOLTIP_CONTAINER
+											TooltipTemplate: SIMPLE_TOOLTIP
+				Container@MAP_PREVIEW_ROOT:
+					X: PARENT_WIDTH - WIDTH - 15
+					Y: 30
+					Width: 174
+					Height: 250
+				Container@SAVE_INFO:
+					X: PARENT_WIDTH - WIDTH - 15
+					Y: 283
+					Width: 174
+					Height: 239
+					Children:
+						Label@INCOMPATIBLE_TITLE_LABEL:
+							Y: -64
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: Bold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-title
+						Label@INCOMPATIBLE_LABEL_A:
+							Y: -49
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: TinyBold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-a
+						Label@INCOMPATIBLE_LABEL_B:
+							Y: -36
+							Width: PARENT_WIDTH
+							Height: 25
+							Font: TinyBold
+							Align: Center
+							Text: label-load-game-browser-panel-incompatible-b
+						Label@SAVEGAME_INFO_DATE:
+							X: 5
+							Y: -32
+							Width: PARENT_WIDTH
+							Height: 16
+							Font: TinyBold
+							Align: Left
+							Visible: False
+						Label@SAVEGAME_INFO_DURATION:
+							X: 5
+							Y: -16
+							Width: PARENT_WIDTH
+							Height: 16
+							Font: TinyBold
+							Align: Left
+							Visible: False
+						ScrollPanel@PLAYER_LIST:
+							Y: 3
+							Width: PARENT_WIDTH
+							Height: 236
+							IgnoreChildMouseOver: true
+							Children:
+								ScrollItem@HEADER:
+									Background: scrollheader
+									Width: PARENT_WIDTH - 27
+									Height: 13
+									X: 2
+									Y: 0
+									Visible: false
+									Children:
+										Label@LABEL:
+											Font: TinyBold
+											Width: PARENT_WIDTH
+											Height: 13
+											Align: Center
+								ScrollItem@TEMPLATE:
+									Width: PARENT_WIDTH - 27
+									Height: 25
+									X: 2
+									Y: 0
+									Visible: false
+									Children:
+										Image@FLAG:
+											X: 4
+											Y: 6
+											Width: 32
+											Height: 16
+										Label@LABEL:
+											X: 40
+											Width: PARENT_WIDTH - 50
+											Height: 25
+											Shadow: True
+				Button@CANCEL_BUTTON:
+					Key: escape
+					X: 0
+					Y: PARENT_HEIGHT - 1
+					Width: 140
+					Height: 35
+					Text: button-back
+				Checkbox@FILTERS_TOGGLE:
+					X: PARENT_WIDTH - 140 - 110 - 110 - 110 - 120
+					Y: PARENT_HEIGHT + 7
+					Width: 120
+					Height: 20
+					Text: checkbox-load-game-filters
+					Font: Regular
+				Button@DELETE_ALL_BUTTON:
+					X: PARENT_WIDTH - 140 - 110 - 110 - 110
+					Y: PARENT_HEIGHT - 1
+					Width: 100
+					Height: 35
+					Text: button-management-mng-delall
+					Font: Bold
+				Button@DELETE_BUTTON:
+					X: PARENT_WIDTH - 140 - 110 - 110
+					Y: PARENT_HEIGHT - 1
+					Width: 100
+					Height: 35
+					Text: button-management-mng-delsel
+					Font: Bold
+					Key: Delete
+				Button@RENAME_BUTTON:
+					X: PARENT_WIDTH - 140 - 110
+					Y: PARENT_HEIGHT - 1
+					Width: 100
+					Height: 35
+					Text: button-management-mng-rensel
+					Font: Bold
+					Key: F2
+				Button@LOAD_BUTTON:
+					Key: return
+					X: PARENT_WIDTH - 140
+					Y: PARENT_HEIGHT - 1
+					Width: 140
+					Height: 35
+					Text: button-load-game-browser-panel-load
+					Font: Bold
+		TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@LOAD_GAME_TITLE_TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -27,6 +27,7 @@ Container@MAP_PREVIEW:
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_SMALL:
+			Visible: false
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT
 			Children:
@@ -170,14 +171,14 @@ Container@MAP_PREVIEW:
 					Y: 158
 					Width: PARENT_WIDTH
 					Height: 25
-					Font: Tiny
+					Font: TinyBold
 					Align: Center
 					Text: label-map-unavailable-a
 				Label@b:
 					Y: 171
 					Width: PARENT_WIDTH
 					Height: 25
-					Font: Tiny
+					Font: TinyBold
 					Align: Center
 					Text: label-map-unavailable-b
 		Label@MAP_ERROR:

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -122,10 +122,23 @@ label-tool-tiling-path = Path Tiler
 ## encyclopedia.yaml, mainmenu.yaml
 label-encyclopedia-title = EVA Database
 
+## load-game-browser.yaml
+label-load-game-browser-panel-title = Load Game
+label-load-game-browser-panel-choose-save = Choose Save
+label-load-game-browser-panel-incompatible-title = Incompatible Savegame
+label-load-game-browser-panel-incompatible-a = This savegame is not compatible
+label-load-game-browser-panel-incompatible-b = with this version of OpenRA
+label-load-game-browser-panel-human-player = Player
+button-load-game-browser-panel-load = Load
+tooltip-savegame-date-created = Date Created
+tooltip-savegame-map = Map
+tooltip-savegame-duration = Duration
+tooltip-savegame-players = Number of players
+
 ## gamesave-browser.yaml
 label-gamesave-browser-panel-load-title = Load game
-label-gamesave-browser-panel-save-title = Save game
-label-bg-title = [CREATE NEW FILE]
+label-gamesave-browser-panel-save-title = Save Game
+label-gamesave-browser-panel-no-save-selected = Select a savegame to overwrite it or type a new savegame name
 button-bg-delete-all = Delete All
 button-bg-delete = Delete
 button-bg-rename = Rename
@@ -636,6 +649,7 @@ label-connection-error-desc-b = Please check your internet connection.
 ## replaybrowser.yaml
 label-replaybrowser-panel-title = Replay Viewer
 label-filters-title = Filter
+label-filters-flt-name-desc = Name:
 label-filters-flt-gametype-desc = Type:
 dropdownbutton-filters-any = Any
 label-filters-flt-date-desc = Date:
@@ -650,6 +664,7 @@ label-management-manage-title = Manage
 button-management-mng-rensel = Rename
 button-management-mng-delsel = Delete
 button-management-mng-delall = Delete All
+checkbox-load-game-filters = Filters
 label-replay-list-container-replaybrowser-title = Choose Replay
 button-replaybrowser-panel-watch = Watch
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -114,6 +114,7 @@ ChromeLayout:
 	cnc|chrome/mapchooser.yaml
 	cnc|chrome/replaybrowser.yaml
 	cnc|chrome/gamesave-browser.yaml
+	cnc|chrome/load-game-browser.yaml
 	cnc|chrome/gamesave-loading.yaml
 	cnc|chrome/ingame.yaml
 	cnc|chrome/ingame-chat.yaml

--- a/mods/common/chrome/gamesave-browser.yaml
+++ b/mods/common/chrome/gamesave-browser.yaml
@@ -2,8 +2,8 @@ Background@GAMESAVE_BROWSER_PANEL:
 	Logic: GameSaveBrowserLogic
 	X: (WINDOW_WIDTH - WIDTH) / 2
 	Y: (WINDOW_HEIGHT - HEIGHT) / 2
-	Width: 700
-	Height: 500
+	Width: 900
+	Height: 600
 	Children:
 		Label@LOAD_TITLE:
 			Width: PARENT_WIDTH
@@ -24,20 +24,22 @@ Background@GAMESAVE_BROWSER_PANEL:
 		ScrollPanel@GAME_LIST:
 			X: 20
 			Y: 45
-			Width: PARENT_WIDTH - 40
-			Height: PARENT_HEIGHT - 97
+			Width: PARENT_WIDTH - 225
+			Height: PARENT_HEIGHT - 99
 			Children:
-				ScrollItem@NEW_TEMPLATE:
+				ScrollItem@DATE_HEADER:
+					Background: scrollheader
 					Width: PARENT_WIDTH - 27
-					Height: 25
+					Height: 13
 					X: 2
+					Y: 0
 					Visible: false
 					Children:
-						Label@TITLE:
+						Label@LABEL:
+							Font: TinyBold
 							Width: PARENT_WIDTH
-							Height: PARENT_HEIGHT
+							Height: 13
 							Align: Center
-							Text: label-gamesave-browser-panel-title
 				ScrollItem@GAME_TEMPLATE:
 					Width: PARENT_WIDTH - 27
 					Height: 25
@@ -47,24 +49,113 @@ Background@GAMESAVE_BROWSER_PANEL:
 					Children:
 						LabelWithTooltip@TITLE:
 							X: 10
-							Width: PARENT_WIDTH - 200 - 10
+							Width: PARENT_WIDTH - 10
 							Height: 25
 							TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
-						Label@DATE:
-							X: PARENT_WIDTH - WIDTH - 10
-							Width: 200
+		Container@MAP_PREVIEW_ROOT:
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: 45
+			Width: 174
+			Height: 250
+		Container@SAVE_INFO:
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: 300
+			Width: 174
+			Height: PARENT_HEIGHT - 324
+			Children:
+				Label@NO_SAVE_SELECTED_LABEL:
+					Y: -75
+					Width: PARENT_WIDTH
+					Height: 65
+					Font: Tiny
+					Align: Center
+					WordWrap: True
+					Text: label-gamesave-browser-panel-no-save-selected
+					Visible: False
+				Label@INCOMPATIBLE_TITLE_LABEL:
+					Y: -66
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-title
+					Visible: False
+				Label@INCOMPATIBLE_LABEL_A:
+					Y: -51
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-a
+				Label@INCOMPATIBLE_LABEL_B:
+					Y: -38
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-b
+				Label@SAVEGAME_INFO_DATE:
+					X: 5
+					Y: -32
+					Width: PARENT_WIDTH
+					Height: 16
+					Font: TinyBold
+					Align: Left
+					Visible: False
+				Label@SAVEGAME_INFO_DURATION:
+					X: 5
+					Y: -16
+					Width: PARENT_WIDTH
+					Height: 16
+					Font: TinyBold
+					Align: Left
+					Visible: False
+				ScrollPanel@PLAYER_LIST:
+					Y: 3
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 34
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							Background: scrollheader
+							Width: PARENT_WIDTH - 27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_WIDTH
+									Height: 13
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_WIDTH - 27
 							Height: 25
-							Align: Right
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: PARENT_WIDTH - 50
+									Height: 25
+									Shadow: True
 		Container@SAVE_WIDGETS:
 			X: 20
-			Y: PARENT_HEIGHT - 77
+			Y: PARENT_HEIGHT - 81
 			Width: PARENT_WIDTH - 40
 			Height: 32
 			Visible: False
 			Children:
 				TextField@SAVE_TEXTFIELD:
-					Width: PARENT_WIDTH
+					Width: PARENT_WIDTH - 184
 					Height: 25
 					Type: Filename
 		Button@DELETE_ALL_BUTTON:

--- a/mods/common/chrome/load-game-browser.yaml
+++ b/mods/common/chrome/load-game-browser.yaml
@@ -1,0 +1,295 @@
+﻿Background@LOAD_GAME_BROWSER_PANEL:
+	Logic: LoadGameBrowserLogic
+	X: (WINDOW_WIDTH - WIDTH) / 2
+	Y: (WINDOW_HEIGHT - HEIGHT) / 2
+	Width: 900
+	Height: 600
+	Children:
+		Label@TITLE:
+			Y: 16
+			Width: PARENT_WIDTH
+			Height: 25
+			Text: label-load-game-browser-panel-title
+			Align: Center
+			Font: Bold
+		Container@FILTER_AND_MANAGE_CONTAINER:
+			X: 21
+			Y: 37
+			Width: 264
+			Height: PARENT_HEIGHT - 75
+			Children:
+				Label@FILTERS_TITLE:
+					Y: 6
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: label-filters-title
+				Background@FILTERS:
+					Y: 30
+					Width: PARENT_WIDTH
+					Height: 231
+					Background: dialog3
+					Children:
+						Label@FLT_NAME_DESC:
+							X: 0
+							Y: 8
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-name-desc
+							Align: Right
+						TextField@FLT_NAME_INPUT:
+							X: 85
+							Y: 8
+							Width: PARENT_WIDTH - 93
+							Height: 25
+						Label@FLT_TYPE_DESC:
+							X: 0
+							Y: 38
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-gametype-desc
+							Align: Right
+						DropDownButton@FLT_TYPE_DROPDOWNBUTTON:
+							X: 85
+							Y: 38
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_DATE_DESC:
+							X: 0
+							Y: 68
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-date-desc
+							Align: Right
+						DropDownButton@FLT_DATE_DROPDOWNBUTTON:
+							X: 85
+							Y: 68
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_DURATION_DESC:
+							X: 0
+							Y: 98
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-duration-desc
+							Align: Right
+						DropDownButton@FLT_DURATION_DROPDOWNBUTTON:
+							X: 85
+							Y: 98
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_MAPNAME_DESC:
+							X: 0
+							Y: 128
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-mapname-desc
+							Align: Right
+						DropDownButton@FLT_MAPNAME_DROPDOWNBUTTON:
+							X: 85
+							Y: 128
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Label@FLT_FACTION_DESC:
+							X: 0
+							Y: 158
+							Width: 80
+							Height: 25
+							Text: label-filters-flt-faction-desc
+							Align: Right
+						DropDownButton@FLT_FACTION_DROPDOWNBUTTON:
+							X: 85
+							Y: 158
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: dropdownbutton-filters-any
+						Button@FLT_RESET_BUTTON:
+							X: 85
+							Y: 198
+							Width: PARENT_WIDTH - 93
+							Height: 25
+							Text: button-filters-flt-reset
+							Font: Bold
+		Container@SAVE_LIST_CONTAINER:
+			X: 296
+			Y: 37
+			Width: 399
+			Height: PARENT_HEIGHT - 37 - 55
+			Children:
+				Label@SAVE_LIST_LABEL:
+					Y: 6
+					Width: PARENT_WIDTH
+					Height: 25
+					Text: label-load-game-browser-panel-choose-save
+					Align: Center
+					Font: Bold
+				ScrollPanel@GAME_LIST:
+					X: 0
+					Y: 30
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
+					CollapseHiddenChildren: True
+					Children:
+						ScrollItem@DATE_HEADER:
+							Background: scrollheader
+							Width: PARENT_WIDTH - 27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_WIDTH
+									Height: 13
+									Align: Center
+						ScrollItem@GAME_TEMPLATE:
+							Width: PARENT_WIDTH - 27
+							Height: 25
+							X: 2
+							Visible: false
+							EnableChildMouseOver: True
+							Children:
+								LabelWithTooltip@TITLE:
+									X: 10
+									Width: PARENT_WIDTH - 10
+									Height: 25
+									TooltipContainer: LOAD_GAME_TITLE_TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
+		Container@MAP_PREVIEW_ROOT:
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: 67
+			Width: 174
+			Height: 250
+		Container@SAVE_INFO:
+			X: PARENT_WIDTH - WIDTH - 20
+			Y: 320
+			Width: 174
+			Height: PARENT_HEIGHT - 320 - 45
+			Children:
+				Label@INCOMPATIBLE_TITLE_LABEL:
+					Y: -64
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-title
+				Label@INCOMPATIBLE_LABEL_A:
+					Y: -49
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-a
+				Label@INCOMPATIBLE_LABEL_B:
+					Y: -36
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					Text: label-load-game-browser-panel-incompatible-b
+				Label@SAVEGAME_INFO_DATE:
+					X: 5
+					Y: -32
+					Width: PARENT_WIDTH
+					Height: 16
+					Font: TinyBold
+					Align: Left
+					Visible: False
+				Label@SAVEGAME_INFO_DURATION:
+					X: 5
+					Y: -16
+					Width: PARENT_WIDTH
+					Height: 16
+					Font: TinyBold
+					Align: Left
+					Visible: False
+				ScrollPanel@PLAYER_LIST:
+					Y: 3
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 13
+					IgnoreChildMouseOver: true
+					Children:
+						ScrollItem@HEADER:
+							Background: scrollheader
+							Width: PARENT_WIDTH - 27
+							Height: 13
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_WIDTH
+									Height: 13
+									Align: Center
+						ScrollItem@TEMPLATE:
+							Width: PARENT_WIDTH - 27
+							Height: 25
+							X: 2
+							Y: 0
+							Visible: false
+							Children:
+								Image@FLAG:
+									X: 4
+									Y: 6
+									Width: 32
+									Height: 16
+								Label@LABEL:
+									X: 40
+									Width: PARENT_WIDTH - 50
+									Height: 25
+									Shadow: True
+		Checkbox@FILTERS_TOGGLE:
+			X: 20
+			Y: PARENT_HEIGHT - 43
+			Width: 120
+			Height: 20
+			Text: checkbox-load-game-filters
+			Font: Regular
+		Button@DELETE_ALL_BUTTON:
+			X: 150
+			Y: PARENT_HEIGHT - 45
+			Width: 100
+			Height: 25
+			Text: button-management-mng-delall
+			Font: Bold
+		Button@DELETE_BUTTON:
+			Key: Delete
+			X: 260
+			Y: PARENT_HEIGHT - 45
+			Width: 100
+			Height: 25
+			Text: button-management-mng-delsel
+			Font: Bold
+		Button@RENAME_BUTTON:
+			Key: F2
+			X: 370
+			Y: PARENT_HEIGHT - 45
+			Width: 100
+			Height: 25
+			Text: button-management-mng-rensel
+			Font: Bold
+		Button@LOAD_BUTTON:
+			Key: return
+			X: PARENT_WIDTH - 140 - 130
+			Y: PARENT_HEIGHT - 45
+			Width: 120
+			Height: 25
+			Text: button-load-game-browser-panel-load
+			Font: Bold
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: PARENT_WIDTH - 140
+			Y: PARENT_HEIGHT - 45
+			Width: 120
+			Height: 25
+			Text: button-back
+			Font: Bold
+		TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@LOAD_GAME_TITLE_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -173,14 +173,14 @@ Container@MAP_PREVIEW:
 					Y: 158
 					Width: PARENT_WIDTH
 					Height: 25
-					Font: Tiny
+					Font: TinyBold
 					Align: Center
 					Text: label-map-unavailable-a
 				Label@b:
 					Y: 171
 					Width: PARENT_WIDTH
 					Height: 25
-					Font: Tiny
+					Font: TinyBold
 					Align: Center
 					Text: label-map-unavailable-b
 		Label@MAP_ERROR:

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -121,13 +121,26 @@ label-tool-tiling-path = Path Tiler
 
 ## gamesave-browser.yaml
 label-gamesave-browser-panel-load-title = Load game
-label-gamesave-browser-panel-save-title = Save game
-label-gamesave-browser-panel-title = [CREATE NEW FILE]
+label-gamesave-browser-panel-save-title = Save Game
 button-gamesave-browser-panel-delete-all = Delete All
 button-gamesave-browser-panel-delete = Delete
 button-gamesave-browser-panel-rename = Rename
 button-gamesave-browser-panel-load = Load
 button-gamesave-browser-panel-save = Save
+label-gamesave-browser-panel-no-save-selected = Select a savegame to overwrite it or type a new savegame name
+
+## load-game-browser.yaml
+label-load-game-browser-panel-title = Load Game
+label-load-game-browser-panel-choose-save = Choose Save
+label-load-game-browser-panel-incompatible-title = Incompatible Savegame
+label-load-game-browser-panel-incompatible-a = This savegame is not compatible
+label-load-game-browser-panel-incompatible-b = with this version of OpenRA
+label-load-game-browser-panel-human-player = Player
+button-load-game-browser-panel-load = Load
+tooltip-savegame-date-created = Date Created
+tooltip-savegame-map = Map
+tooltip-savegame-duration = Duration
+tooltip-savegame-players = Number of players
 
 ## ingame-chat.yaml, ingame-infochat.yaml
 button-chat-chrome-mode =
@@ -585,6 +598,7 @@ label-connection-error-desc-b = Please check your internet connection.
 ## replaybrowser.yaml
 label-replaybrowser-panel-title = Replay Viewer
 label-filters-title = Filter
+label-filters-flt-name-desc = Name:
 label-filters-flt-gametype-desc = Type:
 dropdownbutton-filters-any = Any
 label-filters-flt-date-desc = Date:
@@ -599,6 +613,7 @@ label-management-manage-title = Manage
 button-management-mng-rensel = Rename
 button-management-mng-delsel = Delete
 button-management-mng-delall = Delete All
+checkbox-load-game-filters = Filters
 label-replay-list-container-replaybrowser-title = Choose Replay
 button-replaybrowser-panel-watch = Watch
 

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -553,6 +553,10 @@ options-winstate =
     .victory = Victory
     .defeat = Defeat
 
+options-save-type =
+    .autosave = Autosave
+    .manual = Manual save
+
 options-replay-date =
     .today = Today
     .last-week = Last 7 days

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -130,6 +130,7 @@ ChromeLayout:
 	common|chrome/editor.yaml
 	common|chrome/replaybrowser.yaml
 	common|chrome/gamesave-browser.yaml
+	common|chrome/load-game-browser.yaml
 	common|chrome/gamesave-loading.yaml
 	common|chrome/text-notifications.yaml
 	d2k|chrome/encyclopedia.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -156,6 +156,7 @@ ChromeLayout:
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
 	common|chrome/gamesave-browser.yaml
+	common|chrome/load-game-browser.yaml
 	ra|chrome/gamesave-loading.yaml
 	common|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -164,6 +164,7 @@ ChromeLayout:
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
 	common|chrome/gamesave-browser.yaml
+	common|chrome/load-game-browser.yaml
 	common|chrome/gamesave-loading.yaml
 	ts|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml


### PR DESCRIPTION
Based on this [suggestion](https://github.com/OpenRA/OpenRA/issues/17070#issuecomment-529928354), this PR changes the **Load Game** interface to match the layout and filtering capabilities of the Replay Viewer, replacing the previous minimal Load Game dialog.

Here are some of the changes compared to the previous Load Game UI and Replay Viewer UI:
- savegames are now grouped by date headers (yyyy-MM-dd)
- the "Type" drop-down menu allows to filter savegames by Any / Autosave / Manual save
- the “Duration” filter is calculated from the difference between the file’s Date Modified and Date Created
- "Unknown Map" message is displayed when the map file is not available locally and "Incompatible savegame" is displayed when a save file exists but cannot be parsed (e.g. saved with a different version of OpenRA)
- player list: Human player slots always display "Player" regardless of the slot name in the map definition (which could be e.g. "Multi0", "Greece", etc.)

https://github.com/user-attachments/assets/11aec6b6-f629-4168-a4a9-c6d9926f9a67


