### PR TITLE
ChangesTerrain trait: remove requirement on Immobile and limit affected terrain types

### DIFF
--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -22,13 +23,17 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		public readonly string TerrainType = null;
 
+		[Desc("Only change terrain, if the cell's original terrain type is in this list.",
+			"By default, the terrain type is changed regardless of the original terrain type.")]
+		public readonly FrozenSet<string> TerrainTypes = null;
+
 		public override object Create(ActorInitializer init) { return new ChangesTerrain(this); }
 	}
 
 	sealed class ChangesTerrain : INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		readonly ChangesTerrainInfo info;
-		byte previousTerrain;
+		byte? previousTerrain;
 
 		public ChangesTerrain(ChangesTerrainInfo info)
 		{
@@ -39,16 +44,24 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var cell = self.Location;
 			var map = self.World.Map;
+
+			if (info.TerrainTypes?.Contains(map.GetTerrainInfo(cell).Type) == false)
+				return;
+
 			var terrain = map.Rules.TerrainInfo.GetTerrainIndex(info.TerrainType);
+
 			previousTerrain = map.CustomTerrain[cell];
 			map.CustomTerrain[cell] = terrain;
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
+			if (previousTerrain == null)
+				return;
+
 			var cell = self.Location;
 			var map = self.World.Map;
-			map.CustomTerrain[cell] = previousTerrain;
+			map.CustomTerrain[cell] = previousTerrain.Value;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -13,8 +13,11 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Modifies the terrain type underneath the actors location.")]
-	sealed class ChangesTerrainInfo : TraitInfo, Requires<ImmobileInfo>
+	[Desc("Modifies the terrain type underneath the actor's location.",
+		"Make sure that the actor doesn't move, as the terrain is changed only on actor creation.",
+		"In other words using Mobile, Aircraft nor any other IMove-based trait is supported " +
+		"and can cause unintended side effects.")]
+	sealed class ChangesTerrainInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly string TerrainType = null;


### PR DESCRIPTION
Removes `ChangesTerrain`'s requirement on `Immobile` trait. This makes the `ChangesTerrain` trait more flexible.

In addition to this, the second commit adds option to specify terrain types, where the terrain can be changed.