### PR TITLE
Fix bot defence failed to place

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -103,11 +103,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Chance that the AI will place the defenses in the direction of the closest enemy building.")]
 		public readonly int PlaceDefenseTowardsEnemyChance = 100;
 
-		[Desc("Minimum range at which to build defensive structures near a combat hotspot.")]
-		public readonly int MinimumDefenseRadius = 5;
-
-		[Desc("Maximum range at which to build defensive structures near a combat hotspot.")]
-		public readonly int MaximumDefenseRadius = 20;
+		[Desc("Desired range at which to build defensive structures near a combat hotspot if possible.")]
+		public readonly int TryMaintainDefenseRange = 5;
 
 		[Desc("Try to build another production building if there is too much cash.")]
 		public readonly int NewProductionCashThreshold = 5000;
@@ -173,13 +170,21 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public CPos GetRandomBaseCenter()
 		{
-			var randomConstructionYard = ConstructionYardBuildings.Actors
+			var randomConstructionYard = ConstructionYardBuildings.Actors.Where(a => !a.IsDead)
 				.RandomOrDefault(world.LocalRandom);
 
 			return randomConstructionYard?.Location ?? initialBaseCenter;
 		}
 
-		public CPos DefenseCenter { get; private set; }
+		public CPos GetDefenseBaseCenter()
+		{
+			var defenceConstructionYard = DefenseCenter != null ? ConstructionYardBuildings.Actors.OrderBy(a => (DefenseCenter.Value - a.Location).LengthSquared)
+				.FirstOrDefault(a => !a.IsDead) : null;
+
+			return defenceConstructionYard?.Location ?? GetRandomBaseCenter();
+		}
+
+		public CPos? DefenseCenter { get; private set; }
 
 		// Actor, ActorCount.
 		public Dictionary<string, int> BuildingsBeingProduced = [];

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -452,7 +452,7 @@ namespace OpenRA.Mods.Common.Traits
 				return (null, null, 0);
 
 			// Find the buildable cell that is closest to pos and centered around center
-			(CPos? Location, CPos Center, int Variant) FindPos(CPos center, CPos target, int minRange, int maxRange)
+			(CPos? Location, CPos Center, int Variant) FindPos(CPos center, CPos target, int minRange, int maxRange, int? tryMaintainRange = null)
 			{
 				var actorVariant = 0;
 				var buildingVariantInfo = actorInfo.TraitInfoOrDefault<PlaceBuildingVariantsInfo>();
@@ -464,7 +464,14 @@ namespace OpenRA.Mods.Common.Traits
 				// Sort by distance to target if we have one
 				if (center != target)
 				{
-					cells = cells.OrderBy(c => (c - target).LengthSquared);
+					if (tryMaintainRange == null)
+						cells = cells.OrderBy(c => (c - target).LengthSquared);
+					else
+					{
+						var theta = tryMaintainRange;
+						var deta = (target - center).Length - tryMaintainRange;
+						cells = cells.OrderBy(c => deta * (c - target).LengthSquared + theta * (c - center).LengthSquared);
+					}
 
 					// Rotate building if we have a Facings in buildingVariantInfo.
 					// If we don't have Facings in buildingVariantInfo, use a random variant
@@ -525,20 +532,20 @@ namespace OpenRA.Mods.Common.Traits
 				return (null, center, 0);
 			}
 
-			var baseCenter = baseBuilder.GetRandomBaseCenter();
+			var baseCenter = type == BuildingType.Defense ? baseBuilder.GetDefenseBaseCenter() : baseBuilder.GetRandomBaseCenter();
 
 			switch (type)
 			{
 				case BuildingType.Defense:
 
-					// Build near the closest enemy structure
-					var closestEnemy = world.ActorsHavingTrait<Building>()
-						.Where(a => !a.Disposed && player.RelationshipWith(a.Owner) == PlayerRelationship.Enemy)
-						.ClosestToIgnoringPath(world.Map.CenterOfCell(baseBuilder.DefenseCenter));
+					// Build near the closest enemy
+					var closestEnemy = world.ActorsHavingTrait<Targetable>()
+						.Where(a => !a.Disposed && a.IsInWorld && player.RelationshipWith(a.Owner) == PlayerRelationship.Enemy)
+						.ClosestToIgnoringPath(world.Map.CenterOfCell(baseCenter));
 
 					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
 
-					return FindPos(baseBuilder.DefenseCenter, targetCell, baseBuilder.Info.MinimumDefenseRadius, baseBuilder.Info.MaximumDefenseRadius);
+					return FindPos(baseCenter, targetCell, baseBuilder.Info.MinBaseRadius, baseBuilder.Info.MaxBaseRadius, baseBuilder.Info.TryMaintainDefenseRange);
 
 				case BuildingType.Refinery:
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		Actor[] playerBuildings;
 		int failCount;
 		int failRetryTicks;
+		string lastFailedBuilding;
 		int checkForBasesTicks;
 		int cachedBases;
 		int cachedBuildings;
@@ -64,14 +65,18 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (baseBuilder.BaseExpansionModules != null && baseCenterKeepsFailing != null)
 				{
-					var stuckConyard = baseBuilder.ConstructionYardBuildings.Actors
-						.Where(a => (a.Location - baseCenterKeepsFailing.Value).LengthSquared <= baseBuilder.Info.MaxBaseRadius * baseBuilder.Info.MaxBaseRadius)
-						.MinByOrDefault(a => (a.Location - baseCenterKeepsFailing.Value).LengthSquared);
-
-					if (stuckConyard != null)
+					// we should not give a nudge for defence
+					if (!baseBuilder.Info.DefenseTypes.Contains(lastFailedBuilding))
 					{
-						foreach (var be in baseBuilder.BaseExpansionModules)
-							be.UpdateExpansionParams(bot, false, true, stuckConyard);
+						var stuckConyard = baseBuilder.ConstructionYardBuildings.Actors
+							.Where(a => (a.Location - baseCenterKeepsFailing.Value).LengthSquared <= baseBuilder.Info.MaxBaseRadius * baseBuilder.Info.MaxBaseRadius)
+							.MinByOrDefault(a => (a.Location - baseCenterKeepsFailing.Value).LengthSquared);
+
+						if (stuckConyard != null)
+						{
+							foreach (var be in baseBuilder.BaseExpansionModules)
+								be.UpdateExpansionParams(bot, false, true, stuckConyard);
+						}
 					}
 
 					failCount = 0;
@@ -209,6 +214,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						AIUtils.BotDebug($"{player} has nowhere to place {currentBuilding.Item}");
 						bot.QueueOrder(Order.CancelProduction(queue.Actor, currentBuilding.Item, 1));
+						lastFailedBuilding = currentBuilding.Item;
 						if (baseBuilder.BaseExpansionModules == null)
 						{
 							cachedBuildings = world.ActorsHavingTrait<Building>().Count(a => a.Owner == player);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveAndRenameDefenseRadiusInBaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/RemoveAndRenameDefenseRadiusInBaseBuilderBotModule.cs
@@ -1,0 +1,36 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	/// <summary>
+	/// Remove MaximumDefenseRadius and replaces the MinimumDefenseRadius with TryMaintainDefenseRange
+	/// with a new range check system.
+	/// </summary>
+	public class RemoveAndRenameDefenseRadiusInBaseBuilderBotModule : UpdateRule, IBeforeUpdateActors
+	{
+		public override string Name => "Remove and rename DefenseRadius in BaseBuilderBotModule";
+		public override string Description => "Remove MaximumDefenseRadius and replaces the MinimumDefenseRadius with TryMaintainDefenseRange";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var baseBuilderBotModuleinfo in actorNode.ChildrenMatching("BaseBuilderBotModule"))
+			{
+				baseBuilderBotModuleinfo.RemoveNodes("MaximumDefenseRadius");
+				baseBuilderBotModuleinfo.RenameChildrenMatching("MinimumDefenseRadius", "TryMaintainDefenseRange");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new EditorMarkerTileLabels(),
 				new RemoveBarracksTypesAndVehiclesTypesInBaseBuilderBotModule(),
 				new RemoveAlwaysVisible(),
+				new RemoveAndRenameDefenseRadiusInBaseBuilderBotModule(),
 
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new WithDamageOverlayPropertyRename(),


### PR DESCRIPTION
Fix #22198. I found this bug also trigger the mcv undeploy (used for there is no place for building) on too many failed attempts , which is unacceptable.

I use the same try-maintain-range method in [expansion-pr](https://github.com/OpenRA/OpenRA/pull/22028#issuecomment-3242518793) for putting defence to enemy while maintaining a distance, which should supersede previous method.