### PR TITLE
Constrain Path Tiler's automatic start and end directions based on type

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTilingPathBrush.cs
@@ -112,12 +112,14 @@ namespace OpenRA.Mods.Common.Widgets
 							.Where(p => p.CPos == cpos)
 							.Select(p => p.RallyIndex)
 							.FirstOrDefault(0);
+				var autoStart = plan.AutoStart(tool.AutoStartDirectionMask);
+				var autoEnd = plan.AutoEnd(tool.AutoEndDirectionMask);
 				var isStartDirector =
-					plan.AutoStart != Direction.None
-						&& cpos == plan.FirstPoint - plan.AutoStart.ToCVec();
+					autoStart != Direction.None
+						&& cpos == plan.FirstPoint - autoStart.ToCVec();
 				var isEndDirector =
-					plan.AutoEnd != Direction.None
-						&& cpos == plan.LastPoint + plan.AutoEnd.ToCVec();
+					autoEnd != Direction.None
+						&& cpos == plan.LastPoint + autoEnd.ToCVec();
 				return (isInside, isRally, rallyIndex, isStartDirector, isEndDirector);
 			}
 
@@ -251,17 +253,19 @@ namespace OpenRA.Mods.Common.Widgets
 					mainColor);
 			}
 
-			if (plan.AutoEnd != Direction.None)
+			var autoStart = plan.AutoStart(tool.AutoStartDirectionMask);
+			var autoEnd = plan.AutoEnd(tool.AutoEndDirectionMask);
+			if (autoEnd != Direction.None)
 				yield return new CircleAnnotationRenderable(
-					CornerOfCell(plan.LastPoint) + map.Offset(plan.AutoEnd.ToCVec(), 0) * 768 / 1024,
+					CornerOfCell(plan.LastPoint) + map.Offset(autoEnd.ToCVec(), 0) * 768 / 1024,
 					new WDist(256),
 					2,
 					plan.End != Direction.None ? Color.Magenta : Color.Gray,
 					false);
 
-			if (plan.AutoStart != Direction.None)
+			if (autoStart != Direction.None)
 				yield return new CircleAnnotationRenderable(
-					CornerOfCell(plan.FirstPoint) - map.Offset(plan.AutoStart.ToCVec(), 0) * 768 / 1024,
+					CornerOfCell(plan.FirstPoint) - map.Offset(autoStart.ToCVec(), 0) * 768 / 1024,
 					new WDist(256),
 					2,
 					plan.Start != Direction.None ? Color.Magenta : Color.Gray,

--- a/OpenRA.Mods.Common/MapGenerator/Direction.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Direction.cs
@@ -78,6 +78,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 		/// <summary>Bitmask right-up.</summary>
 		MRU = 1 << Direction.RU,
+
+		All = MR | MRD | MD | MLD | ML | MLU | MU | MRU,
 	}
 
 	public static class DirectionExts
@@ -125,6 +127,19 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </summary>
 		public static readonly ImmutableArray<CVec> Spread8CVec =
 			Spread8.Select(xy => new CVec(xy.X, xy.Y)).ToImmutableArray();
+
+		/// <summary>Euclidean 1024x unit distance vectors for directions.</summary>
+		static readonly ImmutableArray<(int2, Direction)> EuclideanSpread8D =
+		[
+			(new int2(1024, 0), Direction.R),
+			(new int2(724, 724), Direction.RD),
+			(new int2(0, 1024), Direction.D),
+			(new int2(-724, 724), Direction.LD),
+			(new int2(-1024, 0), Direction.L),
+			(new int2(-724, -724), Direction.LU),
+			(new int2(0, -1024), Direction.U),
+			(new int2(724, -724), Direction.RU)
+		];
 
 		/// <summary>Convert a non-none direction to an int2 offset.</summary>
 		public static int2 ToInt2(this Direction direction)
@@ -185,7 +200,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 		/// <summary>
 		/// Convert an offset (of arbitrary non-zero magnitude) to a direction.
-		/// The direction with the closest angle wins. Keep inputs to 1000000 or less.
+		/// The direction with the closest angle wins. Keep input magnitudes to 1000000 or less.
 		/// Supplying a zero-offset will throw.
 		/// </summary>
 		public static Direction ClosestFrom(int dx, int dy)
@@ -215,6 +230,38 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>
+		/// Find a direction in a DirectionMask which best matches dx, dy.
+		/// Keep input magnitudes to 1000000 or less.
+		/// Supplying a zero-offset or an empty mask will throw.
+		/// </summary>
+		public static Direction ClosestInMaskFrom(int dx, int dy, DirectionMask mask)
+		{
+			if (dx == 0 && dy == 0)
+				throw new ArgumentException("bad direction");
+
+			if (mask == DirectionMask.None)
+				throw new ArgumentException("empty mask");
+
+			var dxy = new int2(dx, dy);
+			var best = Direction.None;
+			var bestScore = int.MinValue;
+			foreach (var (xy, direction) in EuclideanSpread8D)
+			{
+				if ((mask & direction.ToMask()) != 0)
+				{
+					var score = int2.Dot(xy, dxy);
+					if (score > bestScore)
+					{
+						best = direction;
+						bestScore = score;
+					}
+				}
+			}
+
+			return best;
+		}
+
+		/// <summary>
 		/// Convert an offset (of arbitrary non-zero magnitude) to a direction.
 		/// Supplying a zero-offset will throw.
 		/// </summary>
@@ -236,6 +283,13 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </summary>
 		public static Direction ClosestFromCVec(CVec delta)
 			=> ClosestFrom(delta.X, delta.Y);
+
+		/// <summary>
+		/// Find a direction in a DirectionMask which best matches an offset.
+		/// Supplying a zero-offset or an empty mask will throw.
+		/// </summary>
+		public static Direction ClosestInMaskFromCVec(CVec delta, DirectionMask mask)
+			=> ClosestInMaskFrom(delta.X, delta.Y, mask);
 
 		/// <summary>
 		/// Convert an offset (of arbitrary non-zero magnitude) to a non-diagonal direction.

--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -62,43 +62,37 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly Direction End;
 			public readonly bool Loop;
 			public readonly ImmutableArray<CPos> Rallies;
-			public Direction AutoStart
+			public Direction AutoStart(DirectionMask mask)
 			{
-				get
+				if (Start != Direction.None)
 				{
-					if (Start != Direction.None)
-					{
-						return Start;
-					}
+					return Start;
+				}
+				else
+				{
+					if (Rallies.Length >= 2 && mask != DirectionMask.None)
+						return DirectionExts.ClosestInMaskFromCVec(Rallies[1] - Rallies[0], mask);
 					else
-					{
-						if (Rallies.Length >= 2)
-							return DirectionExts.ClosestFromCVec(Rallies[1] - Rallies[0]);
-						else
-							return Direction.None;
-					}
+						return Direction.None;
 				}
 			}
 
-			public Direction AutoEnd
+			public Direction AutoEnd(DirectionMask mask)
 			{
-				get
+				if (End != Direction.None)
 				{
-					if (End != Direction.None)
-					{
-						return End;
-					}
-					else if (Loop)
-					{
-						return AutoStart;
-					}
+					return End;
+				}
+				else if (Loop)
+				{
+					return AutoStart(mask);
+				}
+				else
+				{
+					if (Rallies.Length >= 2 && mask != DirectionMask.None)
+						return DirectionExts.ClosestInMaskFromCVec(Rallies[^1] - Rallies[^2], mask);
 					else
-					{
-						if (Rallies.Length >= 2)
-							return DirectionExts.ClosestFromCVec(Rallies[^1] - Rallies[^2]);
-						else
-							return Direction.None;
-					}
+						return Direction.None;
 				}
 			}
 
@@ -190,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 					var reversedEnd = Start;
 					if (Start != Direction.None && End == Direction.None)
 					{
-						reversedStart = AutoEnd;
+						reversedStart = AutoEnd(DirectionMask.All);
 						reversedEnd = Direction.None;
 					}
 
@@ -232,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 				var points = new List<(CPos CPos, int RallyIndex)>();
 				var cpos = Rallies[0];
 				points.Add((cpos, 0));
-				var inertia = AutoStart.ToCVec();
+				var inertia = AutoStart(DirectionMask.All).ToCVec();
 				if (inertia.X != 0 && inertia.Y != 0)
 					inertia = new CVec(inertia.X, 0);
 
@@ -329,6 +323,8 @@ namespace OpenRA.Mods.Common.Traits
 		public string StartType { get; private set; } = null;
 		public string InnerType { get; private set; } = null;
 		public string EndType { get; private set; } = null;
+		public DirectionMask AutoStartDirectionMask = DirectionMask.None;
+		public DirectionMask AutoEndDirectionMask = DirectionMask.None;
 		public bool ClosedLoops { get; private set; } = true;
 		public int RandomSeed { get; private set; } = 0;
 		public int MaxDeviation { get; private set; } = 5;
@@ -462,8 +458,8 @@ namespace OpenRA.Mods.Common.Traits
 					startType,
 					endType,
 					permittedTemplates);
-				tilingPath.Start.Direction = plan.AutoStart;
-				tilingPath.End.Direction = plan.AutoEnd;
+				tilingPath.Start.Direction = plan.AutoStart(AutoStartDirectionMask);
+				tilingPath.End.Direction = plan.AutoEnd(AutoEndDirectionMask);
 				var result = tilingPath.Tile(random);
 				if (result != null)
 					return result.ToEditorBlitSource(WorldRenderer, random);
@@ -488,11 +484,42 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (string.IsNullOrEmpty(innerType))
 				InnerType = InnerTypes[0];
+
+			UpdateStartDirectionMask();
+			UpdateEndDirectionMask();
 		}
 
 		void Update()
 		{
 			EditorBlitSource = TilePlan(Plan);
+		}
+
+		void UpdateStartDirectionMask()
+		{
+			AutoStartDirectionMask = DirectionMask.None;
+			foreach (var brush in SegmentedBrushes)
+			{
+				if (brush.Segment != null &&
+					brush.Segment.HasInnerType(InnerType) &&
+					brush.Segment.HasStartType(StartType))
+				{
+					AutoStartDirectionMask |= brush.Segment.StartDirection.ToMask();
+				}
+			}
+		}
+
+		void UpdateEndDirectionMask()
+		{
+			AutoEndDirectionMask = DirectionMask.None;
+			foreach (var brush in SegmentedBrushes)
+			{
+				if (brush.Segment != null &&
+					brush.Segment.HasInnerType(InnerType) &&
+					brush.Segment.HasEndType(EndType))
+				{
+					AutoEndDirectionMask |= brush.Segment.EndDirection.ToMask();
+				}
+			}
 		}
 
 		public void SetPlan(PathPlan value)
@@ -504,6 +531,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetStartType(string value)
 		{
 			StartType = value;
+			UpdateStartDirectionMask();
 			Update();
 		}
 
@@ -517,6 +545,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetEndType(string value)
 		{
 			EndType = value;
+			UpdateEndDirectionMask();
 			Update();
 		}
 


### PR DESCRIPTION
The automatically chosen start and end directions of a path (grey circles) in the Map Editor's Path Tiler tool could be invalid for the given start and end types of the path. This change constrains the automatic directions based on the directions seen in the MultiBrush segment definitions.

Essentially, types which only use cardinal directions, such as cliffs, will now only pick cardinal directions; and types which only use diagonals, such as Road.In/Road.Out, will now only pick diagonals.

This should greatly reduce user confusion and friction when using the Path Tiler tool.

If the user explicitly sets the directions (magenta circles), these still take precedence and are not constrained. This is intended behavior.

Fixes #22367

Example Before:
<img width="439" height="575" alt="image" src="https://github.com/user-attachments/assets/fae876e8-a8cf-4c58-b648-84d5716e6ac7" />

Example After:
<img width="439" height="575" alt="image" src="https://github.com/user-attachments/assets/f835a586-7d1d-4c71-867c-390caa348fe2" />
