### PR TITLE
Fix mines not damaging units teleported or parachuted onto them

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -252,6 +252,7 @@ namespace OpenRA.Traits
 		void AddPosition(Actor a, IOccupySpace ios);
 		void RemovePosition(Actor a, IOccupySpace ios);
 		void UpdatePosition(Actor a, IOccupySpace ios);
+		void FlushUpdatedPositions();
 		IEnumerable<Actor> ActorsInBox(WPos a, WPos b);
 
 		WDist LargestActorRadius { get; }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -573,6 +573,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsAtGroundLevel())
 				return;
 
+			// Ensure the actor's new position is reflected in the spatial bins before crushing,
+			// so that any explosion triggered by the crush can find the actor at its new position.
+			self.World.ActorMap.FlushUpdatedPositions();
+
 			CrushAction(self, (notifyCrushed) => notifyCrushed.OnCrush);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -472,6 +472,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
+			FlushUpdatedPositions();
+
+			foreach (var t in cellTriggers)
+				t.Value.Tick(this);
+
+			foreach (var t in proximityTriggers)
+				t.Value.Tick(this);
+		}
+
+		public void FlushUpdatedPositions()
+		{
 			// Position updates are done in one pass
 			// to ensure consistency during a tick
 			if (removeActorPosition.Count > 0)
@@ -500,12 +511,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			addActorPosition.Clear();
-
-			foreach (var t in cellTriggers)
-				t.Value.Tick(this);
-
-			foreach (var t in proximityTriggers)
-				t.Value.Tick(this);
 		}
 
 		public int AddCellTrigger(CPos[] cells, Action<Actor> onEntry, Action<Actor> onExit)


### PR DESCRIPTION
Fixes #14262

When `SetPosition` was called (e.g. via chronosphere or paratrooper landing), the cell influence layer was updated immediately, but the spatial bins used by `FindActorsInCircle` were only flushed at the next tick. As a result, the mine would detect and detonate on the incoming actor, but the warhead explosion would find no targets at the new position.

This PR fixes this by extracting the spatial bin flush from `ITick.Tick` into a new `FlushUpdatedPositions` method on `IActorMap` and calling it in `FinishedMoving` before `CrushAction`.

Here's a good map to test: https://resource.openra.net/maps/22233/