### PR TITLE
Make sure open dropdowns are closed when opening the ingame menu

### DIFF
--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -33,6 +33,23 @@ namespace OpenRA.Mods.Common.Widgets
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getMarkerImage;
 		CachedTransform<(bool Disabled, bool Pressed, bool Hover, bool Focused, bool Highlighted), Sprite> getSeparatorImage;
 
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (HasKeyboardFocus && e.Event == KeyInputEvent.Down && e.Key == Keycode.ESCAPE)
+			{
+				RemovePanel();
+				return true;
+			}
+
+			return base.HandleKeyPress(e);
+		}
+
+		public override bool YieldKeyboardFocus()
+		{
+			RemovePanel();
+			return base.YieldKeyboardFocus();
+		}
+
 		[ObjectCreator.UseCtor]
 		public DropDownButtonWidget(ModData modData)
 			: base(modData) { }
@@ -101,6 +118,7 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.RemoveChild(panel);
 			panel = fullscreenMask = null;
 
+			YieldKeyboardFocus();
 			Ui.ResetTooltips();
 		}
 
@@ -110,6 +128,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (panel != null)
 				throw new InvalidOperationException("Attempted to attach a panel to an open dropdown");
 			panel = p;
+			TakeKeyboardFocus();
 
 			// Mask to prevent any clicks from being sent to other widgets
 			fullscreenMask = new MaskWidget


### PR DESCRIPTION
Make sure open dropdowns are closed when opening the ingame menu (in Spectator mode)

Before: 
https://github.com/user-attachments/assets/9a65ba86-ffee-43e7-be17-db97afc42a43

After:
https://github.com/user-attachments/assets/bc7b8e1a-bc82-4155-ba53-28964cddf996

