### PR TITLE
Allow to adjust game speed after the game has started

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Network
 		[FluentReference("player")]
 		const string GameUnpaused = "notification-game-unpaused";
 
+		[FluentReference("speed")]
+		const string GameSpeedChanged = "notification-ingame-game-speed-changed";
+
 		public static int? KickVoteTarget { get; internal set; }
 
 		static Player FindPlayerByClient(this World world, Session.Client c)
@@ -213,6 +216,25 @@ namespace OpenRA.Network
 					foreach (var nsr in orderManager.World.WorldActor.TraitsImplementing<INotifyGameSaved>())
 						nsr.GameSaved(orderManager.World, order.ExtraData != 0);
 					break;
+
+				case "SetGameSpeed":
+				{
+					if (OrderNotFromServerOrWorldIsReplay(clientId, world))
+						break;
+
+					var gameSpeeds = Game.ModData.GetOrCreate<GameSpeeds>();
+					if (gameSpeeds.Speeds.TryGetValue(order.TargetString, out var gameSpeed))
+					{
+						if (orderManager.LobbyInfo.GlobalSettings.LobbyOptions.TryGetValue("gamespeed", out var lobbyOption))
+							lobbyOption.Value = order.TargetString;
+
+						world.Timestep = gameSpeed.Timestep;
+						TextNotificationsManager.AddSystemLine("Options", FluentProvider.GetMessage(GameSpeedChanged,
+							"speed", FluentProvider.GetMessage(gameSpeed.Name)));
+					}
+
+					break;
+				}
 
 				case "PauseGame":
 				{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -582,9 +582,10 @@ namespace OpenRA.Traits
 		public readonly bool IsLocked;
 		public readonly bool IsVisible;
 		public readonly int DisplayOrder;
+		public readonly bool IsIngameGameSpeedAdjustable;
 
 		public LobbyOption(MapPreview map, string id, string name, string description, bool visible, int displayorder,
-			IReadOnlyDictionary<string, string> values, string defaultValue, bool locked)
+			IReadOnlyDictionary<string, string> values, string defaultValue, bool locked, bool ingameGameSpeedAdjustable = false)
 		{
 			Id = id;
 			Name = map.GetMessage(name);
@@ -594,6 +595,7 @@ namespace OpenRA.Traits
 			Values = values.ToDictionary(v => v.Key, v => map.GetMessage(v.Value));
 			DefaultValue = defaultValue;
 			IsLocked = locked;
+			IsIngameGameSpeedAdjustable = ingameGameSpeedAdjustable;
 		}
 
 		public virtual string Label(string value)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -41,7 +41,7 @@ namespace OpenRA
 
 		public readonly GameSpeed GameSpeed;
 
-		public readonly int Timestep;
+		public int Timestep { get; internal set; }
 
 		public int ReplayTimestep;
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -183,7 +183,8 @@ namespace OpenRA.Mods.Common.Server
 				{ "spawn", Spawn },
 				{ "clear_spawn", ClearPlayerSpawn },
 				{ "color", PlayerColor },
-				{ "sync_lobby", SyncLobby }
+				{ "sync_lobby", SyncLobby },
+				{ "ingame_gamespeed", IngameGameSpeed }
 			};
 
 		static bool ValidateSlotCommand(S server, Connection conn, Session.Client client, string arg, bool requiresHost)
@@ -212,6 +213,10 @@ namespace OpenRA.Mods.Common.Server
 			{
 				// Kick command is always valid for the host
 				if (command.StartsWith("kick ", StringComparison.Ordinal) || command.StartsWith("vote_kick ", StringComparison.Ordinal))
+					return true;
+
+				// Game speed change is allowed during games with no other human players
+				if (command.StartsWith("ingame_gamespeed ", StringComparison.Ordinal))
 					return true;
 
 				if (server.State == ServerState.GameStarted)
@@ -724,6 +729,34 @@ namespace OpenRA.Mods.Common.Server
 					c.State = Session.ClientState.NotReady;
 
 				server.SyncLobbyClients();
+
+				return true;
+			}
+		}
+
+		static bool IngameGameSpeed(S server, Connection conn, Session.Client client, string s)
+		{
+			lock (server.LobbyInfo)
+			{
+				// Only allow while the game is running, for the admin, and only when there are no other human players
+				if (server.State != ServerState.GameStarted || !client.IsAdmin || server.LobbyInfo.NonBotClients.Count() > 1)
+				{
+					server.SendFluentMessageTo(conn, InvalidConfigurationCommand);
+					return true;
+				}
+
+				if (!Game.ModData.GetOrCreate<GameSpeeds>().Speeds.ContainsKey(s))
+				{
+					server.SendFluentMessageTo(conn, InvalidConfigurationCommand);
+					return true;
+				}
+
+				var oo = server.LobbyInfo.GlobalSettings.LobbyOptions["gamespeed"];
+				oo.Value = oo.PreferredValue = s;
+
+				foreach (var c in server.Conns.ToList())
+					if (c.Validated)
+						server.SendOrderTo(c, "SetGameSpeed", s);
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new LobbyOption(map, "gamespeed",
 				GameSpeedDropdownLabel, GameSpeedDropdownDescription,
 				GameSpeedDropdownVisible, GameSpeedDropdownDisplayOrder, speeds,
-				GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked);
+				GameSpeed ?? gameSpeeds.DefaultSpeed, GameSpeedDropdownLocked, ingameGameSpeedAdjustable: true);
 		}
 
 		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -158,7 +158,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.LoadWidget(world, "LOBBY_OPTIONS_PANEL", optionsPanelContainer, new WidgetArgs()
 			{
 				{ "getMap", () => modData.MapCache[world.Map.Uid] },
-				{ "configurationDisabled", () => true }
+				{ "configurationDisabled", () => true },
+				{ "ingameGameSpeedEnabled", () => !world.IsReplay && world.LobbyInfo.NonBotClients.Count() == 1 && world.LobbyInfo.NonBotClients.First().IsAdmin }
 			});
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/IngameGameSpeedHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/IngameGameSpeedHotkeyLogic.cs
@@ -1,0 +1,59 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
+{
+	[ChromeLogicArgsHotkeys("IngameGameSpeedDecreaseKey", "IngameGameSpeedIncreaseKey")]
+	public class IngameGameSpeedHotkeyLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public IngameGameSpeedHotkeyLogic(Widget widget, ModData modData, World world, OrderManager orderManager, Dictionary<string, MiniYaml> logicArgs)
+		{
+			var decreaseKey = new HotkeyReference();
+			if (logicArgs.TryGetValue("IngameGameSpeedDecreaseKey", out var yaml))
+				decreaseKey = modData.Hotkeys[yaml.Value];
+
+			var increaseKey = new HotkeyReference();
+			if (logicArgs.TryGetValue("IngameGameSpeedIncreaseKey", out yaml))
+				increaseKey = modData.Hotkeys[yaml.Value];
+
+			var keyhandler = widget.Get<LogicKeyListenerWidget>("WORLD_KEYHANDLER");
+			keyhandler.AddHandler(e =>
+			{
+				if (e.Event == KeyInputEvent.Down &&
+					(decreaseKey.IsActivatedBy(e) || increaseKey.IsActivatedBy(e)) &&
+					!world.IsReplay &&
+					orderManager.LobbyInfo.NonBotClients.Count() == 1 &&
+					orderManager.LobbyInfo.NonBotClients.First().IsAdmin)
+				{
+					var gameSpeeds = Game.ModData.GetOrCreate<GameSpeeds>();
+					var speedKeys = gameSpeeds.Speeds.Keys.ToList();
+					var currentSpeed = orderManager.LobbyInfo.GlobalSettings.OptionOrDefault("gamespeed", gameSpeeds.DefaultSpeed);
+					var currentIndex = speedKeys.IndexOf(currentSpeed);
+					if (currentIndex >= 0)
+					{
+						var newIndex = decreaseKey.IsActivatedBy(e) ? currentIndex - 1 : currentIndex + 1;
+						if (newIndex >= 0 && newIndex < speedKeys.Count)
+							orderManager.IssueOrder(Order.Command($"ingame_gamespeed {speedKeys[newIndex]}"));
+					}
+				}
+
+				return false;
+			});
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -399,7 +399,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				{ "orderManager", orderManager },
 				{ "getMap", () => map },
-				{ "configurationDisabled", configurationDisabled }
+				{ "configurationDisabled", configurationDisabled },
+				{ "ingameGameSpeedEnabled", () => false }
 			});
 
 			optionsBin.IsVisible = () => panel == PanelType.Options;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -33,15 +33,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Func<MapPreview> getMap;
 		readonly OrderManager orderManager;
 		readonly Func<bool> configurationDisabled;
+		readonly Func<bool> ingameGameSpeedEnabled;
 		MapPreview mapPreview;
 		MapStatus mapStatus;
 
 		[ObjectCreator.UseCtor]
-		internal LobbyOptionsLogic(Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled)
+		internal LobbyOptionsLogic(
+			Widget widget, OrderManager orderManager, Func<MapPreview> getMap, Func<bool> configurationDisabled, Func<bool> ingameGameSpeedEnabled)
 		{
 			this.getMap = getMap;
 			this.orderManager = orderManager;
 			this.configurationDisabled = configurationDisabled;
+			this.ingameGameSpeedEnabled = ingameGameSpeedEnabled;
 
 			panel = (ScrollPanelWidget)widget;
 			optionsContainer = widget.Get("LOBBY_OPTIONS");
@@ -163,15 +166,26 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				dropdown.IsVisible = () => true;
-				dropdown.IsDisabled = () => configurationDisabled() ||
-					optionValue.Update(orderManager.LobbyInfo.GlobalSettings).IsLocked;
+				dropdown.IsDisabled = () =>
+				{
+					if (option.IsIngameGameSpeedAdjustable && ingameGameSpeedEnabled())
+						return false;
+
+					return configurationDisabled() || optionValue.Update(orderManager.LobbyInfo.GlobalSettings).IsLocked;
+				};
 
 				dropdown.OnMouseDown = _ =>
 				{
 					ScrollItemWidget SetupItem(KeyValuePair<string, string> c, ScrollItemWidget template)
 					{
 						bool IsSelected() => optionValue.Update(orderManager.LobbyInfo.GlobalSettings).Value == c.Key;
-						void OnClick() => orderManager.IssueOrder(Order.Command($"option {option.Id} {c.Key}"));
+						void OnClick()
+						{
+							if (option.IsIngameGameSpeedAdjustable && ingameGameSpeedEnabled())
+								orderManager.IssueOrder(Order.Command($"ingame_gamespeed {c.Key}"));
+							else
+								orderManager.IssueOrder(Order.Command($"option {option.Id} {c.Key}"));
+						}
 
 						var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
 						item.Get<LabelWidget>("LABEL").GetText = () => c.Value;

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -10,7 +10,7 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, CycleHarvestersHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, SelectUnitsByTypeHotkeyLogic, SelectAllUnitsHotkeyLogic, IngameGameSpeedHotkeyLogic
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				CycleHarvestersKey: CycleHarvesters
@@ -22,6 +22,8 @@ Container@INGAME_ROOT:
 				PauseKey: Pause
 				SelectAllUnitsKey: SelectAllUnits
 				SelectUnitsByTypeKey: SelectUnitsByType
+				IngameGameSpeedDecreaseKey: IngameGameSpeedDecrease
+				IngameGameSpeedIncreaseKey: IngameGameSpeedIncrease
 		Container@WORLD_ROOT:
 			Logic: LoadIngamePerfLogic
 			Children:

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -742,6 +742,9 @@ description-surrender-description = self-destruct everything and lose the game.
 ## DeveloperMode
 notification-cheat-used = Cheat used: { $cheat } by { $player }{ $suffix }.
 
+## MapOptions
+notification-ingame-game-speed-changed = Game speed set to { $speed }.
+
 ## CustomTerrainDebugOverlay
 description-custom-terrain-debug-overlay = toggles the custom terrain debug overlay.
 

--- a/mods/common/fluent/hotkeys.ftl
+++ b/mods/common/fluent/hotkeys.ftl
@@ -111,6 +111,9 @@ hotkey-description-pausemusic = Pause or Resume
 hotkey-description-prevmusic = Previous
 hotkey-description-nextmusic = Next
 
+hotkey-description-ingamegamespeeddecrease = Decrease game speed
+hotkey-description-ingamegamespeedincrease = Increase game speed
+
 ## observer.yaml
 hotkey-description-observercombinedview = All Players
 hotkey-description-observerworldview = Disable Shroud

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -33,6 +33,21 @@ Pause: PAUSE
 	Types: World
 	Contexts: player, spectator
 
+IngameGameSpeedDecrease: F11 Shift
+	Description: hotkey-description-ingamegamespeeddecrease
+	Types: World
+	Contexts: player
+
+CycleStatusBars: COMMA
+	Description: hotkey-description-cyclestatusbars
+	Types: World
+	Contexts: player, spectator
+
+IngameGameSpeedIncrease: F12 Shift
+	Description: hotkey-description-ingamegamespeedincrease
+	Types: World
+	Contexts: player
+
 Sell: Z
 	Description: hotkey-description-sell
 	Types: OrderGenerator
@@ -47,11 +62,6 @@ PlaceBeacon: B
 	Description: hotkey-description-placebeacon
 	Types: OrderGenerator
 	Contexts: player
-
-CycleStatusBars: COMMA
-	Description: hotkey-description-cyclestatusbars
-	Types: World
-	Contexts: player, spectator
 
 ToggleMute: M
 	Description: hotkey-description-togglemute


### PR DESCRIPTION
Fixes #16323

Allow to adjust game speed during a singleplayer game, during missions and during a multiplayer game versus AI bots.

Skirmish: 
https://github.com/user-attachments/assets/9d4fb1fb-2548-465b-8f0a-0d11ec7a961f

Mission:
https://github.com/user-attachments/assets/6fc44de7-6433-4d2a-a965-f1bd465e8812

Multiplayer vs AI bots:
https://github.com/user-attachments/assets/a992a083-6610-4add-a186-03195f1a1ece

