### PR TITLE
D2K mod: Make the starport delivery instant when the "Instant build speed" deb…

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
@@ -97,8 +97,13 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (HasDeliveryStarted() && DeliveryDelay > 0)
 				{
-					DeliveryDelay--;
-					PlayDeliveryProgressNotifications();
+					if (developerMode.FastBuild)
+						DeliveryDelay = 0;
+					else
+					{
+						DeliveryDelay--;
+						PlayDeliveryProgressNotifications();
+					}
 				}
 				else if (HasDeliveryStarted() && DeliveryDelay == 0)
 				{


### PR DESCRIPTION
D2K mod: Make the starport delivery instant when the "Instant build speed" debug checkbox is activated
