### PR TITLE
Add Chronosphere idle animation

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -468,6 +468,8 @@ PDOX:
 	Inherits@shape: ^2x2Shape
 	Selectable:
 		Bounds: 2048, 2048
+	WithSpriteBody:
+		PauseOnCondition: disabled
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 120

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -782,8 +782,12 @@ pdox:
 	Defaults:
 		Filename: pdox.shp
 	idle:
+		Length: 4
+		Tick: 120
 	damaged-idle:
 		Start: 29
+		Length: 4
+		Tick: 120
 	active:
 		Length: 29
 	damaged-active:


### PR DESCRIPTION
Add the small 4-frame idle sequences that the current sphere doesn't use: https://github.com/electronicarts/CnC_Red_Alert/blob/main/CODE/BDATA.CPP#L3061.

Like Gap Generators, these are paused while the sphere is unpowered.

Before/after in OpenRA:

https://github.com/user-attachments/assets/f2655df9-3701-49a6-9e83-45f3162f93d2



A '96 sphere in its natural habitat for comparison:

https://github.com/user-attachments/assets/63a53731-3312-4118-a337-90fc5a9c1ba2