### PR TITLE
Fixes in mission Harkonnen 8

### DIFF
--- a/mods/d2k/maps/harkonnen-08/harkonnen08.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08.lua
@@ -217,7 +217,9 @@ BuildSaboteur = function()
 		end)
 
 		SendSaboteur(saboteur)
-		ScanForBetterTargets(saboteur)
+		Trigger.AfterDelay(200, function()
+			ScanForBetterTargets(saboteur)
+		end)
 	end
 
 	Trigger.AfterDelay(DateTime.Minutes(5) + DateTime.Seconds(30), BuildSaboteur)
@@ -399,6 +401,7 @@ WorldLoaded = function()
 	end)
 
 	Trigger.OnKilledOrCaptured(OPalace, function()
+		if AtreidesEnemy.HasNoRequiredUnits() then return  end
 		Media.DisplayMessage(UserInterface.GetFluentMessage("cannot-stand-harkonnen-must-become-neutral"), UserInterface.GetFluentMessage("atreides-commander"), HSLColor.FromHex("5A7394"))
 
 		ChangeOwner(AtreidesEnemy, AtreidesNeutral)


### PR DESCRIPTION
Fix situation when Atreides message _We-cannot-stand-harkonnen-must-become-neutral_ is shown even if Atreides are already destroyed.
Fix Saboteur  function _ScanForBetterTargets_ is activated after actor is added into the world.