### PR TITLE
Fix D2k terrain speed modifiers

### DIFF
--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -32,18 +32,18 @@
 			Spice: 100
 			SpiceBlobs: 100
 			Dune: 80
-			Rough: 80
+			Rough: 70
 	Locomotor@VEHICLE:
 		Name: vehicle
 		Crushes: crate, spicebloom
 		TerrainSpeeds:
-			Sand: 100
+			Sand: 90
 			Rock: 100
 			Transition: 100
 			Concrete: 100
-			SpiceSand: 100
-			Spice: 100
-			SpiceBlobs: 100
+			SpiceSand: 90
+			Spice: 90
+			SpiceBlobs: 90
 			Dune: 50
 	Locomotor@TANK:
 		Name: tank
@@ -56,7 +56,7 @@
 			SpiceSand: 100
 			Spice: 100
 			SpiceBlobs: 100
-			Dune: 50
+			Dune: 70
 	Locomotor@DEVASTATOR:
 		Name: devastator
 		Crushes: crate, infantry, spicebloom, wall
@@ -68,7 +68,7 @@
 			SpiceSand: 100
 			Spice: 100
 			SpiceBlobs: 100
-			Dune: 50
+			Dune: 70
 	Locomotor@WORM:
 		Name: worm
 		TerrainSpeeds:


### PR DESCRIPTION
While digging in D2kEditor I noticed that we got wrong speed modifiers:

<img width="1104" height="776" alt="image" src="https://github.com/user-attachments/assets/f7fc4575-27ef-42d5-b81e-2c738bdb6246" />

Modifiers 3, 4 and 5 are infantry only. 
Modifier 3 is used for Cliff passage while modifier 5 for Rough terrain, but because they are the same it doesnt matter.
Modifier 4 is never used. At least not in any vanilla tilesets.

