### PR TITLE
Add a link to the Resource Center in Map Chooser

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -38,7 +38,8 @@ namespace OpenRA
 		System = 1,
 		User = 2,
 		Remote = 4,
-		Generated = 8
+		Generated = 8,
+		Community = 16
 	}
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules",

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -12,6 +12,8 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Mods.Common.Traits;
@@ -96,6 +98,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[FluentReference]
 		const string GeneratedMapsTab = "button-mapchooser-generated-maps-tab";
+
+		[FluentReference]
+		const string CommunityMapsTab = "button-mapchooser-community-maps-tab";
 
 		public static string MapSizeLabel(Size size)
 		{
@@ -182,7 +187,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var okButton = widget.Get<ButtonWidget>("BUTTON_OK");
 			if (onSelect != null)
-				okButton.IsDisabled = () => currentTab == MapClassification.Generated && generatedMapArgs == null;
+				okButton.IsDisabled = () => currentTab == MapClassification.Community ||
+					(currentTab == MapClassification.Generated && generatedMapArgs == null);
 			else
 				okButton.Disabled = true;
 
@@ -198,7 +204,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var filterContainer = widget.GetOrNull("FILTER_ORDER_CONTROLS");
 			if (filterContainer != null)
-				filterContainer.IsVisible = () => currentTab != MapClassification.Generated;
+				filterContainer.IsVisible = () => currentTab != MapClassification.Generated && currentTab != MapClassification.Community;
 
 			var mapFilterInput = widget.GetOrNull<TextFieldWidget>("MAPFILTER_INPUT");
 			if (mapFilterInput != null)
@@ -234,7 +240,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					scrollpanels[currentTab].ScrollToItem(uid, smooth: true);
 				};
 				randomMapButton.IsDisabled = () => visibleMaps == null || visibleMaps.Length == 0;
-				randomMapButton.IsVisible = () => currentTab != MapClassification.Generated;
+				randomMapButton.IsVisible = () => currentTab != MapClassification.Generated && currentTab != MapClassification.Community;
 			}
 
 			var deleteMapButton = widget.Get<ButtonWidget>("DELETE_MAP_BUTTON");
@@ -287,6 +293,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SetupMapPanel(MapClassification.User, "USER_MAPS_TAB");
 			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB");
 			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB");
+			SetupCommunityMapsPanel("COMMUNITY_MAPS_TAB");
 
 			var hasGenerator = modData.DefaultRules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorMapGeneratorInfo>();
 			if (onSelectGenerated != null && hasGenerator)
@@ -302,6 +309,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else
 			{
 				tabLabels[MapClassification.System] = SystemMapsTab;
+				tabLabels[MapClassification.Community] = CommunityMapsTab;
 				tabLabels[MapClassification.User] = UserMapsTab;
 				if (onSelectGenerated != null && hasGenerator)
 					tabLabels[MapClassification.Generated] = GeneratedMapsTab;
@@ -331,7 +339,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void SwitchTab(MapClassification tab)
 		{
 			currentTab = tab;
-			EnumerateMaps(tab);
+			if (tab != MapClassification.Community)
+				EnumerateMaps(tab);
 		}
 
 		void RefreshMaps(MapClassification tab)
@@ -379,14 +388,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void SetupMapTabs()
 		{
-			for (var i = 0; i < 3; i++)
+			for (var i = 0; i < 5; i++)
 				widget.Get<ButtonWidget>($"BUTTON{i + 1}").Visible = false;
 
 			var tabCount = 0;
 			foreach (var kv in tabLabels)
 			{
 				var tab = kv.Key;
-				if (tab == MapClassification.User && tabMaps[tab].Length == 0)
+				if (tab == MapClassification.User && tabMaps.TryGetValue(tab, out var maps) && maps.Length == 0)
 					continue;
 
 				var tabButton = widget.Get<ButtonWidget>($"BUTTON{++tabCount}");
@@ -425,6 +434,48 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					})
 				}
 			});
+		}
+
+		void SetupCommunityMapsPanel(string tabContainerName)
+		{
+			var tabContainer = widget.Get<ContainerWidget>(tabContainerName);
+			tabContainer.IsVisible = () => currentTab == MapClassification.Community;
+
+			var linkButton = tabContainer.Get<ButtonWidget>("BUTTON_COMMUNITY_MAPS_LINK");
+			linkButton.OnClick = () => Game.Renderer.TryOpenUrl("https://resource.openra.net/");
+
+			var wikiMappingButton = tabContainer.Get<ButtonWidget>("BUTTON_WIKI_MAPPING");
+			wikiMappingButton.OnClick = () => Game.Renderer.TryOpenUrl("https://github.com/OpenRA/OpenRA/wiki/Mapping");
+
+			var wikiScriptingButton = tabContainer.Get<ButtonWidget>("BUTTON_WIKI_MAP_SCRIPTING");
+			wikiScriptingButton.OnClick = () => Game.Renderer.TryOpenUrl("https://github.com/OpenRA/OpenRA/wiki/Map-scripting");
+
+			var openFolderButton = tabContainer.Get<ButtonWidget>("BUTTON_OPEN_MAPS_FOLDER");
+			openFolderButton.OnClick = () =>
+			{
+				var userMapFolder = modData.Manifest.MapFolders
+					.FirstOrDefault(kv => kv.Value == "User").Key;
+
+				if (userMapFolder == null)
+					return;
+
+				var folderPath = Platform.ResolvePath(userMapFolder.TrimStart('~'));
+				if (!Directory.Exists(folderPath))
+					Directory.CreateDirectory(folderPath);
+
+				try
+				{
+					Process.Start(new ProcessStartInfo
+					{
+						FileName = folderPath,
+						UseShellExecute = true
+					});
+				}
+				catch (Exception e)
+				{
+					Log.Write("debug", $"Failed to open custom maps folder: {e.Message}");
+				}
+			};
 		}
 
 		void SetupGameModeDropdown(MapClassification tab, DropDownButtonWidget gameModeDropdown)

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -33,6 +33,16 @@ Container@MAPCHOOSER_PANEL:
 					Y: 15
 					Height: 31
 					Width: 135
+				Button@BUTTON4:
+					X: 435
+					Y: 15
+					Height: 31
+					Width: 135
+				Button@BUTTON5:
+					X: 575
+					Y: 15
+					Height: 31
+					Width: 135
 				Container@MAP_TAB_PANES:
 					Width: PARENT_WIDTH - 30
 					Height: PARENT_HEIGHT - 90
@@ -63,6 +73,94 @@ Container@MAPCHOOSER_PANEL:
 									Width: PARENT_WIDTH
 									Height: PARENT_HEIGHT
 									ItemSpacing: 1
+						Container@COMMUNITY_MAPS_TAB:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Children:
+								ScrollPanel@COMMUNITY_MAPS_PANEL:
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
+									Children:
+										Background@RESOURCE_HEADER:
+											X: 5
+											Y: 10
+											Width: PARENT_WIDTH - 24 - 10
+											Height: 13
+											Background: separator
+											ClickThrough: true
+											Children:
+												Label@LABEL:
+													Width: PARENT_WIDTH
+													Height: PARENT_HEIGHT
+													Font: TinyBold
+													Align: Center
+													Text: label-mapchooser-community-resource-header
+										Label@COMMUNITY_RESOURCE_DESC:
+											X: 20
+											Y: 30
+											Width: PARENT_WIDTH - 40
+											Height: 40
+											WordWrap: true
+											Align: Center
+											Text: label-mapchooser-community-resource-desc
+										Button@BUTTON_COMMUNITY_MAPS_LINK:
+											X: (PARENT_WIDTH - WIDTH) / 2
+											Y: 75
+											Width: 200
+											Height: 25
+											Text: button-mapchooser-community-maps-link
+											Font: Bold
+										Label@COMMUNITY_WIKI_DESC:
+											X: 20
+											Y: 110
+											Width: PARENT_WIDTH - 40
+											Height: 40
+											WordWrap: true
+											Align: Center
+											Text: label-mapchooser-community-wiki-desc
+										Button@BUTTON_WIKI_MAPPING:
+											X: (PARENT_WIDTH - WIDTH) / 2 - 110
+											Y: 170
+											Width: 180
+											Height: 25
+											Text: button-mapchooser-wiki-mapping
+											Font: Bold
+										Button@BUTTON_WIKI_MAP_SCRIPTING:
+											X: (PARENT_WIDTH - WIDTH) / 2 + 110
+											Y: 170
+											Width: 180
+											Height: 25
+											Text: button-mapchooser-wiki-map-scripting
+											Font: Bold
+										Background@FOLDER_HEADER:
+											X: 5
+											Y: 210
+											Width: PARENT_WIDTH - 24 - 10
+											Height: 13
+											Background: separator
+											ClickThrough: true
+											Children:
+												Label@LABEL:
+													Width: PARENT_WIDTH
+													Height: PARENT_HEIGHT
+													Font: TinyBold
+													Align: Center
+													Text: label-mapchooser-community-folder-header
+										Label@COMMUNITY_FOLDER_DESC:
+											X: 20
+											Y: 230
+											Width: PARENT_WIDTH - 40
+											Height: 100
+											WordWrap: true
+											Align: Center
+											Text: label-mapchooser-community-folder-desc
+										Button@BUTTON_OPEN_MAPS_FOLDER:
+											X: (PARENT_WIDTH - WIDTH) / 2
+											Y: 340
+											Width: 200
+											Height: 25
+											Text: button-mapchooser-open-maps-folder
+											Font: Bold
 						Container@GENERATE_MAP_TAB:
 							Width: PARENT_WIDTH
 							Height: PARENT_HEIGHT + 30

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -30,6 +30,18 @@ Background@MAPCHOOSER_PANEL:
 			Height: 31
 			Width: 140
 			Font: Bold
+		Button@BUTTON4:
+			X: 440
+			Y: 48
+			Height: 31
+			Width: 140
+			Font: Bold
+		Button@BUTTON5:
+			X: 580
+			Y: 48
+			Height: 31
+			Width: 140
+			Font: Bold
 		Container@MAP_TAB_PANES:
 			Width: PARENT_WIDTH - 40
 			Height: 438
@@ -57,6 +69,94 @@ Background@MAPCHOOSER_PANEL:
 						ScrollPanel@MAP_LIST:
 							Width: PARENT_WIDTH
 							Height: PARENT_HEIGHT
+				Container@COMMUNITY_MAPS_TAB:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT
+					Children:
+						ScrollPanel@COMMUNITY_MAPS_PANEL:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+							Children:
+								Background@RESOURCE_HEADER:
+									X: 5
+									Y: 10
+									Width: PARENT_WIDTH - 24 - 10
+									Height: 13
+									Background: separator
+									ClickThrough: true
+									Children:
+										Label@LABEL:
+											Width: PARENT_WIDTH
+											Height: PARENT_HEIGHT
+											Font: TinyBold
+											Align: Center
+											Text: label-mapchooser-community-resource-header
+								Label@COMMUNITY_RESOURCE_DESC:
+									X: 20
+									Y: 30
+									Width: PARENT_WIDTH - 40
+									Height: 40
+									WordWrap: true
+									Align: Center
+									Text: label-mapchooser-community-resource-desc
+								Button@BUTTON_COMMUNITY_MAPS_LINK:
+									X: (PARENT_WIDTH - WIDTH) / 2
+									Y: 75
+									Width: 200
+									Height: 25
+									Text: button-mapchooser-community-maps-link
+									Font: Bold
+								Label@COMMUNITY_WIKI_DESC:
+									X: 20
+									Y: 110
+									Width: PARENT_WIDTH - 40
+									Height: 40
+									WordWrap: true
+									Align: Center
+									Text: label-mapchooser-community-wiki-desc
+								Button@BUTTON_WIKI_MAPPING:
+									X: (PARENT_WIDTH - WIDTH) / 2 - 110
+									Y: 170
+									Width: 180
+									Height: 25
+									Text: button-mapchooser-wiki-mapping
+									Font: Bold
+								Button@BUTTON_WIKI_MAP_SCRIPTING:
+									X: (PARENT_WIDTH - WIDTH) / 2 + 110
+									Y: 170
+									Width: 180
+									Height: 25
+									Text: button-mapchooser-wiki-map-scripting
+									Font: Bold
+								Background@FOLDER_HEADER:
+									X: 5
+									Y: 210
+									Width: PARENT_WIDTH - 24 - 10
+									Height: 13
+									Background: separator
+									ClickThrough: true
+									Children:
+										Label@LABEL:
+											Width: PARENT_WIDTH
+											Height: PARENT_HEIGHT
+											Font: TinyBold
+											Align: Center
+											Text: label-mapchooser-community-folder-header
+								Label@COMMUNITY_FOLDER_DESC:
+									X: 20
+									Y: 230
+									Width: PARENT_WIDTH - 40
+									Height: 100
+									WordWrap: true
+									Align: Center
+									Text: label-mapchooser-community-folder-desc
+								Button@BUTTON_OPEN_MAPS_FOLDER:
+									X: (PARENT_WIDTH - WIDTH) / 2
+									Y: 340
+									Width: 200
+									Height: 25
+									Text: button-mapchooser-open-maps-folder
+									Font: Bold
 				Container@GENERATE_MAP_TAB:
 					Width: PARENT_WIDTH
 					Height: PARENT_HEIGHT

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -513,6 +513,25 @@ button-mapchooser-system-maps-tab = Official Maps
 button-mapchooser-remote-maps-tab = Server Maps
 button-mapchooser-user-maps-tab = Custom Maps
 button-mapchooser-generated-maps-tab = Generate Map
+button-mapchooser-community-maps-tab = Community Maps
+label-mapchooser-community-resource-header = Resource Center
+label-mapchooser-community-resource-desc =
+    You can browse the Resource Center to download maps created by the community, 22,350 maps have already been uploaded.
+label-mapchooser-community-wiki-desc =
+    It's also the place where you can upload your own maps, if you want to share them with other players.
+
+    Check the Wiki pages to learn how to create maps and add Lua scripting:
+button-mapchooser-community-maps-link = Resource Center
+button-mapchooser-wiki-mapping = Wiki: Mapping
+button-mapchooser-wiki-map-scripting = Wiki: Map Scripting
+label-mapchooser-community-folder-header = Maps Folder Location
+label-mapchooser-community-folder-desc =
+    Custom maps are stored in the following directory. Once the .oramap file is downloaded, place it in this folder:
+
+    Windows: %AppData%\OpenRA\maps\<mod name>\
+    Mac OSX: ~/Library/Application Support/OpenRA/maps/<mod name>/
+    Linux: ~/.config/openra/maps/<mod name>/
+button-mapchooser-open-maps-folder = Open Maps Folder
 
 ## MissionBrowserLogic
 dialog-no-video =


### PR DESCRIPTION
Fixes: https://github.com/OpenRA/OpenRA/issues/10171

Add a Community Maps tab in Map Chooser featuring:

- a Resource Center button
- two buttons that lead to Wiki pages related to [Mapping](https://github.com/OpenRA/OpenRA/wiki/Mapping) and [Map Scripting](https://github.com/OpenRA/OpenRA/wiki/Map-scripting)
- a button to open the local map folder

![screenshot_005](https://github.com/user-attachments/assets/5ed334dd-6a03-43c0-b5ed-0f61c04b4ab4)

