### PR TITLE
Resource center button on map chooser

### DIFF
--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common
 		public readonly string ServerList = "https://master.openra.net/games";
 		public readonly string ServerAdvertise = "https://master.openra.net/ping";
 		public readonly string MapRepository = "https://resource.openra.net/map/";
+		public readonly string ResourceCenter = "https://resource.openra.net/";
 		public readonly string GameNews = "https://master.openra.net/gamenews";
 		public readonly string GameNewsFileName = "news.yaml";
 		public readonly string VersionCheck = "https://master.openra.net/versioncheck";

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -265,6 +265,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
+			var resourceCenterButton = widget.Get<ButtonWidget>("RESOURCE_CENTER_BUTTON");
+			resourceCenterButton.IsVisible = () => currentTab == MapClassification.User;
+			resourceCenterButton.OnClick = () => Game.Renderer.TryOpenUrl(modData.GetOrCreate<WebServices>().ResourceCenter);
+
 			var remoteMapLabel = widget.Get<LabelWidget>("REMOTE_MAP_LABEL");
 			var remoteMapText = new CachedTransform<(int Searching, int Unavailable), string>(counts =>
 			{

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -181,6 +181,12 @@ Container@MAPCHOOSER_PANEL:
 					Width: 140
 					Height: 35
 					Text: button-bg-delete-all-maps
+				Button@RESOURCE_CENTER_BUTTON:
+					X: PARENT_WIDTH - 600 - WIDTH
+					Y: PARENT_HEIGHT - 1
+					Width: 140
+					Height: 35
+					Text: button-mapchooser-resource-center
 				Button@BUTTON_OK:
 					Key: return
 					X: PARENT_WIDTH - WIDTH

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -164,6 +164,13 @@ Background@MAPCHOOSER_PANEL:
 			Height: 25
 			Text: button-mapchooser-panel-delete-all-maps
 			Font: Bold
+		Button@RESOURCE_CENTER_BUTTON:
+			X: 440
+			Y: PARENT_HEIGHT - 45
+			Width: 140
+			Height: 25
+			Text: button-mapchooser-resource-center
+			Font: Bold
 		Label@REMOTE_MAP_LABEL:
 			X: 140
 			Y: PARENT_HEIGHT - HEIGHT - 20

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -513,6 +513,7 @@ button-mapchooser-system-maps-tab = Official Maps
 button-mapchooser-remote-maps-tab = Server Maps
 button-mapchooser-user-maps-tab = Custom Maps
 button-mapchooser-generated-maps-tab = Generate Map
+button-mapchooser-resource-center = Resource Center
 
 ## MissionBrowserLogic
 dialog-no-video =


### PR DESCRIPTION
Here is another proposal to add a _Resource Center_ button on the Map Chooser window (this time, with a much simpler approch: just the button).

Fixes: https://github.com/OpenRA/OpenRA/issues/10171
Previous PR: https://github.com/OpenRA/OpenRA/pull/22404


<details> 
  <summary>Screenshots (now outdated by the code update)</summary>
  <img src="https://github.com/user-attachments/assets/4571a9bf-608c-4734-a2e3-2ca8306b68f0" data-canonical-src="https://github.com/user-attachments/assets/4571a9bf-608c-4734-a2e3-2ca8306b68f0" />

  <img src="https://github.com/user-attachments/assets/8db3784f-731f-4d9c-9db0-33ad95cf5d20" data-canonical-src="https://github.com/user-attachments/assets/8db3784f-731f-4d9c-9db0-33ad95cf5d20" />
  
  <img src="https://github.com/user-attachments/assets/bda3794f-28dc-4836-be71-71a849597b2a" data-canonical-src="https://github.com/user-attachments/assets/bda3794f-28dc-4836-be71-71a849597b2a" />
    
  <img src="https://github.com/user-attachments/assets/4cae8284-abb5-4f72-9eae-be4379e8ceb4" data-canonical-src="https://github.com/user-attachments/assets/4cae8284-abb5-4f72-9eae-be4379e8ceb4" />
</details>



