### PR TITLE
Fix style rule

### DIFF
--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -283,7 +283,7 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
-		public unsafe delegate int GetIntegerv(int pname, out int param);
+		public delegate int GetIntegerv(int pname, out int param);
 		public static GetIntegerv glGetIntegerv { get; private set; }
 
 		public delegate void Finish();


### PR DESCRIPTION
.net 10 is picking up this as unnecesary unsafe