### PR TITLE
Allow end point deviation in Path Tiler tool

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
+++ b/OpenRA.Mods.Common/Traits/World/TilingPathTool.cs
@@ -325,9 +325,10 @@ namespace OpenRA.Mods.Common.Traits
 		public string EndType { get; private set; } = null;
 		public DirectionMask AutoStartDirectionMask = DirectionMask.None;
 		public DirectionMask AutoEndDirectionMask = DirectionMask.None;
+		public int MaxDeviation { get; private set; } = 5;
+		public bool AllowEndDeviation { get; private set; } = true;
 		public bool ClosedLoops { get; private set; } = true;
 		public int RandomSeed { get; private set; } = 0;
-		public int MaxDeviation { get; private set; } = 5;
 		public EditorBlitSource? EditorBlitSource { get; private set; } = null;
 
 		bool disposed;
@@ -460,6 +461,9 @@ namespace OpenRA.Mods.Common.Traits
 					permittedTemplates);
 				tilingPath.Start.Direction = plan.AutoStart(AutoStartDirectionMask);
 				tilingPath.End.Direction = plan.AutoEnd(AutoEndDirectionMask);
+				if (AllowEndDeviation)
+					tilingPath.SetAutoEndDeviation();
+
 				var result = tilingPath.Tile(random);
 				if (result != null)
 					return result.ToEditorBlitSource(WorldRenderer, random);
@@ -564,6 +568,12 @@ namespace OpenRA.Mods.Common.Traits
 		public void SetMaxDeviation(int value)
 		{
 			MaxDeviation = value;
+			Update();
+		}
+
+		public void SetAllowEndDeviation(bool value)
+		{
+			AllowEndDeviation = value;
 			Update();
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TilingPathToolLogic.cs
@@ -98,6 +98,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			deviationSlider.GetValue = () => tool.MaxDeviation;
 			deviationSlider.OnChange += (value) => tool.SetMaxDeviation((int)value);
 
+			var allowEndDeviationCheckbox = widget.Get<CheckboxWidget>("ALLOW_END_DEVIATION");
+			allowEndDeviationCheckbox.IsChecked = () => tool.AllowEndDeviation;
+			allowEndDeviationCheckbox.OnClick = () => tool.SetAllowEndDeviation(!tool.AllowEndDeviation);
+
 			var closedLoopsCheckbox = widget.Get<CheckboxWidget>("CLOSED_LOOPS");
 			closedLoopsCheckbox.IsChecked = () => tool.ClosedLoops;
 			closedLoopsCheckbox.OnClick = () => tool.SetClosedLoops(!tool.ClosedLoops);

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -1189,6 +1189,11 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 					MinimumValue: 0
 					MaximumValue: 10
 					Ticks: 11
+		Checkbox@ALLOW_END_DEVIATION:
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 25
+			Text: checkbox-tiling-path-allow-end-deviation
 		Checkbox@CLOSED_LOOPS:
 			X: 5
 			Width: PARENT_WIDTH - 35

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -82,6 +82,7 @@ label-tiling-path-type-start = Start type
 label-tiling-path-type-inner = Inner type
 label-tiling-path-type-end = End type
 label-tiling-path-deviation = Deviation limit
+checkbox-tiling-path-allow-end-deviation = Allow end point deviation
 checkbox-tiling-path-closed-loops = Loops use only inner types
 button-tiling-path-reverse = Reverse path
 button-tiling-path-reset = Discard path

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -1161,6 +1161,11 @@ ScrollPanel@TILING_PATH_TOOL_PANEL:
 					MinimumValue: 0
 					MaximumValue: 10
 					Ticks: 11
+		Checkbox@ALLOW_END_DEVIATION:
+			X: 5
+			Width: PARENT_WIDTH - 35
+			Height: 25
+			Text: checkbox-tiling-path-allow-end-deviation
 		Checkbox@CLOSED_LOOPS:
 			X: 5
 			Width: PARENT_WIDTH - 35

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -78,6 +78,7 @@ label-tiling-path-type-start = Start type
 label-tiling-path-type-inner = Inner type
 label-tiling-path-type-end = End type
 label-tiling-path-deviation = Deviation limit
+checkbox-tiling-path-allow-end-deviation = Allow end point deviation
 checkbox-tiling-path-closed-loops = Loops use only inner types
 button-tiling-path-reverse = Reverse path
 button-tiling-path-reset = Discard path


### PR DESCRIPTION
This change allows the Path Tiler tool to offer tilings that don't quite match up to the end point specified by the user in cases where there is no valid precise tiling. This greatly reduces user confusion about why certain paths previously weren't accepted, and provides better visual feedback on how to adjust the path.

As a concrete example, TD beaches cannot be tiled between arbitrary points, due all beach templates travelling 3 steps. The tiling of TD beaches and their limitations are now far more intuitive.

An option is added into the panel to control this behavior. This can be useful if precision is important and the user wants to retain a clearer signal that the tiling won't be precise.

Depends on #22375
