### PR TITLE
Add an Ingame Map Browser

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -221,7 +221,8 @@ namespace OpenRA
 		}
 
 		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids,
-			Action<MapPreview> mapDetailsReceived = null, Action<MapPreview> mapQueryFailed = null)
+			Action<MapPreview> mapDetailsReceived = null, Action<MapPreview> mapQueryFailed = null,
+			MapClassification targetClass = MapClassification.Remote)
 		{
 			var queryUids = uids.Distinct()
 				.Where(uid => uid != null)
@@ -231,7 +232,7 @@ namespace OpenRA
 				.ToList();
 
 			foreach (var uid in queryUids)
-				previews[uid].BeginRemoteSearch();
+				previews[uid].BeginRemoteSearch(targetClass);
 
 			Task.Run(async () =>
 			{
@@ -248,7 +249,7 @@ namespace OpenRA
 						{
 							var result = await client.GetStreamAsync(url);
 							foreach (var kv in MiniYaml.FromStream(result, url, stringPool: stringPool))
-								previews[kv.Key].CompleteRemoteSearch(kv.Value, mapDetailsReceived);
+								previews[kv.Key].CompleteRemoteSearch(kv.Value, mapDetailsReceived, targetClass);
 						}
 						catch (Exception e)
 						{
@@ -261,7 +262,7 @@ namespace OpenRA
 						{
 							var p = previews[uid];
 							if (p.Status == MapStatus.Searching)
-								p.CompleteRemoteSearch(null, mapQueryFailed);
+								p.CompleteRemoteSearch(null, mapQueryFailed, targetClass);
 						}
 					}
 				}

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -38,7 +38,8 @@ namespace OpenRA
 		System = 1,
 		User = 2,
 		Remote = 4,
-		Generated = 8
+		Generated = 8,
+		Community = 16,
 	}
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules",
@@ -546,23 +547,24 @@ namespace OpenRA
 			});
 		}
 
-		public void BeginRemoteSearch()
+		public void BeginRemoteSearch(MapClassification targetClass = MapClassification.Remote)
 		{
 			var newData = innerData.Clone();
-			newData.Class = MapClassification.Remote;
+			newData.Class = targetClass;
 			newData.Status = MapStatus.Searching;
 
 			// We may have been resolved to a local/generated map by another
 			// async task. Make sure we don't stomp over their state!
 			lock (syncRoot)
-				if (innerData.Class == MapClassification.Unknown || innerData.Class == MapClassification.Remote)
+				if (innerData.Class == MapClassification.Unknown || innerData.Class == targetClass)
 					innerData = newData;
 		}
 
-		public void CompleteRemoteSearch(MiniYaml yaml, Action<MapPreview> parseMetadata = null)
+		public void CompleteRemoteSearch(MiniYaml yaml, Action<MapPreview> parseMetadata = null,
+			MapClassification targetClass = MapClassification.Remote)
 		{
 			var newData = innerData.Clone();
-			newData.Class = MapClassification.Remote;
+			newData.Class = targetClass;
 			newData.Status = MapStatus.Unavailable;
 
 			if (yaml != null)
@@ -627,11 +629,11 @@ namespace OpenRA
 			lock (syncRoot)
 			{
 				mapClassification = innerData.Class;
-				if (mapClassification == MapClassification.Remote)
+				if (mapClassification == targetClass)
 					innerData = newData;
 			}
 
-			if (mapClassification == MapClassification.Remote)
+			if (mapClassification == targetClass)
 			{
 				if (innerData.Preview != null)
 					cache.CacheMinimap(this);

--- a/OpenRA.Mods.Common/CommunityMapQuery.cs
+++ b/OpenRA.Mods.Common/CommunityMapQuery.cs
@@ -1,0 +1,326 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenRA.Support;
+
+namespace OpenRA.Mods.Common
+{
+	public sealed class CommunityMapQuery
+	{
+		const int PageSize = 20;
+		const int MaxPage = 10000;
+
+		readonly string apiUrl;
+		readonly string mapRepositoryUrl;
+		readonly ModData modData;
+		readonly MapCache mapCache;
+
+		CancellationTokenSource searchCts;
+		CancellationTokenSource countCts;
+
+		/// <summary>Hashes of maps on the current page.</summary>
+		readonly HashSet<string> currentResultHashes = [];
+
+		public string SortBy { get; set; } = "latest";
+		public string Tileset { get; set; }
+		public int? Players { get; set; }
+		public bool OnlyAdvanced { get; set; }
+		public bool OnlyLua { get; set; }
+		public bool IsLoading { get; private set; }
+
+		/// <summary>Current page number (1-based).</summary>
+		public int CurrentPage { get; private set; } = 1;
+
+		/// <summary>Total number of pages, or null while still being determined.</summary>
+		public int? TotalPages { get; private set; }
+
+		/// <summary>Total number of maps matching the current filters on the server.
+		/// Null while the count is being determined.</summary>
+		public int? TotalAvailable { get; private set; }
+
+		/// <summary>Returns whether the given map hash is part of the current page results.</summary>
+		public bool ContainsHash(string hash) => currentResultHashes.Contains(hash);
+
+		public CommunityMapQuery(ModData modData, string apiUrl, string mapRepositoryUrl)
+		{
+			this.modData = modData;
+			this.apiUrl = apiUrl;
+			this.mapRepositoryUrl = mapRepositoryUrl;
+			mapCache = modData.MapCache;
+		}
+
+		public void Search(Action onComplete, Action<string> onError)
+		{
+			// Cancel any in-flight request before starting a new search.
+			CancelPending();
+
+			CurrentPage = 1;
+			TotalPages = null;
+			TotalAvailable = null;
+			IsLoading = false;
+			currentResultHashes.Clear();
+			LoadPage(1, onComplete, onError);
+			CountTotalAsync();
+		}
+
+		public void GoToPage(int page, Action onComplete, Action<string> onError)
+		{
+			if (IsLoading || page < 1)
+				return;
+
+			// If we know the total pages, clamp.
+			if (TotalPages.HasValue && page > TotalPages.Value)
+				return;
+
+			CancelSearchPending();
+			currentResultHashes.Clear();
+			LoadPage(page, onComplete, onError);
+		}
+
+		HttpQueryBuilder BuildQuery(int page, string sortBy, string tileset,
+			int? players = null, bool onlyAdvanced = false, bool onlyLua = false)
+		{
+			var query = new HttpQueryBuilder(apiUrl)
+			{
+				{ "mod", modData.Manifest.Id },
+				{ "page", page },
+				{ "sort_by", sortBy },
+				{ "format", Map.CurrentMapFormat },
+				{ "with_problems", "hide_lint_failed" },
+			};
+
+			if (!string.IsNullOrEmpty(tileset))
+				query.Add("tileset", tileset);
+
+			if (players.HasValue)
+				query.Add("players", players.Value);
+
+			if (onlyAdvanced)
+				query.Add("only_advanced", "on");
+
+			if (onlyLua)
+				query.Add("only_lua", "on");
+
+			return query;
+		}
+
+		void LoadPage(int page, Action onComplete, Action<string> onError)
+		{
+			if (IsLoading)
+				return;
+
+			IsLoading = true;
+
+			searchCts ??= new CancellationTokenSource();
+			var token = searchCts.Token;
+
+			var query = BuildQuery(page, SortBy, Tileset, Players, OnlyAdvanced, OnlyLua);
+
+			Task.Run(async () =>
+			{
+				try
+				{
+					var client = HttpClientFactory.Create();
+					var json = await client.GetStringAsync(query.ToString(), token);
+
+					if (token.IsCancellationRequested)
+						return;
+
+					var hashes = ParseMapHashes(json);
+
+					foreach (var hash in hashes)
+						currentResultHashes.Add(hash);
+
+					// Filter out maps already known locally as System or User.
+					var newHashes = hashes
+						.Where(h =>
+						{
+							var p = mapCache[h];
+							return p.Status == MapStatus.Unavailable
+								&& p.Class != MapClassification.System
+								&& p.Class != MapClassification.User;
+						})
+						.ToList();
+
+					if (newHashes.Count > 0)
+					{
+						mapCache.QueryRemoteMapDetails(
+							mapRepositoryUrl,
+							newHashes,
+							targetClass: MapClassification.Community);
+					}
+
+					Game.RunAfterTick(() =>
+					{
+						CurrentPage = page;
+						IsLoading = false;
+						onComplete?.Invoke();
+					});
+				}
+				catch (OperationCanceledException)
+				{
+					// Request was cancelled by a new Search call. Do nothing.
+				}
+				catch (Exception e)
+				{
+					Log.Write("debug", $"Community map query failed: {e}");
+					Game.RunAfterTick(() =>
+					{
+						IsLoading = false;
+						onError?.Invoke(e.Message);
+					});
+				}
+			});
+		}
+
+		/// <summary>Uses binary search to find the total number of maps matching
+		/// the current filters without downloading all pages.</summary>
+		void CountTotalAsync()
+		{
+			CancelCountPending();
+			countCts = new CancellationTokenSource();
+			var token = countCts.Token;
+
+			// Capture current filter state so the result is discarded if filters change.
+			var queryTileset = Tileset;
+			var queryPlayers = Players;
+			var queryAdvanced = OnlyAdvanced;
+			var queryLua = OnlyLua;
+
+			Task.Run(async () =>
+			{
+				try
+				{
+					var client = HttpClientFactory.Create();
+
+					// Binary search for the last page that contains results.
+					var low = 1;
+					var high = 1;
+
+					// First, find an upper bound by doubling.
+					while (high <= MaxPage)
+					{
+						if (token.IsCancellationRequested)
+							return;
+
+						var count = await GetPageCount(client, high, queryTileset, queryPlayers, queryAdvanced, queryLua, token);
+						if (count < PageSize)
+							break;
+
+						low = high;
+						high = Math.Min(high * 2, MaxPage + 1);
+					}
+
+					// Binary search between low and high.
+					while (low < high)
+					{
+						if (token.IsCancellationRequested)
+							return;
+
+						var mid = low + (high - low) / 2;
+						var count = await GetPageCount(client, mid, queryTileset, queryPlayers, queryAdvanced, queryLua, token);
+						if (count < PageSize)
+							high = mid;
+						else
+							low = mid + 1;
+					}
+
+					// low == high == the first page with fewer than PageSize results.
+					// Count that page to get the exact remainder.
+					if (token.IsCancellationRequested)
+						return;
+
+					var lastPageCount = await GetPageCount(client, low, queryTileset, queryPlayers, queryAdvanced, queryLua, token);
+					var total = (low - 1) * PageSize + lastPageCount;
+
+					Game.RunAfterTick(() =>
+					{
+						if (!token.IsCancellationRequested)
+						{
+							TotalAvailable = total;
+							TotalPages = total == 0 ? 1 : (total + PageSize - 1) / PageSize;
+						}
+					});
+				}
+				catch (OperationCanceledException)
+				{
+					// Cancelled by a new search — ignore.
+				}
+				catch (Exception e)
+				{
+					Log.Write("debug", $"Community map count failed: {e}");
+				}
+			});
+		}
+
+		async Task<int> GetPageCount(System.Net.Http.HttpClient client, int page,
+			string tileset, int? players, bool onlyAdvanced, bool onlyLua, CancellationToken token)
+		{
+			var query = BuildQuery(page, "latest", tileset, players, onlyAdvanced, onlyLua);
+			var json = await client.GetStringAsync(query.ToString(), token);
+			using var doc = JsonDocument.Parse(json);
+			return doc.RootElement.EnumerateObject().Count();
+		}
+
+		void CancelCountPending()
+		{
+			if (countCts != null)
+			{
+				countCts.Cancel();
+				countCts.Dispose();
+				countCts = null;
+			}
+		}
+
+		void CancelSearchPending()
+		{
+			if (searchCts != null)
+			{
+				searchCts.Cancel();
+				searchCts.Dispose();
+				searchCts = null;
+			}
+		}
+
+		public void CancelPending()
+		{
+			CancelSearchPending();
+			CancelCountPending();
+		}
+
+		static List<string> ParseMapHashes(string json)
+		{
+			var hashes = new List<string>();
+
+			using var doc = JsonDocument.Parse(json);
+			foreach (var property in doc.RootElement.EnumerateObject())
+			{
+				if (property.Value.ValueKind != JsonValueKind.Object)
+					continue;
+
+				if (!property.Value.TryGetProperty("map_hash", out var hashElement))
+					continue;
+
+				var hash = hashElement.GetString();
+				if (!string.IsNullOrEmpty(hash))
+					hashes.Add(hash);
+			}
+
+			return hashes;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -21,6 +21,8 @@ namespace OpenRA.Mods.Common
 		public readonly string ServerList = "https://master.openra.net/games";
 		public readonly string ServerAdvertise = "https://master.openra.net/ping";
 		public readonly string MapRepository = "https://resource.openra.net/map/";
+		public readonly string MapBrowserApi = "https://resource.openra.net/api/map";
+		public readonly string ResourceCenter = "https://resource.openra.net";
 		public readonly string GameNews = "https://master.openra.net/gamenews";
 		public readonly string GameNewsFileName = "news.yaml";
 		public readonly string VersionCheck = "https://master.openra.net/versioncheck";

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Mods.Common.Traits;
@@ -95,7 +96,67 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string RemoteMapsTab = "button-mapchooser-remote-maps-tab";
 
 		[FluentReference]
+		const string CommunityMapsTab = "button-mapchooser-community-maps-tab";
+
+		[FluentReference]
 		const string GeneratedMapsTab = "button-mapchooser-generated-maps-tab";
+
+		[FluentReference]
+		const string CommunityMapsLoading = "label-community-maps-loading";
+
+		[FluentReference]
+		const string CommunityMapsError = "label-community-maps-error";
+
+		[FluentReference("total")]
+		const string CommunityPageTotal = "label-community-page-total";
+
+		[FluentReference]
+		const string CommunityPageTotalLoading = "label-community-page-total-loading";
+
+		[FluentReference]
+		const string CommunitySortLatest = "label-community-sort-latest";
+
+		[FluentReference]
+		const string CommunitySortOldest = "label-community-sort-oldest";
+
+		[FluentReference]
+		const string CommunitySortTitle = "label-community-sort-title";
+
+		[FluentReference]
+		const string CommunitySortTitleReversed = "label-community-sort-title-reversed";
+
+		[FluentReference]
+		const string CommunitySortPlayers = "label-community-sort-players";
+
+		[FluentReference]
+		const string CommunitySortLatelyCommented = "label-community-sort-lately-commented";
+
+		[FluentReference]
+		const string CommunitySortRating = "label-community-sort-rating";
+
+		[FluentReference]
+		const string CommunitySortViews = "label-community-sort-views";
+
+		[FluentReference]
+		const string CommunitySortDownloads = "label-community-sort-downloads";
+
+		[FluentReference]
+		const string CommunitySortRevisions = "label-community-sort-revisions";
+
+		[FluentReference]
+		const string CommunityFilterTilesetAny = "label-community-filter-tileset-any";
+
+		[FluentReference]
+		const string CommunityFilterTagsChoose = "label-community-filter-tags-choose";
+
+		[FluentReference]
+		const string CommunityFilterTagsAdvanced = "label-community-filter-tags-advanced";
+
+		[FluentReference]
+		const string CommunityFilterTagsLua = "label-community-filter-tags-lua";
+
+		[FluentReference("count")]
+		const string CommunityCount = "label-community-count";
 
 		public static string MapSizeLabel(Size size)
 		{
@@ -122,6 +183,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int remoteSearching = 0;
 		int remoteUnavailable = 0;
 
+		readonly Widget filterContainer;
+		readonly int filterContainerDefaultY;
+
 		readonly Dictionary<MapClassification, ScrollPanelWidget> scrollpanels = [];
 		readonly Dictionary<MapClassification, MapPreview[]> tabMaps = [];
 		readonly Dictionary<MapClassification, string> tabLabels = [];
@@ -137,6 +201,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string mapFilter;
 
 		Func<MapPreview, long> orderByFunc;
+
+		CommunityMapQuery communityQuery;
+		int communitySearching;
+		string communityStatusText;
+		TextFieldWidget communityPageInput;
+		bool communityFiltersDirty;
+
+		// Community sort options: display label → API sort_by value.
+		readonly Dictionary<string, string> communitySortOptions = [];
+		string selectedCommunitySortLabel;
+
+		// Community filter state.
+		string selectedCommunityTileset;
+		string selectedCommunityTilesetLabel;
+		bool filterAdvanced;
+		bool filterLua;
 
 		[ObjectCreator.UseCtor]
 		internal MapChooserLogic(Widget widget, ModData modData, string initialMap, MapGenerationArgs initialGeneratedMap, FrozenSet<string> remoteMapPool,
@@ -196,9 +276,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			SetupOrderByDropdown();
 
-			var filterContainer = widget.GetOrNull("FILTER_ORDER_CONTROLS");
+			filterContainer = widget.GetOrNull("FILTER_ORDER_CONTROLS");
 			if (filterContainer != null)
+			{
+				filterContainerDefaultY = filterContainer.Bounds.Y;
 				filterContainer.IsVisible = () => currentTab != MapClassification.Generated;
+			}
 
 			var mapFilterInput = widget.GetOrNull<TextFieldWidget>("MAPFILTER_INPUT");
 			if (mapFilterInput != null)
@@ -234,7 +317,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					scrollpanels[currentTab].ScrollToItem(uid, smooth: true);
 				};
 				randomMapButton.IsDisabled = () => visibleMaps == null || visibleMaps.Length == 0;
-				randomMapButton.IsVisible = () => currentTab != MapClassification.Generated;
+				randomMapButton.IsVisible = () => currentTab != MapClassification.Generated
+					&& currentTab != MapClassification.Community;
 			}
 
 			var deleteMapButton = widget.Get<ButtonWidget>("DELETE_MAP_BUTTON");
@@ -288,6 +372,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SetupMapPanel(MapClassification.System, "SYSTEM_MAPS_TAB");
 			SetupMapPanel(MapClassification.Remote, "REMOTE_MAPS_TAB");
 
+			// Community maps tab is available when downloading is allowed and not in a server pool.
+			if (remoteMapPool == null && Game.Settings.Game.AllowDownloading)
+				SetupCommunityMapsPanel();
+
 			var hasGenerator = modData.DefaultRules.Actors[SystemActors.EditorWorld].HasTraitInfo<IEditorMapGeneratorInfo>();
 			if (onSelectGenerated != null && hasGenerator)
 				SetupGenerateMapPanel(MapClassification.Generated, "GENERATE_MAP_TAB", initialGeneratedMap);
@@ -302,6 +390,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else
 			{
 				tabLabels[MapClassification.System] = SystemMapsTab;
+				tabLabels[MapClassification.Community] = CommunityMapsTab;
 				tabLabels[MapClassification.User] = UserMapsTab;
 				if (onSelectGenerated != null && hasGenerator)
 					tabLabels[MapClassification.Generated] = GeneratedMapsTab;
@@ -328,9 +417,402 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SetupMapTabs();
 		}
 
+		void SetupCommunityMapsPanel()
+		{
+			var services = modData.GetOrCreate<WebServices>();
+			communityQuery = new CommunityMapQuery(modData, services.MapBrowserApi, services.MapRepository);
+
+			SetupMapPanel(MapClassification.Community, "COMMUNITY_MAPS_TAB");
+
+			var communityMapLabel = widget.GetOrNull<LabelWidget>("COMMUNITY_MAP_LABEL");
+			if (communityMapLabel != null)
+			{
+				communityMapLabel.IsVisible = () => currentTab == MapClassification.Community && communityStatusText != null;
+				communityMapLabel.GetText = () => communityStatusText;
+			}
+
+			var communityFilterControls = widget.GetOrNull("COMMUNITY_FILTER_CONTROLS");
+			if (communityFilterControls != null)
+				communityFilterControls.IsVisible = () => currentTab == MapClassification.Community;
+
+			SetupCommunityTilesetFilter();
+			SetupCommunityTagsFilter();
+			SetupCommunityPlayersFilter();
+			SetupCommunitySortDropdown();
+			SetupCommunityPagination();
+			SetupCommunitySearchButton();
+
+			// Start loading the first page automatically.
+			SearchCommunityMaps();
+		}
+
+		void SetupCommunityTilesetFilter()
+		{
+			var tilesetDropdown = widget.GetOrNull<DropDownButtonWidget>("COMMUNITY_TILESET_FILTER");
+			if (tilesetDropdown == null)
+				return;
+
+			var anyLabel = FluentProvider.GetMessage(CommunityFilterTilesetAny);
+			selectedCommunityTilesetLabel = anyLabel;
+
+			// Build tileset options from the current mod's terrain definitions.
+			var tilesets = new List<(string Id, string Label)> { (null, anyLabel) };
+			foreach (var kv in modData.DefaultTerrainInfo)
+				tilesets.Add((kv.Key, kv.Key));
+
+			tilesetDropdown.GetText = () => selectedCommunityTilesetLabel;
+			tilesetDropdown.OnClick = () =>
+			{
+				ScrollItemWidget SetupItem((string Id, string Label) ts, ScrollItemWidget template)
+				{
+					var item = ScrollItemWidget.Setup(template,
+						() => selectedCommunityTileset == ts.Id,
+						() =>
+						{
+							selectedCommunityTileset = ts.Id;
+							selectedCommunityTilesetLabel = ts.Label;
+							communityQuery.Tileset = ts.Id;
+							communityFiltersDirty = true;
+						});
+					item.Get<LabelWidget>("LABEL").GetText = () => ts.Label;
+					return item;
+				}
+
+				tilesetDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", tilesets.Count * 30, tilesets, SetupItem);
+			};
+		}
+
+		void SetupCommunityTagsFilter()
+		{
+			var tagsDropdown = widget.GetOrNull<DropDownButtonWidget>("COMMUNITY_TAGS_FILTER");
+			if (tagsDropdown == null)
+				return;
+
+			var advancedLabel = FluentProvider.GetMessage(CommunityFilterTagsAdvanced);
+			var luaLabel = FluentProvider.GetMessage(CommunityFilterTagsLua);
+
+			var chooseLabel = FluentProvider.GetMessage(CommunityFilterTagsChoose);
+			tagsDropdown.GetText = () =>
+			{
+				if (filterAdvanced && filterLua)
+					return $"{advancedLabel}, {luaLabel}";
+				if (filterAdvanced)
+					return advancedLabel;
+				if (filterLua)
+					return luaLabel;
+				return chooseLabel;
+			};
+
+			var tagsPanel = CreateCommunityTagsPanel(advancedLabel, luaLabel);
+			tagsDropdown.OnMouseDown = _ =>
+			{
+				tagsDropdown.RemovePanel();
+				tagsDropdown.AttachPanel(tagsPanel);
+			};
+		}
+
+		Widget CreateCommunityTagsPanel(string advancedLabel, string luaLabel)
+		{
+			var panel = Ui.LoadWidget("COMMUNITY_TAGS_PANEL", null, []);
+			var template = panel.Get<CheckboxWidget>("COMMUNITY_TAG_TEMPLATE");
+
+			var advancedCheckbox = template.Clone();
+			advancedCheckbox.GetText = () => advancedLabel;
+			advancedCheckbox.IsChecked = () => filterAdvanced;
+			advancedCheckbox.IsVisible = () => true;
+			advancedCheckbox.OnClick = () =>
+			{
+				filterAdvanced = !filterAdvanced;
+				communityQuery.OnlyAdvanced = filterAdvanced;
+				communityFiltersDirty = true;
+			};
+
+			panel.AddChild(advancedCheckbox);
+
+			var luaCheckbox = template.Clone();
+			luaCheckbox.GetText = () => luaLabel;
+			luaCheckbox.IsChecked = () => filterLua;
+			luaCheckbox.IsVisible = () => true;
+			luaCheckbox.OnClick = () =>
+			{
+				filterLua = !filterLua;
+				communityQuery.OnlyLua = filterLua;
+				communityFiltersDirty = true;
+			};
+
+			panel.AddChild(luaCheckbox);
+
+			return panel;
+		}
+
+		void SetupCommunityPlayersFilter()
+		{
+			var playersField = widget.GetOrNull<TextFieldWidget>("COMMUNITY_PLAYERS_FILTER");
+			if (playersField == null)
+				return;
+
+			playersField.Type = TextFieldType.Integer;
+			playersField.MaxLength = 2;
+			playersField.OnTextEdited = () =>
+			{
+				if (int.TryParse(playersField.Text, out var players) && players > 0)
+					communityQuery.Players = players;
+				else
+					communityQuery.Players = null;
+
+				communityFiltersDirty = true;
+			};
+		}
+
+		void SetupCommunitySortDropdown()
+		{
+			var sortDropdown = widget.GetOrNull<DropDownButtonWidget>("COMMUNITY_SORT");
+			if (sortDropdown == null)
+				return;
+
+			// Build the sort options mapping display labels to API sort_by values.
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortLatest)] = "latest";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortOldest)] = "oldest";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortTitle)] = "title";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortTitleReversed)] = "title_reversed";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortPlayers)] = "players";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortLatelyCommented)] = "lately_commented";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortRating)] = "rating";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortViews)] = "views";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortDownloads)] = "downloads";
+			communitySortOptions[FluentProvider.GetMessage(CommunitySortRevisions)] = "revisions";
+
+			selectedCommunitySortLabel = communitySortOptions.Keys.First();
+
+			sortDropdown.GetText = () => selectedCommunitySortLabel;
+			sortDropdown.OnClick = () =>
+			{
+				ScrollItemWidget SetupItem(string label, ScrollItemWidget template)
+				{
+					var item = ScrollItemWidget.Setup(template,
+						() => selectedCommunitySortLabel == label,
+						() =>
+						{
+							selectedCommunitySortLabel = label;
+							communityQuery.SortBy = communitySortOptions[label];
+							communityFiltersDirty = true;
+						});
+					item.Get<LabelWidget>("LABEL").GetText = () => label;
+					return item;
+				}
+
+				sortDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", communitySortOptions.Count * 30, communitySortOptions.Keys, SetupItem);
+			};
+		}
+
+		void SetupCommunitySearchButton()
+		{
+			var searchButton = widget.GetOrNull<ButtonWidget>("COMMUNITY_SEARCH");
+			if (searchButton == null)
+				return;
+
+			searchButton.IsVisible = () => currentTab == MapClassification.Community;
+			searchButton.IsDisabled = () => communityQuery.IsLoading;
+			searchButton.OnClick = SearchCommunityMaps;
+		}
+
+		void SetupCommunityPagination()
+		{
+			var pageFirst = widget.GetOrNull<ButtonWidget>("COMMUNITY_PAGE_FIRST");
+			if (pageFirst != null)
+			{
+				pageFirst.IsVisible = () => currentTab == MapClassification.Community;
+				pageFirst.IsDisabled = () => communityFiltersDirty || communityQuery.IsLoading || communityQuery.CurrentPage <= 1;
+				pageFirst.OnClick = () => GoToCommunityPage(1);
+			}
+
+			var pagePrev = widget.GetOrNull<ButtonWidget>("COMMUNITY_PAGE_PREV");
+			if (pagePrev != null)
+			{
+				pagePrev.IsVisible = () => currentTab == MapClassification.Community;
+				pagePrev.IsDisabled = () => communityFiltersDirty || communityQuery.IsLoading || communityQuery.CurrentPage <= 1;
+				pagePrev.OnClick = () => GoToCommunityPage(communityQuery.CurrentPage - 1);
+
+				var prevIcon = pagePrev.GetOrNull<ImageWidget>("IMAGE_PREV");
+				if (prevIcon != null)
+					prevIcon.GetImageName = () => pagePrev.IsDisabled() ? "left-disabled" : "left";
+			}
+
+			var pageNext = widget.GetOrNull<ButtonWidget>("COMMUNITY_PAGE_NEXT");
+			if (pageNext != null)
+			{
+				pageNext.IsVisible = () => currentTab == MapClassification.Community;
+				pageNext.IsDisabled = () => communityFiltersDirty || communityQuery.IsLoading
+					|| (communityQuery.TotalPages.HasValue && communityQuery.CurrentPage >= communityQuery.TotalPages.Value);
+				pageNext.OnClick = () => GoToCommunityPage(communityQuery.CurrentPage + 1);
+
+				var nextIcon = pageNext.GetOrNull<ImageWidget>("IMAGE_NEXT");
+				if (nextIcon != null)
+					nextIcon.GetImageName = () => pageNext.IsDisabled() ? "right-disabled" : "right";
+			}
+
+			var pageLast = widget.GetOrNull<ButtonWidget>("COMMUNITY_PAGE_LAST");
+			if (pageLast != null)
+			{
+				pageLast.IsVisible = () => currentTab == MapClassification.Community;
+				pageLast.IsDisabled = () => communityFiltersDirty || communityQuery.IsLoading || !communityQuery.TotalPages.HasValue
+					|| communityQuery.CurrentPage >= communityQuery.TotalPages.Value;
+				pageLast.OnClick = () => GoToCommunityPage(communityQuery.TotalPages.Value);
+			}
+
+			var pageLabel = widget.GetOrNull<LabelWidget>("COMMUNITY_PAGE_LABEL");
+			if (pageLabel != null)
+				pageLabel.IsVisible = () => currentTab == MapClassification.Community;
+
+			communityPageInput = widget.GetOrNull<TextFieldWidget>("COMMUNITY_PAGE_INPUT");
+			if (communityPageInput != null)
+			{
+				communityPageInput.IsVisible = () => currentTab == MapClassification.Community;
+				communityPageInput.IsDisabled = () => communityFiltersDirty || communityQuery.IsLoading;
+				communityPageInput.Type = TextFieldType.Integer;
+				communityPageInput.MaxLength = 4;
+				communityPageInput.Text = communityQuery.CurrentPage.ToString(CultureInfo.InvariantCulture);
+				communityPageInput.OnEnterKey = _ =>
+				{
+					if (int.TryParse(communityPageInput.Text, out var page) && page >= 1)
+					{
+						if (communityQuery.TotalPages.HasValue)
+							page = Math.Min(page, communityQuery.TotalPages.Value);
+
+						GoToCommunityPage(page);
+					}
+
+					return true;
+				};
+
+				communityPageInput.OnLoseFocus = () =>
+					communityPageInput.Text = communityQuery.CurrentPage.ToString(CultureInfo.InvariantCulture);
+			}
+
+			var pageTotal = widget.GetOrNull<LabelWidget>("COMMUNITY_PAGE_TOTAL");
+			if (pageTotal != null)
+			{
+				pageTotal.IsVisible = () => currentTab == MapClassification.Community;
+				pageTotal.GetText = () =>
+				{
+					var totalPages = communityQuery.TotalPages;
+					return totalPages.HasValue
+						? FluentProvider.GetMessage(CommunityPageTotal, "total", totalPages.Value)
+						: FluentProvider.GetMessage(CommunityPageTotalLoading);
+				};
+			}
+
+			var countLabel = widget.GetOrNull<LabelWidget>("COMMUNITY_COUNT_LABEL");
+			if (countLabel != null)
+			{
+				countLabel.IsVisible = () => currentTab == MapClassification.Community && communityQuery.TotalAvailable.HasValue;
+				countLabel.GetText = () =>
+				{
+					var total = communityQuery.TotalAvailable;
+					return total.HasValue
+						? FluentProvider.GetMessage(CommunityCount, "count", total.Value)
+						: "";
+				};
+			}
+
+			var resourceCenterButton = widget.GetOrNull<ButtonWidget>("COMMUNITY_RESOURCE_CENTER_BUTTON");
+			if (resourceCenterButton != null)
+			{
+				var services = modData.GetOrCreate<WebServices>();
+				resourceCenterButton.IsVisible = () => currentTab == MapClassification.Community;
+				resourceCenterButton.OnClick = () => Game.Renderer.TryOpenUrl(services.ResourceCenter);
+			}
+		}
+
+		void GoToCommunityPage(int page)
+		{
+			communityStatusText = FluentProvider.GetMessage(CommunityMapsLoading);
+			communityQuery.GoToPage(page, OnCommunityMapsLoaded, OnCommunityMapsError);
+		}
+
+		void SearchCommunityMaps()
+		{
+			communityFiltersDirty = false;
+			communityStatusText = FluentProvider.GetMessage(CommunityMapsLoading);
+			communityQuery.Search(OnCommunityMapsLoaded, OnCommunityMapsError);
+		}
+
+		void OnCommunityMapsLoaded()
+		{
+			if (disposed)
+				return;
+
+			// Update the page input field to reflect the current page.
+			if (communityPageInput != null)
+				communityPageInput.Text = communityQuery.CurrentPage.ToString(CultureInfo.InvariantCulture);
+
+			// Community maps are loaded asynchronously via QueryRemoteMapDetails.
+			// Poll for results until all previews are resolved.
+			communitySearching = 0;
+			RefreshCommunityMaps();
+
+			if (communitySearching > 0)
+			{
+				Game.RunAfterDelay(1000, () =>
+				{
+					if (disposed)
+						return;
+
+					OnCommunityMapsLoaded();
+				});
+			}
+			else
+				communityStatusText = null;
+
+			if (currentTab == MapClassification.Community)
+				EnumerateMaps(MapClassification.Community);
+
+			SetupMapTabs();
+		}
+
+		void OnCommunityMapsError(string error)
+		{
+			if (disposed)
+				return;
+
+			communityStatusText = FluentProvider.GetMessage(CommunityMapsError);
+			Log.Write("debug", $"Community map browser error: {error}");
+		}
+
+		void RefreshCommunityMaps()
+		{
+			var loaded = new List<MapPreview>();
+			communitySearching = 0;
+			foreach (var preview in modData.MapCache)
+			{
+				if (preview.Class != MapClassification.Community)
+					continue;
+
+				// Only include maps that belong to the current query results.
+				if (!communityQuery.ContainsHash(preview.Uid))
+					continue;
+
+				if (preview.Status == MapStatus.Searching)
+					communitySearching++;
+				else if (preview.Status == MapStatus.DownloadAvailable || preview.Status == MapStatus.Available
+					|| preview.Status == MapStatus.Downloading)
+					loaded.Add(preview);
+			}
+
+			tabMaps[MapClassification.Community] = loaded.ToArray();
+		}
+
 		void SwitchTab(MapClassification tab)
 		{
 			currentTab = tab;
+
+			// On the Community tab, move the filter row up to make room
+			// for the community-specific filter controls on the row below.
+			if (filterContainer != null)
+				filterContainer.Bounds.Y = tab == MapClassification.Community
+					? filterContainerDefaultY - 30
+					: filterContainerDefaultY;
+
 			EnumerateMaps(tab);
 		}
 
@@ -339,6 +821,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (tab == MapClassification.System || tab == MapClassification.User)
 				tabMaps[tab] = modData.MapCache.Where(m => m.Status == MapStatus.Available &&
 					m.Class == tab && (m.Visibility & filter) != 0).ToArray();
+			else if (tab == MapClassification.Community)
+				RefreshCommunityMaps();
 			else if (remoteMapPool != null)
 			{
 				var loaded = new List<MapPreview>();
@@ -379,7 +863,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void SetupMapTabs()
 		{
-			for (var i = 0; i < 3; i++)
+			for (var i = 0; i < 4; i++)
 				widget.Get<ButtonWidget>($"BUTTON{i + 1}").Visible = false;
 
 			var tabCount = 0;
@@ -387,6 +871,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var tab = kv.Key;
 				if (tab == MapClassification.User && tabMaps[tab].Length == 0)
+					continue;
+
+				// Hide the Community tab when downloading is disabled or not configured.
+				if (tab == MapClassification.Community && communityQuery == null)
 					continue;
 
 				var tabButton = widget.Get<ButtonWidget>($"BUTTON{++tabCount}");
@@ -480,6 +968,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var orderByDropdown = widget.GetOrNull<DropDownButtonWidget>("ORDERBY");
 			if (orderByDropdown == null)
 				return;
+
+			// Hide the standard Order By controls on the Community tab (replaced by COMMUNITY_SORT).
+			orderByDropdown.IsVisible = () => currentTab != MapClassification.Community;
+
+			var orderByLabel = widget.GetOrNull<LabelWidget>("ORDERBY_LABEL");
+			if (orderByLabel != null)
+				orderByLabel.IsVisible = () => currentTab != MapClassification.Community;
 
 			var orderByPlayer = FluentProvider.GetMessage(OrderMapsByPlayers);
 
@@ -650,6 +1145,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected override void Dispose(bool disposing)
 		{
 			disposed = true;
+
+			communityQuery?.CancelPending();
 
 			generatedMapPackage?.Dispose();
 			generatedMapPackage = null;

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -33,6 +33,11 @@ Container@MAPCHOOSER_PANEL:
 					Y: 15
 					Height: 31
 					Width: 135
+				Button@BUTTON4:
+					X: 435
+					Y: 15
+					Height: 31
+					Width: 135
 				Container@MAP_TAB_PANES:
 					Width: PARENT_WIDTH - 30
 					Height: PARENT_HEIGHT - 90
@@ -58,6 +63,14 @@ Container@MAPCHOOSER_PANEL:
 						Container@USER_MAPS_TAB:
 							Width: PARENT_WIDTH
 							Height: PARENT_HEIGHT
+							Children:
+								ScrollPanel@MAP_LIST:
+									Width: PARENT_WIDTH
+									Height: PARENT_HEIGHT
+									ItemSpacing: 1
+						Container@COMMUNITY_MAPS_TAB:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT - 30
 							Children:
 								ScrollPanel@MAP_LIST:
 									Width: PARENT_WIDTH
@@ -125,17 +138,17 @@ Container@MAPCHOOSER_PANEL:
 							Text: label-filter-order-controls-desc
 						TextField@MAPFILTER_INPUT:
 							X: 45
-							Width: 150
+							Width: 155
 							Height: 25
 						Label@FILTER_DESC_JOINER:
-							X: 195
+							X: 200
 							Width: 30
 							Height: 24
 							Font: Bold
 							Align: Center
 							Text: label-filter-order-controls-desc-joiner
 						DropDownButton@GAMEMODE_FILTER:
-							X: 225
+							X: 230
 							Width: 200
 							Height: 25
 						Label@ORDERBY_LABEL:
@@ -156,6 +169,151 @@ Container@MAPCHOOSER_PANEL:
 					Height: 35
 					Align: Center
 					Font: Bold
+				Label@COMMUNITY_MAP_LABEL:
+					X: 450
+					Y: PARENT_HEIGHT - 70
+					Width: PARENT_WIDTH - 670
+					Height: 25
+					Align: Center
+					Font: Bold
+				Label@COMMUNITY_COUNT_LABEL:
+					X: PARENT_WIDTH - 215
+					Y: PARENT_HEIGHT - 70
+					Width: 200
+					Height: 25
+					Align: Right
+					Font: Bold
+				Container@COMMUNITY_FILTER_CONTROLS:
+					X: 15
+					Y: PARENT_HEIGHT - 40
+					Width: PARENT_WIDTH - 30
+					Height: 25
+					Children:
+						Label@COMMUNITY_TILESET_DESC:
+							Width: 50
+							Height: 24
+							Font: Bold
+							Align: Right
+							Text: label-community-filter-tileset-desc
+						DropDownButton@COMMUNITY_TILESET_FILTER:
+							X: 55
+							Width: 120
+							Height: 25
+						Label@COMMUNITY_TAGS_DESC:
+							X: 185
+							Width: 40
+							Height: 24
+							Font: Bold
+							Align: Right
+							Text: label-community-filter-tags-desc
+						DropDownButton@COMMUNITY_TAGS_FILTER:
+							X: 230
+							Width: 135
+							Height: 25
+						Label@COMMUNITY_SORT_DESC:
+							X: 375
+							Width: 55
+							Height: 24
+							Font: Bold
+							Align: Right
+							Text: label-community-filter-sort-desc
+						DropDownButton@COMMUNITY_SORT:
+							X: 435
+							Width: 160
+							Height: 25
+						Label@COMMUNITY_PLAYERS_DESC:
+							X: 605
+							Width: 55
+							Height: 24
+							Font: Bold
+							Align: Right
+							Text: label-community-filter-players-desc
+						TextField@COMMUNITY_PLAYERS_FILTER:
+							X: 665
+							Width: 40
+							Height: 25
+						Button@COMMUNITY_SEARCH:
+							X: PARENT_WIDTH - WIDTH
+							Width: 140
+							Height: 25
+							Text: button-community-search
+				Button@COMMUNITY_PAGE_FIRST:
+					X: PARENT_WIDTH - 580
+					Y: PARENT_HEIGHT - 1
+					Width: 35
+					Height: 35
+					Children:
+						Image@IMAGE_FIRST:
+							X: 9
+							Y: 9
+							Width: 16
+							Height: 16
+							ImageCollection: music
+							ImageName: prev
+				Button@COMMUNITY_PAGE_PREV:
+					X: PARENT_WIDTH - 540
+					Y: PARENT_HEIGHT - 1
+					Width: 35
+					Height: 35
+					Children:
+						Image@IMAGE_PREV:
+							X: 9
+							Y: 9
+							Width: 16
+							Height: 16
+							ImageCollection: scrollpanel-decorations
+							ImageName: left
+				Label@COMMUNITY_PAGE_LABEL:
+					X: PARENT_WIDTH - 500
+					Y: PARENT_HEIGHT - 1
+					Width: 40
+					Height: 35
+					Font: Bold
+					Text: label-community-page-label
+				TextField@COMMUNITY_PAGE_INPUT:
+					X: PARENT_WIDTH - 460
+					Y: PARENT_HEIGHT - 1
+					Width: 40
+					Height: 35
+					Font: Bold
+				Label@COMMUNITY_PAGE_TOTAL:
+					X: PARENT_WIDTH - 417
+					Y: PARENT_HEIGHT - 1
+					Width: 45
+					Height: 35
+					Font: Bold
+				Button@COMMUNITY_PAGE_NEXT:
+					X: PARENT_WIDTH - 375
+					Y: PARENT_HEIGHT - 1
+					Width: 35
+					Height: 35
+					Children:
+						Image@IMAGE_NEXT:
+							X: 9
+							Y: 9
+							Width: 16
+							Height: 16
+							ImageCollection: scrollpanel-decorations
+							ImageName: right
+				Button@COMMUNITY_PAGE_LAST:
+					X: PARENT_WIDTH - 335
+					Y: PARENT_HEIGHT - 1
+					Width: 35
+					Height: 35
+					Children:
+						Image@IMAGE_LAST:
+							X: 9
+							Y: 9
+							Width: 16
+							Height: 16
+							ImageCollection: music
+							ImageName: next
+				Button@COMMUNITY_RESOURCE_CENTER_BUTTON:
+					X: PARENT_WIDTH - 290
+					Y: PARENT_HEIGHT - 1
+					Width: 140
+					Height: 35
+					Text: button-community-resource-center
 				Button@BUTTON_CANCEL:
 					Key: escape
 					Y: PARENT_HEIGHT - 1
@@ -289,3 +447,15 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 							Width: PARENT_WIDTH - 20
 							Height: 25
 							PanelRoot: DROPDOWN_PANEL_ROOT
+
+ScrollPanel@COMMUNITY_TAGS_PANEL:
+	Width: 150
+	Height: 55
+	ItemSpacing: 5
+	TopBottomSpacing: 0
+	Children:
+		Checkbox@COMMUNITY_TAG_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_WIDTH - 29
+			Height: 20

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -30,6 +30,12 @@ Background@MAPCHOOSER_PANEL:
 			Height: 31
 			Width: 140
 			Font: Bold
+		Button@BUTTON4:
+			X: 440
+			Y: 48
+			Height: 31
+			Width: 140
+			Font: Bold
 		Container@MAP_TAB_PANES:
 			Width: PARENT_WIDTH - 40
 			Height: 438
@@ -53,6 +59,13 @@ Background@MAPCHOOSER_PANEL:
 				Container@USER_MAPS_TAB:
 					Width: PARENT_WIDTH
 					Height: PARENT_HEIGHT
+					Children:
+						ScrollPanel@MAP_LIST:
+							Width: PARENT_WIDTH
+							Height: PARENT_HEIGHT
+				Container@COMMUNITY_MAPS_TAB:
+					Width: PARENT_WIDTH
+					Height: PARENT_HEIGHT - 30
 					Children:
 						ScrollPanel@MAP_LIST:
 							Width: PARENT_WIDTH
@@ -119,17 +132,17 @@ Background@MAPCHOOSER_PANEL:
 					Text: label-filter-order-controls-desc
 				TextField@MAPFILTER_INPUT:
 					X: 45
-					Width: 150
+					Width: 155
 					Height: 25
 				Label@FILTER_DESC_JOINER:
-					X: 195
+					X: 200
 					Width: 30
 					Height: 24
 					Font: Bold
 					Align: Center
 					Text: label-filter-order-controls-desc-joiner
 				DropDownButton@GAMEMODE_FILTER:
-					X: 225
+					X: 230
 					Width: 200
 					Height: 25
 				Label@ORDERBY_LABEL:
@@ -170,6 +183,153 @@ Background@MAPCHOOSER_PANEL:
 			Width: PARENT_WIDTH - 410
 			Height: 25
 			Align: Center
+			Font: Bold
+		Label@COMMUNITY_MAP_LABEL:
+			X: 450
+			Y: PARENT_HEIGHT - 110
+			Width: PARENT_WIDTH - 700
+			Height: 25
+			Align: Center
+			Font: Bold
+		Label@COMMUNITY_COUNT_LABEL:
+			X: PARENT_WIDTH - 240
+			Y: PARENT_HEIGHT - 110
+			Width: 220
+			Height: 25
+			Align: Right
+			Font: Bold
+		Container@COMMUNITY_FILTER_CONTROLS:
+			X: 20
+			Y: PARENT_HEIGHT - 80
+			Width: PARENT_WIDTH - 40
+			Height: 25
+			Children:
+				Label@COMMUNITY_TILESET_DESC:
+					Width: 50
+					Height: 24
+					Font: Bold
+					Align: Right
+					Text: label-community-filter-tileset-desc
+				DropDownButton@COMMUNITY_TILESET_FILTER:
+					X: 55
+					Width: 120
+					Height: 25
+				Label@COMMUNITY_TAGS_DESC:
+					X: 185
+					Width: 40
+					Height: 24
+					Font: Bold
+					Align: Right
+					Text: label-community-filter-tags-desc
+				DropDownButton@COMMUNITY_TAGS_FILTER:
+					X: 230
+					Width: 135
+					Height: 25
+				Label@COMMUNITY_SORT_DESC:
+					X: 375
+					Width: 55
+					Height: 24
+					Font: Bold
+					Align: Right
+					Text: label-community-filter-sort-desc
+				DropDownButton@COMMUNITY_SORT:
+					X: 435
+					Width: 160
+					Height: 25
+				Label@COMMUNITY_PLAYERS_DESC:
+					X: 605
+					Width: 55
+					Height: 24
+					Font: Bold
+					Align: Right
+					Text: label-community-filter-players-desc
+				TextField@COMMUNITY_PLAYERS_FILTER:
+					X: 665
+					Width: 40
+					Height: 25
+				Button@COMMUNITY_SEARCH:
+					X: PARENT_WIDTH - WIDTH
+					Width: 120
+					Height: 25
+					Text: button-community-search
+					Font: Bold
+		Button@COMMUNITY_PAGE_FIRST:
+			X: 20
+			Y: PARENT_HEIGHT - 45
+			Width: 30
+			Height: 25
+			Children:
+				Image@IMAGE_FIRST:
+					X: 7
+					Y: 4
+					Width: 16
+					Height: 16
+					ImageCollection: music
+					ImageName: prev
+		Button@COMMUNITY_PAGE_PREV:
+			X: 55
+			Y: PARENT_HEIGHT - 45
+			Width: 30
+			Height: 25
+			Children:
+				Image@IMAGE_PREV:
+					X: 7
+					Y: 4
+					Width: 16
+					Height: 16
+					ImageCollection: scrollpanel-decorations
+					ImageName: left
+		Label@COMMUNITY_PAGE_LABEL:
+			X: 90
+			Y: PARENT_HEIGHT - 45
+			Width: 35
+			Height: 25
+			Font: Bold
+			Text: label-community-page-label
+		TextField@COMMUNITY_PAGE_INPUT:
+			X: 125
+			Y: PARENT_HEIGHT - 45
+			Width: 40
+			Height: 25
+			Font: Bold
+		Label@COMMUNITY_PAGE_TOTAL:
+			X: 168
+			Y: PARENT_HEIGHT - 45
+			Width: 45
+			Height: 25
+			Font: Bold
+		Button@COMMUNITY_PAGE_NEXT:
+			X: 215
+			Y: PARENT_HEIGHT - 45
+			Width: 30
+			Height: 25
+			Children:
+				Image@IMAGE_NEXT:
+					X: 7
+					Y: 4
+					Width: 16
+					Height: 16
+					ImageCollection: scrollpanel-decorations
+					ImageName: right
+		Button@COMMUNITY_PAGE_LAST:
+			X: 250
+			Y: PARENT_HEIGHT - 45
+			Width: 30
+			Height: 25
+			Children:
+				Image@IMAGE_LAST:
+					X: 7
+					Y: 4
+					Width: 16
+					Height: 16
+					ImageCollection: music
+					ImageName: next
+		Button@COMMUNITY_RESOURCE_CENTER_BUTTON:
+			X: 290
+			Y: PARENT_HEIGHT - 45
+			Width: 140
+			Height: 25
+			Text: button-community-resource-center
 			Font: Bold
 		Button@BUTTON_OK:
 			X: PARENT_WIDTH - 270
@@ -290,3 +450,15 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 							Width: PARENT_WIDTH - 20
 							Height: 25
 							PanelRoot: DROPDOWN_PANEL_ROOT
+
+ScrollPanel@COMMUNITY_TAGS_PANEL:
+	Width: 150
+	Height: 55
+	ItemSpacing: 5
+	TopBottomSpacing: 0
+	Children:
+		Checkbox@COMMUNITY_TAG_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_WIDTH - 29
+			Height: 20

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -511,8 +511,43 @@ options-order-maps =
 
 button-mapchooser-system-maps-tab = Official Maps
 button-mapchooser-remote-maps-tab = Server Maps
+button-mapchooser-community-maps-tab = Community Maps
 button-mapchooser-user-maps-tab = Custom Maps
 button-mapchooser-generated-maps-tab = Generate Map
+
+label-community-maps-loading =
+    Searching for maps...
+label-community-maps-error =
+    Could not connect to the Resource Center.
+label-community-page-label = Page
+label-community-page-total =
+    / { $total }
+label-community-page-total-loading = / ?
+label-community-count =
+    { $count } maps
+button-community-search = Search
+button-community-resource-center = Resource Center
+
+label-community-sort-latest = Latest first
+label-community-sort-oldest = Oldest first
+label-community-sort-title = Title
+label-community-sort-title-reversed = Title in reverse
+label-community-sort-players = Players
+label-community-sort-lately-commented = Lately commented
+label-community-sort-rating = Rating
+label-community-sort-views = Views
+label-community-sort-downloads = Downloads
+label-community-sort-revisions = Upgrade activity
+
+label-community-filter-tileset-any = Any Tileset
+label-community-filter-tags-choose = Choose
+label-community-filter-tags-advanced = Advanced
+label-community-filter-tags-lua = Lua
+
+label-community-filter-tileset-desc = Tileset:
+label-community-filter-tags-desc = Tags:
+label-community-filter-players-desc = Players:
+label-community-filter-sort-desc = Sort by:
 
 ## MissionBrowserLogic
 dialog-no-video =


### PR DESCRIPTION
This PR adds a new Community Maps tab to the Map Chooser, allowing players to browse and download maps from the Resource Center directly from within the game, without having to visit the website.

Features:

- Browse maps (up to 20 maps per page) fetched from the [resource.openra.net](https://resource.openra.net/maps/) website thanks to the Resource Center API.
- Pagination controls with first/previous/next/last page buttons, an editable page number input field, and total map count.
- Filters:  tileset (dropdown), player count (input field), tags (dropdown with Advanced maps and Lua maps checkboxes).
- Sort results by: latest, oldest, title, title reversed, players, lately commented, rating, views, downloads, or upgrade activity.
- A Search button to apply filter/sort changes
- The usual map previews with minimap thumbnails, title, author, category, player count, and map size.
- Incompatible maps are automatically excluded from results.
- A Resource Center button that opens the website in the user's browser.

TODO: 
- Use other icons for pagination buttons? The First/Last page buttons currently use icons from the music player & asset browser but these playback icons don't have grayed out (disabled) icons.

https://github.com/user-attachments/assets/fd065d4f-c79b-4c94-91d1-d23dcbb533e7

