### PR TITLE
Fix D2K carryall and starport frigate behaviors to better match vanilla D2K

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -139,11 +139,34 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
+			// VTOLApproach defaults to true when VTOL is true, but can be overridden to use a fixed-wing approach.
+			var useVTOLApproach = aircraft.Info.VTOLApproach ?? aircraft.Info.VTOL;
+
 			// Move towards landing location/facing
-			if (aircraft.Info.VTOL)
+			if (useVTOLApproach)
 			{
-				if ((pos - targetPosition).HorizontalLengthSquared != 0)
+				var approachDelta = targetPosition - pos;
+				if (approachDelta.HorizontalLengthSquared != 0)
 				{
+					// Non-sliding VTOL aircraft with explicit VTOLApproach handle the final
+					// approach directly, avoiding the turn circle logic in Fly that would cause circling.
+					if (!aircraft.Info.CanSlide && aircraft.Info.VTOLApproach == true)
+					{
+						var approachFacing = approachDelta.Yaw;
+						var moveStep = aircraft.FlyStep(approachFacing);
+
+						// Close enough to set the final position directly.
+						if (approachDelta.HorizontalLengthSquared < moveStep.HorizontalLengthSquared)
+						{
+							var finalMove = new WVec(approachDelta.X, approachDelta.Y, 0);
+							Fly.FlyTick(self, aircraft, approachFacing, aircraft.Info.CruiseAltitude, finalMove);
+						}
+						else
+							Fly.FlyTick(self, aircraft, approachFacing, aircraft.Info.CruiseAltitude, moveStep);
+
+						return false;
+					}
+
 					QueueChild(new Fly(self, Target.FromPos(targetPosition)));
 					return false;
 				}
@@ -155,7 +178,7 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			if (!aircraft.Info.VTOL && !finishedApproach)
+			if (!useVTOLApproach && !finishedApproach)
 			{
 				// Calculate approach trajectory
 				var altitude = aircraft.Info.CruiseAltitude.Length;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -55,7 +55,14 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(new Land(self, destination, deliverRange));
 			QueueChild(new Wait(carryall.Info.BeforeUnloadDelay, false));
 			QueueChild(new ReleaseUnit(self));
+			QueueChild(new RevokeApproaching(self));
 			QueueChild(new TakeOff(self));
+		}
+
+		public override void Cancel(Actor self, bool keepQueue = false)
+		{
+			carryall.RevokeApproachingCondition(self);
+			base.Cancel(self, keepQueue);
 		}
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
@@ -106,6 +113,21 @@ namespace OpenRA.Mods.Common.Activities
 					carryable.UnReserve(cargo);
 					carryable.Detached(cargo);
 				});
+			}
+		}
+
+		sealed class RevokeApproaching : Activity
+		{
+			readonly Carryall carryall;
+
+			public RevokeApproaching(Actor self)
+			{
+				carryall = self.Trait<Carryall>();
+			}
+
+			protected override void OnFirstRun(Actor self)
+			{
+				carryall.RevokeApproachingCondition(self);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -97,6 +97,9 @@ namespace OpenRA.Mods.Common.Activities
 					// Pickup position and facing are now known - swap the fly/wait activity with Land
 					ChildActivity.Cancel(self);
 
+					// Slow down for the final approach.
+					carryall.GrantApproachingCondition(self);
+
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(cargo.Orientation));
 					QueueChild(new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), carryableFacing.Facing));
 
@@ -106,6 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 
 					// Remove our carryable from world
 					QueueChild(new AttachUnit(self, cargo));
+					QueueChild(new RevokeApproaching(self));
 					QueueChild(new TakeOff(self));
 
 					state = PickupState.Pickup;
@@ -118,6 +122,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override void Cancel(Actor self, bool keepQueue = false)
 		{
+			carryall.RevokeApproachingCondition(self);
 			base.Cancel(self, keepQueue);
 
 			// We are safe to bail here as base won't set IsCanceling to true if not interruptible.
@@ -148,6 +153,21 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (targetLineColor != null)
 				yield return new TargetLineNode(Target.FromActor(cargo), targetLineColor.Value);
+		}
+
+		sealed class RevokeApproaching : Activity
+		{
+			readonly Carryall carryall;
+
+			public RevokeApproaching(Actor self)
+			{
+				carryall = self.Trait<Carryall>();
+			}
+
+			protected override void OnFirstRun(Actor self)
+			{
+				carryall.RevokeApproachingCondition(self);
+			}
 		}
 
 		sealed class AttachUnit : Activity

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -119,6 +119,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Does the actor land and take off vertically?")]
 		public readonly bool VTOL = false;
 
+		[Desc("Does this VTOL actor use a direct approach when landing, rather than a fixed-wing approach trajectory?",
+			"Defaults to true for VTOL actors. Set to false to use the fixed-wing approach even when VTOL is true.")]
+		public readonly bool? VTOLApproach = null;
+
 		[Desc("Does this VTOL actor need to turn before landing (on terrain)?")]
 		public readonly bool TurnToLand = false;
 
@@ -644,7 +648,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			var cellRange = (maxSearchDistance.Length + 1023) / 1024;
 			var centerPosition = self.World.Map.CenterOfCell(targetCell);
-			foreach (var c in self.World.Map.FindTilesInCircle(targetCell, cellRange))
+
+			foreach (var c in self.World.Map.FindTilesInCircle(targetCell, cellRange)
+				.OrderBy(c => (self.World.Map.CenterOfCell(c) - centerPosition).LengthSquared))
 			{
 				if (!CanLand(c, blockedByMobile: false))
 					continue;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -67,6 +67,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Condition to grant to the Carryall while it is carrying something.")]
 		public readonly string CarryCondition = null;
 
+		[GrantedConditionReference]
+		[Desc("Condition to grant to the Carryall while it is approaching to pick up or deliver a unit.")]
+		public readonly string ApproachingCondition = null;
+
 		[ActorReference(dictionaryReference: LintDictionaryReference.Keys)]
 		[Desc("Conditions to grant when a specified actor is being carried.",
 			"A dictionary of [actor name]: [condition].")]
@@ -111,6 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 		FrozenSet<string> landableTerrainTypes;
 		int carryConditionToken = Actor.InvalidConditionToken;
 		int carryableConditionToken = Actor.InvalidConditionToken;
+		int approachingConditionToken = Actor.InvalidConditionToken;
 
 		/// <summary>Offset between the carryall's and the carried actor's CenterPositions.</summary>
 		public WVec CarryableOffset { get; private set; }
@@ -164,6 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 				Carryable = null;
 			}
 
+			RevokeApproachingCondition(self);
 			UnreserveCarryable(self);
 		}
 
@@ -181,6 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 				Carryable = null;
 			}
 
+			RevokeApproachingCondition(self);
 			UnreserveCarryable(self);
 		}
 
@@ -223,6 +230,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual void DetachCarryable(Actor self)
 		{
 			UnreserveCarryable(self);
+			RevokeApproachingCondition(self);
 			self.World.ScreenMap.AddOrUpdate(self);
 			if (carryConditionToken != Actor.InvalidConditionToken)
 				carryConditionToken = self.RevokeCondition(carryConditionToken);
@@ -259,6 +267,18 @@ namespace OpenRA.Mods.Common.Traits
 
 			Carryable = null;
 			State = CarryallState.Idle;
+		}
+
+		public void GrantApproachingCondition(Actor self)
+		{
+			if (approachingConditionToken == Actor.InvalidConditionToken && Info.ApproachingCondition != null)
+				approachingConditionToken = self.GrantCondition(Info.ApproachingCondition);
+		}
+
+		public void RevokeApproachingCondition(Actor self)
+		{
+			if (approachingConditionToken != Actor.InvalidConditionToken)
+				approachingConditionToken = self.RevokeCondition(approachingConditionToken);
 		}
 
 		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -19,8 +19,8 @@ carryall.reinforce:
 		Repulsable: False
 		AirborneCondition: airborne
 		CanForceLand: false
-		CanSlide: True
 		VTOL: true
+		VTOLApproach: true
 		IdleTurnSpeed: 5
 		IdleSpeed: 115
 	Targetable@GROUND:
@@ -39,6 +39,13 @@ carryall.reinforce:
 		BeforeLoadDelay: 10
 		BeforeUnloadDelay: 15
 		LocalOffset: 0, 0, -128
+		DropRange: 1c0
+		ApproachingCondition: carryall-approaching
+	SpeedMultiplier@APPROACHING:
+		RequiresCondition: carryall-approaching
+		Modifier: 50
+	Cargo:
+		BetweenUnloadDelay: 25
 	RenderSprites:
 		Image: carryall
 	ChangesHealth:
@@ -59,12 +66,14 @@ carryall:
 		BeforeLoadDelay: 10
 		BeforeUnloadDelay: 15
 		LocalOffset: 0, 0, -128
+		ApproachingCondition: carryall-approaching
 	Encyclopedia:
 		Description: actor-carryall-encyclopedia
 		Order: 230
 		Category: Units
 	Aircraft:
 		MinAirborneAltitude: 400
+		VTOLApproach: true
 	RevealsShroud@lifting_low:
 		Range: 2c512
 		Type: GroundPosition

--- a/mods/d2k/sequences/aircraft.yaml
+++ b/mods/d2k/sequences/aircraft.yaml
@@ -4,6 +4,7 @@ carryall:
 		Start: 1923
 		Facings: -32
 		Remap: 54F94B
+		ZOffset: 1024
 	icon:
 		Filename: DATA.R16
 		Start: 4290
@@ -29,3 +30,4 @@ frigate:
 		Start: 2517
 		Facings: 1
 		Remap: 54F94B
+		ZOffset: 1024


### PR DESCRIPTION
Fixes: #21120.
                                                                                                                                                                                                            
**Carryall behavior:**
- Removed `CanSlide` from carryalls, they now bank and turn like planes instead of sliding sideways.
- Added a `VTOLApproach` property to Aircraft so carryalls can land with a direct VTOL descent while the reinforcement variant (`carryall.reinforce`) uses a fixed-wing approach trajectory. Other aircraft are unaffected (defaults to existing behavior).
- Carryalls now slow down (50% speed) when approaching to pick up or deliver a harvester, via a new `ApproachingCondition` on the Carryall trait.
- Added `BetweenUnloadDelay: 25` to `carryall.reinforce` Cargo so delivered units are spaced out.

**Starport frigate:**
- Added `ZOffset: 1024` to the frigate sprite so it renders above ground units.
  

https://github.com/user-attachments/assets/192a86b5-c841-4417-978f-25836e1db25e

