### PR TITLE
Fix potential Saboteur stuck in mission Harkonnen 8

### DIFF
--- a/mods/d2k/maps/harkonnen-08/harkonnen08.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08.lua
@@ -254,6 +254,7 @@ ScanForBetterTargets = function(saboteur)
 		local dfd = Utils.Random(possibleTargets)
 		saboteur.Demolish(dfd)
 		saboteur.CallFunc(function()
+			SendSaboteur(saboteur)
 			ScanForBetterTargets(saboteur)
 		end)
 	else


### PR DESCRIPTION
Reported in #22388 by @JovialFeline 
Fix situation when saboteur dont choose another building target if current vehicle target is destroyed.