### PR TITLE
D2k fixes and balance feedback

### DIFF
--- a/mods/d2k/fluent/rules.ftl
+++ b/mods/d2k/fluent/rules.ftl
@@ -172,7 +172,7 @@ actor-light-inf =
     .description =
     General-purpose infantry.
       Strong vs Infantry
-      Weak vs Vehicles and Artillery
+      Weak vs Tanks and Artillery
     .encyclopedia =
     Lightly armored foot soldiers, equipped with 9mm RP assault rifles. They are effective against infantry and lightly armored vehicles.
 
@@ -287,9 +287,9 @@ actor-saboteur =
     .description =
     Sneaky infantry with explosives.
     Turns invisible for a limited time.
-      Strong vs Buildings
+      Strong vs Buildings, Vehicles
       Weak vs Everything
-      Special Ability: Destroys buildings
+      Special Ability: Destroys buildings and vehicles
     .encyclopedia =
     A specialized military unit of House Ordos, capable of demolishing enemy buildings and vehicles upon entry, but dying in the resulting explosion. It can activate self destruction and damage near by enemy units.
 
@@ -582,7 +582,7 @@ actor-trike =
     Summary:
 
         - Explosion Radius: Small
-        - Vision: Medium
+        - Vision: Large
         - Strong vs Light Infantry, Trooper, Missile tank, Deviator
         - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars
 
@@ -593,7 +593,7 @@ actor-quad =
     .description =
     Missile Scout.
       Strong vs Vehicles
-      Weak vs Infantry
+      Weak vs Infantry, Tanks
     .encyclopedia =
     Superior to the Trike in both armor and firepower, the Quad is a four-wheeled vehicle firing armor-piercing rockets. It is effective against most vehicles.
 
@@ -656,7 +656,7 @@ actor-sonic-tank =
     .description =
     Fires sonic shocks.
       Strong vs Infantry and Vehicles
-      Weak vs Artillery
+      Weak vs Tanks, Rocket Artillery
     .encyclopedia =
     Most effective against infantry and lightly armored vehicles, but weaker against armored targets.
 
@@ -678,7 +678,7 @@ actor-devastator =
     .description =
     Super Heavy Tank.
       Strong vs Tanks
-      Weak vs Artillery
+      Weak vs Rocket Artillery
     .encyclopedia =
     As the most powerful tank on Dune, the Devastator is slow but highly effective against most units. It fires dual plasma charges and can self-destruct on command, damaging nearby units and structures.
 
@@ -707,7 +707,7 @@ actor-raider =
     Summary:
 
         - Explosion Radius: small
-        - Vision: small
+        - Vision: Large
         - Strong vs Light Infantry, Trooper, Missile tank, Deviator, Trike
         - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars, Quad
 
@@ -723,7 +723,7 @@ actor-stealth-raider =
     Summary:
 
         - Explosion Radius: Small
-        - Vision: Small
+        - Vision: Large
         - Strong vs Light Infantry, Trooper, Missile tank, Deviator, Trike
         - Weak vs Combat tank, Siege tank, Grenadier, Sardaukars
 
@@ -742,7 +742,7 @@ actor-deviator =
     Summary:
 
         - Explosion Radius: Small
-        - Vision: Large
+        - Vision: Medium
         - Strong vs Combat tank,  Quad, Devastator, Missile tank
         - Weak vs any infantry, Missile tank, Sonic Tank, Trike
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -536,6 +536,7 @@
 	CaptureNotification:
 		TextNotification: notification-enemy-building-captured
 		LoseTextNotification: notification-one-of-our-buildings-has-been-captured
+		LoseNotification: BuildingLost
 	ActorLostNotification:
 		Notification: BuildingLost
 		TextNotification: notification-building-lost

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -105,10 +105,6 @@ deviator.husk:
 		IntoActor: deviator
 	InfiltrateForTransform:
 		IntoActor: deviator
-	FireWarheads:
-		Weapons: DeviatorGas
-		Interval: 50
-		StartCooldown: 100
 
 ^combat_tank.husk:
 	Inherits: ^VehicleHusk

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -242,7 +242,7 @@ upgrade.barracks:
 		Prerequisites: barracks
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 260
+		BuildDuration: 700
 		BuildDurationModifier: 100
 		Description: actor-upgrade-barracks.description
 	Valued:
@@ -266,7 +266,7 @@ upgrade.light:
 		Prerequisites: light_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 330
+		BuildDuration: 800
 		BuildDurationModifier: 100
 		Description: actor-upgrade-light.description
 	Valued:
@@ -290,7 +290,7 @@ upgrade.heavy:
 		Prerequisites: heavy_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 600
+		BuildDuration: 900
 		BuildDurationModifier: 100
 		Description: actor-upgrade-heavy.description
 	Valued:
@@ -315,7 +315,7 @@ upgrade.hightech:
 		Prerequisites: ~hightech.atreides, ~techlevel.superweapons
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 937
+		BuildDuration: 1100
 		BuildDurationModifier: 100
 		Description: actor-upgrade-hightech.description
 	Valued:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -22,7 +22,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
-		BuildTimeSpeedReduction: 100, 66, 50
+		BuildTimeSpeedReduction: 100, 75, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		DisplayOrder: 1
@@ -35,7 +35,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
-		BuildTimeSpeedReduction: 100, 66, 50
+		BuildTimeSpeedReduction: 100, 75, 50
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		DisplayOrder: 2
@@ -48,7 +48,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
-		BuildTimeSpeedReduction: 100, 66, 50
+		BuildTimeSpeedReduction: 100, 75, 50
 	ClassicProductionQueue@Armor:
 		Type: Armor
 		DisplayOrder: 3
@@ -61,7 +61,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
-		BuildTimeSpeedReduction: 100, 66, 50
+		BuildTimeSpeedReduction: 100, 75, 50
 	BulkProductionQueue@Starport:
 		Type: Starport
 		DisplayOrder: 4
@@ -85,7 +85,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
-		BuildTimeSpeedReduction: 100, 66, 50
+		BuildTimeSpeedReduction: 100, 75, 50
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
 		ReadyAudio: NewOptions

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -7,7 +7,7 @@
 	FootprintPlaceBuildingPreview:
 	RequiresBuildableArea:
 		AreaTypes: building
-		Adjacent: 4
+		Adjacent: 3
 	Tooltip:
 		GenericName: meta-concrete.generic-name
 	RenderSprites:
@@ -369,7 +369,9 @@ refinery:
 	StoresPlayerResources:
 		Capacity: 2000
 	CustomSellValue:
-		Value: 500
+		Value: 300
+	SpawnActorsOnSell:
+		ValuePercent: 75
 	FreeActorWithDelivery:
 		Actor: harvester
 		DeliveryOffset: 2,2
@@ -506,13 +508,13 @@ light_factory:
 		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 230
-		BuildDuration: 390
+		BuildDuration: 360
 		BuildDurationModifier: 100
 		Description: actor-light-factory.description
 	Selectable:
 		Bounds: 3072, 2048
 	Valued:
-		Cost: 600
+		Cost: 500
 	Tooltip:
 		Name: actor-light-factory.name
 	D2kBuilding:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -137,7 +137,7 @@ trike:
 		BuildDurationModifier: 100
 		Description: actor-trike.description
 	Valued:
-		Cost: 300
+		Cost: 275
 	Tooltip:
 		Name: actor-trike.name
 	UpdatesPlayerStatistics:
@@ -156,7 +156,7 @@ trike:
 		TurnSpeed: 40
 		Speed: 128
 	RevealsShroud:
-		Range: 5c512
+		Range: 6c0
 	WithMuzzleOverlay:
 	Armament:
 		Weapon: HMG
@@ -182,7 +182,7 @@ quad:
 		BuildDurationModifier: 100
 		Description: actor-quad.description
 	Valued:
-		Cost: 400
+		Cost: 350
 	Tooltip:
 		Name: actor-quad.name
 	UpdatesPlayerStatistics:
@@ -242,7 +242,7 @@ siege_tank:
 		Speed: 40
 		TurnSpeed: 12
 	RevealsShroud:
-		Range: 6c768
+		Range: 6c256
 	Turreted:
 		TurnSpeed: 12
 		Offset: 0,0,-32
@@ -305,13 +305,12 @@ missile_tank:
 		Order: 190
 		Category: Units
 	RevealsShroud:
-		Range: 6c768
+		Range: 6c256
 	Armament:
 		Weapon: mtank_pri
 		LocalOffset: -128,128,171, -128,-128,171
 	AttackFrontal:
 		FacingTolerance: 0
-		ForceFireIgnoresActors: True
 		TargetFrozenActors: True
 	AutoTarget:
 		InitialStanceAI: Defend
@@ -392,7 +391,7 @@ devastator:
 		BuildDurationModifier: 100
 		Description: actor-devastator.description
 	Valued:
-		Cost: 1200
+		Cost: 1050
 	Tooltip:
 		Name: actor-devastator.name
 	UpdatesPlayerStatistics:
@@ -463,12 +462,12 @@ devastator:
 	Selectable:
 		DecorationBounds: 1408, 1216, 0, 0
 	FireProjectilesOnDeath@OnMeldown:
-		Weapons: Debris2, Debris3, Debris4
+		Weapons: Debris2, Debris3, Debris4, ExplosiveDebris
 		Pieces: 7, 15
 		Range: 3c512, 6c0
 		RequiresCondition: meltdown
 	FireProjectilesOnDeath@standart:
-		Weapons: Debris, ExplosiveDebris
+		Weapons: Debris
 		Pieces: 1, 2
 		RequiresCondition: !meltdown
 
@@ -484,7 +483,7 @@ raider:
 		BuildDurationModifier: 100
 		Description: actor-raider.description
 	Valued:
-		Cost: 330
+		Cost: 325
 	Tooltip:
 		Name: actor-raider.name
 	Encyclopedia:
@@ -501,7 +500,7 @@ raider:
 		TurnSpeed: 40
 		Speed: 140
 	RevealsShroud:
-		Range: 4c768
+		Range: 5c768
 	WithMuzzleOverlay:
 	Armament:
 		Weapon: HMGo
@@ -524,7 +523,7 @@ stealth_raider:
 		BuildDurationModifier: 100
 		Description: actor-stealth-raider.description
 	Valued:
-		Cost: 400
+		Cost: 350
 	Tooltip:
 		Name: actor-stealth-raider.name
 	UpdatesPlayerStatistics:
@@ -569,7 +568,7 @@ deviator:
 		TurnSpeed: 12
 		Speed: 53
 	Health:
-		HP: 12500
+		HP: 12000
 	Armor:
 		Type: wood
 	Encyclopedia:
@@ -577,7 +576,7 @@ deviator:
 		Order: 210
 		Category: Units
 	RevealsShroud:
-		Range: 6c0
+		Range: 5c768
 	Armament:
 		Weapon: DeviatorMissile
 		LocalOffset: -299,0,85
@@ -590,7 +589,7 @@ deviator:
 		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: deviator.husk
-		OwnerType: Victim
+		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
@@ -617,7 +616,7 @@ deviator:
 		Speed: 75
 		TurnSpeed: 20
 	RevealsShroud:
-		Range: 5c768
+		Range: 5c512
 	Turreted:
 		TurnSpeed: 20
 		RealignDelay: 0
@@ -674,8 +673,11 @@ combat_tank_h:
 		Weapon: 80mm_H
 	Mobile:
 		Speed: 64
+	SpeedMultiplier@HEAVYDAMAGE:
+		RequiresCondition: heavy-damage
+		Modifier: 80
 	Health:
-		HP: 28500
+		HP: 29000
 	SpawnActorOnDeath:
 		Actor: combat_tank_h.husk
 

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -40,7 +40,7 @@
 			Sand: 90
 			Rock: 100
 			Transition: 100
-			Concrete: 100
+			Concrete: 110
 			SpiceSand: 90
 			Spice: 90
 			SpiceBlobs: 90
@@ -52,7 +52,7 @@
 			Sand: 100
 			Rock: 100
 			Transition: 100
-			Concrete: 100
+			Concrete: 110
 			SpiceSand: 100
 			Spice: 100
 			SpiceBlobs: 100
@@ -64,7 +64,7 @@
 			Sand: 100
 			Rock: 100
 			Transition: 100
-			Concrete: 100
+			Concrete: 110
 			SpiceSand: 100
 			Spice: 100
 			SpiceBlobs: 100

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -8,7 +8,7 @@
 		InaccuracyType: PerCellIncrement
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Damage: 2800
+		Damage: 2700
 		Spread: 1c0
 		Falloff: 100, 0
 		Versus:
@@ -51,7 +51,7 @@
 
 80mm_A:
 	Inherits: ^Cannon
-	Range: 5c112
+	Range: 5c0
 
 80mm_H:
 	Inherits: ^Cannon
@@ -88,7 +88,7 @@ DevBullet:
 
 155mm:
 	Inherits: ^Cannon
-	ReloadDelay: 105
+	ReloadDelay: 90
 	Range: 6c900
 	Report: MORTAR1.WAV
 	Projectile: Bullet

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -1,6 +1,6 @@
 ^Rocket:
 	ReloadDelay: 40
-	Range: 3c870
+	Range: 3c624
 	Report: ROCKET1.WAV
 	Projectile: Bullet
 		Blockable: false
@@ -43,7 +43,7 @@
 	MinRange: 0c512
 	Projectile: Missile
 		Shadow: true
-		InaccuracyType: Maximum
+		InaccuracyType: Absolute
 		Inaccuracy: 250
 		HorizontalRateOfTurn: 22
 		RangeLimit: 10c0
@@ -66,11 +66,7 @@
 			invulnerable: 0
 			cy: 30
 			harvester: 50
-		DamageTypes: Prone80Percent, SmallExplosionDeath
-	Warhead@proneeffect: TargetDamage
-		Damage: 1
-		Spread: 600
-		DamageTypes: TriggerProne
+		DamageTypes: Prone80Percent, TriggerProne, SmallExplosionDeath
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 720
 	Warhead@3Eff: CreateEffect
@@ -109,8 +105,6 @@ Rocket:
 TowerMissile:
 	Inherits: ^Missile
 	ReloadDelay: 60
-	Burst: 2
-	BurstDelays: 60
 	ValidTargets: Ground, Air
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Air
@@ -119,8 +113,6 @@ TowerMissile:
 mtank_pri:
 	Inherits: ^Missile
 	ReloadDelay: 115
-	Burst: 2
-	BurstDelays: 115
 	Range: 7c900
 	MinRange: 1c0
 	ValidTargets: Ground, Air

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -26,7 +26,7 @@ Sound:
 			invulnerable: 0
 			cy: 20
 			harvester: 50
-		DamageTypes: TriggerProne, SoundDeath
+		DamageTypes: Prone80Percent, TriggerProne, SoundDeath
 	Warhead@3Concrete: DamagesConcrete
 		Damage: 1720
 
@@ -202,11 +202,11 @@ WallExplode:
 SiegeExplode:
 	Inherits: 155mm
 	Warhead@1Dam: SpreadDamage
-		Damage: 4500
 		Spread: 2c0
 	Warhead@3Eff: CreateEffect
-		Explosions: med_explosion
+		Explosions: building
 		ImpactSounds: EXPLSML2.WAV
+		ImpactActors: false
 
 CliffExplode:
 	Warhead@1Eff: CreateEffect
@@ -442,7 +442,7 @@ ExplosiveDebris:
 		BounceCount: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 1c562
+		Spread: 2c0
 		Versus:
 			none: 100
 			wood: 100
@@ -457,14 +457,3 @@ ExplosiveDebris:
 		ImpactSounds: EXPLSML4.WAV
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 4500
-
-DeviatorGas:
-	Warhead@5OwnerChange: ChangeOwner
-		Range: 1c850
-		Duration: 160
-		ValidRelationships: Enemy, Neutral
-		InvalidTargets: Infantry, Structure
-	Warhead@3Eff: CreateEffect
-		Explosions: deviator
-		ExplosionPalette: player
-		UsePlayerPalette: true

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -55,7 +55,7 @@ M_HMG:
 	InvalidTargets: Infantry
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
-		Spread: 512
+		Spread: 1c0
 		Versus:
 			none: 25
 			wall: 100


### PR DESCRIPTION
Balance created by me and Blacksir. Fix multipley issues found during playtest 1v1 games.

This PR do 2 things: 
-	Fix problems that are not directly related to previous balance changes. 
-	Tweaks some details from #21930

Fixes:
-	Fix wrong AoE on `M_HMG `weapon. Was missed in #21810
-	Fix wrong sell value on Refinery. In OG refinery sell give 125$ and 4 light infantry
-	Fix wrong Adjacent in `RequiresBuildableArea `for concrete from 3 to 2 ( reported by Psycho on Discord )
-	Fix Sound weapon don’t trigger Prone80Percent
-	Fix missing animation in SiegeExplode. Remove unnecessary damage definition. ( its inherited from 155mm )
-	`^Missile` weapon: move TriggerProne into main SpreadDamage warhead.
-	Fix wrong placement of  ExplosiveDebris weapon  in Devastator 
-	Set ExplosiveDebris AoE to 2c0 ( missed in  #21810 )
- Remove unused Burst from `^Missile` weapons.
- Remove `ForceFireIgnoresActors `from Missile_tank ( request from Blacksir )

Balance changes:
-	Removed gas leaks from Deviator husk. This feature confuses people, so rather don’t have it.
-	Trike,  `RevealsShroud ` from 5c512 to 6c0
- Raider, Stealth Raider: `RevealsShroud ` from 5c512 to 5c768
- Trike cost from 300$ to 375$
- Raider cost from 330$ to 325$
- Stealth Raider cost from 400$ to 350$
- Quad cost from 400$ to 350$
- Trooper: Range from 3c870 ti 3c624
-	 Siege tank 155mm weapon reload time revert from 105 to 90
- Siege tank HP revert from 11500 to 12000
-	Mtank_pri InaccuracyType from Maximum to Absolute
-	Devastator cost revert to OG from 1200$ to 1050$
- Deviator HP from 12500 to 12000
-	Light_factory: cost revert from 600$ to 500$. Build time from 390 to 355
-	Barracks HP from 32000 to 30000
-	Deviator `RevealsShroud `from 6c0 to 5c768
- Siege tank, Missile tank `RevealsShroud `from 6c756 to 6c256
-	Combat_tank_h HP from 28500 to 29000
- Combat tanks `RevealsShroud `from 5c756 to 5c512
- 80mm damaged revert from 2800 to 2700
- Atreides tank range from 5c112 to 5c0
- Harkonnen tank speed penalty when damaged from 25% to 20%
- Play notification "Building lost" to old owner when building is captured by engineer
- Barracks upgrade building time: from 260 to 700
-  Light upgrade  building time: from 330 to 800
-  Heavy upgrade building time: from 600 to 900
- High tech upgrade  building time: from 937 to 1100
- `BuildTimeSpeedReduction `for all production from 100, 66, 50 to 100, 75, 50
- vehicles and tanks speed on concrete terrain from 100 to 110




Updated unit descriptions to better match actual state.


