### PR TITLE
Fix ambiguous SHA1Hash call for empty map packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Also thanks to:
     * Andreas Beck (baxtor)
     * Ang Soon Li (asl97)
     * Arik Lirette (Angusm3)
+    * Artem Legotin
     * Ashley Newson
     * Barnaby Smith (mvi)
     * Bellator

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -283,7 +283,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash([]);
+					return CryptoUtil.SHA1Hash(Array.Empty<byte>());
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)


### PR DESCRIPTION
This fixes a build break in `Map.ComputeUID` under the current C#/.NET toolchain.

`CryptoUtil.SHA1Hash([])` is ambiguous because `CryptoUtil` exposes both `SHA1Hash(byte[])` and `SHA1Hash(string)`. Replacing the empty collection expression with `Array.Empty<byte>()` preserves behavior and restores a clean build.

Validation:
- `make test`
- `TZ=UTC make tests`