### PR TITLE
Improve frozen actor performance

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Traits
 
 		public Polygon MouseBounds = Polygon.Empty;
 
+		internal int LayerIndex;
 
 		int flashTicks;
 		TintModifiers flashModifiers;
@@ -252,7 +253,9 @@ namespace OpenRA.Traits
 		readonly int binSize;
 		readonly World world;
 		readonly Player owner;
-		readonly Dictionary<uint, FrozenActor> frozenActorsById;
+		readonly List<FrozenActor> actors = [];
+		readonly Dictionary<uint, FrozenActor> frozenActorsById = [];
+
 		readonly SpatiallyPartitioned<FrozenActor> partitionedFrozenActors;
 
 		public FrozenActorLayer(Actor self, FrozenActorLayerInfo info)
@@ -260,7 +263,6 @@ namespace OpenRA.Traits
 			binSize = info.BinSize;
 			world = self.World;
 			owner = self.Owner;
-			frozenActorsById = [];
 
 			partitionedFrozenActors = new SpatiallyPartitioned<FrozenActor>(
 				world.Map.MapSize.Width, world.Map.MapSize.Height, binSize);
@@ -275,7 +277,11 @@ namespace OpenRA.Traits
 		public void Add(FrozenActor fa)
 		{
 			FrozenHash += (int)fa.ID;
+
+			fa.LayerIndex = actors.Count;
+			actors.Add(fa);
 			frozenActorsById.Add(fa.ID, fa);
+
 			world.ScreenMap.AddOrUpdate(owner, fa);
 			partitionedFrozenActors.Add(fa, FootprintBounds(fa));
 		}
@@ -283,6 +289,16 @@ namespace OpenRA.Traits
 		public void Remove(FrozenActor fa)
 		{
 			FrozenHash -= (int)fa.ID;
+
+			// PERF: Swap with last element and remove.
+			var index = fa.LayerIndex;
+			var lastIdx = actors.Count - 1;
+			var lastActor = actors[lastIdx];
+
+			actors[index] = lastActor;
+			lastActor.LayerIndex = index;
+			actors.RemoveAt(lastIdx);
+
 			partitionedFrozenActors.Remove(fa);
 			world.ScreenMap.Remove(owner, fa);
 			frozenActorsById.Remove(fa.ID);
@@ -313,26 +329,19 @@ namespace OpenRA.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			List<FrozenActor> frozenActorsToRemove = null;
 			VisibilityHash = 0;
 
-			foreach (var kvp in frozenActorsById)
+			// Iterate backwards to allow safe removal during iteration.
+			for (var i = actors.Count - 1; i >= 0; i--)
 			{
-				var frozenActor = kvp.Value;
+				var frozenActor = actors[i];
 				frozenActor.Tick();
 
 				if (frozenActor.Visible)
 					VisibilityHash += (int)frozenActor.ID;
 				else if (frozenActor.Actor == null)
-				{
-					frozenActorsToRemove ??= [];
-					frozenActorsToRemove.Add(frozenActor);
-				}
+					Remove(frozenActor);
 			}
-
-			if (frozenActorsToRemove != null)
-				foreach (var fa in frozenActorsToRemove)
-					Remove(fa);
 		}
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -34,7 +35,7 @@ namespace OpenRA.Traits
 
 	public class FrozenActor
 	{
-		public readonly PPos[] Footprint;
+		public readonly ImmutableArray<PPos> Footprint;
 		public readonly WPos CenterPosition;
 		readonly Actor actor;
 		readonly ICreatesFrozenActors frozenTrait;
@@ -48,7 +49,7 @@ namespace OpenRA.Traits
 
 		public ITooltipInfo TooltipInfo { get; private set; }
 		public Player TooltipOwner { get; private set; }
-		readonly ITooltip[] tooltips;
+		readonly ImmutableArray<ITooltip> tooltips;
 
 		public int HP { get; private set; }
 		public DamageState DamageState { get; private set; }
@@ -70,20 +71,18 @@ namespace OpenRA.Traits
 		public bool Shrouded { get; private set; }
 		public bool NeedRenderables { get; set; }
 		public bool UpdateVisibilityNextTick { get; set; }
-		public IRenderable[] Renderables = NoRenderables;
-		public Rectangle[] ScreenBounds = NoBounds;
+		public ImmutableArray<IRenderable> Renderables = [];
+		public ImmutableArray<Rectangle> ScreenBounds = [];
 
 		public Polygon MouseBounds = Polygon.Empty;
 
-		static readonly IRenderable[] NoRenderables = [];
-		static readonly Rectangle[] NoBounds = [];
 
 		int flashTicks;
 		TintModifiers flashModifiers;
 		float3 flashTint;
 		float? flashAlpha;
 
-		public FrozenActor(Actor actor, ICreatesFrozenActors frozenTrait, PPos[] footprint, Player viewer, bool startsRevealed)
+		public FrozenActor(Actor actor, ICreatesFrozenActors frozenTrait, ImmutableArray<PPos> footprint, Player viewer, bool startsRevealed)
 		{
 			this.actor = actor;
 			this.frozenTrait = frozenTrait;
@@ -94,7 +93,7 @@ namespace OpenRA.Traits
 			// Consider all cells inside the map area (ignoring the current map bounds)
 			Footprint = footprint
 				.Where(m => shroud.Contains(m))
-				.ToArray();
+				.ToImmutableArray();
 
 			if (Footprint.Length == 0)
 				throw new ArgumentException("This frozen actor has no footprint.\n" +
@@ -105,7 +104,7 @@ namespace OpenRA.Traits
 
 			CenterPosition = actor.CenterPosition;
 
-			tooltips = actor.TraitsImplementing<ITooltip>().ToArray();
+			tooltips = actor.TraitsImplementing<ITooltip>().ToImmutableArray();
 			health = actor.TraitOrDefault<IHealth>();
 			visibilityModifiers = actor.TraitsImplementing<IVisibilityModifier>().ToArray();
 
@@ -215,7 +214,7 @@ namespace OpenRA.Traits
 		public IEnumerable<IRenderable> Render()
 		{
 			if (Shrouded)
-				return NoRenderables;
+				return [];
 
 			if (flashTicks > 0 && flashTicks % 2 == 0)
 			{

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -183,12 +183,12 @@ namespace OpenRA.Traits
 					Shrouded = false;
 			}
 
+			NeedRenderables |= Visible && !wasVisible;
+
 			// Force the backing trait to update so other actors can't
 			// query inconsistent state (both hidden or both visible)
 			if (Visible != wasVisible)
 				frozenTrait.OnVisibilityChanged(this);
-
-			NeedRenderables |= Visible && !wasVisible;
 		}
 
 		public void Invalidate()

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -274,6 +274,7 @@ namespace OpenRA.Traits
 
 		public void Add(FrozenActor fa)
 		{
+			FrozenHash += (int)fa.ID;
 			frozenActorsById.Add(fa.ID, fa);
 			world.ScreenMap.AddOrUpdate(owner, fa);
 			partitionedFrozenActors.Add(fa, FootprintBounds(fa));
@@ -281,6 +282,7 @@ namespace OpenRA.Traits
 
 		public void Remove(FrozenActor fa)
 		{
+			FrozenHash -= (int)fa.ID;
 			partitionedFrozenActors.Remove(fa);
 			world.ScreenMap.Remove(owner, fa);
 			frozenActorsById.Remove(fa.ID);
@@ -313,19 +315,14 @@ namespace OpenRA.Traits
 		{
 			List<FrozenActor> frozenActorsToRemove = null;
 			VisibilityHash = 0;
-			FrozenHash = 0;
 
 			foreach (var kvp in frozenActorsById)
 			{
-				var id = kvp.Key;
-				var hash = (int)id;
-				FrozenHash += hash;
-
 				var frozenActor = kvp.Value;
 				frozenActor.Tick();
 
 				if (frozenActor.Visible)
-					VisibilityHash += hash;
+					VisibilityHash += (int)frozenActor.ID;
 				else if (frozenActor.Actor == null)
 				{
 					frozenActorsToRemove ??= [];

--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -9,13 +9,14 @@
  */
 #endregion
 
+using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
 	public static class ShroudExts
 	{
-		public static bool AnyExplored(this Shroud shroud, (CPos Cell, SubCell SubCell)[] cells)
+		public static bool AnyExplored(this Shroud shroud, ReadOnlySpan<(CPos Cell, SubCell SubCell)> cells)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var cell in cells)
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Common
 			return false;
 		}
 
-		public static bool AnyExplored(this Shroud shroud, PPos[] puvs)
+		public static bool AnyExplored(this Shroud shroud, ReadOnlySpan<PPos> puvs)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var puv in puvs)
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common
 			return false;
 		}
 
-		public static bool AnyVisible(this Shroud shroud, (CPos Cell, SubCell SubCell)[] cells)
+		public static bool AnyVisible(this Shroud shroud, ReadOnlySpan<(CPos Cell, SubCell SubCell)> cells)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var cell in cells)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -37,20 +37,22 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool startsRevealed;
 		readonly ImmutableArray<PPos> footprint;
 
+		readonly HashSet<int> playersRequiringUpdate = [];
+
 		PlayerDictionary<FrozenState> frozenStates;
 		bool isRendering;
 		bool created;
 
-		sealed class FrozenState(FrozenActor frozenActor)
+		sealed class FrozenState(FrozenActor frozenActor, int playerIndex)
 		{
 			public readonly FrozenActor FrozenActor = frozenActor;
+			public readonly int PlayerIndex = playerIndex;
 			public bool IsVisible;
 		}
 
 		public FrozenUnderFog(ActorInitializer init, FrozenUnderFogInfo info)
 		{
 			this.info = info;
-
 			var map = init.World.Map;
 
 			// Explore map-placed actors if the "Explore Map" option is enabled
@@ -69,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var frozenActor = new FrozenActor(self, this, footprint, player, startsRevealed);
 				player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
-				return new FrozenState(frozenActor) { IsVisible = !frozenActor.Visible };
+				return new FrozenState(frozenActor, playerIndex) { IsVisible = !frozenActor.Visible };
 			});
 
 			// Set the initial visibility state
@@ -82,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 					var state = frozenStates[playerIndex];
 					var frozen = state.FrozenActor;
 					if (startsRevealed || state.IsVisible)
-						UpdateFrozenActor(frozen, playerIndex);
+						UpdateFrozenActor(frozen, state.PlayerIndex);
 
 					frozen.RefreshHidden();
 				}
@@ -95,6 +97,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			VisibilityHash |= 1 << (playerIndex % 32);
 			frozenActor.RefreshState();
+
+			if (frozenActor.NeedRenderables)
+				playersRequiringUpdate.Add(playerIndex);
 		}
 
 		void ICreatesFrozenActors.OnVisibilityChanged(FrozenActor frozen)
@@ -105,11 +110,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Update state visibility to match the frozen actor to ensure consistency
 			var state = frozenStates[frozen.Viewer];
-			var isVisible = !frozen.Visible;
-			state.IsVisible = isVisible;
+			state.IsVisible = !frozen.Visible;
 
-			if (isVisible)
-				UpdateFrozenActor(frozen, frozen.Viewer.World.Players.IndexOf(frozen.Viewer));
+			if (state.IsVisible || frozen.NeedRenderables)
+				UpdateFrozenActor(frozen, state.PlayerIndex);
 
 			frozen.RefreshHidden();
 		}
@@ -134,12 +138,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
+			if (playersRequiringUpdate.Count == 0)
+				return;
+
 			ImmutableArray<IRenderable> renderables = default;
 			ImmutableArray<Rectangle> bounds = default;
 			var mouseBounds = Polygon.Empty;
-			for (var playerIndex = 0; playerIndex < frozenStates.Count; playerIndex++)
+			foreach (var playerIndex in playersRequiringUpdate)
 			{
-				var frozen = frozenStates[playerIndex].FrozenActor;
+				var state = frozenStates[playerIndex];
+				var frozen = state.FrozenActor;
+
 				if (!frozen.NeedRenderables)
 					continue;
 
@@ -157,13 +166,16 @@ namespace OpenRA.Mods.Common.Traits
 				frozen.Renderables = renderables;
 				frozen.ScreenBounds = bounds;
 				frozen.MouseBounds = mouseBounds;
+
 				self.World.ScreenMap.AddOrUpdate(self.World.Players[playerIndex], frozen);
 			}
+
+			playersRequiringUpdate.Clear();
 		}
 
 		IEnumerable<IRenderable> IRenderModifier.ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
-			return IsVisible(self, self.World.RenderPlayer) || isRendering ? r : SpriteRenderable.None;
+			return isRendering || IsVisible(self, self.World.RenderPlayer) ? r : SpriteRenderable.None;
 		}
 
 		IEnumerable<Rectangle> IRenderModifier.ModifyScreenBounds(Actor self, WorldRenderer wr, IEnumerable<Rectangle> bounds)
@@ -174,10 +186,9 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			// Force a state update for the old owner so the tooltip etc doesn't show them as the owner
-			var oldOwnerIndex = self.World.Players.IndexOf(oldOwner);
-			var frozen = frozenStates[oldOwnerIndex].FrozenActor;
-			UpdateFrozenActor(frozen, oldOwnerIndex);
-			frozen.RefreshHidden();
+			var oldState = frozenStates[oldOwner];
+			UpdateFrozenActor(oldState.FrozenActor, oldState.PlayerIndex);
+			oldState.FrozenActor.RefreshHidden();
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -34,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly FrozenUnderFogInfo info;
 		readonly bool startsRevealed;
-		readonly PPos[] footprint;
+		readonly ImmutableArray<PPos> footprint;
 
 		PlayerDictionary<FrozenState> frozenStates;
 		bool isRendering;
@@ -56,9 +57,10 @@ namespace OpenRA.Mods.Common.Traits
 			var shroudInfo = init.World.Map.Rules.Actors[SystemActors.Player].TraitInfo<ShroudInfo>();
 			var exploredMap = init.World.LobbyInfo.GlobalSettings.OptionOrDefault("explored", shroudInfo.ExploredMapCheckboxEnabled);
 			startsRevealed = exploredMap && init.Contains<SpawnedByMapInit>() && !init.Contains<HiddenUnderFogInit>();
+
 			var buildingInfo = init.Self.Info.TraitInfoOrDefault<BuildingInfo>();
-			var footprintCells = buildingInfo?.FrozenUnderFogTiles(init.Self.Location).ToList() ?? [init.Self.Location];
-			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
+			var footprintCells = buildingInfo?.FrozenUnderFogTiles(init.Self.Location).ToArray() ?? [init.Self.Location];
+			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToImmutableArray();
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -116,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// If fog is disabled visibility is determined by shroud
 			if (!byPlayer.Shroud.FogEnabled)
-				return byPlayer.Shroud.AnyExplored(footprint);
+				return byPlayer.Shroud.AnyExplored(footprint.AsSpan());
 
 			return frozenStates[byPlayer].IsVisible;
 		}
@@ -132,8 +134,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
-			IRenderable[] renderables = null;
-			Rectangle[] bounds = null;
+			ImmutableArray<IRenderable> renderables = default;
+			ImmutableArray<Rectangle> bounds = default;
 			var mouseBounds = Polygon.Empty;
 			for (var playerIndex = 0; playerIndex < frozenStates.Count; playerIndex++)
 			{
@@ -141,11 +143,11 @@ namespace OpenRA.Mods.Common.Traits
 				if (!frozen.NeedRenderables)
 					continue;
 
-				if (renderables == null)
+				if (renderables == default)
 				{
 					isRendering = true;
-					renderables = self.Render(wr).ToArray();
-					bounds = self.ScreenBounds(wr).ToArray();
+					renderables = self.Render(wr).ToImmutableArray();
+					bounds = self.ScreenBounds(wr).ToImmutableArray();
 					mouseBounds = self.MouseBounds(wr);
 
 					isRendering = false;


### PR DESCRIPTION
Speed up FrozenUnderFog and FrozenActorLayer.

When you start pushing into thousands of actors on map, the frozen layer starts to struggle.
- Transition to immutable data structures
- Reduce the cost of hash functions
- Stop itterating through dictionaries
- Don't itterate through a `FrozenUnderFog` dictionary every render frame per every actor per every player
- Reduce usage of IndexOf