### PR TITLE
Fixup positioning in world

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -74,12 +74,12 @@ namespace OpenRA
 				return val;
 		}
 
-		static int WindingDirectionTest(int2 v0, int2 v1, int2 p)
+		static int WindingDirectionTest(int2 v0, int2 v1, float2 p)
 		{
 			return Math.Sign((v1.X - v0.X) * (p.Y - v0.Y) - (p.X - v0.X) * (v1.Y - v0.Y));
 		}
 
-		public static bool PolygonContains(this ImmutableArray<int2> polygon, int2 p)
+		public static bool PolygonContains(this ImmutableArray<int2> polygon, float2 p)
 		{
 			var windingNumber = 0;
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -725,7 +725,7 @@ namespace OpenRA
 				// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
 				if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
 				{
-					Renderer.BeginWorld(worldRenderer.Viewport.CenterLocation, worldRenderer.Viewport.ViewportSize);
+					Renderer.BeginWorld(worldRenderer.Viewport.CenterLocation, worldRenderer.Viewport.Rect);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
 					using (new PerfSample("render_world"))
 						worldRenderer.Draw();

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Graphics
 			return [imageRenderable];
 		}
 
-		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, in WVec offset, int zOffset, PaletteReference palette, float scale = 1f, float rotation = 0f)
+		public IRenderable[] RenderUI(WorldRenderer wr, float2 pos, in WVec offset, int zOffset, PaletteReference palette, float scale = 1f, float rotation = 0f)
 		{
 			scale *= CurrentSequence.Scale;
 			var screenOffset = (scale * wr.ScreenVectorComponents(offset)).XY.ToInt2();

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Graphics
 			DrawTargetMarker(color, first);
 		}
 
-		public static void DrawTargetMarker(Color color, int2 screenPos, int size = 1)
+		public static void DrawTargetMarker(Color color, float2 screenPos, int size = 1)
 		{
 			var offset = new int2(size, size);
 			var tl = screenPos - offset;

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -16,12 +16,12 @@ namespace OpenRA.Graphics
 	public class UISpriteRenderable : IRenderable, IPalettedRenderable, IFinalizedRenderable
 	{
 		readonly Sprite sprite;
-		readonly int2 screenPos;
+		readonly float2 screenPos;
 		readonly float scale;
 		readonly float alpha;
 		readonly float rotation = 0f;
 
-		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, int2 screenPos, int zOffset, PaletteReference palette,
+		public UISpriteRenderable(Sprite sprite, WPos effectiveWorldPos, float2 screenPos, int zOffset, PaletteReference palette,
 			float scale = 1f, float alpha = 1f, float rotation = 0f)
 		{
 			this.sprite = sprite;

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -266,7 +266,7 @@ namespace OpenRA.Graphics
 				t.ViewportZoomExtentsChanged(minZoom, MaxZoom);
 		}
 
-		public CPos ViewToWorld(int2 view)
+		public CPos ViewToWorld(float2 view)
 		{
 			var world = ViewToWorldPx(view);
 			var map = worldRenderer.World.Map;
@@ -307,7 +307,7 @@ namespace OpenRA.Graphics
 		}
 
 		/// <summary>Returns an unfiltered list of all cells that could potentially contain the mouse cursor.</summary>
-		IEnumerable<MPos> CandidateMouseoverCells(int2 world)
+		IEnumerable<MPos> CandidateMouseoverCells(float2 world)
 		{
 			var map = worldRenderer.World.Map;
 			var tileScale = map.Grid.TileScale / 2;
@@ -333,9 +333,9 @@ namespace OpenRA.Graphics
 					yield return new MPos(u, v);
 		}
 
-		public int2 ViewToWorldPx(int2 view) => (graphicSettings.UIScale / Zoom * view.ToFloat2() + CenterLocation - ViewportSize.ToInt2() / 2).ToInt2();
-		public int2 WorldToViewPx(int2 world) => (Zoom / graphicSettings.UIScale * (world - CenterLocation + ViewportSize.ToInt2() / 2)).ToInt2();
-		public int2 WorldToViewPx(in float3 world) => (Zoom / graphicSettings.UIScale * (world - CenterLocation + ViewportSize.ToInt2() / 2).XY).ToInt2();
+		public float2 ViewToWorldPx(float2 view) => graphicSettings.UIScale / Zoom * view + CenterLocation - ViewportSize.ToInt2() / 2;
+		public float2 WorldToViewPx(int2 world) => Zoom / graphicSettings.UIScale * (world - CenterLocation + ViewportSize.ToInt2() / 2);
+		public float2 WorldToViewPx(in float3 world) => Zoom / graphicSettings.UIScale * (world - CenterLocation + ViewportSize.ToInt2() / 2).XY;
 
 		public void Center(IEnumerable<Actor> actors)
 		{

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -53,9 +53,19 @@ namespace OpenRA.Graphics
 		public float2 CenterLocation { get; private set; }
 
 		public WPos CenterPosition => worldRenderer.ProjectedPosition(CenterLocation.ToInt2());
-
 		public int2 TopLeft => CenterLocation.ToInt2() - ViewportSize.ToInt2() / 2;
-		public int2 BottomRight => CenterLocation.ToInt2() + ViewportSize.ToInt2() / 2;
+
+		public Rectangle Rect
+		{
+			get
+			{
+				var topLeft = TopLeft;
+
+				// We need to add 1 to scroll in order to handle interpixel 0-0.99 fractionalOffset.
+				return new Rectangle(topLeft.X, topLeft.Y, ViewportSize.Width + 1, ViewportSize.Height + 1);
+			}
+		}
+
 		public Size ViewportSize { get; private set; }
 		ProjectedCellRegion cells;
 		bool cellsDirty = true;
@@ -384,10 +394,11 @@ namespace OpenRA.Graphics
 		ProjectedCellRegion CalculateVisibleCells(bool insideBounds)
 		{
 			var map = worldRenderer.World.Map;
+			var rect = Rect;
 
 			// Calculate the projected cell position at the corners of the visible area
-			var tl = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(TopLeft)).ToMPos(map);
-			var br = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(BottomRight)).ToMPos(map);
+			var tl = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(rect.TopLeft)).ToMPos(map);
+			var br = (PPos)map.CellContaining(worldRenderer.ProjectedPosition(rect.BottomRight)).ToMPos(map);
 
 			// RectangularIsometric maps don't have straight edges, and so we need an additional
 			// cell margin to include the cells that are half visible on each edge.

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Graphics
 				renderablesBuffer.AddRange(e.Render(this));
 
 			// Partitioned, currently on-screen effects
-			foreach (var e in World.ScreenMap.RenderableEffectsInBox(Viewport.TopLeft, Viewport.BottomRight))
+			foreach (var e in World.ScreenMap.RenderableEffectsInBox(Viewport.Rect))
 				renderablesBuffer.AddRange(e.Render(this));
 
 			// Renderables must be ordered using a stable sorting algorithm to avoid flickering artefacts
@@ -263,7 +263,7 @@ namespace OpenRA.Graphics
 			RefreshPalette();
 
 			// PERF: Reuse collection to avoid allocations.
-			onScreenActors.UnionWith(World.ScreenMap.RenderableActorsInBox(Viewport.TopLeft, Viewport.BottomRight));
+			onScreenActors.UnionWith(World.ScreenMap.RenderableActorsInBox(Viewport.Rect));
 
 			GenerateRenderables();
 			GenerateOverlayRenderables();

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -373,7 +373,7 @@ namespace OpenRA.Graphics
 					for (var index = 0; index < b.Vertices.Length; index++)
 					{
 						var vertex = b.Vertices[index];
-						points[index] = Viewport.WorldToViewPx(vertex).ToFloat2();
+						points[index] = Viewport.WorldToViewPx(vertex);
 					}
 
 					Game.Renderer.RgbaColorRenderer.DrawPolygon(points, 1, Color.OrangeRed);
@@ -467,6 +467,11 @@ namespace OpenRA.Graphics
 		public WPos ProjectedPosition(int2 screenPx)
 		{
 			return new WPos(TileScale * screenPx.X / TileSize.Width, TileScale * screenPx.Y / TileSize.Height, 0);
+		}
+
+		public WPos ProjectedPosition(float2 screenPx)
+		{
+			return new WPos((int)(TileScale * screenPx.X / TileSize.Width), (int)(TileScale * screenPx.Y / TileSize.Height), 0);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -89,6 +89,7 @@ namespace OpenRA
 		public float2 Round() { return new float2((float)Math.Round(X), (float)Math.Round(Y)); }
 
 		public int2 ToInt2() { return new int2((int)X, (int)Y); }
+		public int2 ToInt2Ceiling() { return new int2((int)Math.Ceiling(X), (int)Math.Ceiling(Y)); }
 
 		public static float2 Max(float2 a, float2 b) { return new float2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)); }
 		public static float2 Min(float2 a, float2 b) { return new float2(Math.Min(a.X, b.X), Math.Min(a.Y, b.Y)); }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -259,7 +259,7 @@ namespace OpenRA
 
 				// We need to add 1 to scroll in order to handle interpixel 0-0.99 fractionalOffset.
 				var s = new Size(vw / WorldDownscaleFactor + 1, vh / WorldDownscaleFactor + 1);
-				var fractionalOffset = centerLocation - viewportLocation;
+				var fractionalOffset = (centerLocation - viewportLocation) / WorldDownscaleFactor;
 				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, s), 0, fractionalOffset, TextureChannel.RGBA);
 			}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -55,7 +55,6 @@ namespace OpenRA
 		Sheet worldSheet;
 		Sprite worldSprite;
 		Size lastMaximumViewportSize;
-		Size lastWorldViewportSize;
 
 		public Size WorldFrameBufferSize => worldSheet.Size;
 		public int WorldDownscaleFactor { get; private set; } = 1;
@@ -232,7 +231,7 @@ namespace OpenRA
 			lastMaximumViewportSize = size;
 		}
 
-		public void BeginWorld(float2 viewportLocation, Size viewportSize)
+		public void BeginWorld(float2 viewportLocation, Rectangle viewport)
 		{
 			if (renderType != RenderType.None)
 				throw new InvalidOperationException($"BeginWorld called with renderType = {renderType}, expected RenderType.None.");
@@ -243,14 +242,13 @@ namespace OpenRA
 				throw new InvalidOperationException("BeginWorld called before SetMaximumViewportSize has been set.");
 
 			var centerLocation = viewportLocation.ToInt2();
-			if (worldSprite == null || viewportSize != lastWorldViewportSize || viewportLocation != lastViewportLocation)
+			if (worldSprite == null || viewport != lastWorldViewport || viewportLocation != lastViewportLocation)
 			{
 				lastViewportLocation = viewportLocation;
-				lastWorldViewportSize = viewportSize;
 
 				// Downscale world rendering if needed to fit within the framebuffer
-				var vw = viewportSize.Width;
-				var vh = viewportSize.Height;
+				var vw = viewport.Width - 1;
+				var vh = viewport.Height - 1;
 				var bw = worldSheet.Size.Width;
 				var bh = worldSheet.Size.Height;
 				WorldDownscaleFactor = 1;
@@ -264,12 +262,10 @@ namespace OpenRA
 			}
 
 			worldBuffer.Bind();
-			var rect = new Rectangle(centerLocation, viewportSize);
-			if (lastWorldViewport != rect)
+			if (lastWorldViewport != viewport)
 			{
-				var topLeft = centerLocation - viewportSize.ToInt2() / 2;
-				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, WorldDownscaleFactor, depthMargin, topLeft);
-				lastWorldViewport = rect;
+				WorldSpriteRenderer.SetViewportParams(worldSheet.Size, WorldDownscaleFactor, depthMargin, viewport.TopLeft);
+				lastWorldViewport = viewport;
 			}
 
 			renderType = RenderType.World;

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -341,7 +341,7 @@ namespace OpenRA.Traits
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			return world.ScreenMap.RenderableFrozenActorsInBox(owner, wr.Viewport.TopLeft, wr.Viewport.BottomRight)
+			return world.ScreenMap.RenderableFrozenActorsInBox(owner, wr.Viewport.Rect)
 				.Where(f => f.Visible)
 				.SelectMany(ff => ff.Render());
 		}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -294,7 +294,7 @@ namespace OpenRA.Traits
 	public interface ISelectionDecorations
 	{
 		IEnumerable<IRenderable> RenderSelectionAnnotations(Actor self, WorldRenderer worldRenderer, Color color);
-		int2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin);
+		float2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin);
 	}
 
 	public interface IEditorSelectionLayer : ITraitInfoInterface { }

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<FrozenActor> FrozenActorsAtMouse(Player viewer, MouseInput mi)
 		{
-			return FrozenActorsAtMouse(viewer, worldRenderer.Viewport.ViewToWorldPx(mi.Location));
+			return FrozenActorsAtMouse(viewer, worldRenderer.Viewport.ViewToWorldPx(mi.Location).ToInt2());
 		}
 
 		public IEnumerable<ActorBoundsPair> ActorsAtMouse(int2 worldPx)
@@ -169,7 +169,7 @@ namespace OpenRA.Traits
 
 		public IEnumerable<ActorBoundsPair> ActorsAtMouse(MouseInput mi)
 		{
-			return ActorsAtMouse(worldRenderer.Viewport.ViewToWorldPx(mi.Location));
+			return ActorsAtMouse(worldRenderer.Viewport.ViewToWorldPx(mi.Location).ToInt2());
 		}
 
 		static Rectangle RectWithCorners(int2 a, int2 b)

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -190,22 +190,22 @@ namespace OpenRA.Traits
 				.Where(x => x.Bounds.IntersectsWith(r));
 		}
 
-		public IEnumerable<Actor> RenderableActorsInBox(int2 a, int2 b)
+		public IEnumerable<Actor> RenderableActorsInBox(Rectangle rect)
 		{
-			return partitionedRenderableActors.InBox(RectWithCorners(a, b)).Where(actorIsInWorld);
+			return partitionedRenderableActors.InBox(rect).Where(actorIsInWorld);
 		}
 
-		public IEnumerable<IEffect> RenderableEffectsInBox(int2 a, int2 b)
+		public IEnumerable<IEffect> RenderableEffectsInBox(Rectangle rect)
 		{
-			return partitionedRenderableEffects.InBox(RectWithCorners(a, b));
+			return partitionedRenderableEffects.InBox(rect);
 		}
 
-		public IEnumerable<FrozenActor> RenderableFrozenActorsInBox(Player p, int2 a, int2 b)
+		public IEnumerable<FrozenActor> RenderableFrozenActorsInBox(Player p, Rectangle rect)
 		{
 			if (p == null)
 				return NoFrozenActors;
 
-			return partitionedRenderableFrozenActors[p].InBox(RectWithCorners(a, b)).Where(frozenActorIsValid);
+			return partitionedRenderableFrozenActors[p].InBox(rect).Where(frozenActorIsValid);
 		}
 
 		public void TickRender()

--- a/OpenRA.Mods.Cnc/Graphics/ChronoVortexRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ChronoVortexRenderable.cs
@@ -59,8 +59,8 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public Rectangle ScreenBounds(WorldRenderer wr)
 		{
 			var pos = wr.Screen3DPxPosition(Pos);
-			var tl = wr.Viewport.WorldToViewPx(pos);
-			var br = wr.Viewport.WorldToViewPx(pos + new float3(64, 64, 0));
+			var tl = wr.Viewport.WorldToViewPx(pos).ToInt2();
+			var br = wr.Viewport.WorldToViewPx(pos + new float3(64, 64, 0)).ToInt2Ceiling();
 			return new Rectangle(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y);
 		}
 	}

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Widgets
 				&& mi.Event != MouseInputEvent.Move && mi.Event != MouseInputEvent.Scroll)
 				return false;
 
-			worldPixel = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
+			worldPixel = worldRenderer.Viewport.ViewToWorldPx(mi.Location).ToInt2();
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
 
 			var underCursor = editorLayer.PreviewsAtWorldPixel(worldPixel).MinByOrDefault(CalculateActorSelectionPriority);
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				if (mi.Event == MouseInputEvent.Down && underCursor != null && (mi.Modifiers.HasModifier(Modifiers.Shift) || underCursor == Selection.Actor))
 				{
-					var cellViewPx = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPosition(world.Map.CenterOfCell(cell)));
+					var cellViewPx = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPosition(world.Map.CenterOfCell(cell))).ToInt2();
 					dragPixelOffset = cellViewPx - mi.Location;
 					dragCellOffset = underCursor.Location - cell;
 					moveAction = new MoveActorAction(underCursor, actorLayer);

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -71,8 +71,8 @@ namespace OpenRA.Mods.Common.Graphics
 			var stepAspect = new float2(1f, -0.5f);
 
 			var offset = barNum * BarStride * barAspect - new float2(0, BarHeight + 1);
-			var start = wr.Viewport.WorldToViewPx(bounds.Vertices[1]).ToFloat2() + offset;
-			var end = wr.Viewport.WorldToViewPx(bounds.Vertices[0]).ToFloat2() + offset;
+			var start = wr.Viewport.WorldToViewPx(bounds.Vertices[1]) + offset;
+			var end = wr.Viewport.WorldToViewPx(bounds.Vertices[0]) + offset;
 
 			// HACK: Work around rounding errors that may cause a few-px offset in the end relative to the start
 			// Force the bar to take a 45 degree angle

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBoxAnnotationRenderable.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public void Render(WorldRenderer wr)
 		{
-			var screen = bounds.Vertices.Select(v => wr.Viewport.WorldToViewPx(v).ToFloat2()).ToArray();
+			var screen = bounds.Vertices.Select(wr.Viewport.WorldToViewPx).ToArray();
 
 			var tl = new float2(-12, -6);
 			var tr = new float2(12, -6);

--- a/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var verts = vertices.Select(v => wr.Viewport.WorldToViewPx(wr.ScreenPosition(v)).ToFloat2()).ToArray();
+			var verts = vertices.Select(v => wr.Viewport.WorldToViewPx(wr.ScreenPosition(v))).ToArray();
 			Game.Renderer.RgbaColorRenderer.DrawPolygon(verts, width, color);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
@@ -41,8 +41,8 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var tl = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left, decorationBounds.Top)).ToFloat2();
-			var br = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right, decorationBounds.Bottom)).ToFloat2();
+			var tl = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left, decorationBounds.Top));
+			var br = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right, decorationBounds.Bottom));
 			var tr = new float2(br.X, tl.Y);
 			var bl = new float2(tl.X, br.Y);
 			var u = new float2(4, 0);

--- a/OpenRA.Mods.Common/Graphics/UITextRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/UITextRenderable.cs
@@ -18,13 +18,13 @@ namespace OpenRA.Mods.Common.Graphics
 	public class UITextRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly SpriteFont font;
-		readonly int2 screenPos;
+		readonly float2 screenPos;
 		readonly Color color;
 		readonly Color bgDark;
 		readonly Color bgLight;
 		readonly string text;
 
-		public UITextRenderable(SpriteFont font, WPos effectiveWorldPos, int2 screenPos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
+		public UITextRenderable(SpriteFont font, WPos effectiveWorldPos, float2 screenPos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
 		{
 			this.font = font;
 			Pos = effectiveWorldPos;
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Graphics
 			this.text = text;
 		}
 
-		public UITextRenderable(SpriteFont font, WPos effectiveWorldPos, int2 screenPos, int zOffset, Color color, string text)
+		public UITextRenderable(SpriteFont font, WPos effectiveWorldPos, float2 screenPos, int zOffset, Color color, string text)
 			: this(font, effectiveWorldPos, screenPos, zOffset, color,
 				ChromeMetrics.Get<Color>("TextContrastColorDark"),
 				ChromeMetrics.Get<Color>("TextContrastColorLight"),

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Orders
 			{
 				var offsetPos = Viewport.LastMousePos;
 				if (variants[variant].Preview != null)
-					offsetPos = viewport.WorldToViewPx(viewport.ViewToWorldPx(offsetPos) + variants[variant].Preview.TopLeftScreenOffset);
+					offsetPos = viewport.WorldToViewPx(viewport.ViewToWorldPx(offsetPos) + variants[variant].Preview.TopLeftScreenOffset).ToInt2();
 
 				return viewport.ViewToWorld(offsetPos);
 			}

--- a/OpenRA.Mods.Common/Traits/Render/IsometricSelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/IsometricSelectionDecorations.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		protected override int2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
+		protected override float2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
 		{
 			return wr.Viewport.WorldToViewPx(GetDecorationPosition(self, wr, pos)) + GetDecorationMargin(pos, margin);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		protected override int2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
+		protected override float2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
 		{
 			return wr.Viewport.WorldToViewPx(GetDecorationPosition(self, wr, pos)) + GetDecorationMargin(pos, margin);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -123,12 +123,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return RenderSelectionBox(self, worldRenderer, color);
 		}
 
-		int2 ISelectionDecorations.GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
+		float2 ISelectionDecorations.GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin)
 		{
 			return GetDecorationOrigin(self, wr, pos, margin);
 		}
 
-		protected abstract int2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin);
+		protected abstract float2 GetDecorationOrigin(Actor self, WorldRenderer wr, string pos, int2 margin);
 		protected abstract IEnumerable<IRenderable> RenderSelectionBox(Actor self, WorldRenderer wr, Color color);
 		protected abstract IEnumerable<IRenderable> RenderSelectionBars(Actor self, WorldRenderer wr, bool displayHealth, bool displayExtra);
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAmmoPipsDecoration.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			pips = new Animation(self.World, info.Image);
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCargoPipsDecoration.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return Info.EmptySequence;
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return wr.Palette(Info.IsPlayerPalette ? Info.Palette + self.Owner.InternalName : Info.Palette);
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			if (anim == null)
 				return [];

--- a/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecorationBase.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		bool IDecoration.RequiresSelection => Info.RequiresSelection;
 
-		protected abstract IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 pos);
+		protected abstract IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 pos);
 
 		IEnumerable<IRenderable> IDecoration.RenderDecoration(Actor self, WorldRenderer wr, ISelectionDecorations container)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNameTagDecoration.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				name = name[..info.MaxLength];
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			if (IsTraitDisabled || self.IsDead || !self.IsInWorld || !ShouldRender(self))
 				return [];

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceStoragePipsDecoration.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			pips = new Animation(self.World, info.Image);
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithStoresResourcesPipsDecoration.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return Info.EmptySequence;
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			pips.PlayRepeating(Info.EmptySequence);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			color = info.UsePlayerColor ? self.OwnerColor() : info.Color;
 		}
 
-		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, int2 screenPos)
+		protected override IEnumerable<IRenderable> RenderDecoration(Actor self, WorldRenderer wr, float2 screenPos)
 		{
 			if (IsTraitDisabled || self.IsDead || !self.IsInWorld || !ShouldRender(self))
 				return [];

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
-			foreach (var p in PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight))
+			foreach (var p in PreviewsInScreenBox(wr.Viewport.Rect))
 				foreach (var r in p.Render())
 					yield return r;
 		}
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
 		{
-			return PreviewsInScreenBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight)
+			return PreviewsInScreenBox(wr.Viewport.Rect)
 				.SelectMany(p => p.RenderAnnotations());
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Track particles in a viewport fixed to the minimum zoom level
 			var s = (1f / minZoom * new float2(Game.Renderer.NativeResolution)).ToInt2();
-			viewportSize = new Size(s.X, s.Y);
+			viewportSize = new Size(s.X + 1, s.Y + 1);
 
 			// Randomly distribute particles within the initial viewport
 			var particleCount = viewportSize.Width * viewportSize.Height * Info.ParticleDensityFactor / 10000;

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var fps = (newestFrame - oldestFrame) / (newestTime - oldestTime).TotalSeconds;
 
 				var wfbSize = Game.Renderer.WorldFrameBufferSize;
-				var viewportSize = worldRenderer.Viewport.ViewportSize;
+				var viewportSize = worldRenderer.Viewport.Rect.Size;
 				return $"FPS: {fps:0}\n" +
 					$"Tick: {worldRenderer.World.WorldTick} / {Game.LocalTick} @ {PerfHistory.Items["tick_time"].Average(Game.Settings.Debug.Samples):F1} ms\n" +
 					$"Render {Game.RenderFrame} @ {PerfHistory.Items["render"].Average(Game.Settings.Debug.Samples):F1} ms\n" +

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -297,7 +297,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var cell = world.Map.CellContaining(wpos);
 
 			var worldPixel = worldRenderer.ScreenPxPosition(wpos);
-			var location = worldRenderer.Viewport.WorldToViewPx(worldPixel);
+			var location = worldRenderer.Viewport.WorldToViewPx(worldPixel).ToInt2();
 			var mi = new MouseInput
 			{
 				Location = location,
@@ -337,7 +337,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var wpos = new WPos(worldPos.X, worldPos.Y, 0);
 
 				// fake a mousedown/mouseup here
-				var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(wpos));
+				var location = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(wpos)).ToInt2();
 				var fakemi = new MouseInput
 				{
 					Event = MouseInputEvent.Down,

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -379,8 +379,9 @@ namespace OpenRA.Mods.Common.Widgets
 			// Draw viewport rect
 			if (hasRadar)
 			{
-				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.TopLeft)));
-				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(worldRenderer.Viewport.BottomRight)));
+				var viewport = worldRenderer.Viewport.Rect;
+				var tl = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(viewport.TopLeft)));
+				var br = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(viewport.BottomRight)));
 
 				Game.Renderer.EnableScissor(mapRect);
 				DrawRadarPings();

--- a/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/SelectionUtils.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public static IEnumerable<Actor> SelectActorsOnScreen(
 			World world, WorldRenderer wr, IEnumerable<string> selectionClasses, IEnumerable<Player> players)
 		{
-			var actors = world.ScreenMap.ActorsInMouseBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight).Select(a => a.Actor);
+			var actors = world.ScreenMap.ActorsInMouseBox(wr.Viewport.Rect).Select(a => a.Actor);
 			return SelectActorsByOwnerAndSelectionClass(actors, players, selectionClasses);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -237,7 +237,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 			}
 
-			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos);
+			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos).ToInt2();
 			var underCursor = world.ScreenMap.ActorsAtMouse(worldPixel)
 				.Where(a => a.Actor.Info.HasTraitInfo<ITooltipInfo>() && !world.FogObscures(a.Actor))
 				.WithHighestSelectionPriority(worldPixel, modifiers);

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			mousePos = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
+			mousePos = worldRenderer.Viewport.ViewToWorldPx(mi.Location).ToInt2();
 
 			var useClassicMouseStyle = gameSettings.MouseControlStyle == MouseControlStyle.Classic;
 			var actionButton = World.OrderGenerator.ActionButton;
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
-			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(mi.Location);
+			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(mi.Location).ToInt2();
 			var orders = world.OrderGenerator.Order(world, cell, worldPixel, mi).ToArray();
 			orders.PlayVoiceForOrders();
 
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Widgets
 					return null;
 
 				var cell = worldRenderer.Viewport.ViewToWorld(screenPos);
-				var worldPixel = worldRenderer.Viewport.ViewToWorldPx(screenPos);
+				var worldPixel = worldRenderer.Viewport.ViewToWorldPx(screenPos).ToInt2();
 
 				var mi = new MouseInput
 				{

--- a/OpenRA.Mods.D2k/Graphics/SonicBlastRenderable.cs
+++ b/OpenRA.Mods.D2k/Graphics/SonicBlastRenderable.cs
@@ -56,8 +56,8 @@ namespace OpenRA.Mods.D2k.Graphics
 		public Rectangle ScreenBounds(WorldRenderer wr)
 		{
 			var pos = wr.Screen3DPxPosition(Pos);
-			var tl = wr.Viewport.WorldToViewPx(pos - r);
-			var br = wr.Viewport.WorldToViewPx(pos + r);
+			var tl = wr.Viewport.WorldToViewPx(pos - r).ToInt2();
+			var br = wr.Viewport.WorldToViewPx(pos + r).ToInt2Ceiling();
 			return new Rectangle(tl.X, tl.Y, br.X - tl.X, br.Y - tl.Y);
 		}
 	}


### PR DESCRIPTION
- When WorldDownscaleFactor was non-one, the fractional offset was incorrect. It's basically impossible to get WorldDownscaleFactor to be anything another than one, but if you force WorldSheet to be smaller then you'd see the glitch.
- Now viewport provides it's rect, that other systems can use for culling and other things.
- Now annotations can be positioned fractionally. No longer are they incorrectly placed in world.

Note: currently for input we do ToInt(). This will change with SDL3 as it uses float3 mouse positioning.

Marking a draft as I still want to work on some polishing. Even though annotations go through anti-aliasing, they still alias quite a bit, be it on bleed or in this PR.