### PR TITLE
Fix selection priority being from top left

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		long CalculateActorSelectionPriority(EditorActorPreview actor)
 		{
-			var centerPixel = new int2(actor.Bounds.X, actor.Bounds.Y);
+			var centerPixel = new int2(actor.Bounds.X + actor.Bounds.Width / 2, actor.Bounds.Y + actor.Bounds.Height / 2);
 			var pixelDistance = (centerPixel - worldPixel).Length;
 
 			// If 2+ actors have the same pixel position, then the highest appears on top.


### PR DESCRIPTION
Sort by distance from cursor to center.

When actors overlap the current rule can make selection confusing. It also seems the original desire was to sort by actor center