### PR TITLE
Transition a VAO per buffer.

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -84,8 +84,8 @@ namespace OpenRA
 
 	public interface IGraphicsContext : IDisposable
 	{
-		IVertexBuffer<T> CreateEmptyVertexBuffer<T>(int size) where T : struct;
-		IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic = true) where T : struct;
+		IVertexBuffer<T> CreateEmptyVertexBuffer<T>(IShaderBindings bindings, int size) where T : struct;
+		IVertexBuffer<T> CreateVertexBuffer<T>(IShaderBindings bindings, T[] data, bool dynamic = true) where T : struct;
 		T[] CreateVertices<T>(int size) where T : struct;
 		IIndexBuffer CreateIndexBuffer(uint[] indices);
 		ITexture CreateTexture();
@@ -132,6 +132,7 @@ namespace OpenRA
 
 	public interface IShader
 	{
+		IShaderBindings Bindings { get; }
 		void SetBool(string name, bool value);
 		void SetVec(string name, float x);
 		void SetVec(string name, float x, float y);

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -22,8 +22,8 @@ namespace OpenRA.Graphics
 		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
 		static readonly int UintSize = Marshal.SizeOf<uint>();
 
+		public readonly IShader Shader;
 		readonly Renderer renderer;
-		readonly IShader shader;
 
 		Vertex[] vertices;
 		readonly Sheet[] sheets = new Sheet[SheetCount];
@@ -34,8 +34,8 @@ namespace OpenRA.Graphics
 
 		public SpriteRenderer(Renderer renderer, IShader shader)
 		{
+			Shader = shader;
 			this.renderer = renderer;
-			this.shader = shader;
 			vertices = renderer.Context.CreateVertices<Vertex>(renderer.TempVertexBufferSize);
 		}
 
@@ -45,14 +45,14 @@ namespace OpenRA.Graphics
 			{
 				for (var i = 0; i < sheetCount; i++)
 				{
-					shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
+					Shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
 					sheets[i] = null;
 				}
 
 				renderer.Context.SetBlendMode(currentBlend);
-				shader.PrepareRender();
+				Shader.PrepareRender();
 
-				renderer.DrawQuadBatch(ref vertices, shader, vertexCount);
+				renderer.DrawQuadBatch(ref vertices, Shader, vertexCount);
 				renderer.Context.SetBlendMode(BlendMode.None);
 
 				vertexCount = 0;
@@ -172,7 +172,7 @@ namespace OpenRA.Graphics
 			vertexCount += 4;
 		}
 
-		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, IIndexBuffer indices, int start, int length, IEnumerable<Sheet> sheets, BlendMode blendMode)
+		public void DrawVertexBuffer(IVertexBuffer<Vertex> buffer, int start, int length, IEnumerable<Sheet> sheets, BlendMode blendMode)
 		{
 			var i = 0;
 			foreach (var s in sheets)
@@ -181,12 +181,12 @@ namespace OpenRA.Graphics
 					ThrowSheetOverflow(nameof(sheets));
 
 				if (s != null)
-					shader.SetTexture(SheetIndexToTextureName[i++], s.GetTexture());
+					Shader.SetTexture(SheetIndexToTextureName[i++], s.GetTexture());
 			}
 
 			renderer.Context.SetBlendMode(blendMode);
-			shader.PrepareRender();
-			renderer.DrawQuadBatch(buffer, indices, shader, length, UintSize * start);
+			Shader.PrepareRender();
+			renderer.DrawQuadBatch(buffer, Shader, length, UintSize * start);
 			renderer.Context.SetBlendMode(BlendMode.None);
 		}
 
@@ -212,9 +212,9 @@ namespace OpenRA.Graphics
 
 		public void SetPalette(HardwarePalette palette)
 		{
-			shader.SetTexture("Palette", palette.Texture);
-			shader.SetTexture("ColorShifts", palette.ColorShifts);
-			shader.SetVec("PaletteRows", palette.Height);
+			Shader.SetTexture("Palette", palette.Texture);
+			Shader.SetTexture("ColorShifts", palette.ColorShifts);
+			Shader.SetVec("PaletteRows", palette.Height);
 		}
 
 		public void SetViewportParams(Size sheetSize, int downscale, float depthMargin, int2 scroll)
@@ -241,21 +241,21 @@ namespace OpenRA.Graphics
 			//   extend beyond the top of bottom edges of the screen may be pushed outside [-1, 1] and
 			//   culled by the GPU. We avoid this by forcing everything into the z = 0 plane.
 			var depth = depthMargin != 0f ? 2f / (downscale * (sheetSize.Height + depthMargin)) : 0;
-			shader.SetVec("DepthTextureScale", 128 * depth);
-			shader.SetVec("Scroll", scroll.X, scroll.Y, depthMargin != 0f ? scroll.Y : 0);
-			shader.SetVec("p1", width, height, -depth);
-			shader.SetVec("p2", -1, -1, depthMargin != 0f ? 1 : 0);
+			Shader.SetVec("DepthTextureScale", 128 * depth);
+			Shader.SetVec("Scroll", scroll.X, scroll.Y, depthMargin != 0f ? scroll.Y : 0);
+			Shader.SetVec("p1", width, height, -depth);
+			Shader.SetVec("p2", -1, -1, depthMargin != 0f ? 1 : 0);
 		}
 
 		public void SetDepthPreview(bool enabled, float contrast, float offset)
 		{
-			shader.SetBool("EnableDepthPreview", enabled);
-			shader.SetVec("DepthPreviewParams", contrast, offset);
+			Shader.SetBool("EnableDepthPreview", enabled);
+			Shader.SetVec("DepthPreviewParams", contrast, offset);
 		}
 
 		public void EnablePixelArtScaling(bool enabled)
 		{
-			shader.SetBool("EnablePixelArtScaling", enabled);
+			Shader.SetBool("EnablePixelArtScaling", enabled);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Graphics
 
 			vertexRowStride = 4 * map.MapSize.Width;
 			vertices = new Vertex[vertexRowStride * map.MapSize.Height];
-			vertexBuffer = Game.Renderer.Context.CreateEmptyVertexBuffer<Vertex>(vertices.Length);
+			var bindings = Game.Renderer.WorldSpriteRenderer.Shader.Bindings;
+			vertexBuffer = Game.Renderer.Context.CreateEmptyVertexBuffer<Vertex>(bindings, vertices.Length);
 
 			indexRowStride = 6 * map.MapSize.Width;
 			lock (IndexBuffers)
@@ -59,6 +60,9 @@ namespace OpenRA.Graphics
 				indexBufferWrapper = IndexBuffers.GetValue(world, world => new IndexBufferRc(world));
 				indexBufferWrapper.AddRef();
 			}
+
+			// Bind to the VAO, as we may not have done yet.
+			indexBufferWrapper.Buffer.Bind();
 
 			palettes = new PaletteReference[map.MapSize.Width * map.MapSize.Height];
 			wr.PaletteInvalidated += UpdatePaletteIndices;
@@ -225,7 +229,7 @@ namespace OpenRA.Graphics
 			}
 
 			Game.Renderer.WorldSpriteRenderer.DrawVertexBuffer(
-				vertexBuffer, indexBufferWrapper.Buffer, indexRowStride * firstRow,
+				vertexBuffer, indexRowStride * firstRow,
 				indexRowStride * (lastRow - firstRow), sheets, BlendMode);
 
 			Game.Renderer.Flush();

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -106,7 +106,7 @@ namespace OpenRA
 			RgbaSpriteRenderer = new RgbaSpriteRenderer(SpriteRenderer);
 			RgbaColorRenderer = new RgbaColorRenderer(SpriteRenderer);
 
-			tempVertexBuffer = Context.CreateEmptyVertexBuffer<Vertex>(TempVertexBufferSize);
+			tempVertexBuffer = Context.CreateEmptyVertexBuffer<Vertex>(combinedBindings, TempVertexBufferSize);
 			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
 			bufferSnapshot = Context.CreateTexture();
 		}
@@ -363,14 +363,13 @@ namespace OpenRA
 		public void DrawQuadBatch(ref Vertex[] vertices, IShader shader, int numVertices)
 		{
 			tempVertexBuffer.SetData(ref vertices, numVertices);
-			DrawQuadBatch(tempVertexBuffer, quadIndexBuffer, shader, numVertices / 4 * 6, 0);
+			DrawQuadBatch(tempVertexBuffer, shader, numVertices / 4 * 6, 0);
 		}
 
-		public void DrawQuadBatch<T>(IVertexBuffer<T> vertices, IIndexBuffer indices, IShader shader, int numIndices, int start)
+		public void DrawQuadBatch<T>(IVertexBuffer<T> vertices, IShader shader, int numIndices, int start)
 			where T : struct
 		{
 			vertices.Bind();
-			indices.Bind();
 			shader.Bind();
 			Context.DrawElements(numIndices, start);
 			PerfHistory.Increment("batches", 1);
@@ -413,9 +412,9 @@ namespace OpenRA
 			return Context.CreateShader(bindings);
 		}
 
-		public IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic) where T : struct
+		public IVertexBuffer<T> CreateVertexBuffer<T>(IShaderBindings bindings, T[] data, bool dynamic) where T : struct
 		{
-			return Context.CreateVertexBuffer(data, dynamic);
+			return Context.CreateVertexBuffer(bindings, data, dynamic);
 		}
 
 		public void EnableScissor(Rectangle rect)

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.FileFormats;
+using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.Graphics
@@ -26,6 +27,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		readonly List<ModelVertex[]> vertices = [];
 		readonly Cache<(string, string), Voxel> voxels;
 		readonly IReadOnlyFileSystem fileSystem;
+		readonly ModelRenderer modelRenderer;
 		readonly int sheetSize;
 		IVertexBuffer<ModelVertex> vertexBuffer;
 		int totalVertexCount;
@@ -47,10 +49,11 @@ namespace OpenRA.Mods.Cnc.Graphics
 			return new SheetBuilder(SheetType.Indexed, Allocate);
 		}
 
-		public VoxelLoader(IReadOnlyFileSystem fileSystem, int sheetSize)
+		public VoxelLoader(IReadOnlyFileSystem fileSystem, int sheetSize, ModelRenderer modelRenderer)
 		{
 			this.fileSystem = fileSystem;
 			this.sheetSize = sheetSize;
+			this.modelRenderer = modelRenderer;
 			voxels = new Cache<(string, string), Voxel>(LoadFile);
 			vertices = [];
 			totalVertexCount = 0;
@@ -197,7 +200,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 		public void RefreshBuffer()
 		{
 			vertexBuffer?.Dispose();
-			vertexBuffer = Game.Renderer.CreateVertexBuffer(vertices.SelectMany(v => v).ToArray(), false);
+			vertexBuffer = Game.Renderer.CreateVertexBuffer(modelRenderer.Shader.Bindings, vertices.SelectMany(v => v).ToArray(), false);
 			cachedVertexCount = totalVertexCount;
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ChronoVortexRenderer.cs
@@ -34,7 +34,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		public ChronoVortexRenderer(Actor self)
 		{
 			renderer = Game.Renderer;
-			shader = renderer.CreateShader(new RenderPostProcessPassTexturedShaderBindings("vortex"));
+			var bindings = new RenderPostProcessPassTexturedShaderBindings("vortex");
+			shader = renderer.CreateShader(bindings);
 
 			vortexSheet = new Sheet(SheetType.BGRA, new Size(512, 512));
 			var vertices = new RenderPostProcessPassTexturedVertex[288];
@@ -71,7 +72,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				vertices[j++] = new RenderPostProcessPassTexturedVertex(-32, -32, tl.X, tl.Y);
 			}
 
-			vortexBuffer = renderer.CreateVertexBuffer(vertices, false);
+			vortexBuffer = renderer.CreateVertexBuffer(bindings, vertices, false);
 			vortexSheet.CommitBufferedData();
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ModelRenderer.cs
@@ -37,13 +37,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Render voxels")]
-	public class ModelRendererInfo : TraitInfo, Requires<IModelCacheInfo>
+	public class ModelRendererInfo : TraitInfo
 	{
 		public readonly int RenderBufferSize = 2048;
 		public override object Create(ActorInitializer init) { return new ModelRenderer(this, init.Self); }
 	}
 
-	public sealed class ModelRenderer : IDisposable, IRenderer, INotifyActorDisposing
+	public sealed class ModelRenderer : IDisposable, IRenderer, INotifyActorDisposing, INotifyCreated
 	{
 		// Static constants
 		static readonly ImmutableArray<float> ShadowDiffuse = [0, 0, 0];
@@ -55,9 +55,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		static readonly float[] ShadowScaleFlipMtx = Util.ScaleMatrix(2, -2, 2);
 		static readonly float[] GroundNormal = [0, 0, 1, 1];
 
+		public readonly IShader Shader;
 		readonly Renderer renderer;
-		readonly IShader shader;
-		public readonly IModelCache ModelCache;
+		public IModelCache ModelCache;
 
 		readonly Dictionary<Sheet, IFrameBuffer> mappedBuffers = [];
 		readonly Stack<KeyValuePair<Sheet, IFrameBuffer>> unmappedBuffers = [];
@@ -69,17 +69,15 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public void SetPalette(HardwarePalette palette)
 		{
-			shader.SetTexture("Palette", palette.Texture);
-			shader.SetVec("PaletteRows", palette.Height);
+			Shader.SetTexture("Palette", palette.Texture);
+			Shader.SetVec("PaletteRows", palette.Height);
 		}
 
 		public ModelRenderer(ModelRendererInfo info, Actor self)
 		{
 			renderer = Game.Renderer;
-			shader = renderer.CreateShader(new ModelShaderBindings());
+			Shader = renderer.CreateShader(new ModelShaderBindings());
 			renderer.WorldRenderers = renderer.WorldRenderers.Append(this).ToArray();
-
-			ModelCache = self.Trait<IModelCache>();
 
 			sheetSize = info.RenderBufferSize;
 			var a = 2f / sheetSize;
@@ -91,7 +89,12 @@ namespace OpenRA.Mods.Cnc.Traits
 				-1, 1, 0, 1
 			};
 
-			shader.SetMatrix("View", view);
+			Shader.SetMatrix("View", view);
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			ModelCache = self.Trait<IModelCache>();
 		}
 
 		public ModelRenderProxy RenderAsync(
@@ -286,15 +289,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			ImmutableArray<float> ambientLight, ImmutableArray<float> diffuseLight,
 			float colorPaletteTextureIndex, float normalsPaletteTextureIndex)
 		{
-			shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
-			shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
-			shader.SetMatrix("TransformMatrix", t);
-			shader.SetVec("LightDirection", lightDirection, 4);
-			shader.SetVec("AmbientLight", ambientLight.AsMemory(), 3);
-			shader.SetVec("DiffuseLight", diffuseLight.AsMemory(), 3);
+			Shader.SetTexture("DiffuseTexture", renderData.Sheet.GetTexture());
+			Shader.SetVec("Palettes", colorPaletteTextureIndex, normalsPaletteTextureIndex);
+			Shader.SetMatrix("TransformMatrix", t);
+			Shader.SetVec("LightDirection", lightDirection, 4);
+			Shader.SetVec("AmbientLight", ambientLight.AsMemory(), 3);
+			Shader.SetVec("DiffuseLight", diffuseLight.AsMemory(), 3);
 
-			shader.PrepareRender();
-			renderer.DrawBatch(cache.VertexBuffer, shader, renderData.Start, renderData.Count, PrimitiveType.TriangleList);
+			Shader.PrepareRender();
+			renderer.DrawBatch(cache.VertexBuffer, Shader, renderData.Start, renderData.Count, PrimitiveType.TriangleList);
 		}
 
 		public void BeginFrame()

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelCache.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	[TraitLocation(SystemActors.World | SystemActors.EditorWorld)]
 	[Desc("Loads voxel models.")]
-	public sealed class VoxelCacheInfo : TraitInfo, IModelCacheInfo
+	public sealed class VoxelCacheInfo : TraitInfo, IModelCacheInfo, Requires<ModelRendererInfo>
 	{
 		public readonly int SheetSize = 2048;
 		public override object Create(ActorInitializer init) { return new VoxelCache(this, init.Self); }
@@ -34,7 +34,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		public VoxelCache(VoxelCacheInfo info, Actor self)
 		{
 			var map = self.World.Map;
-			loader = new VoxelLoader(map, info.SheetSize);
+			var modelRenderer = self.Trait<ModelRenderer>();
+			loader = new VoxelLoader(map, info.SheetSize, modelRenderer);
 			foreach (var kv in map.Rules.ModelSequences)
 			{
 				Game.ModData.LoadScreen.Display();

--- a/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/RenderPostProcessPassBase.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.type = type;
 			renderer = Game.Renderer;
-			shader = renderer.CreateShader(new RenderPostProcessPassShaderBindings(name));
+			var bindings = new RenderPostProcessPassShaderBindings(name);
+			shader = renderer.CreateShader(bindings);
 			var vertices = new RenderPostProcessPassVertex[]
 			{
 				new(-1, -1),
@@ -36,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 				new(-1, -1)
 			};
 
-			buffer = renderer.CreateVertexBuffer(vertices, false);
+			buffer = renderer.CreateVertexBuffer(bindings, vertices, false);
 		}
 
 		PostProcessPassType IRenderPostProcessPass.Type => type;

--- a/OpenRA.Mods.D2k/Traits/World/SonicBlastRenderer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/SonicBlastRenderer.cs
@@ -41,7 +41,8 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			Info = info;
 			renderer = Game.Renderer;
-			shader = renderer.CreateShader(new RenderPostProcessPassTexturedShaderBindings("sonic"));
+			var bindings = new RenderPostProcessPassTexturedShaderBindings("sonic");
+			shader = renderer.CreateShader(bindings);
 
 			var r = 0.5f * info.Size;
 			shader.SetVec("Scale", r * (1f / info.Zoom - 1));
@@ -55,7 +56,7 @@ namespace OpenRA.Mods.D2k.Traits
 				new(-r, -r, -1, -1)
 			};
 
-			buffer = renderer.CreateVertexBuffer(vertices, false);
+			buffer = renderer.CreateVertexBuffer(bindings, vertices, false);
 		}
 
 		public void Draw(float3 pos)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -368,6 +368,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void BindVertexArray(uint buffer);
 		public static BindVertexArray glBindVertexArray { get; private set; }
 
+		public delegate void DeleteVertexArrays(int n, ref uint buffers);
+		public static DeleteVertexArrays glDeleteVertexArrays { get; private set; }
+
 		public delegate void BufferData(int target, IntPtr size, IntPtr data, int usage);
 		public static BufferData glBufferData { get; private set; }
 
@@ -634,6 +637,7 @@ namespace OpenRA.Platforms.Default
 
 				glGenVertexArrays = Bind<GenVertexArrays>("glGenVertexArrays");
 				glBindVertexArray = Bind<BindVertexArray>("glBindVertexArray");
+				glDeleteVertexArrays = Bind<DeleteVertexArrays>("glDeleteVertexArrays");
 				glGenFramebuffers = Bind<GenFramebuffers>("glGenFramebuffers");
 				glBindFramebuffer = Bind<BindFramebuffer>("glBindFramebuffer");
 				glFramebufferTexture2D = Bind<FramebufferTexture2D>("glFramebufferTexture2D");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -42,23 +42,18 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.Initialize();
 			OpenGL.CheckGLError();
-
-			OpenGL.glGenVertexArrays(1, out var vao);
-			OpenGL.CheckGLError();
-			OpenGL.glBindVertexArray(vao);
-			OpenGL.CheckGLError();
 		}
 
-		public IVertexBuffer<T> CreateEmptyVertexBuffer<T>(int size) where T : struct
+		public IVertexBuffer<T> CreateEmptyVertexBuffer<T>(IShaderBindings bindings, int size) where T : struct
 		{
 			VerifyThreadAffinity();
-			return new VertexBuffer<T>(size);
+			return new VertexBuffer<T>(bindings, size);
 		}
 
-		public IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic = true) where T : struct
+		public IVertexBuffer<T> CreateVertexBuffer<T>(IShaderBindings bindings, T[] data, bool dynamic = true) where T : struct
 		{
 			VerifyThreadAffinity();
-			return new VertexBuffer<T>(data, dynamic);
+			return new VertexBuffer<T>(bindings, data, dynamic);
 		}
 
 		public IIndexBuffer CreateIndexBuffer(uint[] indices)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -22,6 +22,10 @@ namespace OpenRA.Platforms.Default
 
 		public string GLVersion => OpenGL.Version;
 
+		// Shadowing state.
+		internal static uint ActiveVAO;
+		internal static uint ActiveProgram;
+
 		public Sdl2GraphicsContext(Sdl2PlatformWindow window)
 		{
 			this.window = window;

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -10,20 +10,20 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using OpenRA.Graphics;
 
 namespace OpenRA.Platforms.Default
 {
 	sealed class Shader : ThreadAffine, IShader
 	{
-		readonly Dictionary<string, int> samplers = [];
-		readonly Dictionary<string, int> uniformCache = [];
+		public IShaderBindings Bindings { get; }
+		readonly FrozenDictionary<string, int> samplers;
+		readonly FrozenDictionary<string, int> uniformCache;
 		readonly Dictionary<int, ITexture> textures = [];
 		readonly Queue<int> unbindTextures = [];
-		readonly IShaderBindings bindings;
 		readonly uint program;
 
 		static uint CompileShaderObject(int type, string code, string name)
@@ -60,18 +60,25 @@ namespace OpenRA.Platforms.Default
 
 		public Shader(IShaderBindings bindings)
 		{
+			Bindings = bindings;
+
 			var vertexShader = CompileShaderObject(OpenGL.GL_VERTEX_SHADER, bindings.VertexShaderCode, bindings.VertexShaderName);
 			var fragmentShader = CompileShaderObject(OpenGL.GL_FRAGMENT_SHADER, bindings.FragmentShaderCode, bindings.FragmentShaderName);
 
 			// Assemble program
 			program = OpenGL.glCreateProgram();
 			OpenGL.CheckGLError();
+			(uniformCache, samplers) = SetupProgram(program, vertexShader, fragmentShader, bindings);
+		}
 
-			this.bindings = bindings;
+		static (FrozenDictionary<string, int> UniformCache, FrozenDictionary<string, int> Samplers) SetupProgram(
+			uint program,
+			uint vertexShader,
+			uint fragmentShader,
+			IShaderBindings bindings)
+		{
 			for (ushort i = 0; i < bindings.Attributes.Length; i++)
 			{
-				OpenGL.glEnableVertexAttribArray(i);
-				OpenGL.CheckGLError();
 				OpenGL.glBindAttribLocation(program, i, bindings.Attributes[i].Name);
 				OpenGL.CheckGLError();
 			}
@@ -109,6 +116,8 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 
 			var nextTexUnit = 0;
+			var uniformCache = new Dictionary<string, int>();
+			var samplers = new Dictionary<string, int>();
 			for (var i = 0; i < numUniforms; i++)
 			{
 				var sb = new StringBuilder(128);
@@ -129,19 +138,16 @@ namespace OpenRA.Platforms.Default
 					nextTexUnit++;
 				}
 			}
+
+			return (uniformCache.ToFrozenDictionary(), samplers.ToFrozenDictionary());
 		}
 
 		public void Bind()
 		{
-			for (ushort i = 0; i < bindings.Attributes.Length; i++)
-			{
-				var attribute = bindings.Attributes[i];
-				if (attribute.Type == ShaderVertexAttributeType.Float)
-					OpenGL.glVertexAttribPointer(i, attribute.Components, OpenGL.GL_FLOAT, false, bindings.Stride, new IntPtr(attribute.Offset));
-				else
-					OpenGL.glVertexAttribIPointer(i, attribute.Components, (int)attribute.Type, bindings.Stride, new IntPtr(attribute.Offset));
-				OpenGL.CheckGLError();
-			}
+			VerifyThreadAffinity();
+
+			OpenGL.glUseProgram(program);
+			OpenGL.CheckGLError();
 		}
 
 		public void PrepareRender()

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.glUseProgram(program);
 			OpenGL.CheckGLError();
+			Sdl2GraphicsContext.ActiveProgram = program;
 
 			OpenGL.glGetProgramiv(program, OpenGL.GL_ACTIVE_UNIFORMS, out var numUniforms);
 
@@ -146,15 +147,17 @@ namespace OpenRA.Platforms.Default
 		{
 			VerifyThreadAffinity();
 
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			if (Sdl2GraphicsContext.ActiveProgram != program)
+			{
+				OpenGL.glUseProgram(program);
+				OpenGL.CheckGLError();
+				Sdl2GraphicsContext.ActiveProgram = program;
+			}
 		}
 
 		public void PrepareRender()
 		{
-			VerifyThreadAffinity();
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			Bind();
 
 			// bind the textures
 			foreach (var kv in textures)
@@ -189,43 +192,40 @@ namespace OpenRA.Platforms.Default
 
 		public void SetBool(string name, bool value)
 		{
-			VerifyThreadAffinity();
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			Bind();
+
 			OpenGL.glUniform1i(uniformCache[name], value ? 1 : 0);
 			OpenGL.CheckGLError();
 		}
 
 		public void SetVec(string name, float x)
 		{
-			VerifyThreadAffinity();
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			Bind();
+
 			OpenGL.glUniform1f(uniformCache[name], x);
 			OpenGL.CheckGLError();
 		}
 
 		public void SetVec(string name, float x, float y)
 		{
-			VerifyThreadAffinity();
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			Bind();
+
 			OpenGL.glUniform2f(uniformCache[name], x, y);
 			OpenGL.CheckGLError();
 		}
 
 		public void SetVec(string name, float x, float y, float z)
 		{
-			VerifyThreadAffinity();
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
+			Bind();
+
 			OpenGL.glUniform3f(uniformCache[name], x, y, z);
 			OpenGL.CheckGLError();
 		}
 
 		public void SetVec(string name, ReadOnlyMemory<float> vec, int length)
 		{
-			VerifyThreadAffinity();
+			Bind();
+
 			var param = uniformCache[name];
 			unsafe
 			{
@@ -248,12 +248,10 @@ namespace OpenRA.Platforms.Default
 
 		public void SetMatrix(string name, float[] mtx)
 		{
-			VerifyThreadAffinity();
+			Bind();
+
 			if (mtx.Length != 16)
 				throw new InvalidDataException("Invalid 4x4 matrix");
-
-			OpenGL.glUseProgram(program);
-			OpenGL.CheckGLError();
 
 			unsafe
 			{

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -100,22 +100,22 @@ namespace OpenRA.Platforms.Default
 					getCreateEmptyVertexBuffer =
 						tuple =>
 						{
-							(object t, var type) = ((int, Type))tuple;
+							(var bindings, object t, var type) = ((IShaderBindings, int, Type))tuple;
 							var vertexBuffer = context.GetType()
 								.GetMethod(nameof(CreateEmptyVertexBuffer))
 								.MakeGenericMethod(type)
-								.Invoke(context, [t]);
+								.Invoke(context, [bindings, t]);
 
 							return typeof(ThreadedVertexBuffer<>).MakeGenericType(type).GetConstructors()[0].Invoke([this, vertexBuffer]);
 						};
 					getCreateVertexBuffer =
 						tuple =>
 						{
-							var (array, dynamic, type) = ((object, bool, Type))tuple;
+							var (bindings, array, dynamic, type) = ((IShaderBindings, object, bool, Type))tuple;
 							var vertexBuffer = context.GetType()
 								.GetMethod(nameof(CreateVertexBuffer))
 								.MakeGenericMethod(type)
-								.Invoke(context, [array, dynamic]);
+								.Invoke(context, [bindings, array, dynamic]);
 							return typeof(ThreadedVertexBuffer<>).MakeGenericType(type).GetConstructors()[0].Invoke([this, vertexBuffer]);
 						};
 					getCreateIndexBuffer = indices => new ThreadedIndexBuffer(this, context.CreateIndexBuffer((uint[])indices));
@@ -441,14 +441,14 @@ namespace OpenRA.Platforms.Default
 			return Send(getCreateTexture);
 		}
 
-		public IVertexBuffer<T> CreateEmptyVertexBuffer<T>(int size) where T : struct
+		public IVertexBuffer<T> CreateEmptyVertexBuffer<T>(IShaderBindings bindings, int size) where T : struct
 		{
-			return (IVertexBuffer<T>)Send(getCreateEmptyVertexBuffer, (size, typeof(T)));
+			return (IVertexBuffer<T>)Send(getCreateEmptyVertexBuffer, (bindings, size, typeof(T)));
 		}
 
-		public IVertexBuffer<T> CreateVertexBuffer<T>(T[] data, bool dynamic = true) where T : struct
+		public IVertexBuffer<T> CreateVertexBuffer<T>(IShaderBindings bindings, T[] data, bool dynamic = true) where T : struct
 		{
-			return (IVertexBuffer<T>)Send(getCreateVertexBuffer, ((object)data, dynamic, typeof(T)));
+			return (IVertexBuffer<T>)Send(getCreateVertexBuffer, (bindings, (object)data, dynamic, typeof(T)));
 		}
 
 		public IIndexBuffer CreateIndexBuffer(uint[] indices)
@@ -760,6 +760,7 @@ namespace OpenRA.Platforms.Default
 
 	sealed class ThreadedShader : IShader
 	{
+		public IShaderBindings Bindings { get; }
 		readonly ThreadedGraphicsContext device;
 		readonly Action prepareRender;
 		readonly Action<object> setBool;
@@ -774,6 +775,7 @@ namespace OpenRA.Platforms.Default
 		public ThreadedShader(ThreadedGraphicsContext device, IShader shader)
 		{
 			this.device = device;
+			Bindings = shader.Bindings;
 			bind = shader.Bind;
 			prepareRender = shader.PrepareRender;
 			setBool = tuple => { var t = ((string, bool))tuple; shader.SetBool(t.Item1, t.Item2); };

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using OpenRA.Graphics;
 
 namespace OpenRA.Platforms.Default
 {
@@ -19,13 +20,20 @@ namespace OpenRA.Platforms.Default
 	{
 		static readonly int VertexSize = Marshal.SizeOf<T>();
 		uint buffer;
+		uint vao;
 		bool disposed;
 
-		public VertexBuffer(int size)
+		public VertexBuffer(IShaderBindings bindings, int size)
 		{
+			OpenGL.glGenVertexArrays(1, out vao);
+			OpenGL.CheckGLError();
+			OpenGL.glBindVertexArray(vao);
+			OpenGL.CheckGLError();
+
 			OpenGL.glGenBuffers(1, out buffer);
 			OpenGL.CheckGLError();
-			Bind();
+			OpenGL.glBindBuffer(OpenGL.GL_ARRAY_BUFFER, buffer);
+			OpenGL.CheckGLError();
 
 			// Generates a buffer with uninitialized memory.
 			OpenGL.glBufferData(OpenGL.GL_ARRAY_BUFFER,
@@ -53,13 +61,33 @@ namespace OpenRA.Platforms.Default
 			{
 				ptr.Free();
 			}
+
+			var attributes = bindings.Attributes;
+			for (ushort i = 0; i < attributes.Length; i++)
+			{
+				var attribute = attributes[i];
+				OpenGL.glEnableVertexAttribArray(i);
+
+				if (attribute.Type == ShaderVertexAttributeType.Float)
+					OpenGL.glVertexAttribPointer(i, attribute.Components, OpenGL.GL_FLOAT, false, bindings.Stride, new IntPtr(attribute.Offset));
+				else
+					OpenGL.glVertexAttribIPointer(i, attribute.Components, (int)attribute.Type, bindings.Stride, new IntPtr(attribute.Offset));
+			}
+
+			OpenGL.CheckGLError();
 		}
 
-		public VertexBuffer(T[] data, bool dynamic = true)
+		public VertexBuffer(IShaderBindings bindings, T[] data, bool dynamic = true)
 		{
+			OpenGL.glGenVertexArrays(1, out vao);
+			OpenGL.CheckGLError();
+			OpenGL.glBindVertexArray(vao);
+			OpenGL.CheckGLError();
+
 			OpenGL.glGenBuffers(1, out buffer);
 			OpenGL.CheckGLError();
-			Bind();
+			OpenGL.glBindBuffer(OpenGL.GL_ARRAY_BUFFER, buffer);
+			OpenGL.CheckGLError();
 
 			var ptr = GCHandle.Alloc(data, GCHandleType.Pinned);
 			try
@@ -72,6 +100,20 @@ namespace OpenRA.Platforms.Default
 			finally
 			{
 				ptr.Free();
+			}
+
+			OpenGL.CheckGLError();
+
+			var attributes = bindings.Attributes;
+			for (ushort i = 0; i < attributes.Length; i++)
+			{
+				var attribute = attributes[i];
+				OpenGL.glEnableVertexAttribArray(i);
+
+				if (attribute.Type == ShaderVertexAttributeType.Float)
+					OpenGL.glVertexAttribPointer(i, attribute.Components, OpenGL.GL_FLOAT, false, bindings.Stride, new IntPtr(attribute.Offset));
+				else
+					OpenGL.glVertexAttribIPointer(i, attribute.Components, (int)attribute.Type, bindings.Stride, new IntPtr(attribute.Offset));
 			}
 
 			OpenGL.CheckGLError();
@@ -90,6 +132,9 @@ namespace OpenRA.Platforms.Default
 		public void SetData(T[] data, int offset, int start, int length)
 		{
 			Bind();
+
+			OpenGL.glBindBuffer(OpenGL.GL_ARRAY_BUFFER, buffer);
+			OpenGL.CheckGLError();
 
 			var ptr = GCHandle.Alloc(data, GCHandleType.Pinned);
 			try
@@ -110,15 +155,20 @@ namespace OpenRA.Platforms.Default
 		public void Bind()
 		{
 			VerifyThreadAffinity();
-			OpenGL.glBindBuffer(OpenGL.GL_ARRAY_BUFFER, buffer);
+			OpenGL.glBindVertexArray(vao);
+			OpenGL.CheckGLError();
 		}
 
 		public void Dispose()
 		{
 			if (disposed)
 				return;
+
 			disposed = true;
 			OpenGL.glDeleteBuffers(1, ref buffer);
+			OpenGL.CheckGLError();
+
+			OpenGL.glDeleteVertexArrays(1, ref vao);
 			OpenGL.CheckGLError();
 		}
 	}

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Platforms.Default
 			OpenGL.glGenVertexArrays(1, out vao);
 			OpenGL.CheckGLError();
 			OpenGL.glBindVertexArray(vao);
+			Sdl2GraphicsContext.ActiveVAO = vao;
 			OpenGL.CheckGLError();
 
 			OpenGL.glGenBuffers(1, out buffer);
@@ -82,6 +83,7 @@ namespace OpenRA.Platforms.Default
 			OpenGL.glGenVertexArrays(1, out vao);
 			OpenGL.CheckGLError();
 			OpenGL.glBindVertexArray(vao);
+			Sdl2GraphicsContext.ActiveVAO = vao;
 			OpenGL.CheckGLError();
 
 			OpenGL.glGenBuffers(1, out buffer);
@@ -155,7 +157,12 @@ namespace OpenRA.Platforms.Default
 		public void Bind()
 		{
 			VerifyThreadAffinity();
-			OpenGL.glBindVertexArray(vao);
+			if (Sdl2GraphicsContext.ActiveVAO != vao)
+			{
+				OpenGL.glBindVertexArray(vao);
+				Sdl2GraphicsContext.ActiveVAO = vao;
+			}
+
 			OpenGL.CheckGLError();
 		}
 


### PR DESCRIPTION
Transition from Global VAO, to VAO per buffer.

Vertex Array Object holds a Vertex Buffer, Index Buffer and Vertex attribute offsets. By binding to a VAO, you effectivelly bind to all 3. But because we use 1 global VAO, we were constantly forced to rebind everything on any draw, and binding attributes is especially not cheap.

With this PR on creating a `VertexBuffer` we immediately bind attributes and make sure we bind the IndexBuffer if it exists. We are also shadowing which VAO and shader is bound, so we don't re-bind unnecesarily.

In RA render loop on shellmap goes from average 2.23 -> 2.13 ms, so about 5% improvement.
In TS render loop on shellmap from average 2.69 -> 2.51 ms, so about 9% improvement.

In the future if we shadow the active blendmodes, textures and deduplicate uniforms we could get much larger gains. As well as unlocking naked draw calls, where there's nothing in the command buffer except for the draw call.