### PR TITLE
Allow to batch render interleaved blend modes

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -13,61 +13,98 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 namespace OpenRA.Graphics
 {
 	public class SpriteRenderer : Renderer.IBatchRenderer
 	{
+		struct BlendSpan
+		{
+			public readonly int Start;
+			public int Length;
+			public readonly BlendMode Mode;
+
+			public BlendSpan(int start, int length, BlendMode mode)
+			{
+				Start = start;
+				Length = length;
+				Mode = mode;
+			}
+		}
+
 		public const int SheetCount = 8;
 		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
 		static readonly int UintSize = Marshal.SizeOf<uint>();
 
 		readonly Renderer renderer;
 		readonly IShader shader;
+		readonly IVertexBuffer<Vertex> vertexBuffer;
+		readonly IIndexBuffer indexBuffer;
 
 		Vertex[] vertices;
 		readonly Sheet[] sheets = new Sheet[SheetCount];
 
-		BlendMode currentBlend = BlendMode.Alpha;
+		readonly List<BlendSpan> blendSpans = [];
 		int vertexCount = 0;
 		int sheetCount = 0;
 
-		public SpriteRenderer(Renderer renderer, IShader shader)
+		public SpriteRenderer(Renderer renderer, IVertexBuffer<Vertex> tempVertexBuffer, IIndexBuffer tempIndexBuffer, IShader shader)
 		{
 			this.renderer = renderer;
 			this.shader = shader;
+			vertexBuffer = tempVertexBuffer;
+			indexBuffer = tempIndexBuffer;
 			vertices = renderer.Context.CreateVertices<Vertex>(renderer.TempVertexBufferSize);
 		}
 
 		public void Flush()
 		{
-			if (vertexCount > 0)
+			if (vertexCount <= 0)
+				return;
+
+			for (var i = 0; i < sheetCount; i++)
+				shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
+
+			shader.PrepareRender();
+			vertexBuffer.SetData(ref vertices, vertexCount);
+			vertexBuffer.Bind();
+			indexBuffer.Bind();
+			shader.Bind();
+
+			// PERF: this allows us to batch render sprites with interleaved blend modes
+			// without expensive binding and data writing between draw calls.
+			foreach (var span in blendSpans)
 			{
-				for (var i = 0; i < sheetCount; i++)
-				{
-					shader.SetTexture(SheetIndexToTextureName[i], sheets[i].GetTexture());
-					sheets[i] = null;
-				}
+				if (span.Length <= 0)
+					continue;
 
-				renderer.Context.SetBlendMode(currentBlend);
-				shader.PrepareRender();
-
-				renderer.DrawQuadBatch(ref vertices, shader, vertexCount);
-				renderer.Context.SetBlendMode(BlendMode.None);
-
-				vertexCount = 0;
-				sheetCount = 0;
+				renderer.Context.SetBlendMode(span.Mode);
+				renderer.Context.DrawElements(span.Length / 4 * 6, span.Start * 6);
 			}
+
+			PerfHistory.Increment("batches", 1);
+			blendSpans.Clear();
+			Array.Clear(sheets, 0, SheetCount);
+			vertexCount = 0;
+			sheetCount = 0;
 		}
 
 		int2 SetRenderStateForSprite(Sprite s)
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (s.BlendMode != currentBlend || vertexCount + 4 > renderer.TempVertexBufferSize)
+			if (vertexCount + 4 > renderer.TempVertexBufferSize)
 				Flush();
 
-			currentBlend = s.BlendMode;
+			if (blendSpans.Count == 0 || blendSpans[^1].Mode != s.BlendMode)
+				blendSpans.Add(new BlendSpan(vertexCount, 4, s.BlendMode));
+			else
+			{
+				// PERF: modify in-place.
+				var span = CollectionsMarshal.AsSpan(blendSpans);
+				span[^1].Length += 4;
+			}
 
 			// Check if the sheet (or secondary data sheet) have already been mapped
 			var sheet = s.Sheet;
@@ -201,10 +238,17 @@ namespace OpenRA.Graphics
 		{
 			renderer.CurrentBatchRenderer = this;
 
-			if (currentBlend != blendMode || vertexCount + 4 > renderer.TempVertexBufferSize)
+			if (vertexCount + 4 > renderer.TempVertexBufferSize)
 				Flush();
 
-			currentBlend = blendMode;
+			if (blendSpans.Count == 0 || blendSpans[^1].Mode != blendMode)
+				blendSpans.Add(new BlendSpan(vertexCount, 4, blendMode));
+			else
+			{
+				// PERF: modify in-place.
+				var span = CollectionsMarshal.AsSpan(blendSpans);
+				span[^1].Length += 4;
+			}
 
 			Array.Copy(v, 0, vertices, vertexCount, v.Length);
 			vertexCount += 4;

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -98,16 +98,17 @@ namespace OpenRA
 
 			Context = Window.Context;
 
+			tempVertexBuffer = Context.CreateEmptyVertexBuffer<Vertex>(TempVertexBufferSize);
+			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
+
 			var combinedBindings = new CombinedShaderBindings();
-			WorldSpriteRenderer = new SpriteRenderer(this, Context.CreateShader(combinedBindings));
+			WorldSpriteRenderer = new SpriteRenderer(this, tempVertexBuffer, quadIndexBuffer, Context.CreateShader(combinedBindings));
 			WorldRgbaSpriteRenderer = new RgbaSpriteRenderer(WorldSpriteRenderer);
 			WorldRgbaColorRenderer = new RgbaColorRenderer(WorldSpriteRenderer);
-			SpriteRenderer = new SpriteRenderer(this, Context.CreateShader(combinedBindings));
+			SpriteRenderer = new SpriteRenderer(this, tempVertexBuffer, quadIndexBuffer, Context.CreateShader(combinedBindings));
 			RgbaSpriteRenderer = new RgbaSpriteRenderer(SpriteRenderer);
 			RgbaColorRenderer = new RgbaColorRenderer(SpriteRenderer);
 
-			tempVertexBuffer = Context.CreateEmptyVertexBuffer<Vertex>(TempVertexBufferSize);
-			quadIndexBuffer = Context.CreateIndexBuffer(Util.CreateQuadIndices(TempIndexBufferSize / 6));
 			bufferSnapshot = Context.CreateTexture();
 		}
 
@@ -358,12 +359,6 @@ namespace OpenRA
 			shader.Bind();
 			Context.DrawPrimitives(type, firstVertex, numVertices);
 			PerfHistory.Increment("batches", 1);
-		}
-
-		public void DrawQuadBatch(ref Vertex[] vertices, IShader shader, int numVertices)
-		{
-			tempVertexBuffer.SetData(ref vertices, numVertices);
-			DrawQuadBatch(tempVertexBuffer, quadIndexBuffer, shader, numVertices / 4 * 6, 0);
 		}
 
 		public void DrawQuadBatch<T>(IVertexBuffer<T> vertices, IIndexBuffer indices, IShader shader, int numIndices, int start)


### PR DESCRIPTION
Now instead of immediatelly flushing on sprite being defined by different blendmode, we queue up several draw calls.

This allows us to set the entire vertex buffer and bind systems once. With everything setup, we can draw with minimal overheads, the draw call itself can easilly be 10x faster. Setting blend mode itself appears to be cheap.

As Tiberian Sun and D2K use blendmodes more liberaly, it is likelly to affect their performance. The effect  most noticeable in cases where you have interleaving sprites with altering blendmodes.