### PR TITLE
Reduce spawn resource bias for RA and CnC RMGs

### DIFF
--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -39,7 +39,7 @@
 						MinimumSpawnRadius: 5
 						SpawnResourceSpawns: 3
 						SpawnReservation: 16
-						SpawnResourceBias: 1050
+						SpawnResourceBias: 500
 						ResourcesPerPlayer: 50000
 						OreUniformity: 500
 						OreClumpiness: 1

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -43,7 +43,7 @@
 						MinimumSpawnRadius: 5
 						SpawnResourceSpawns: 3
 						SpawnReservation: 16
-						SpawnResourceBias: 1150
+						SpawnResourceBias: 500
 						ResourcesPerPlayer: 50000
 						OreUniformity: 250
 						OreClumpiness: 2


### PR DESCRIPTION
Config-only change that reduces the strength at which starting resources are biased towards player spawns in the RA and CnC map generator. The previous config frequently resulted in maps where spawn resource patches were excessively large, which also leached away from the resource budget allocated towards expansions.

For typical generator settings, this now results in spawn resource patch sizes that more closely resemble official or competitive maps. The map generator may still have a tendency to overgrow spawn patch resources on average and with greater variability, but the disparity is now far less extreme.

Comparison for RA of Original config, Proposed config, and RAGL map spawn patch total value.:
<img width="2049" height="1155" alt="spawn ore analysis" src="https://github.com/user-attachments/assets/0dd434b6-19dc-4c78-abe6-453c043add4b" />
(RA TEMPERAT tileset, 96x96, Seeds 0 to 24 inclusive, other settings default. RAGL pool excludes Selection Bias, which was a generated map.)