### PR TITLE
Show default stance for bot units in editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -124,7 +124,9 @@ namespace OpenRA.Mods.Common.Traits
 				(actor, _) =>
 				{
 					var init = actor.GetInitOrDefault<StanceInit>(this);
-					var stance = init?.Value ?? InitialStance;
+					var botOwned = actor.Owner.Bot != null || !actor.Owner.Playable;
+					var stance = init?.Value;
+					stance ??= botOwned ? InitialStanceAI : InitialStance;
 					return stances[(int)stance];
 				},
 				(actor, value) => actor.ReplaceInit(new StanceInit(this, (UnitStance)stances.IndexOf(value))));


### PR DESCRIPTION
In the map editor, units with AutoTarget show their assigned stance. If a particular unit has no stance assigned, InitialStance is always shown. This PR should instead show InitialStanceAI when appropriate, better matching how stances initialize.

https://github.com/user-attachments/assets/c4c5d3a9-a661-4d90-8f80-5ff9ab441c1f

https://github.com/OpenRA/OpenRA/issues/22372 is related but may not be fully addressed by this.