### PR TITLE
Mission AI - stop hunt function after some time inside defence perimenter routine

### DIFF
--- a/mods/d2k/scripts/campaign.lua
+++ b/mods/d2k/scripts/campaign.lua
@@ -509,7 +509,9 @@ FindTargetsInArea = function(owner, unit)
 
 		if #enemies > 0 then
 			unit.Hunt()
-			unit.Wait(10)
+			Trigger.AfterDelay(420, function()
+				if not unit.IsDead then unit.Stop() end
+			end)
 		else
 			unit.Wait(Utils.RandomInteger(200 , 500))
 			if DefencePerimeter[owner] ~= nil then


### PR DESCRIPTION
Prevent rare case when AI trigger `checkarea ` inside player base while on defense routine.
Also prevents two AI nonstop attacking each other. ( Will be relevant in upcoming ordos missions. )
