### PR TITLE
Make beacon cursor configurable in PlaceBeacon trait

### DIFF
--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -11,16 +11,22 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
 	public class BeaconOrderGenerator : OrderGenerator
 	{
+		readonly string cursor;
+
 		protected override MouseActionType ActionType => MouseActionType.PlaceBuilding;
 
 		public BeaconOrderGenerator(World world)
-			: base(world) { }
+			: base(world)
+		{
+			cursor = world.LocalPlayer.PlayerActor.Info.TraitInfo<PlaceBeaconInfo>().BeaconCursor;
+		}
 
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
@@ -33,7 +39,8 @@ namespace OpenRA.Mods.Common.Orders
 		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			return "ability"; // TODO: [CursorReference]
+			// Always return the beacon cursor as the command cannot be blocked.
+			return cursor;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(nameof(BeaconImage))]
 		public readonly string CircleSequence = "circles";
 
+		[CursorReference]
+		public readonly string BeaconCursor = "ability";
+
 		public override object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
 	}
 


### PR DESCRIPTION
As title says. Originally created by @towelcoded in #21494.

Now that `OrderGenerators` have access to `World` in their constructor (#22224), this change has become much simpler.

Closes #20850