### PR TITLE
Allow spectators to place beacons and draw waypoint paths

### DIFF
--- a/OpenRA.Game/Effects/IEffect.cs
+++ b/OpenRA.Game/Effects/IEffect.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Primitives;
 
 namespace OpenRA.Effects
 {
@@ -25,4 +26,10 @@ namespace OpenRA.Effects
 
 	public interface IEffectAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr); }
 	public interface IEffectAnnotation { IEnumerable<IRenderable> RenderAnnotation(WorldRenderer wr); }
+
+	// Effect that can provide a tooltip when the cursor is near it.
+	public interface IEffectWithTooltip { bool IsNearCursor(WPos cursorWorldPos); string GetTooltip(); }
+
+	// Effect that contributes line segments to the radar/minimap overlay.
+	public interface IRadarEffect { IEnumerable<(WPos From, WPos To, Color Color)> RadarLineSegments { get; } }
 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -12,6 +12,7 @@
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Server;
 using OpenRA.Traits;
 
@@ -394,6 +395,41 @@ namespace OpenRA.Network
 						preview.UpdateFromGenerationArgs(args);
 						preview.Generate();
 					}
+
+					break;
+				}
+
+				case "SpectatorBeacon":
+				{
+					if (world == null)
+						break;
+
+					var beaconParts = order.TargetString.Split('|');
+					var position = FieldLoader.GetValue<WPos>("SpectatorBeacon", beaconParts[0]);
+					var beaconColor = beaconParts.Length > 1 && Color.TryParse(beaconParts[1], out var parsedBeaconColor)
+						? parsedBeaconColor : Color.White;
+					var spectatorBeaconName = orderManager.LobbyInfo.ClientWithIndex(clientId)?.Name ?? "";
+					foreach (var t in world.WorldActor.TraitsImplementing<INotifySpectatorBeacon>())
+						t.SpectatorBeaconPlaced(world, position, beaconColor, spectatorBeaconName);
+
+					break;
+				}
+
+				case "SpectatorWaypoint":
+				{
+					if (world == null)
+						break;
+
+					var waypointParts = order.TargetString.Split('|');
+					var waypointColor = Color.TryParse(waypointParts[0], out var parsedWaypointColor)
+						? parsedWaypointColor : Color.White;
+					var points = waypointParts.Skip(1)
+						.Select(s => FieldLoader.GetValue<WPos>("SpectatorWaypoint", s))
+						.ToArray();
+
+					var spectatorName = orderManager.LobbyInfo.ClientWithIndex(clientId)?.Name ?? "";
+					foreach (var t in world.WorldActor.TraitsImplementing<INotifySpectatorWaypoint>())
+						t.SpectatorWaypointDrawn(world, points, waypointColor, spectatorName);
 
 					break;
 				}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -374,6 +374,8 @@ namespace OpenRA.Traits
 	public interface INotifyGameLoading { void GameLoading(World w); }
 	public interface INotifyGameLoaded { void GameLoaded(World w); }
 	public interface INotifyGameSaved { void GameSaved(World w, bool isAutoSave); }
+	public interface INotifySpectatorBeacon { void SpectatorBeaconPlaced(World w, WPos position, Color color, string spectatorName); }
+	public interface INotifySpectatorWaypoint { void SpectatorWaypointDrawn(World w, IReadOnlyList<WPos> waypoints, Color color, string spectatorName); }
 
 	public interface IGameSaveTraitData
 	{

--- a/OpenRA.Mods.Common/Effects/Beacon.cs
+++ b/OpenRA.Mods.Common/Effects/Beacon.cs
@@ -17,9 +17,12 @@ using OpenRA.Scripting;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class Beacon : IEffect, IScriptBindable, IEffectAboveShroud
+	public class Beacon : IEffect, IScriptBindable, IEffectAboveShroud, IEffectWithTooltip
 	{
 		const int MaxArrowHeight = 512;
+
+		// Tolerance squared in world units (~half a cell radius) for cursor proximity detection.
+		const long HoverToleranceSq = 512L * 512;
 
 		readonly Player owner;
 		readonly WPos position;
@@ -27,6 +30,7 @@ namespace OpenRA.Mods.Common.Effects
 		readonly string beaconPalette, posterPalette;
 		readonly Animation arrow, beacon, circles, clock, poster;
 		readonly int duration;
+		readonly string spectatorName;
 
 		int delay;
 		int arrowHeight = MaxArrowHeight;
@@ -35,10 +39,11 @@ namespace OpenRA.Mods.Common.Effects
 
 		// Player-placed beacons are removed after a delay
 		public Beacon(Player owner, WPos position, int duration, string beaconPalette, bool isPlayerPalette,
-			string beaconCollection, string beaconSequence, string arrowSprite, string circleSprite, int delay = 0)
+			string beaconCollection, string beaconSequence, string arrowSprite, string circleSprite, int delay = 0, string spectatorName = null)
 		{
 			this.owner = owner;
 			this.position = position;
+			this.spectatorName = spectatorName;
 			this.beaconPalette = beaconPalette;
 			this.isPlayerPalette = isPlayerPalette;
 			this.duration = duration;
@@ -112,7 +117,13 @@ namespace OpenRA.Mods.Common.Effects
 			if (delay > 0)
 				yield break;
 
-			if (!owner.IsAlliedWith(owner.World.RenderPlayer))
+			if (owner.Spectating)
+			{
+				// Spectator beacons are only visible in spectator views (all-players or unrestricted view).
+				if (owner.World.RenderPlayer != null && !owner.World.RenderPlayer.Spectating)
+					yield break;
+			}
+			else if (!owner.IsAlliedWith(owner.World.RenderPlayer))
 				yield break;
 
 			var palette = r.Palette(isPlayerPalette ? beaconPalette + owner.InternalName : beaconPalette);
@@ -139,5 +150,17 @@ namespace OpenRA.Mods.Common.Effects
 						yield return a;
 			}
 		}
+
+		bool IEffectWithTooltip.IsNearCursor(WPos cursorWorldPos)
+		{
+			if (!owner.Spectating || string.IsNullOrEmpty(spectatorName))
+				return false;
+
+			var dx = (long)cursorWorldPos.X - position.X;
+			var dy = (long)cursorWorldPos.Y - position.Y;
+			return dx * dx + dy * dy <= HoverToleranceSq;
+		}
+
+		string IEffectWithTooltip.GetTooltip() => spectatorName;
 	}
 }

--- a/OpenRA.Mods.Common/Effects/SpectatorWaypointEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpectatorWaypointEffect.cs
@@ -1,0 +1,103 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Effects;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Effects
+{
+	// Local-only effect that renders a waypoint path for spectators.
+	public class SpectatorWaypointEffect : IEffect, IEffectAnnotation, IEffectWithTooltip, IRadarEffect
+	{
+		const int LineWidth = 2;
+		const int MarkerSize = 3;
+
+		// Tolerance squared in world units (~half a cell radius) for cursor proximity detection.
+		const long HoverToleranceSq = 512L * 512;
+
+		readonly IReadOnlyList<WPos> waypoints;
+		readonly int duration;
+		readonly Color color;
+		readonly string spectatorName;
+		int tick;
+
+		public SpectatorWaypointEffect(IReadOnlyList<WPos> waypoints, int duration, Color color, string spectatorName)
+		{
+			this.waypoints = waypoints;
+			this.duration = duration;
+			this.color = color;
+			this.spectatorName = spectatorName;
+		}
+
+		void IEffect.Tick(World world)
+		{
+			if (duration > 0 && tick++ >= duration)
+				world.AddFrameEndTask(w => w.Remove(this));
+		}
+
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr)
+		{
+			return SpriteRenderable.None;
+		}
+
+		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
+		{
+			if (waypoints.Count < 2)
+				yield break;
+
+			yield return new TargetLineRenderable(waypoints, color, LineWidth, MarkerSize);
+		}
+
+		bool IEffectWithTooltip.IsNearCursor(WPos cursorWorldPos)
+		{
+			for (var i = 0; i < waypoints.Count - 1; i++)
+				if (SquaredDistanceToSegment(cursorWorldPos, waypoints[i], waypoints[i + 1]) <= HoverToleranceSq)
+					return true;
+
+			return false;
+		}
+
+		string IEffectWithTooltip.GetTooltip() => spectatorName;
+
+		IEnumerable<(WPos From, WPos To, Color Color)> IRadarEffect.RadarLineSegments
+		{
+			get
+			{
+				for (var i = 0; i < waypoints.Count - 1; i++)
+					yield return (waypoints[i], waypoints[i + 1], color);
+			}
+		}
+
+		static long SquaredDistanceToSegment(WPos point, WPos segA, WPos segB)
+		{
+			var ab = segB - segA;
+			var ap = point - segA;
+			var abLenSq = (long)ab.X * ab.X + (long)ab.Y * ab.Y;
+
+			if (abLenSq == 0)
+			{
+				// Degenerate segment: both endpoints are the same.
+				var dx = (long)point.X - segA.X;
+				var dy = (long)point.Y - segA.Y;
+				return dx * dx + dy * dy;
+			}
+
+			var t = ((long)ap.X * ab.X + (long)ap.Y * ab.Y) * 1024 / abLenSq;
+			t = System.Math.Clamp(t, 0, 1024);
+
+			var ex = (long)point.X - segA.X - ab.X * t / 1024;
+			var ey = (long)point.Y - segA.Y - ab.Y * t / 1024;
+			return ex * ex + ey * ey;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -25,6 +25,18 @@ namespace OpenRA.Mods.Common.Orders
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			world.CancelInputMode();
+
+			if (world.LocalPlayer == null)
+			{
+				// Spectators broadcast a beacon order so all spectators receive it.
+				// Include the preferred color so each spectator's beacon is distinguishable.
+				var pos = world.Map.CenterOfCell(cell);
+				var color = Game.Settings.Player.Color;
+				var spectatorBeaconOrder = new Order("SpectatorBeacon", null, false) { TargetString = $"{pos}|{color}" };
+				yield return spectatorBeaconOrder;
+				yield break;
+			}
+
 			yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 

--- a/OpenRA.Mods.Common/Orders/SpectatorWaypointOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/SpectatorWaypointOrderGenerator.cs
@@ -1,0 +1,95 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Orders;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	// Spectator-only order generator: lets spectators draw a waypoint path on the map.
+	// The path is broadcast over the network so all spectators see it.
+	public class SpectatorWaypointOrderGenerator : IOrderGenerator
+	{
+		const int LineWidth = 2;
+		const int MarkerSize = 3;
+
+		readonly World world;
+		readonly List<WPos> waypoints = [];
+		WPos cursorPos;
+
+		public SpectatorWaypointOrderGenerator(World world)
+		{
+			this.world = world;
+		}
+
+		public MouseButton ActionButton => MouseButton.Left;
+
+		IEnumerable<Order> IOrderGenerator.Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			cursorPos = world.Map.CenterOfCell(cell);
+
+			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
+			{
+				waypoints.Add(cursorPos);
+				return [];
+			}
+
+			if (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up)
+				world.CancelInputMode();
+
+			return [];
+		}
+
+		void IOrderGenerator.Tick(World world) { }
+
+		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world)
+		{
+			return SpriteRenderable.None;
+		}
+
+		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world)
+		{
+			return SpriteRenderable.None;
+		}
+
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world)
+		{
+			if (waypoints.Count == 0)
+				yield break;
+
+			// Draw accumulated waypoints plus a live preview segment to the cursor.
+			var points = new List<WPos>(waypoints) { cursorPos };
+			yield return new TargetLineRenderable(points, Game.Settings.Player.Color, LineWidth, MarkerSize);
+		}
+
+		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			return "ability";
+		}
+
+		void IOrderGenerator.Deactivate()
+		{
+			if (waypoints.Count < 2)
+				return;
+
+			// Broadcast the waypoint path so all spectators receive and display it.
+			// Prefix with the preferred color so each spectator's path is distinguishable.
+			var colorPrefix = Game.Settings.Player.Color.ToString();
+			world.IssueOrder(Order.FromTargetString("SpectatorWaypoint", colorPrefix + "|" + string.Join("|", waypoints.Select(p => p.ToString())), false));
+		}
+
+		bool IOrderGenerator.HandleKeyPress(KeyInput e) { return false; }
+
+		void IOrderGenerator.SelectionChanged(World world, IEnumerable<Actor> selected) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/SpectatorEffects.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpectatorEffects.cs
@@ -1,0 +1,70 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[TraitLocation(SystemActors.World)]
+	[Desc("Handles spectator beacon and waypoint effects broadcast over the network.",
+		"Requires PlaceBeacon on the player actor to define beacon appearance and duration.")]
+	public class SpectatorEffectsInfo : TraitInfo<SpectatorEffects> { }
+
+	public class SpectatorEffects : INotifySpectatorBeacon, INotifySpectatorWaypoint
+	{
+		RadarPings radarPings;
+
+		void INotifySpectatorBeacon.SpectatorBeaconPlaced(World world, WPos position, Color color, string spectatorName)
+		{
+			var spectatorPlayer = world.Players.FirstOrDefault(p => p.Spectating && p.NonCombatant);
+			if (spectatorPlayer == null)
+				return;
+
+			var beaconInfo = spectatorPlayer.PlayerActor.Info.TraitInfoOrDefault<PlaceBeaconInfo>();
+			if (beaconInfo == null)
+				return;
+
+			radarPings ??= world.WorldActor.TraitOrDefault<RadarPings>();
+
+			world.AddFrameEndTask(w =>
+			{
+				var beacon = new Beacon(spectatorPlayer, position, beaconInfo.Duration,
+					"effect", false,
+					beaconInfo.BeaconImage, beaconInfo.BeaconSequence, beaconInfo.ArrowSequence, beaconInfo.CircleSequence, spectatorName: spectatorName);
+
+				w.Add(beacon);
+
+				if (world.RenderPlayer == null || world.RenderPlayer.Spectating)
+					Game.Sound.PlayNotification(world.Map.Rules, null, beaconInfo.NotificationType, beaconInfo.Notification, null);
+
+				radarPings?.Add(
+					() => world.RenderPlayer == null || world.RenderPlayer.Spectating,
+					position,
+					color,
+					beaconInfo.Duration);
+			});
+		}
+
+		void INotifySpectatorWaypoint.SpectatorWaypointDrawn(World world, IReadOnlyList<WPos> waypoints, Color color, string spectatorName)
+		{
+			if (waypoints.Count < 2)
+				return;
+
+			var spectatorPlayer = world.Players.FirstOrDefault(p => p.Spectating && p.NonCombatant);
+			var duration = spectatorPlayer?.PlayerActor.Info.TraitInfoOrDefault<PlaceBeaconInfo>()?.Duration ?? 750;
+
+			world.AddFrameEndTask(w => w.Add(new SpectatorWaypointEffect(waypoints, duration, color, spectatorName)));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -52,4 +52,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	[method: ObjectCreator.UseCtor]
 	public class BeaconOrderButtonLogic(Widget widget, World world)
 		: ChromeOrderButtonLogic<BeaconOrderGenerator>(widget, world, "beacon");
+
+	public class SpectatorWaypointOrderButtonLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public SpectatorWaypointOrderButtonLogic(Widget widget, World world)
+		{
+			if (widget is not ButtonWidget button)
+				return;
+
+			button.OnClick = () =>
+			{
+				if (world.OrderGenerator is SpectatorWaypointOrderGenerator)
+					world.CancelInputMode();
+				else
+					world.OrderGenerator = new SpectatorWaypointOrderGenerator(world);
+			};
+
+			button.IsHighlighted = () => world.OrderGenerator is SpectatorWaypointOrderGenerator;
+
+			var icon = button.GetOrNull<ImageWidget>("ICON");
+			if (icon != null)
+				icon.GetImageName = () => world.OrderGenerator is SpectatorWaypointOrderGenerator ? "waypoint-active" : "waypoint";
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -64,6 +64,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					case WorldTooltipType.Resource:
 						labelText = viewport.ResourceTooltip;
 						break;
+					case WorldTooltipType.Effect:
+						labelText = viewport.EffectTooltip;
+						break;
 					case WorldTooltipType.Actor:
 					{
 						o = viewport.ActorTooltip.Owner;

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -384,6 +385,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				Game.Renderer.EnableScissor(mapRect);
 				DrawRadarPings();
+				DrawRadarEffects();
 				Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.White);
 				Game.Renderer.DisableScissor();
 			}
@@ -400,6 +402,22 @@ namespace OpenRA.Mods.Common.Widgets
 				var pingCell = world.Map.CellContaining(radarPing.Position);
 				var points = radarPing.Points(CellToMinimapPixel(pingCell)).ToArray();
 				Game.Renderer.RgbaColorRenderer.DrawPolygon(points, 2, c);
+			}
+		}
+
+		void DrawRadarEffects()
+		{
+			foreach (var effect in world.UnpartitionedEffects)
+			{
+				if (effect is not IRadarEffect re)
+					continue;
+
+				foreach (var (from, to, color) in re.RadarLineSegments)
+				{
+					var a = CellToMinimapPixel(world.Map.CellContaining(from));
+					var b = CellToMinimapPixel(world.Map.CellContaining(to));
+					Game.Renderer.RgbaColorRenderer.DrawLine(new float3(a.X, a.Y, 0), new float3(b.X, b.Y, 0), 1, color);
+				}
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Mods.Common.Traits;
@@ -21,7 +22,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
-	public enum WorldTooltipType { None, Unexplored, Actor, FrozenActor, Resource }
+	public enum WorldTooltipType { None, Unexplored, Actor, FrozenActor, Resource, Effect }
 
 	public class ViewportControllerWidget : Widget
 	{
@@ -54,6 +55,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public IProvideTooltipInfo[] ActorTooltipExtra { get; private set; }
 		public FrozenActor FrozenActorTooltip { get; private set; }
 		public string ResourceTooltip { get; private set; }
+		public string EffectTooltip { get; private set; }
 
 		static readonly ImmutableArray<(ScrollDirection Direction, string Cursor)> ScrollCursors =
 		[
@@ -279,6 +281,24 @@ namespace OpenRA.Mods.Common.Widgets
 					TooltipType = WorldTooltipType.Resource;
 					ResourceTooltip = resourceTooltip;
 					break;
+				}
+			}
+
+			if (TooltipType != WorldTooltipType.None)
+				return;
+
+			var cursorWorldPos = worldRenderer.ProjectedPosition(worldPixel);
+			foreach (var effect in world.UnpartitionedEffects)
+			{
+				if (effect is IEffectWithTooltip ewt && ewt.IsNearCursor(cursorWorldPos))
+				{
+					var tooltip = ewt.GetTooltip();
+					if (!string.IsNullOrEmpty(tooltip))
+					{
+						TooltipType = WorldTooltipType.Effect;
+						EffectTooltip = tooltip;
+						break;
+					}
 				}
 			}
 		}

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -574,6 +574,9 @@ order-icons:
 		beacon: 921, 68, 16, 16
 		beacon-disabled: 921, 85, 16, 16
 		beacon-active: 921, 102, 16, 16
+		waypoint: 921, 68, 16, 16
+		waypoint-disabled: 921, 85, 16, 16
+		waypoint-active: 921, 102, 16, 16
 		stats: 972, 68, 16, 16
 		stats-disabled: 972, 85, 16, 16
 		stats-active: 972, 102, 16, 16

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -138,6 +138,36 @@ Container@OBSERVER_WIDGETS:
 					Text: label-mute-indicator
 					Contrast: true
 		LogicKeyListener@OBSERVER_KEY_LISTENER:
+		Button@WAYPOINT_BUTTON:
+			Logic: SpectatorWaypointOrderButtonLogic
+			X: WINDOW_WIDTH - 330 - WIDTH
+			Y: 5
+			Width: 30
+			Height: 25
+			Key: DrawSpectatorWaypoint
+			TooltipText: button-top-buttons-spectator-waypoint-tooltip
+			TooltipContainer: TOOLTIP_CONTAINER
+			VisualHeight: 0
+			Children:
+				Image@ICON:
+					X: 7
+					Y: 5
+					ImageCollection: order-icons
+		Button@BEACON_BUTTON:
+			Logic: BeaconOrderButtonLogic, AddFactionSuffixLogic
+			X: WINDOW_WIDTH - 295 - WIDTH
+			Y: 5
+			Width: 30
+			Height: 25
+			Key: PlaceBeacon
+			TooltipText: button-top-buttons-beacon-tooltip
+			TooltipContainer: TOOLTIP_CONTAINER
+			VisualHeight: 0
+			Children:
+				Image@ICON:
+					X: 7
+					Y: 5
+					ImageCollection: order-icons
 		MenuButton@OPTIONS_BUTTON:
 			Key: escape
 			X: WINDOW_WIDTH - 260 - WIDTH

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -365,6 +365,7 @@ label-mute-indicator = Audio Muted
 button-top-buttons-sell-tooltip = Sell
 button-top-buttons-repair-tooltip = Repair
 button-top-buttons-beacon-tooltip = Place Beacon
+button-top-buttons-spectator-waypoint-tooltip = Draw Waypoint Path
 button-top-buttons-options-tooltip = Options
 button-production-types-building-tooltip = Buildings
 button-production-types-support-tooltip = Support

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -265,6 +265,7 @@ World:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	RadarPings:
+	SpectatorEffects:
 	StartGameNotification:
 		Notification:
 		LoadedNotification:

--- a/mods/common/fluent/hotkeys.ftl
+++ b/mods/common/fluent/hotkeys.ftl
@@ -93,6 +93,7 @@ hotkey-description-pause = Pause / Unpause
 hotkey-description-sell = Sell mode
 hotkey-description-repair = Repair mode
 hotkey-description-placebeacon = Place beacon
+hotkey-description-drawspectatorwaypoint = Draw waypoint path
 hotkey-description-cyclestatusbars = Cycle status bars display
 hotkey-description-togglemute = Toggle audio mute
 hotkey-description-toggleplayerstancecolor = Toggle relationship colors

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -46,7 +46,12 @@ Repair: C
 PlaceBeacon: B
 	Description: hotkey-description-placebeacon
 	Types: OrderGenerator
-	Contexts: player
+	Contexts: player, spectator
+
+DrawSpectatorWaypoint: V
+	Description: hotkey-description-drawspectatorwaypoint
+	Types: Observer
+	Contexts: spectator
 
 CycleStatusBars: COMMA
 	Description: hotkey-description-cyclestatusbars

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -129,6 +129,9 @@ order-icons:
 		beacon: 359, 357, 36, 35
 		beacon-disabled: 359, 393, 36, 35
 		beacon-active: 359, 430, 36, 35
+		waypoint: 359, 357, 36, 35
+		waypoint-disabled: 359, 393, 36, 35
+		waypoint-active: 359, 430, 36, 35
 		power: 398, 357, 34, 35
 		power-disabled: 398, 393, 36, 35
 		power-active: 398, 430, 36, 35

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -206,6 +206,36 @@ Container@OBSERVER_WIDGETS:
 					Font: Bold
 					Children:
 						LogicKeyListener@STATS_DROPDOWN_KEYHANDLER:
+				Button@BEACON_BUTTON:
+					Logic: BeaconOrderButtonLogic
+					X: 325
+					Y: 0
+					Width: 36
+					Height: 25
+					Key: PlaceBeacon
+					TooltipText: button-top-buttons-beacon-tooltip
+					TooltipContainer: TOOLTIP_CONTAINER
+					VisualHeight: 0
+					Children:
+						Image@ICON:
+							X: 0
+							Y: 0
+							ImageCollection: order-icons
+				Button@WAYPOINT_BUTTON:
+					Logic: SpectatorWaypointOrderButtonLogic
+					X: 365
+					Y: 0
+					Width: 36
+					Height: 25
+					Key: DrawSpectatorWaypoint
+					TooltipText: button-top-buttons-spectator-waypoint-tooltip
+					TooltipContainer: TOOLTIP_CONTAINER
+					VisualHeight: 0
+					Children:
+						Image@ICON:
+							X: 0
+							Y: 0
+							ImageCollection: order-icons
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0

--- a/mods/d2k/fluent/chrome.ftl
+++ b/mods/d2k/fluent/chrome.ftl
@@ -51,6 +51,7 @@ button-command-bar-deploy =
 button-top-buttons-repair-tooltip = Repair
 button-top-buttons-sell-tooltip = Sell
 button-top-buttons-beacon-tooltip = Place Beacon
+button-top-buttons-spectator-waypoint-tooltip = Draw Waypoint Path
 button-top-buttons-power-tooltip = Power Down
 
 purchase-panel-button-tooltip = Order selected units

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -239,6 +239,7 @@ World:
 	ValidateOrder:
 	DebugPauseState:
 	RadarPings:
+	SpectatorEffects:
 	ObjectivesPanel:
 		ExitDelay: 0
 		PanelName: SKIRMISH_STATS

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -179,6 +179,9 @@ order-icons:
 		beacon: 153, 68, 16, 16
 		beacon-disabled: 153, 85, 16, 16
 		beacon-active: 153, 102, 16, 16
+		waypoint: 153, 68, 16, 16
+		waypoint-disabled: 153, 85, 16, 16
+		waypoint-active: 153, 102, 16, 16
 		power: 170, 68, 16, 16
 		power-disabled: 170, 85, 16, 16
 		power-active: 170, 102, 16, 16

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -33,9 +33,9 @@ Container@OBSERVER_WIDGETS:
 			Children:
 				Background@GAME_TIMER_BLOCK:
 					Logic: GameTimerLogic
-					X: 26
+					X: 21
 					Y: 10
-					Width: 120
+					Width: 100
 					Height: 22
 					Background: sidebar-button-observer
 					Children:
@@ -53,6 +53,36 @@ Container@OBSERVER_WIDGETS:
 					Y: 7
 					Children:
 						LogicKeyListener@OBSERVER_KEY_LISTENER:
+						Button@BEACON_BUTTON:
+							Logic: BeaconOrderButtonLogic
+							X: 124
+							Width: 28
+							Height: 28
+							Background: sidebar-button-observer
+							Key: PlaceBeacon
+							TooltipText: button-top-buttons-beacon-tooltip
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Children:
+								Image@ICON:
+									X: 6
+									Y: 6
+									ImageCollection: order-icons
+						Button@WAYPOINT_BUTTON:
+							Logic: SpectatorWaypointOrderButtonLogic
+							X: 158
+							Width: 28
+							Height: 28
+							Background: sidebar-button-observer
+							Key: DrawSpectatorWaypoint
+							TooltipText: button-top-buttons-spectator-waypoint-tooltip
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Children:
+								Image@ICON:
+									X: 6
+									Y: 6
+									ImageCollection: order-icons
 						MenuButton@OPTIONS_BUTTON:
 							Key: escape
 							X: 192

--- a/mods/ra/fluent/chrome.ftl
+++ b/mods/ra/fluent/chrome.ftl
@@ -44,6 +44,7 @@ button-command-bar-deploy =
 
 
 button-top-buttons-beacon-tooltip = Place Beacon
+button-top-buttons-spectator-waypoint-tooltip = Draw Waypoint Path
 button-top-buttons-sell-tooltip = Sell
 button-top-buttons-power-tooltip = Power Down
 button-top-buttons-repair-tooltip = Repair

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -270,6 +270,7 @@ World:
 	ValidateOrder:
 	DebugPauseState:
 	RadarPings:
+	SpectatorEffects:
 	StartGameNotification:
 		SavedTextNotification: notification-game-saved
 	ObjectivesPanel:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -168,6 +168,9 @@ order-icons-gdi:
 		beacon: 265, 243, 30, 31
 		beacon-disabled: 295, 243, 30, 31
 		beacon-active: 265, 243, 30, 31
+		waypoint: 265, 243, 30, 31
+		waypoint-disabled: 295, 243, 30, 31
+		waypoint-active: 265, 243, 30, 31
 		power: 265, 274, 30, 31
 		power-disabled: 295, 274, 30, 31
 		power-active: 265, 274, 30, 31
@@ -368,6 +371,9 @@ order-icons-nod:
 		beacon: 777, 243, 30, 31
 		beacon-disabled: 807, 243, 30, 31
 		beacon-active: 777, 243, 30, 31
+		waypoint: 777, 243, 30, 31
+		waypoint-disabled: 807, 243, 30, 31
+		waypoint-active: 777, 243, 30, 31
 		power: 777, 274, 30, 31
 		power-disabled: 807, 274, 30, 31
 		power-active: 777, 274, 30, 31

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -206,6 +206,36 @@ Container@OBSERVER_WIDGETS:
 					Font: Bold
 					Children:
 						LogicKeyListener@STATS_DROPDOWN_KEYHANDLER:
+				Button@BEACON_BUTTON:
+					Logic: BeaconOrderButtonLogic
+					X: 325
+					Y: 0
+					Width: 30
+					Height: 25
+					Key: PlaceBeacon
+					TooltipText: button-top-buttons-beacon-tooltip
+					TooltipContainer: TOOLTIP_CONTAINER
+					VisualHeight: 0
+					Children:
+						Image@ICON:
+							X: 0
+							Y: 0
+							ImageCollection: order-icons-gdi
+				Button@WAYPOINT_BUTTON:
+					Logic: SpectatorWaypointOrderButtonLogic
+					X: 361
+					Y: 0
+					Width: 30
+					Height: 25
+					Key: DrawSpectatorWaypoint
+					TooltipText: button-top-buttons-spectator-waypoint-tooltip
+					TooltipContainer: TOOLTIP_CONTAINER
+					VisualHeight: 0
+					Children:
+						Image@ICON:
+							X: 0
+							Y: 0
+							ImageCollection: order-icons-gdi
 				Container@GRAPH_BG:
 					Y: 30
 					X: 0

--- a/mods/ts/fluent/chrome.ftl
+++ b/mods/ts/fluent/chrome.ftl
@@ -54,6 +54,7 @@ button-command-bar-deploy =
 button-top-buttons-repair-tooltip = Repair
 button-top-buttons-sell-tooltip = Sell
 button-top-buttons-beacon-tooltip = Place Beacon
+button-top-buttons-spectator-waypoint-tooltip = Draw Waypoint Path
 button-top-buttons-power-tooltip = Power Down
 
 

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -380,6 +380,7 @@ World:
 	DebugPauseState:
 	ScreenShaker:
 	RadarPings:
+	SpectatorEffects:
 	StartGameNotification:
 		SavedTextNotification: notification-game-saved
 	ObjectivesPanel:


### PR DESCRIPTION
This is draft PR to allow spectators to place beacons and draw waypoint paths (lines).

- only spectators can see other spectators' beacons and waypoint paths. 
- to differentiate beacons and path lines between spectators, their Preferred Color (in Settings - Gameplay - Profile) is used.
- hovering beacons and waypoint paths displays the name of the player who drew them in a tooltip. 
- waypoint paths are also displayed on the minimap.

Todo:
- the `Draw Waypoint Path` button needs its own icon
- the D2K mod needs new glyph icons for `Place Beacon` and `Draw Waypoint Path` buttons (because currently this PR reuses the graphical D2K icons that don't fit well on the Spectator mode)
- allow Spectators to mute beacons and waypoint paths from other spectators

Related: 
https://github.com/OpenRA/OpenRA/issues/14996
https://github.com/RAunplugged/uRA/issues/35
https://github.com/OpenRA/OpenRA/issues/12388
https://github.com/OpenRA/OpenRA/issues/10390
https://github.com/OpenRA/OpenRA/issues/13008
https://github.com/OpenRA/OpenRA/pull/13600


https://github.com/user-attachments/assets/882dc853-4b96-40d3-93f3-3460d2d48ccb

