### PR TITLE
Bump Package 'NuGet.CommandLine' to 6.12.5

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -3,7 +3,7 @@
 		<ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">
 			<Private>False</Private>
 		</ProjectReference>
-		<PackageReference Include="NuGet.CommandLine" Version="6.12.2" />
+		<PackageReference Include="NuGet.CommandLine" Version="6.12.5" />
 		<PackageReference Include="OpenRA-FuzzyLogicLibrary" Version="1.0.1" />
 		<PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
 		<PackageReference Include="MP3Sharp" Version="1.0.5" />


### PR DESCRIPTION
Github vulnerability scan breaks building process with 6.12.2

https://github.com/advisories/GHSA-g4vj-cjjj-v7hg
```

Compiling in Debug mode...
  Determining projects to restore...
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Game/OpenRA.Game.csproj (in 4.08 sec).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Launcher/OpenRA.Launcher.csproj (in 4.07 sec).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj (in 4.08 sec).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Server/OpenRA.Server.csproj (in 4.08 sec).
/home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj : error NU1901: Package 'NuGet.CommandLine' 6.12.2 has a known low severity vulnerability, https://github.com/advisories/GHSA-g4vj-cjjj-v7hg [/home/runner/work/OpenRA/OpenRA/OpenRA.sln]
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Utility/OpenRA.Utility.csproj (in 7 ms).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj (in 6 ms).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj (in 16 ms).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Test/OpenRA.Test.csproj (in 622 ms).
  Restored /home/runner/work/OpenRA/OpenRA/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj (in 1.06 sec).

Build FAILED.

/home/runner/work/OpenRA/OpenRA/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj : error NU1901: Package 'NuGet.CommandLine' 6.12.2 has a known low severity vulnerability, https://github.com/advisories/GHSA-g4vj-cjjj-v7hg [/home/runner/work/OpenRA/OpenRA/OpenRA.sln]
    0 Warning(s)
    1 Error(s)
```