### PR TITLE
Implemented quicksave hotkey

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -71,6 +71,7 @@ Also thanks to:
     * Florian Wiesbauer (FiveAces)
     * Frank Razenberg (zzattack)
     * Gareth Needham (Ripley`)
+    * Gerritt Hooyer (GerrittHooyer)
     * Glen Anderson (glen7)
     * Glenn Martin Jensen (Baxxster)
     * Gordon Martin (Happy0)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/QuickSaveHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/QuickSaveHotkeyLogic.cs
@@ -1,0 +1,42 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame.Hotkeys
+{
+	[ChromeLogicArgsHotkeys("QuickSaveKey")]
+	public class QuickSaveHotkeyLogic : SingleHotkeyBaseLogic
+	{
+		const string QuickSavePattern = "quicksave-";
+		const string SaveFileExtension = ".orasav";
+		readonly World world;
+
+		[ObjectCreator.UseCtor]
+		public QuickSaveHotkeyLogic(Widget widget, World world, ModData modData, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "QuickSaveKey", "GLOBAL_KEYHANDLER", logicArgs)
+		{
+			this.world = world;
+		}
+
+		protected override bool OnHotkeyActivated(KeyInput e)
+		{
+			var dateTime = DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture);
+			var fileName = $"{QuickSavePattern}{dateTime}{SaveFileExtension}";
+			world.RequestGameSave(fileName, false);
+			return true;
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -2,12 +2,13 @@ Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
 		LogicKeyListener@GLOBAL_KEYHANDLER:
-			Logic: MusicHotkeyLogic, ScreenshotHotkeyLogic, MuteHotkeyLogic, DisableUIKeyLogic, DisableAllUIKeyLogic
+			Logic: MusicHotkeyLogic, ScreenshotHotkeyLogic, MuteHotkeyLogic, DisableUIKeyLogic, DisableAllUIKeyLogic, QuickSaveHotkeyLogic
 				StopMusicKey: StopMusic
 				PauseMusicKey: PauseMusic
 				PrevMusicKey: PrevMusic
 				NextMusicKey: NextMusic
 				TakeScreenshotKey: TakeScreenshot
+				QuickSaveKey: QuickSave
 				MuteAudioKey: ToggleMute
 				DisableUIKey: DisableUserInterface
 				DisableAllUIKey: DisableAllUserInterface

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -2,12 +2,13 @@ Container@INGAME_ROOT:
 	Logic: LoadIngamePlayerOrObserverUILogic
 	Children:
 		LogicKeyListener@GLOBAL_KEYHANDLER:
-			Logic: MusicHotkeyLogic, ScreenshotHotkeyLogic, MuteHotkeyLogic, DisableUIKeyLogic, DisableAllUIKeyLogic
+			Logic: MusicHotkeyLogic, ScreenshotHotkeyLogic, MuteHotkeyLogic, DisableUIKeyLogic, DisableAllUIKeyLogic, QuickSaveHotkeyLogic
 				StopMusicKey: StopMusic
 				PauseMusicKey: PauseMusic
 				PrevMusicKey: PrevMusic
 				NextMusicKey: NextMusic
 				TakeScreenshotKey: TakeScreenshot
+				QuickSaveKey: QuickSave
 				MuteAudioKey: ToggleMute
 				DisableUIKey: DisableUserInterface
 				DisableAllUIKey: DisableAllUserInterface

--- a/mods/common/fluent/hotkeys.ftl
+++ b/mods/common/fluent/hotkeys.ftl
@@ -97,6 +97,7 @@ hotkey-description-cyclestatusbars = Cycle status bars display
 hotkey-description-togglemute = Toggle audio mute
 hotkey-description-toggleplayerstancecolor = Toggle relationship colors
 hotkey-description-takescreenshot = Take screenshot
+hotkey-description-quicksave = Quick Save
 hotkey-description-attackmove = Attack Move
 hotkey-description-stop = Stop
 hotkey-description-scatter = Scatter

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -68,6 +68,11 @@ TakeScreenshot: P Ctrl
 	Types: World
 	Contexts: menu, player, spectator
 
+QuickSave: KP_ENTER
+	Description: hotkey-description-quicksave
+	Types: World
+	Contexts: player
+
 AttackMove: A
 	Description: hotkey-description-attackmove
 	Types: Unit


### PR DESCRIPTION
Related to [feature request 22359 - Add hotkey to quick save the game](https://github.com/OpenRA/OpenRA/issues/22359).

I've implemented a very basic QuickSave hotkey when playing in game. I've tested it and it appears to work, hitting Numpad Enter will create a save with the current date & time as the filename for the save.

Let me know if any changes need to be made, this is my first open source contribution, so even though I've tried to adhere to the contribution guidelines and style guide, I wouldn't be surprised if I've missed something!