### PR TITLE
Remember last map in case of internal restart

### DIFF
--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -89,6 +89,11 @@ namespace OpenRA.Server
 			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
 
 			WriteLineWithTimeStamp($"Starting dedicated server for mod: {modID}");
+
+			// Remember whether a map was explicitly specified at launch.
+			// If yes, always restore that map on restart instead of the last played one.
+			var initialMap = settings.Map;
+
 			while (true)
 			{
 				// HACK: The engine code *still* assumes that Game.ModData is set
@@ -106,6 +111,17 @@ namespace OpenRA.Server
 					if (server.State == ServerState.GameStarted && server.Conns.Count < 1)
 					{
 						WriteLineWithTimeStamp("No one is playing, shutting down...");
+
+						// If no map was specified at launch, preserve the last used map so the
+						// next instance starts on the same map. If a map was specified at launch,
+						// always revert to that one.
+						if (string.IsNullOrEmpty(initialMap))
+						{
+							var lastMap = server.LobbyInfo.GlobalSettings.Map;
+							if (!string.IsNullOrEmpty(lastMap))
+								settings.Map = lastMap;
+						}
+
 						server.Shutdown();
 						break;
 					}


### PR DESCRIPTION
When game is done, server is restarted when no players there. As this is defined process as well for the repeated games (players needs to rejoin after game), its better to just leave the map which was played.

This is even more usefull for multiplayer (co-op in case Combined Arms) campaigns, where the missions are often repeated, until sucessfully finished.

When the server is started with the Map hash parameter, game honors map parameter and dont remember last map; after restart the Map with this hash will be choosen again in next empty instance.

This behauviour will stremaline same behauviour, as when play on non-dedicated servers.