### PR TITLE
Add option to generate maps without previews

### DIFF
--- a/OpenRA.Game/Map/MapGenerationArgs.cs
+++ b/OpenRA.Game/Map/MapGenerationArgs.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Primitives;
 
@@ -16,6 +17,15 @@ namespace OpenRA
 {
 	public class MapGenerationArgs
 	{
+		[Flags]
+		public enum PreviewVisibilityFlags
+		{
+			None = 0,
+			Lobby = 1,
+			MapChooser = 2,
+			All = Lobby | MapChooser,
+		}
+
 		[FieldLoader.Require]
 		public string Uid = null;
 
@@ -34,6 +44,8 @@ namespace OpenRA
 		[FieldLoader.Require]
 		public string Author = null;
 
+		public PreviewVisibilityFlags PreviewVisibility = PreviewVisibilityFlags.All;
+
 		[FieldLoader.LoadUsing(nameof(LoadSettings))]
 		public MiniYaml Settings = null;
 		static MiniYaml LoadSettings(MiniYaml yaml)
@@ -51,7 +63,8 @@ namespace OpenRA
 				new("Size", FieldSaver.FormatValue(Size)),
 				new("Settings", Settings),
 				new("Title", Title),
-				new("Author", Author)
+				new("Author", Author),
+				new("PreviewVisibility", FieldSaver.FormatValue(PreviewVisibility)),
 			];
 		}
 	}

--- a/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
@@ -25,9 +25,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly Sprite spawnUnclaimed;
 		readonly SpriteFont spawnFont;
-		readonly Color spawnColor, spawnContrastColor;
+		readonly Color spawnColor, spawnContrastColor, mapPreviewHiddenColor;
 		readonly int2 spawnLabelOffset;
 
+		bool active;
 		Sheet mapSheet;
 		Sprite mapSprite;
 		Rectangle mapRect;
@@ -39,6 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
 			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
 			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+			ChromeMetrics.TryGet("MapPreviewHiddenColor", out mapPreviewHiddenColor);
 		}
 
 		protected GeneratedMapPreviewWidget(GeneratedMapPreviewWidget other)
@@ -50,6 +52,7 @@ namespace OpenRA.Mods.Common.Widgets
 			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
 			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
 			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+			ChromeMetrics.TryGet("MapPreviewHiddenColor", out mapPreviewHiddenColor);
 		}
 
 		public override GeneratedMapPreviewWidget Clone() { return new GeneratedMapPreviewWidget(this); }
@@ -58,7 +61,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Update(MapPreview map)
 		{
-			Update(map.SpawnPoints, map.Bounds, map.GridType, map.Preview);
+			if (map.GenerationArgs.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.MapChooser))
+				Update(map.SpawnPoints, map.Bounds, map.GridType, map.Preview);
+			else
+				Update([], map.Bounds, map.GridType, null);
 		}
 
 		public void Update(Map map)
@@ -72,6 +78,18 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void Update(IEnumerable<CPos> spawnPoints, Rectangle bounds, MapGridType gridType, Png preview)
 		{
+			active = true;
+
+			if (preview == null)
+			{
+				mapSheet?.Dispose();
+				mapSheet = null;
+				mapSprite = null;
+				mapRect = RenderBounds;
+				spawns = [];
+				return;
+			}
+
 			if (mapSheet == null || mapSheet.Size.Width < preview.Width || mapSheet.Size.Height < preview.Height)
 			{
 				mapSheet?.Dispose();
@@ -113,7 +131,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Clear()
 		{
+			active = false;
 			mapSprite = null;
+		}
+
+		public void HiddenUpdate(Map map)
+		{
+			Update([], map.Bounds, map.Grid.Type, null);
 		}
 
 		public int2 ConvertToPreview(CPos cell, Rectangle bounds, MapGridType gridType, float previewScale)
@@ -132,8 +156,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			if (mapSprite == null)
+			if (!active)
 				return;
+
+			if (mapSprite == null)
+			{
+				WidgetUtils.FillRectWithColor(mapRect, mapPreviewHiddenColor);
+				return;
+			}
 
 			WidgetUtils.DrawSprite(mapSprite, mapRect.Location, mapRect.Size);
 			var offset = spawnUnclaimed.Size.XY.ToInt2() / 2;

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -218,6 +218,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "showUnoccupiedSpawnpoints", false },
 				{ "mapUpdatesEnabled", false },
 				{ "onMapUpdate", (Action<string>)(_ => { }) },
+				{ "respectPreviewVisibility", true },
 			});
 
 			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");

--- a/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
@@ -250,6 +250,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "showUnoccupiedSpawnpoints", false },
 				{ "mapUpdatesEnabled", false },
 				{ "onMapUpdate", (Action<string>)(_ => { }) },
+				{ "respectPreviewVisibility", true },
 			});
 
 			gameList = panel.Get<ScrollPanelWidget>("GAME_LIST");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -215,6 +215,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						Game.Settings.Save();
 					})
 				},
+				{ "respectPreviewVisibility", true },
 			});
 
 			mapContainer.IsVisible = () => panel != PanelType.Servers;

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -36,17 +36,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string RetrySearch = "button-retry-search";
 
+		[FluentReference]
+		const string VisibleToNobody = "label-generated-map-visible-to-nobody";
+
+		[FluentReference]
+		const string VisibleToMapChooser = "label-generated-map-visible-to-mapchooser";
+
 		[FluentReference("author")]
 		const string CreatedBy = "label-created-by";
 
 		readonly int blinkTickLength = 10;
 		readonly Dictionary<PreviewStatus, Widget[]> previewWidgets = [];
 		readonly Func<(MapPreview Map, Session.MapStatus Status)> getMap;
+		readonly bool respectPreviewVisibility;
 
 		enum PreviewStatus
 		{
 			Unknown,
 			Playable,
+			PlayableButHidden,
 			Incompatible,
 			Validating,
 			Generating,
@@ -66,16 +74,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool mapUpdateAvailable = false;
 
 		[ObjectCreator.UseCtor]
-		internal MapPreviewLogic(Widget widget, ModData modData, Func<(MapPreview Map, Session.MapStatus Status)> getMap,
+		internal MapPreviewLogic(Widget widget, ModData modData, Func<(MapPreview Map, Session.MapStatus Status)> getMap, bool respectPreviewVisibility,
 			Action<MapPreviewWidget, MapPreview, MouseInput> onMouseDown, Func<Dictionary<int, SpawnOccupant>> getSpawnOccupants,
 			bool mapUpdatesEnabled, Action<string> onMapUpdate, Func<IReadOnlySet<int>> getDisabledSpawnPoints, bool showUnoccupiedSpawnpoints)
 		{
 			this.getMap = getMap;
+			this.respectPreviewVisibility = respectPreviewVisibility;
 
 			Widget SetupMapPreview(Widget parent)
 			{
 				var preview = parent.Get<MapPreviewWidget>("MAP_PREVIEW");
 				preview.Preview = () => getMap().Map;
+				if (respectPreviewVisibility)
+					preview.HidePreview = () => !(getMap().Map.GenerationArgs?.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.Lobby) ?? true);
+
 				if (onMouseDown != null)
 					preview.OnMouseDown = mi => onMouseDown(preview, getMap().Map, mi);
 
@@ -125,6 +137,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				authorLabel.GetText = () => truncateCache.Update(getMap().Map.Author);
 
 				return parent;
+			}
+
+			Widget SetupAuthorMapTypeAndVisibility(Widget parent)
+			{
+				var visibilityLabel = parent.Get<LabelWidget>("VISIBILITY");
+
+				var visibleToMapChooser = FluentProvider.GetMessage(VisibleToMapChooser);
+				var visibleToNobody = FluentProvider.GetMessage(VisibleToNobody);
+				visibilityLabel.GetText = () =>
+					(getMap().Map.GenerationArgs?.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.MapChooser) ?? false)
+						? visibleToMapChooser : visibleToNobody;
+
+				return SetupAuthorAndMapType(parent);
 			}
 
 			var mapRepository = modData.GetOrCreate<WebServices>().MapRepository;
@@ -197,6 +222,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				[previewLarge];
 			previewWidgets[PreviewStatus.Playable] =
 				[previewLarge, SetupAuthorAndMapType(widget.Get("MAP_AVAILABLE"))];
+			previewWidgets[PreviewStatus.PlayableButHidden] =
+				[previewSmall, SetupAuthorMapTypeAndVisibility(widget.Get("MAP_AVAILABLE_HIDDEN"))];
 			previewWidgets[PreviewStatus.Incompatible] =
 				[previewLarge, widget.Get("MAP_INCOMPATIBLE")];
 			previewWidgets[PreviewStatus.Validating] =
@@ -260,7 +287,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					case MapStatus.Available:
 						if (serverStatus.HasFlag(Session.MapStatus.Playable))
-							status = PreviewStatus.Playable;
+						{
+							if (respectPreviewVisibility && !(map.GenerationArgs?.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.Lobby) ?? true))
+								status = PreviewStatus.PlayableButHidden;
+							else
+								status = PreviewStatus.Playable;
+						}
 						else if (serverStatus.HasFlag(Session.MapStatus.Incompatible))
 							status = PreviewStatus.Incompatible;
 						else if (serverStatus.HasFlag(Session.MapStatus.Validating))

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		const string MapSize = "label-mapchooser-random-map-size";
 
 		[FluentReference]
+		const string PreviewVisibility = "label-mapchooser-random-map-preview-visibility";
+
+		[FluentReference]
 		const string RandomMap = "label-mapchooser-random-map-title";
 
 		[FluentReference]
@@ -57,12 +60,29 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string MapSizeHuge = "label-map-size-huge";
 
+		[FluentReference]
+		const string PreviewVisibilityAll = "label-mapchooser-random-map-preview-visibility-all";
+
+		[FluentReference]
+		const string PreviewVisibilityMapChooser = "label-mapchooser-random-map-preview-visibility-mapchooser";
+
+		[FluentReference]
+		const string PreviewVisibilityNone = "label-mapchooser-random-map-preview-visibility-none";
+
 		public static readonly IReadOnlyDictionary<string, int2> MapSizes = new Dictionary<string, int2>()
 		{
 			{ MapSizeSmall, new int2(48, 60) },
 			{ MapSizeMedium, new int2(60, 90) },
 			{ MapSizeLarge, new int2(90, 120) },
 			{ MapSizeHuge, new int2(120, 160) },
+		};
+
+		public static readonly IReadOnlyDictionary<string, MapGenerationArgs.PreviewVisibilityFlags> PreviewVisibilities =
+			new Dictionary<string, MapGenerationArgs.PreviewVisibilityFlags>()
+		{
+			{ PreviewVisibilityAll, MapGenerationArgs.PreviewVisibilityFlags.All },
+			{ PreviewVisibilityMapChooser, MapGenerationArgs.PreviewVisibilityFlags.MapChooser },
+			{ PreviewVisibilityNone, MapGenerationArgs.PreviewVisibilityFlags.None },
 		};
 
 		readonly ModData modData;
@@ -77,10 +97,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget dropdownSettingTemplate;
 		readonly Widget tilesetSetting;
 		readonly Widget sizeSetting;
+		readonly Widget previewVisibilitySetting;
 		readonly Widget parentWidget;
 
 		ITerrainInfo selectedTerrain;
 		string selectedSize;
+		string selectedPreviewVisibility;
 		Size size;
 		bool initialGenerationDone;
 
@@ -197,6 +219,39 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				sizeDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", MapSizes.Count * 30, MapSizes.Keys, SetupItem);
 			};
 
+			var previewVisibilityLabel = FluentProvider.GetMessage(PreviewVisibility);
+			previewVisibilitySetting = dropdownSettingTemplate.Clone();
+			previewVisibilitySetting.Get<LabelWidget>("LABEL").GetText = () => previewVisibilityLabel;
+
+			var previewVisibilityDropdown = previewVisibilitySetting.Get<DropDownButtonWidget>("DROPDOWN");
+			var previewVisibilityDropdownLabel = new CachedTransform<string, string>(s => FluentProvider.GetMessage(s));
+			previewVisibilityDropdown.GetText = () => previewVisibilityDropdownLabel.Update(selectedPreviewVisibility);
+			previewVisibilityDropdown.OnMouseDown = _ =>
+			{
+				ScrollItemWidget SetupItem(string visibility, ScrollItemWidget template)
+				{
+					bool IsSelected() => visibility == selectedPreviewVisibility;
+					void OnClick()
+					{
+						selectedPreviewVisibility = visibility;
+
+						// Changes to visibility should re-randomize so that it's not possible to
+						// peak at a preview by changing the setting back and forth. (Which would
+						// be cheating.)
+						settings.Randomize(Game.CosmeticRandom);
+						RandomizeSize();
+						GenerateMap();
+					}
+
+					var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+					var label = FluentProvider.GetMessage(visibility);
+					item.Get<LabelWidget>("LABEL").GetText = () => label;
+					return item;
+				}
+
+				previewVisibilityDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", PreviewVisibilities.Count * 30, PreviewVisibilities.Keys, SetupItem);
+			};
+
 			var generateButton = widget.Get<ButtonWidget>("BUTTON_GENERATE");
 			generateButton.IsDisabled = () => IsGenerating;
 			generateButton.OnClick = () =>
@@ -207,6 +262,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			selectedSize = MapSizes.Keys.Skip(1).First();
+			selectedPreviewVisibility = PreviewVisibilities.Keys.First();
 			if (initialSettings != null)
 			{
 				selectedTerrain = modData.DefaultTerrainInfo[initialSettings.Tileset];
@@ -260,9 +316,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void RefreshSettings()
 		{
 			settingsPanel.RemoveChildren();
-			tilesetSetting.Bounds = sizeSetting.Bounds = dropdownSettingTemplate.Bounds;
+			tilesetSetting.Bounds = sizeSetting.Bounds = previewVisibilitySetting.Bounds =
+				dropdownSettingTemplate.Bounds;
 			settingsPanel.AddChild(tilesetSetting);
 			settingsPanel.AddChild(sizeSetting);
+			settingsPanel.AddChild(previewVisibilitySetting);
 
 			var playerCount = settings.PlayerCount;
 			foreach (var o in settings.Options)
@@ -425,6 +483,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				try
 				{
 					args = settings.Compile(selectedTerrain, size);
+					args.PreviewVisibility = PreviewVisibilities[selectedPreviewVisibility];
 					map = generator.Generate(modData, args);
 				}
 				catch (MapGenerationException)
@@ -450,7 +509,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						args.Uid = map.Uid;
 
-						preview.Update(map);
+						if (args.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.MapChooser))
+							preview.Update(map);
+						else
+							preview.HiddenUpdate(map);
+
 						lastGeneration = currentGeneration;
 
 						// `onGenerate` assumed to take ownership of package here.

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -180,6 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "showUnoccupiedSpawnpoints", false },
 				{ "mapUpdatesEnabled", false },
 				{ "onMapUpdate", (Action<string>)(_ => { }) },
+				{ "respectPreviewVisibility", false },
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -85,6 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "showUnoccupiedSpawnpoints", false },
 				{ "mapUpdatesEnabled", true },
 				{ "onMapUpdate", (Action<string>)(uid => map = modData.MapCache[uid]) },
+				{ "respectPreviewVisibility", true },
 			});
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -329,7 +329,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			mapPreview = widget.GetOrNull<MapPreviewWidget>("SELECTED_MAP_PREVIEW");
 			if (mapPreview != null)
+			{
 				mapPreview.Preview = () => currentMap;
+				mapPreview.HidePreview = () => !(currentMap.GenerationArgs?.PreviewVisibility.HasFlag(MapGenerationArgs.PreviewVisibilityFlags.Lobby) ?? true);
+			}
 
 			var mapTitle = widget.GetOrNull<LabelWithTooltipWidget>("SELECTED_MAP");
 			if (mapTitle != null)

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly Sprite spawnClaimed, spawnUnclaimed, spawnDisabled;
 		readonly SpriteFont spawnFont;
-		readonly Color spawnColor, spawnContrastColor;
+		readonly Color spawnColor, spawnContrastColor, mapPreviewHiddenColor;
 		readonly int2 spawnLabelOffset;
 
 		public Func<MapPreview> Preview = () => null;
@@ -75,6 +75,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Action<MouseInput> OnMouseDown = _ => { };
 		public int TooltipSpawnIndex = -1;
 		public bool ShowUnoccupiedSpawnpoints = true;
+		public Func<bool> HidePreview = () => false;
 
 		Rectangle mapRect;
 		float previewScale = 0;
@@ -91,6 +92,7 @@ namespace OpenRA.Mods.Common.Widgets
 			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
 			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
 			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+			ChromeMetrics.TryGet("MapPreviewHiddenColor", out mapPreviewHiddenColor);
 		}
 
 		protected MapPreviewWidget(MapPreviewWidget other)
@@ -112,6 +114,7 @@ namespace OpenRA.Mods.Common.Widgets
 			spawnColor = ChromeMetrics.Get<Color>("SpawnColor");
 			spawnContrastColor = ChromeMetrics.Get<Color>("SpawnContrastColor");
 			spawnLabelOffset = ChromeMetrics.Get<int2>("SpawnLabelOffset");
+			ChromeMetrics.TryGet("MapPreviewHiddenColor", out mapPreviewHiddenColor);
 		}
 
 		public override MapPreviewWidget Clone() { return new MapPreviewWidget(this); }
@@ -164,6 +167,12 @@ namespace OpenRA.Mods.Common.Widgets
 			var preview = Preview();
 			if (preview == null)
 				return;
+
+			if (HidePreview())
+			{
+				WidgetUtils.FillRectWithColor(RenderBounds, mapPreviewHiddenColor);
+				return;
+			}
 
 			// Stash a copy of the minimap to ensure consistency
 			// (it may be modified by another thread)

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -67,6 +67,29 @@ Container@MAP_PREVIEW:
 					Height: 25
 					Font: Tiny
 					Align: Center
+		Container@MAP_AVAILABLE_HIDDEN:
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Children:
+				Label@VISIBILITY:
+					Y: 158
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 188
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					IgnoreMouseOver: true
+				Label@MAP_AUTHOR:
+					Y: 201
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Tiny
+					Align: Center
 		Container@MAP_INCOMPATIBLE:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -257,7 +257,7 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 					Children:
 						Checkbox@CHECKBOX:
 							X: 10
-							Y: 5
+							Y: 20
 							Width: PARENT_WIDTH - 20
 							Height: 20
 				Container@TEXT_TEMPLATE:

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -557,6 +557,10 @@ label-mapchooser-random-map-error = Map Generation Failed
 button-mapchooser-random-map-generate = Generate
 label-mapchooser-random-map-tileset = Environment:
 label-mapchooser-random-map-size = Map Size:
+label-mapchooser-random-map-preview-visibility = Preview Visibility:
+label-mapchooser-random-map-preview-visibility-all = Visible to everyone
+label-mapchooser-random-map-preview-visibility-mapchooser = Map chooser only
+label-mapchooser-random-map-preview-visibility-none = Hidden
 label-mapchooser-random-map-error-desc = Adjust the settings or try again.
 
 ## missionbrowser.yaml

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -66,6 +66,29 @@ Container@MAP_PREVIEW:
 					Height: 25
 					Font: Tiny
 					Align: Center
+		Container@MAP_AVAILABLE_HIDDEN:
+			Width: PARENT_WIDTH
+			Height: PARENT_HEIGHT
+			Children:
+				Label@VISIBILITY:
+					Y: 158
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+				Label@MAP_TYPE:
+					Y: 188
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: TinyBold
+					Align: Center
+					IgnoreMouseOver: true
+				Label@MAP_AUTHOR:
+					Y: 201
+					Width: PARENT_WIDTH
+					Height: 25
+					Font: Tiny
+					Align: Center
 		Container@MAP_INCOMPATIBLE:
 			Width: PARENT_WIDTH
 			Height: PARENT_HEIGHT

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -258,7 +258,7 @@ Container@MAPCHOOSER_GENERATE_PANEL:
 					Children:
 						Checkbox@CHECKBOX:
 							X: 10
-							Y: 5
+							Y: 20
 							Width: PARENT_WIDTH - 20
 							Height: 20
 				Container@TEXT_TEMPLATE:

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -515,6 +515,10 @@ label-mapchooser-random-map-error = Map Generation Failed
 button-mapchooser-random-map-generate = Generate
 label-mapchooser-random-map-tileset = Environment:
 label-mapchooser-random-map-size = Map Size:
+label-mapchooser-random-map-preview-visibility = Preview Visibility:
+label-mapchooser-random-map-preview-visibility-all = Visible to everyone
+label-mapchooser-random-map-preview-visibility-mapchooser = Map chooser only
+label-mapchooser-random-map-preview-visibility-none = Hidden
 label-mapchooser-random-map-error-desc = Adjust the settings or try again.
 
 ## missionbrowser.yaml

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -335,6 +335,8 @@ label-downloading-map = Downloading { $size } kB
 label-downloading-map-progress = Downloading { $size } kB ({ $progress }%)
 button-retry-install = Retry Install
 button-retry-search = Retry Search
+label-generated-map-visible-to-nobody = Hidden
+label-generated-map-visible-to-mapchooser = Hidden (previewed by chooser)
 ## also MapChooserLogic
 label-created-by = Created by { $author }
 

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -59,3 +59,4 @@ Metrics:
 	DefaultCursor: default
 	WorldSelectCursor: select
 	WorldDefaultCursor: default
+	MapPreviewHiddenColor: 202020


### PR DESCRIPTION
Adds a "Preview Visibility" option to the map chooser's map generator panel, which can be used to disable previews of the generated map. This allows for gameplay with a truly unexplored map, which players must explore in-game.

The admin can choose whether they themselves see the generated map, which may be useful for a spectator admin to vet the map. If the preview was shown to the admin during creation, a disclaimer is shown in the lobby.

Map visibility restrictions are respected in singleplayer and multiplayer lobbies; the map chooser; and save/load dialogs. The replay viewer, however, ignores map visibility restrictions.

This change includes an adjustment to the map chooser generator panel's checkbox setting template in order to avoid visual inconsistency resulting from the re-arranged settings layout.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/fdb7b02b-cbc7-42d0-a31d-faaaeed07202" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/b0017ef6-46d0-48a4-9ab9-1bf430129ff6" />
