### PR TITLE
Use contextual action in radar on modern/classic controls

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -376,6 +376,11 @@ namespace OpenRA
 		{
 			return ResolveActionButton(actionType) == MouseButton.Left ? MouseButton.Right : MouseButton.Left;
 		}
+
+		public bool CurrentControlStyleHasDedicatedRadarMoveButton()
+		{
+			return MouseControlStyle != MouseControlStyle.OtherRTS;
+		}
 	}
 
 	public class Settings

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -324,8 +324,11 @@ namespace OpenRA.Mods.Common.Widgets
 				return true;
 
 			var worldCoords = MinimapPixelToWorldCoords(mi.Location);
-			if ((mi.Event == MouseInputEvent.Down && mi.Button != world.OrderGenerator.ActionButton) ||
-				(mi.Event == MouseInputEvent.Move && isMinimapMoving && mi.Button == minimapMoveButton))
+			if ((mi.Event == MouseInputEvent.Down && mi.Button !=
+				(gameSettings.CurrentControlStyleHasDedicatedRadarMoveButton() ?
+					gameSettings.ResolveActionButton(MouseActionType.Contextual) :
+					world.OrderGenerator.ActionButton)) ||
+			(mi.Event == MouseInputEvent.Move && isMinimapMoving && mi.Button == minimapMoveButton))
 			{
 				worldRenderer.Viewport.Center(worldCoords);
 				isMinimapMoving = true;


### PR DESCRIPTION
Adds a function to choose whether the mouse button to move the minimap should change based on the current action (desired for Other RTS) or not (desired for Modern). In Settings.cs, rather than a MouseControlStyle check in RadarWidget.cs, in order to keep as much MouseControlStyle logic in one place as possible. 

Also it's a bit of a clunky name, not really sure what would be clearer, though. My other idea was a "ResolveRadarMoveButton(MouseButton)" function that takes the current action button and spits out the correct button to move the minimap, but what logic to use to determine the button for the radar seems like the RadarWidget's problem, it just needs to know whether that control style expects a fixed button or not.

Fixes #22409