### PR TITLE
Hide some map generator options in map chooser

### DIFF
--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorOptions.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorOptions.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -17,10 +18,20 @@ namespace OpenRA.Mods.Common.MapGenerator
 {
 	public abstract class MapGeneratorOption
 	{
+		[Flags]
+		public enum VisibilityFlags
+		{
+			None = 0,
+			Lobby = 1,
+			Editor = 2,
+			All = Lobby | Editor,
+		}
+
 		[FieldLoader.Ignore]
 		public readonly string Id;
 		public readonly string Label = null;
 		public readonly int Priority = 0;
+		public readonly VisibilityFlags Visibility = VisibilityFlags.All;
 
 		protected MapGeneratorOption(string id, MiniYaml yaml)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -123,6 +123,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			foreach (var o in generator.Options)
 			{
+				if (!o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Editor))
+					continue;
+
 				Widget optionWidget = null;
 				switch (o)
 				{

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -284,6 +284,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (o.Id == "Seed")
 					continue;
 
+				if (!o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Lobby))
+					continue;
+
 				Widget optionWidget = null;
 				switch (o)
 				{

--- a/mods/cnc/rules/map-generators.yaml
+++ b/mods/cnc/rules/map-generators.yaml
@@ -402,6 +402,7 @@
 				Label: label-cnc-map-generator-option-civilian-density
 				Default: Default
 				Priority: 3
+				Visibility: Editor
 				Choice@Default:
 					Label: label-cnc-map-generator-choice-civilian-density-default
 					Parameters:
@@ -434,11 +435,13 @@
 				Parameter: DenyWalledAreas
 				Default: True
 				Priority: 1
+				Visibility: Editor
 			BooleanOption@Roads:
 				Label: label-cnc-map-generator-option-roads
 				Parameter: Roads
 				Default: True
 				Priority: 1
+				Visibility: Editor
 	ClearMapGenerator@clear:
 		Type: clear
 		Name: map-generator-clear

--- a/mods/ra/rules/map-generators.yaml
+++ b/mods/ra/rules/map-generators.yaml
@@ -441,6 +441,7 @@
 				Label: label-ra-map-generator-option-civilian-density
 				Default: Default
 				Priority: 3
+				Visibility: Editor
 				Choice@Default:
 					Label: label-ra-map-generator-choice-civilian-density-default
 					Parameters:
@@ -473,11 +474,13 @@
 				Parameter: DenyWalledAreas
 				Default: True
 				Priority: 1
+				Visibility: Editor
 			BooleanOption@Roads:
 				Label: label-ra-map-generator-option-roads
 				Parameter: Roads
 				Default: True
 				Priority: 1
+				Visibility: Editor
 	ClearMapGenerator@clear:
 		Type: clear
 		Name: map-generator-clear

--- a/mods/ts/rules/map-generators.yaml
+++ b/mods/ts/rules/map-generators.yaml
@@ -679,6 +679,7 @@
 				Label: label-ts-map-generator-option-civilian-density
 				Default: Default
 				Priority: 3
+				Visibility: Editor
 				Choice@Default:
 					Label: label-ts-map-generator-choice-civilian-density-default
 					Parameters:
@@ -749,6 +750,7 @@
 				Parameter: DenyWalledAreas
 				Default: True
 				Priority: 1
+				Visibility: Editor
 	ClearMapGenerator@clear:
 		Type: clear
 		Name: map-generator-clear


### PR DESCRIPTION
Adds support for a new "Visibility" MapGeneratorOption property that can restrict where certain options can be used. This allows to simplify the lobby UI for regular players whilst preserving the full capabilities in the map editor.

The following options are hidden from the lobby of applicable mods (RA, CnC, TS) using this feature:

- Civilian Density
- Roads
- Obstruct walled areas

These particular options are unlikely to be used by regular players, but can still be useful in the editor.
