### PR TITLE
Fix location of Steam directory on GNU/Linux

### DIFF
--- a/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
+++ b/OpenRA.Mods.Common/Installer/SourceResolvers/SteamSourceResolver.cs
@@ -94,7 +94,14 @@ namespace OpenRA.Mods.Common.Installer
 					break;
 
 				case PlatformType.Linux:
-					// Direct distro install
+					// Direct distro install.
+					// This could be in ~/.steam/steam...
+					candidatePaths.Add(Path.Combine(
+						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+						".steam",
+						"steam"));
+
+					// ... or in ~/.steam/root/
 					candidatePaths.Add(Path.Combine(
 						Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
 						".steam",


### PR DESCRIPTION
The "modern" path is ~/.steam/steam. Keep the "old" path (~/.steam/root)
as older installations might still be using this.
