### PR TITLE
Limit OS DPI Scale calculation restriction for the Furthest FOV only

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -191,10 +191,8 @@ namespace OpenRA.Graphics
 			ViewportTick?.Invoke();
 		}
 
-		static float CalculateMinimumZoom(float minHeight, float maxHeight)
+		static float CalculateMinimumZoom(float minHeight, float maxHeight, float h)
 		{
-			var h = Game.Renderer.NativeResolution.Height;
-
 			// Check the easy case: the native resolution is within the maximum limit
 			// Also catches the case where the user may force a resolution smaller than the minimum window size
 			if (h <= maxHeight)
@@ -231,7 +229,21 @@ namespace OpenRA.Graphics
 			else
 			{
 				var range = viewportSizes.GetSizeRange(vd);
-				MinZoom = CalculateMinimumZoom(range.X, range.Y) * defaultScale;
+
+				// For Native: keep the original NativeResolution behaviour (DPI-aware).
+				if (vd == WorldViewport.Native)
+				{
+					MinZoom = CalculateMinimumZoom(range.X, range.Y, Game.Renderer.NativeResolution.Height) * defaultScale;
+				}
+
+				// For Close/Medium/Far: use physical pixels for minZoom calculation so the result
+				// is identical regardless of OS DPI scale, then compensate MinZoom by dividing
+				// out NativeWindowScale so ViewportSize (= NativeResolution / zoom) always
+				// covers the same world area as on a 100% DPI system with the same resolution
+				else
+				{
+					MinZoom = CalculateMinimumZoom(range.X, range.Y, Game.Renderer.SurfaceSize.Height) / Game.Renderer.NativeWindowScale * defaultScale;
+				}
 			}
 
 			MaxZoom = Math.Min(

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -386,6 +386,7 @@ namespace OpenRA
 
 		public Size Resolution => Window.EffectiveWindowSize;
 		public Size NativeResolution => Window.NativeWindowSize;
+		public Size SurfaceSize => Window.SurfaceSize;
 		public float WindowScale => Window.EffectiveWindowScale;
 		public float NativeWindowScale => Window.NativeWindowScale;
 		public GLProfile GLProfile => Window.GLProfile;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/DisplaySettingsLogic.cs
@@ -223,7 +223,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			uiScaleDropdown.GetText = () => uiScaleLabel.Update(graphicSettings.UIScale);
 
 			var minResolution = viewportSizes.MinEffectiveResolution;
-			var resolution = Game.Renderer.Resolution;
+
+			// Use physical pixels (SurfaceSize) so OS DPI Scale != 100% does not disable the UI scale option
+			var resolution = Game.Renderer.SurfaceSize;
+
 			var disableUIScale = world.Type != WorldType.Shellmap ||
 				resolution.Width * graphicSettings.UIScale < 1.25f * minResolution.Width ||
 				resolution.Height * graphicSettings.UIScale < 1.25f * minResolution.Height;
@@ -482,17 +485,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			}
 
-			var windowHeight = Game.Renderer.NativeResolution.Height;
+			// SurfaceSize (physical pixels) is used for Close/Medium/Far
+			// so that OS DPI scale does not limit viewport distances
+			// Native/Furthest keeps NativeResolution (DPI-normalised)
+			var nativeHeight = Game.Renderer.NativeResolution.Height;
+			var surfaceHeight = Game.Renderer.SurfaceSize.Height;
 
 			var validSizes = new List<WorldViewport>() { WorldViewport.Close };
-			if (viewportSizes.GetSizeRange(WorldViewport.Medium).X < windowHeight)
+			if (viewportSizes.GetSizeRange(WorldViewport.Medium).X < surfaceHeight)
 				validSizes.Add(WorldViewport.Medium);
 
 			var farRange = viewportSizes.GetSizeRange(WorldViewport.Far);
-			if (farRange.X < windowHeight)
+			if (farRange.X < surfaceHeight)
 				validSizes.Add(WorldViewport.Far);
 
-			if (viewportSizes.AllowNativeZoom && farRange.Y < windowHeight)
+			if (viewportSizes.AllowNativeZoom && farRange.Y < nativeHeight)
 				validSizes.Add(WorldViewport.Native);
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, validSizes, SetupItem);
@@ -565,7 +572,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			var viewportSizes = Game.ModData.GetOrCreate<WorldViewportSizes>();
-			var maxScales = Game.Renderer.NativeResolution.ToVector2() / viewportSizes.MinEffectiveResolution.ToVector2();
+
+			// Use physical pixels (SurfaceSize) so UI scale option is available also for users using OS DPI Scale != 100%
+			var maxScales = Game.Renderer.SurfaceSize.ToVector2() / viewportSizes.MinEffectiveResolution.ToVector2();
 			var maxScale = Math.Min(maxScales.X, maxScales.Y);
 
 			var validScales = new[] { 1f, 1.25f, 1.5f, 1.75f, 2f }.Where(x => x <= maxScale);


### PR DESCRIPTION
When the OS DPI scale is set above 100%, FOV calculations no longer restrict camera options by blocking non-Furthest Battlefield settings.

For example, at 1080p with 100% OS DPI scaling, the "Far" option and internal UI scaling were available. However, at 1080p with 125% scaling, only "Medium" was available and internal scaling was disabled.

As suggested by @pchote, this change limits restrictions (calculated from OS DPI scale) only to the "Furthest/Native" option, as this is the only setting without an upper limit for the world view.

Fixes https://github.com/OpenRA/OpenRA/issues/22466.