### PR TITLE
Fix wrong locomotor on harvester and mcv 

### DIFF
--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,5 +1,5 @@
 mcv:
-	Inherits: ^Tank
+	Inherits: ^Vehicle
 	Inherits@selection: ^SelectableSupportUnit
 	Buildable:
 		Prerequisites: repair_pad, ~techlevel.medium
@@ -44,6 +44,7 @@ mcv:
 		Actor: mcv.husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+		RequiresCondition: !being-demolished
 	AttractsWorms:
 		Intensity: 700
 	ChangesHealth:
@@ -52,7 +53,7 @@ mcv:
 		StartIfBelow: 50
 
 harvester:
-	Inherits: ^Tank
+	Inherits: ^Vehicle
 	Inherits@selection: ^SelectableEconomicUnit
 	Buildable:
 		Queue: Armor
@@ -99,7 +100,7 @@ harvester:
 		Actor: harvester.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
-		RequiresCondition: harvester-empty
+		RequiresCondition: harvester-empty && !being-demolished
 	WithHarvestOverlay:
 	WithDockingAnimation:
 	AttractsWorms:


### PR DESCRIPTION
MCV and Harvester in OG D2k used wheeled locomotor not tracked
<img width="1020" height="734" alt="image" src="https://github.com/user-attachments/assets/8f9b1608-92ed-4610-bd83-1885aa7cacfd" />

<img width="1018" height="743" alt="image" src="https://github.com/user-attachments/assets/88665cc3-c82a-4f41-8b03-3a3fab70272d" />
