### PR TITLE
Preserve setuped lobbyOptions in dedicated server runtime between games

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -236,7 +236,12 @@ namespace OpenRA.Server
 			}
 		}
 
-		public Server(List<IPEndPoint> endpoints, ServerSettings settings, ModData modData, ServerType type)
+		public Server(
+			List<IPEndPoint> endpoints,
+			ServerSettings settings,
+			ModData modData,
+			ServerType type,
+			IReadOnlyDictionary<string, Session.LobbyOptionState> initialLobbyOptions = null)
 		{
 			Log.AddChannel("server", "server.log", true);
 
@@ -335,6 +340,10 @@ namespace OpenRA.Server
 					Dedicated = Type == ServerType.Dedicated
 				}
 			};
+
+			if (initialLobbyOptions != null)
+				foreach (var kv in initialLobbyOptions)
+					LobbyInfo.GlobalSettings.LobbyOptions[kv.Key] = kv.Value;
 
 			if (Settings.RecordReplays && Type == ServerType.Dedicated)
 			{

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -87,6 +87,7 @@ namespace OpenRA.Server
 				[Path.Combine(Platform.EngineDir, "mods")];
 
 			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
+			IReadOnlyDictionary<string, Session.LobbyOptionState> savedLobbyOptions = null;
 
 			WriteLineWithTimeStamp($"Starting dedicated server for mod: {modID}");
 			while (true)
@@ -97,7 +98,7 @@ namespace OpenRA.Server
 				modData.MapCache.LoadMaps(modData);
 
 				var endpoints = new List<IPEndPoint> { new(IPAddress.IPv6Any, settings.ListenPort), new(IPAddress.Any, settings.ListenPort) };
-				var server = new Server(endpoints, settings, modData, ServerType.Dedicated);
+				var server = new Server(endpoints, settings, modData, ServerType.Dedicated, savedLobbyOptions);
 
 				GC.Collect();
 				while (true)
@@ -112,6 +113,7 @@ namespace OpenRA.Server
 				}
 
 				modData.Dispose();
+				savedLobbyOptions = server.LobbyInfo.GlobalSettings.LobbyOptions;
 				WriteLineWithTimeStamp("Starting a new server instance...");
 			}
 		}


### PR DESCRIPTION
In skirmish, lobbyOptions are preserved between plays.
Players @dedicated servers needs to setup options again and again, after each game when the server is refreshed.

This allows them play on the server multiple games in row with settings "refreshed" as well