### PR TITLE
Fix units not moving aside to avoid deadlocks.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -353,7 +353,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		(CPos Cell, SubCell SubCell)? UnblockDestination(Actor self)
 		{
-			var adjacent = mobile.GetAdjacentCell(self.Location);
+			var adjacent = mobile.GetAdjacentEnterableCell(self.Location);
 			if (adjacent == null)
 				return null;
 			return (adjacent.Value, mobile.GetAvailableSubCell(adjacent.Value, mobile.FromSubCell, ignoreActor));

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -170,16 +170,29 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (path.Count == 0)
+			(CPos Cell, SubCell SubCell)? nextCell = null;
+			var shouldTryAgain = false;
+			if (path.Count != 0)
 			{
+				// Continue with the path to our destination.
+				destination = path[0];
+				(nextCell, shouldTryAgain) = PopPath(self);
+			}
+			else if (mobile.IsBlocking)
+			{
+				// We are blocked from our destination, but we're also blocking others. We can be productive and move out of their way at least.
+				var unblockDestination = UnblockDestination(self);
+				if (unblockDestination != null)
+					(nextCell, shouldTryAgain) = (unblockDestination, true);
+			}
+			else
+			{
+				// We're blocked and nothing alternative we can do.
 				hadNoPath = true;
 				destination = mobile.ToCell;
 				return false;
 			}
 
-			destination = path[0];
-
-			var (nextCell, shouldTryAgain) = PopPath(self);
 			if (nextCell == null)
 			{
 				if (!shouldTryAgain)
@@ -324,14 +337,9 @@ namespace OpenRA.Mods.Common.Activities
 				else if (mobile.IsBlocking)
 				{
 					// If there is no way around the blocker and blocker will not move and we are blocking others, back up to let others pass.
-					var newCell = mobile.GetAdjacentCell(nextCell);
+					var newCell = UnblockDestination(self);
 					if (newCell != null)
-					{
-						if ((nextCell - newCell).Value.LengthSquared > 2)
-							path.Add(mobile.ToCell);
-
-						return ((newCell.Value, mobile.GetAvailableSubCell(newCell.Value, mobile.FromSubCell, ignoreActor)), true);
-					}
+						return (newCell, true);
 				}
 
 				return (null, false);
@@ -341,6 +349,14 @@ namespace OpenRA.Mods.Common.Activities
 			path.RemoveAt(path.Count - 1);
 
 			return ((nextCell, mobile.GetAvailableSubCell(nextCell, mobile.FromSubCell, ignoreActor)), true);
+		}
+
+		(CPos Cell, SubCell SubCell)? UnblockDestination(Actor self)
+		{
+			var adjacent = mobile.GetAdjacentCell(self.Location);
+			if (adjacent == null)
+				return null;
+			return (adjacent.Value, mobile.GetAvailableSubCell(adjacent.Value, mobile.FromSubCell, ignoreActor));
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/MoveCooldownHelper.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveCooldownHelper.cs
@@ -82,6 +82,12 @@ namespace OpenRA.Mods.Common.Activities
 				cooldownTicks = world.SharedRandom.Next(Cooldown.MinTicksInclusive, Cooldown.MaxTicksExclusive);
 				return false;
 			}
+			else if (mobile.IsBlocking)
+			{
+				// If we're blocking, don't wait for the cooldown even if we moved recently.
+				// Allow the caller to schedule a move immediately to get us out of the blocking position ASAP.
+				return null;
+			}
 			else
 			{
 				if (cooldownTicks > 0)

--- a/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
@@ -43,10 +43,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (lastVisibleTargetLocation == self.Location)
 				return (true, PathFinder.NoPath);
 
-			// If we are close to the target but can't enter, we wait.
-			if (!Mobile.CanEnterCell(lastVisibleTargetLocation) && Util.AreAdjacentCells(lastVisibleTargetLocation, self.Location))
-				return (false, PathFinder.NoPath);
-
 			// PERF: Don't create a new list every run.
 			// PERF: Also reuse the already created list in the base class.
 			if (SearchCells.Count == 0)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -374,24 +374,36 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region Local misc stuff
 
-		public CPos? GetAdjacentCell(CPos nextCell, Func<CPos, bool> preferToAvoid = null)
+		public CPos? GetAdjacentEnterableCell(CPos nextCell, Func<CPos, bool> preferToAvoid = null)
 		{
 			var availCells = new List<CPos>();
-			var notStupidCells = new List<CPos>();
 			foreach (var direction in CVec.Directions)
 			{
 				var p = ToCell + direction;
 				if (CanEnterCell(p) && CanStayInCell(p) && (preferToAvoid == null || !preferToAvoid(p)))
 					availCells.Add(p);
-				else if (p != nextCell && p != ToCell)
-					notStupidCells.Add(p);
 			}
 
 			CPos? newCell = null;
 			if (availCells.Count > 0)
 				newCell = availCells.Random(self.World.SharedRandom);
-			else
+
+			return newCell;
+		}
+
+		public CPos? GetAdjacentCell(CPos nextCell, Func<CPos, bool> preferToAvoid = null)
+		{
+			var newCell = GetAdjacentEnterableCell(nextCell, preferToAvoid);
+			if (newCell == null)
 			{
+				var notStupidCells = new List<CPos>();
+				foreach (var direction in CVec.Directions)
+				{
+					var p = ToCell + direction;
+					if (p != nextCell && p != ToCell)
+						notStupidCells.Add(p);
+				}
+
 				var cellInfo = notStupidCells
 					.SelectMany(c => self.World.ActorMap.GetActorsAt(c).Where(IsMovable),
 						(c, a) => new { Cell = c, Actor = a })


### PR DESCRIPTION
The Move activity contains a fallback logic where if we can't move to our destination, we'll use the mobile.IsBlocking to realise we are blocking other units, so we can at least move out of their way when we can't move to our destination. This check only kicks in once we've started performing a move.

When the MoveCooldownHelper was introduced, it changed how various parent activities issued move orders. Previously move orders would continue to try forever even if the unit was stuck, and this would allow them to respond to the unblock request. In the new behaviour, the move would abort when the unit got blocked and we'd try again after a ~1 second cooldown to avoid performance issues from stuck units.

This would cause a fresh move order to be issued each second, which for stuck units will fail. However, a fresh request does *not* perform the check to try and unblock others. This causes a regression - stuck units will no longer detect they are blocking others and move out the way.

To fix this regression, we teach the Move activity to perform the "unblock" logic for a fresh order as well. This means stuck units will now get out the way as soon as they attempt a move.

To avoid a delay, the MoveCooldownHelper learns to skip the cooldown if the unit is blocking, so it can be moved immediately rather than needing to wait for the cooldown to expire before moving.

----

Fixes #22477. Fixes #21853. Fixes #22401.

Regressed in #21391.

Recommended for the prep branch.

----

The harvester test case from #22477 is an easy reproduction example. Box in the refinery a bit, and then order 3 harvesters to unload at once. They'll stack up nicely into this configuration.

<img width="264" height="239" alt="image" src="https://github.com/user-attachments/assets/bb53c464-dd41-4fbc-8d8b-6ee3d3336896" />

Bleed: Once unloaded, the harvesters will sit in place and deadlock. You can manually order one aside to resolve the deadlock.

PR: One of the blocking harvesters will move aside on its own to resolve the deadlock, no manual intervention needed.