### PR TITLE
Disable IME text input by default and activate only when widgets require keyboard input

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -519,6 +519,8 @@ namespace OpenRA
 			if (!string.IsNullOrEmpty(metadata.WindowTitleTranslated))
 				Renderer.Window.SetWindowTitle(metadata.WindowTitleTranslated);
 
+			Renderer.Window.SetTextInputActive(false);
+
 			PerfHistory.Items["render"].HasNormalTick = false;
 			PerfHistory.Items["batches"].HasNormalTick = false;
 			PerfHistory.Items["render_world"].HasNormalTick = false;

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -75,6 +75,7 @@ namespace OpenRA
 		void SetHardwareCursor(IHardwareCursor cursor);
 		void SetWindowTitle(string title);
 		void SetRelativeMouseMode(bool mode);
+		void SetTextInputActive(bool active);
 		void SetScaleModifier(float scale);
 
 		GLProfile GLProfile { get; }

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -389,13 +389,17 @@ namespace OpenRA.Widgets
 				return false;
 
 			Ui.KeyboardFocusWidget = this;
+			Game.Renderer.Window.SetTextInputActive(true);
 			return true;
 		}
 
 		public virtual bool YieldKeyboardFocus()
 		{
 			if (Ui.KeyboardFocusWidget == this)
+			{
 				Ui.KeyboardFocusWidget = null;
+				Game.Renderer.Window.SetTextInputActive(false);
+			}
 
 			return true;
 		}

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -442,6 +442,19 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		public void SetTextInputActive(bool active)
+		{
+			VerifyThreadAffinity();
+			if (active)
+			{
+				SDL.SDL_StartTextInput();
+			}
+			else
+			{
+				SDL.SDL_StopTextInput();
+			}
+		}
+
 		internal void WindowSizeChanged()
 		{
 			// The ratio between pixels and points can change when moving between displays in OSX


### PR DESCRIPTION
This pull request changes the IME text input behavior to be disabled by default. It is only activated when a widget that requires keyboard input gains focus.

**Key behavior changes**

- IME text input is initially turned off during game startup
- When a widget takes keyboard focus the text input is enabled
- When a widget yields keyboard focus the text input is disabled

**Why this is beneficial**

This prevents accidental IME activation when pressing Shift followed by other keys during gameplay, while still allowing text input to work correctly in UI elements that need keyboard focus.

