### PR TITLE
Chrome: decouple Fluent string for main menu title from credits tab button

### DIFF
--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -55,7 +55,7 @@ Container@MENU_BACKGROUND:
 							Y: 0 - 28
 							Width: PARENT_WIDTH
 							Height: 20
-							Text: label-main-menu-mainmenu-title
+							Text: label-main-menu-title
 							Align: Center
 							Font: Bold
 							Contrast: True

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -518,7 +518,7 @@ checkbox-edgescroll-container = Screen Edge Panning
 
 ## mainmenu.yaml
 label-singleplayer-title = Singleplayer
-label-main-menu-mainmenu-title = Main Menu
+label-main-menu-title = Main Menu
 button-extras-title = Extras
 button-main-menu-content = Manage Content
 button-singleplayer-menu-skirmish = Skirmish

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -44,7 +44,7 @@ Container@MAINMENU:
 							Y: 22
 							Width: 200
 							Height: 30
-							Text: label-openra
+							Text: label-main-menu-title
 							Align: Center
 							Font: Bold
 						Button@SINGLEPLAYER_BUTTON:

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -32,7 +32,7 @@ label-connection-switchmod-panel-desc2 = Switch mods and join server?
 button-connection-switchmod-panel-switch = Switch
 button-connection-switchmod-panel-abort = Abort
 
-## credits.yaml, mainmenu.yaml
+## credits.yaml
 label-openra = OpenRA
 label-credits-title = Credits
 
@@ -476,6 +476,7 @@ label-mouse-control-desc-modern-edgescroll = or by moving the cursor to the edge
 checkbox-edgescroll-container = Screen Edge Panning
 
 ## mainmenu.yaml
+label-main-menu-title = OpenRA
 label-singleplayer-title = Singleplayer
 button-extras-title = Extras
 button-main-menu-content = Manage Content

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -31,7 +31,7 @@ Container@MAINMENU:
 							Y: 21
 							Width: 200
 							Height: 30
-							Text: label-openra
+							Text: label-main-menu-title
 							Align: Center
 							Font: Bold
 						Button@SINGLEPLAYER_BUTTON:


### PR DESCRIPTION
Currently it's not possible to rename just the title of main menu dialog. The `label-openra`, which is used for it, is also used for OpenRA tab in Credits dialog:

<a href="https://github.com/user-attachments/assets/78476828-a256-4240-ad0f-d6e176ca8242"><img height="300" alt="image" src="https://github.com/user-attachments/assets/78476828-a256-4240-ad0f-d6e176ca8242" /></a> <a href="https://github.com/user-attachments/assets/e2fa8f07-5985-425c-b43f-5a692a503fba"><img height="300" alt="image" src="https://github.com/user-attachments/assets/e2fa8f07-5985-425c-b43f-5a692a503fba" /></a>

This PR adds new Fluent string just for the main menu dialog title, so it can be configured independently from the credits tab button's text.

When it comes to official mods, ts/ra/d2k use default "OpenRA" for the main menu title (this is preserved). The cnc mod uses custom main menu layout including "Main Menu" label. The PR makes cnc mod use the same new Fluent string (to keep it consistent with other mods).