### PR TITLE
Log, generate less context switches.

### DIFF
--- a/OpenRA.Game/Support/Log.cs
+++ b/OpenRA.Game/Support/Log.cs
@@ -81,7 +81,7 @@ namespace OpenRA
 				while (reader.TryRead(out var item))
 					WriteValue(item);
 
-				Thread.Sleep(1);
+				Thread.Sleep(20);
 			}
 
 			while (reader.TryRead(out var item))


### PR DESCRIPTION

Logging thread shows up a making most context switches during a recording session - system wide. 

The sleep of 1 millisecond causes the thread to be rescheduled for execute 1+ milliseconds. Often for something that does not need to be very "real time".

The game does not log much in general. Even with bursts the thread can catch up or else the buffer can grow.

Sleep changes from 1 to 20 millisecond. Where 20 ms hopefully is responsive enough to still be able to follow logs with tail.

At crashes Dispose will be called and logs should still be flushed.

Untested.
