### PR TITLE
TraitDictionary, TypeDictionary, exclude System assembly types.

### DIFF
--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -13,23 +13,29 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenRA.Primitives
 {
 	public class TypeDictionary : IEnumerable<object>
 	{
+		static readonly Assembly SystemAssembly = typeof(object).Assembly;
+
 		static readonly Func<Type, ITypeContainer> CreateTypeContainer = t =>
 			(ITypeContainer)typeof(TypeContainer<>).MakeGenericType(t).GetConstructor(Type.EmptyTypes).Invoke(null);
 
 		readonly Dictionary<Type, ITypeContainer> data;
+		readonly bool includeSystemTypes;
 
-		public TypeDictionary()
+		public TypeDictionary(bool includeSystemTypes = false)
 		{
+			this.includeSystemTypes = includeSystemTypes;
 			data = [];
 		}
 
 		public TypeDictionary(TypeDictionary cloneFrom)
 		{
+			includeSystemTypes = cloneFrom.includeSystemTypes;
 			data = cloneFrom.data.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Clone());
 		}
 
@@ -43,9 +49,17 @@ namespace OpenRA.Primitives
 			var t = val.GetType();
 
 			foreach (var i in t.GetInterfaces())
-				InnerAdd(i, val);
-			foreach (var tt in t.BaseTypes())
-				InnerAdd(tt, val);
+				if (includeSystemTypes || i.Assembly != SystemAssembly)
+					InnerAdd(i, val);
+
+			var baseType = t;
+			while (baseType != null && baseType != typeof(object))
+			{
+				if (includeSystemTypes || baseType.Assembly != SystemAssembly)
+					InnerAdd(baseType, val);
+
+				baseType = baseType.BaseType;
+			}
 		}
 
 		void InnerAdd(Type t, object val)

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -12,8 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
-using OpenRA.Primitives;
 using OpenRA.Support;
 
 namespace OpenRA
@@ -42,6 +42,8 @@ namespace OpenRA
 	/// </summary>
 	sealed class TraitDictionary
 	{
+		static readonly Assembly SystemAssembly = typeof(object).Assembly;
+
 		static readonly Func<Type, ITraitContainer> CreateTraitContainer = t =>
 			(ITraitContainer)typeof(TraitContainer<>).MakeGenericType(t).GetConstructor(Type.EmptyTypes).Invoke(null);
 
@@ -69,9 +71,17 @@ namespace OpenRA
 			var t = val.GetType();
 
 			foreach (var i in t.GetInterfaces())
-				InnerAdd(actor, i, val);
-			foreach (var tt in t.BaseTypes())
-				InnerAdd(actor, tt, val);
+				if (i.Assembly != SystemAssembly)
+					InnerAdd(actor, i, val);
+
+			var baseType = t;
+			while (baseType != null && baseType != typeof(object))
+			{
+				if (baseType.Assembly != SystemAssembly)
+					InnerAdd(actor, baseType, val);
+
+				baseType = baseType.BaseType;
+			}
 		}
 
 		void InnerAdd(Actor actor, Type t, object val)


### PR DESCRIPTION
The type and trait dictionaries are normally only to be used to lookup and query OpenRA or mod types. Not lower level system types.

Change:

Do not add interfaces and types to the `TraitDictionary` and `TypeDictionary` if they are in the System Assembly.


Not all types are in the System assembly - but the current solution already excludes many types - while maintaining performance. The alternative is to compare the assembly name for a "System." prefix.

Advantage:
- We avoid having to do "expensive" search, insert and removal of actors for each of these system types.
- We use less memory - number of types times objects added to dictionary.

Assumes we don't have to query these dictionaries for system types.To maintain backwards compatibility`includeSystemTypes` can be set.

Tested by running a replay.

In-lined iterating the base types - to avoid `Enumerator` allocation.

Example: for a String type this would already mean we no longer maintain lists of each of these types per actor
 System.IComparable                                                                                                   │
│ System.Collections.IEnumerable                                                                                       │
│ System.IConvertible                                                                                                  │
│ System.Collections.Generic.IEnumerable<System.Char>                                                                  │
│ System.IComparable<System.String>                                                                                    │
│ System.IEquatable<System.String>                                                                                     │
│ System.ICloneable                                                                                                    │
│ System.ISpanParsable<System.String>                                                                                  │
│ System.IParsable<System.String>










