### PR TITLE
TraitDictionary, zero alloc enumerators.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Graphics
 			var mapGrid = modData.GetOrCreate<MapGrid>();
 			enableDepthBuffer = mapGrid.EnableDepthBuffer;
 
-			foreach (var pal in world.TraitDict.ActorsWithTrait<ILoadsPalettes>())
+			foreach (var pal in world.TraitDict.ActorsWithTraitAsIterator<ILoadsPalettes>())
 				pal.Trait.LoadPalettes(this);
 
 			Player.SetupRelationshipColors(world.Players, world.LocalPlayer, this, true);

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Network
 			report.Orders.Clear();
 			report.Orders.AddRange(orders);
 
-			foreach (var actor in orderManager.World.ActorsHavingTrait<ISync>())
+			foreach (var actor in orderManager.World.ActorsHavingTraitAsIterator<ISync>())
 			{
 				foreach (var syncHash in actor.SyncHashes)
 				{

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -20,7 +20,7 @@ namespace OpenRA
 {
 	static class SpanExts
 	{
-		public static int BinarySearchMany(this Span<Actor> span, uint searchFor)
+		public static int BinarySearchMany(this ReadOnlySpan<Actor> span, uint searchFor)
 		{
 			var start = 0;
 			var end = span.Length;
@@ -103,14 +103,30 @@ namespace OpenRA
 			return InnerGet<T>().GetMultiple(actor.ActorID);
 		}
 
+		public TraitIterator<T> WithInterfaceAsIterator<T>(Actor actor)
+		{
+			CheckDestroyed(actor);
+			return InnerGet<T>().GetMultipleAsIterator(actor.ActorID);
+		}
+
 		public IEnumerable<TraitPair<T>> ActorsWithTrait<T>()
 		{
 			return InnerGet<T>().All();
 		}
 
+		public TraitPairIterator<T> ActorsWithTraitAsIterator<T>()
+		{
+			return InnerGet<T>().AllAsIterator();
+		}
+
 		public IEnumerable<Actor> ActorsHavingTrait<T>()
 		{
 			return InnerGet<T>().Actors();
+		}
+
+		public ActorIterator ActorsHavingTraitAsIterator<T>()
+		{
+			return InnerGet<T>().ActorsAsIterator();
 		}
 
 		public IEnumerable<Actor> ActorsHavingTrait<T>(Func<T, bool> predicate)
@@ -152,7 +168,7 @@ namespace OpenRA
 			public void Add(Actor actor, object trait)
 			{
 				var actorsSpan = CollectionsMarshal.AsSpan(actors);
-				var insertIndex = actorsSpan.BinarySearchMany(actor.ActorID + 1);
+				var insertIndex = ((ReadOnlySpan<Actor>)actorsSpan).BinarySearchMany(actor.ActorID + 1);
 				actors.Insert(insertIndex, actor);
 				traits.Insert(insertIndex, (T)trait);
 			}
@@ -169,7 +185,7 @@ namespace OpenRA
 			public T GetOrDefault(Actor actor)
 			{
 				++Queries;
-				var actorsSpan = CollectionsMarshal.AsSpan(actors);
+				var actorsSpan = (ReadOnlySpan<Actor>)CollectionsMarshal.AsSpan(actors);
 				var index = actorsSpan.BinarySearchMany(actor.ActorID);
 				if (index >= actorsSpan.Length || actorsSpan[index] != actor)
 					return default;
@@ -185,6 +201,13 @@ namespace OpenRA
 				// PERF: Custom enumerator for efficiency - using `yield` is slower.
 				++Queries;
 				return new MultipleEnumerable(this, actor);
+			}
+
+			public TraitIterator<T> GetMultipleAsIterator(uint actor)
+			{
+				// PERF: Custom zero alloc enumerator for efficiency
+				++Queries;
+				return new TraitIterator<T>(this.actors, this.traits, actor);
 			}
 
 			sealed class MultipleEnumerable : IEnumerable<T>
@@ -211,7 +234,7 @@ namespace OpenRA
 					Reset();
 				}
 
-				public void Reset() { index = CollectionsMarshal.AsSpan(actors).BinarySearchMany(actor) - 1; }
+				public void Reset() { index = ((ReadOnlySpan<Actor>)CollectionsMarshal.AsSpan(actors)).BinarySearchMany(actor) - 1; }
 				public bool MoveNext() { return ++index < actors.Count && actors[index].ActorID == actor; }
 				public readonly T Current => traits[index];
 				readonly object System.Collections.IEnumerator.Current => Current;
@@ -223,6 +246,13 @@ namespace OpenRA
 				// PERF: Custom enumerator for efficiency - using `yield` is slower.
 				++Queries;
 				return new AllEnumerable(this);
+			}
+
+			public TraitPairIterator<T> AllAsIterator()
+			{
+				// PERF: Zero alloc enumerator
+				++Queries;
+				return new TraitPairIterator<T>(this.actors, this.traits);
 			}
 
 			public IEnumerable<Actor> Actors()
@@ -238,6 +268,12 @@ namespace OpenRA
 					yield return current;
 					last = current;
 				}
+			}
+
+			public ActorIterator ActorsAsIterator()
+			{
+				++Queries;
+				return new ActorIterator(this.actors);
 			}
 
 			public IEnumerable<Actor> Actors(Func<T, bool> predicate)
@@ -287,7 +323,7 @@ namespace OpenRA
 			public void RemoveActor(uint actor)
 			{
 				var actorsSpan = CollectionsMarshal.AsSpan(actors);
-				var startIndex = actorsSpan.BinarySearchMany(actor);
+				var startIndex = ((ReadOnlySpan<Actor>)actorsSpan).BinarySearchMany(actor);
 				if (startIndex >= actorsSpan.Length || actorsSpan[startIndex].ActorID != actor)
 					return;
 
@@ -325,5 +361,84 @@ namespace OpenRA
 				}
 			}
 		}
+	}
+
+	public ref struct TraitPairIterator<T>
+	{
+		readonly ReadOnlySpan<Actor> actors;
+		readonly ReadOnlySpan<T> traits;
+		int index;
+
+		public TraitPairIterator(List<Actor> actors, List<T> traits)
+		{
+			this.actors = CollectionsMarshal.AsSpan(actors);
+			this.traits = CollectionsMarshal.AsSpan(traits);
+			index = -1;
+		}
+
+		public bool MoveNext()
+		{
+			return ++index < actors.Length;
+		}
+
+		public readonly TraitPair<T> Current => new(actors[index], traits[index]);
+
+		public static void Dispose() { }
+		public readonly TraitPairIterator<T> GetEnumerator() => this;
+	}
+
+	public ref struct TraitIterator<T>
+	{
+		readonly ReadOnlySpan<Actor> actors;
+		readonly ReadOnlySpan<T> traits;
+		readonly uint actor;
+		int index;
+
+		public TraitIterator(List<Actor> actors, List<T> traits, uint actor)
+		{
+			this.actors = CollectionsMarshal.AsSpan(actors);
+			this.traits = CollectionsMarshal.AsSpan(traits);
+			this.actor = actor;
+			index = this.actors.BinarySearchMany(actor) - 1;
+		}
+
+		public bool MoveNext() { return ++index < actors.Length && actors[index].ActorID == actor; }
+		public readonly T Current => traits[index];
+		public static void Dispose() { }
+		public readonly TraitIterator<T> GetEnumerator() => this;
+	}
+
+	public ref struct ActorIterator
+	{
+		readonly ReadOnlySpan<Actor> actors;
+		int index;
+
+		public ActorIterator(List<Actor> actors)
+		{
+			this.actors = CollectionsMarshal.AsSpan(actors);
+			index = -1;
+		}
+
+		public bool MoveNext()
+		{
+			if (index >= actors.Length)
+				return false;
+
+			while (++index < actors.Length)
+			{
+				var next = actors[index];
+				if (index == 0 || next.ActorID != Current.ActorID)
+				{
+					Current = next;
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		public Actor Current { get; private set; }
+		public static void Dispose() { }
+		public readonly ActorIterator GetEnumerator() => this;
 	}
 }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -491,7 +491,7 @@ namespace OpenRA
 					ret += n++ * (int)(1 + a.ActorID) * Sync.HashActor(a);
 
 				// Hash fields marked with the ISync interface.
-				foreach (var actor in ActorsHavingTrait<ISync>())
+				foreach (var actor in TraitDict.ActorsHavingTraitAsIterator<ISync>())
 					foreach (var syncHash in actor.SyncHashes)
 						ret += n++ * (int)(1 + actor.ActorID) * syncHash.Hash();
 
@@ -516,6 +516,11 @@ namespace OpenRA
 			return TraitDict.ActorsWithTrait<T>();
 		}
 
+		public TraitPairIterator<T> ActorsWithTraitAsIterator<T>()
+		{
+			return TraitDict.ActorsWithTraitAsIterator<T>();
+		}
+
 		public void ApplyToActorsWithTraitTimed<T>(Action<Actor, T> action, string text)
 		{
 			TraitDict.ApplyToActorsWithTraitTimed(action, text);
@@ -529,6 +534,11 @@ namespace OpenRA
 		public IEnumerable<Actor> ActorsHavingTrait<T>()
 		{
 			return TraitDict.ActorsHavingTrait<T>();
+		}
+
+		public ActorIterator ActorsHavingTraitAsIterator<T>()
+		{
+			return TraitDict.ActorsHavingTraitAsIterator<T>();
 		}
 
 		public IEnumerable<Actor> ActorsHavingTrait<T>(Func<T, bool> predicate)
@@ -568,7 +578,7 @@ namespace OpenRA
 			// at the end of the save restoration
 			// TODO: This will need to be generalized to a request / response pair for multiplayer game saves
 			var i = 0;
-			foreach (var tp in TraitDict.ActorsWithTrait<IGameSaveTraitData>())
+			foreach (var tp in TraitDict.ActorsWithTraitAsIterator<IGameSaveTraitData>())
 			{
 				var data = tp.Trait.IssueTraitData(tp.Actor);
 				if (data != null)

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 			// Trigger screen desaturate effect
 			if (screenFlash)
-				foreach (var a in self.World.ActorsWithTrait<ChronoshiftPostProcessEffect>())
+				foreach (var a in self.World.ActorsWithTraitAsIterator<ChronoshiftPostProcessEffect>())
 					a.Trait.Enable();
 
 			if (teleporter != null && self != teleporter && !teleporter.Disposed)

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				TriggerVortex();
 
 			// Trigger screen desaturate effect
-			foreach (var cpa in self.World.ActorsWithTrait<ChronoshiftPostProcessEffect>())
+			foreach (var cpa in self.World.ActorsWithTraitAsIterator<ChronoshiftPostProcessEffect>())
 				cpa.Trait.Enable();
 
 			Game.Sound.Play(SoundType.World, info.ChronoshiftSound, self.CenterPosition);

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -80,12 +80,27 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			var wasGranted = Granted;
 			var wasGrantedAllies = GrantedAllies;
-			var allyWatchers = owner.World.ActorsWithTrait<GpsWatcher>().Where(kv => kv.Actor.Owner.IsAlliedWith(owner)).ToList();
+
+			GrantedAllies = false;
+			var anyLaunched = false;
+			foreach (var tp in owner.World.ActorsWithTraitAsIterator<GpsWatcher>())
+			{
+				if (!tp.Actor.Owner.IsAlliedWith(owner))
+					continue;
+
+				if (tp.Trait.Granted)
+					GrantedAllies = true;
+
+				if (tp.Trait.Launched)
+					anyLaunched = true;
+
+				if (GrantedAllies && (explored || Launched || anyLaunched))
+					break;
+			}
 
 			Granted = actors.Count > 0 && Launched;
-			GrantedAllies = allyWatchers.Any(w => w.Trait.Granted);
 
-			if (!explored && (Launched || allyWatchers.Any(w => w.Trait.Launched)))
+			if (!explored && (Launched || anyLaunched))
 			{
 				explored = true;
 				owner.Shroud.ExploreAll();

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -277,8 +277,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (--assignRallyPointsTicks <= 0)
 			{
 				assignRallyPointsTicks = Math.Max(2, Info.AssignRallyPointsInterval);
-				foreach (var rp in world.ActorsWithTrait<RallyPoint>().Where(rp => rp.Actor.Owner == player))
-					rallyPoints.Push(rp);
+				foreach (var rp in world.ActorsWithTraitAsIterator<RallyPoint>())
+				{
+					if (rp.Actor.Owner == player)
+						rallyPoints.Push(rp);
+				}
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -329,9 +329,11 @@ namespace OpenRA.Mods.Common.Traits
 				harvesters.Remove(a);
 
 			// Find new harvesters
-			var newHarvesters = world.ActorsHavingTrait<Harvester>().Where(a => !unitCannotBeOrdered(a) && !harvesters.ContainsKey(a));
-			foreach (var a in newHarvesters)
-				harvesters[a] = new HarvesterTraitWrapper(a);
+			foreach (var actor in world.ActorsHavingTraitAsIterator<Harvester>())
+			{
+				if (!unitCannotBeOrdered(actor) && !harvesters.ContainsKey(actor))
+					harvesters[actor] = new HarvesterTraitWrapper(actor);
+			}
 
 			harvestersNeedingOrders.Clear();
 			foreach (var h in harvesters)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (mapBuildRadius == null || !mapBuildRadius.BuildRadiusEnabled)
 				return null;
 
-			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
+			foreach (var bp in world.ActorsWithTraitAsIterator<BaseProvider>())
 			{
 				var validOwner = bp.Actor.Owner == p || (allyBuildEnabled && bp.Actor.Owner.RelationshipWith(p) == PlayerRelationship.Ally);
 				if (!validOwner || !bp.Trait.Ready())

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 				value = playerResources.ChangeCash(value);
 
-			foreach (var notify in self.World.ActorsWithTrait<INotifyResourceAccepted>())
+			foreach (var notify in self.World.ActorsWithTraitAsIterator<INotifyResourceAccepted>())
 			{
 				if (notify.Actor.Owner != self.Owner)
 					continue;

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			foreach (var pair in self.World.ActorsWithTrait<INotifyProximityOwnerChanged>())
+			foreach (var pair in self.World.ActorsWithTraitAsIterator<INotifyProximityOwnerChanged>())
 				pair.Trait.OnProximityOwnerChanged(self, oldOwner, newOwner);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HealActorsCrateAction.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -36,9 +35,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void Activate(Actor collector)
 		{
-			foreach (var healable in collector.World.ActorsWithTrait<IHealth>().Where(tp => tp.Actor.Owner == collector.Owner))
+			foreach (var healable in collector.World.ActorsWithTraitAsIterator<IHealth>())
+			{
+				if (healable.Actor.Owner != collector.Owner)
+					continue;
+
 				if (!healable.Trait.IsDead && (info.TargetTypes.IsEmpty || info.TargetTypes.Overlaps(healable.Actor.GetEnabledTargetTypes())))
 					healable.Trait.InflictDamage(healable.Actor, healable.Actor, new Damage(-(healable.Trait.MaxHP - healable.Trait.HP)), true);
+			}
 
 			base.Activate(collector);
 		}

--- a/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BulkProductionQueue.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Avoid LINQ.
 			Enabled = false;
 			var isActive = false;
-			foreach (var x in self.World.ActorsWithTrait<Production>())
+			foreach (var x in self.World.ActorsWithTraitAsIterator<Production>())
 			{
 				if (x.Trait.IsTraitDisabled)
 					continue;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Avoid LINQ.
 			Enabled = false;
 			var isActive = false;
-			foreach (var x in self.World.ActorsWithTrait<Production>())
+			foreach (var x in self.World.ActorsWithTraitAsIterator<Production>())
 			{
 				if (x.Trait.IsTraitDisabled)
 					continue;

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Avoid LINQ.
 			Enabled = false;
 			var isActive = false;
-			foreach (var x in self.World.ActorsWithTrait<Production>())
+			foreach (var x in self.World.ActorsWithTraitAsIterator<Production>())
 			{
 				if (x.Trait.IsTraitDisabled)
 					continue;

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -100,8 +100,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyWinStateChanged.OnPlayerLost(Player player)
 		{
-			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
-				a.Trait.OnOwnerLost(a.Actor);
+			foreach (var a in player.World.ActorsWithTraitAsIterator<INotifyOwnerLost>())
+				if (a.Actor.Owner == player)
+					a.Trait.OnOwnerLost(a.Actor);
 
 			if (info.SuppressNotifications)
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				case Orders.GrowResources:
 				{
-					foreach (var a in self.World.ActorsWithTrait<ISeedableResource>())
+					foreach (var a in self.World.ActorsWithTraitAsIterator<ISeedableResource>())
 						for (var i = 0; i < info.ResourceGrowth; i++)
 							a.Trait.Seed(a.Actor);
 

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 			visibleActorIds = [];
 			playedNotifications = [];
 
-			foreach (var actor in self.World.ActorsWithTrait<AnnounceOnSeen>())
+			foreach (var actor in self.World.ActorsWithTraitAsIterator<AnnounceOnSeen>())
 			{
 				// We don't want notifications for allied actors or actors disguised as such
 				if (actor.Actor.AppearsFriendlyTo(self))

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -146,8 +146,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyWinStateChanged.OnPlayerLost(Player player)
 		{
-			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
-				a.Trait.OnOwnerLost(a.Actor);
+			foreach (var a in player.World.ActorsWithTraitAsIterator<INotifyOwnerLost>())
+				if (a.Actor.Owner == player)
+					a.Trait.OnOwnerLost(a.Actor);
 
 			if (info.SuppressNotifications)
 				return;

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				ConvertBridgeToActor(w, cell);
 
 			// Link adjacent (long)-bridges so that artwork is updated correctly
-			foreach (var p in w.ActorsWithTrait<Bridge>())
+			foreach (var p in w.ActorsWithTraitAsIterator<Bridge>())
 				p.Trait.LinkNeighbouringBridges(this);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -425,7 +425,7 @@ namespace OpenRA.Mods.Common.Widgets
 					{
 						var colors = (uint*)colorBytes;
 
-						foreach (var t in world.ActorsWithTrait<IRadarSignature>())
+						foreach (var t in world.ActorsWithTraitAsIterator<IRadarSignature>())
 						{
 							if (!t.Actor.IsInWorld || world.FogObscures(t.Actor))
 								continue;

--- a/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
+++ b/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
@@ -33,9 +33,9 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public void TryActivate()
 		{
-			var harvesters = self.World.ActorsHavingTrait<Harvester>().Where(x => x.Owner == self.Owner);
-			if (harvesters.Any())
-				return;
+			foreach (var harv in self.World.ActorsHavingTraitAsIterator<Harvester>())
+				if (harv.Owner == self.Owner)
+					return;
 
 			var refinery = self.World.ActorsHavingTrait<Refinery>().FirstOrDefault(x => x.Owner == self.Owner && x.Info.HasTraitInfo<FreeActorWithDeliveryInfo>());
 			if (refinery == null)


### PR DESCRIPTION

- Avoid allocation of Enumerator and Enumerable objects in hot paths.
- To make the distinction with Enumerator i named them Iterator. 

We could consider removing the Enumerator's but the Iterators do not work with LINQ.

Tested with replay. 

I did not measure the performance improvement. Likely trivial - although the loops are in the hot path.

