### PR TITLE
Disable IME text input by default and activate only when widgets require keyboard input

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -75,6 +75,7 @@ namespace OpenRA
 		void SetHardwareCursor(IHardwareCursor cursor);
 		void SetWindowTitle(string title);
 		void SetRelativeMouseMode(bool mode);
+		void SetTextInputActive(bool active);
 		void SetScaleModifier(float scale);
 
 		GLProfile GLProfile { get; }

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -389,13 +389,17 @@ namespace OpenRA.Widgets
 				return false;
 
 			Ui.KeyboardFocusWidget = this;
+			Game.Renderer.Window.SetTextInputActive(true);
 			return true;
 		}
 
 		public virtual bool YieldKeyboardFocus()
 		{
 			if (Ui.KeyboardFocusWidget == this)
+			{
 				Ui.KeyboardFocusWidget = null;
+				Game.Renderer.Window.SetTextInputActive(false);
+			}
 
 			return true;
 		}
@@ -403,7 +407,10 @@ namespace OpenRA.Widgets
 		void ForceYieldKeyboardFocus()
 		{
 			if (Ui.KeyboardFocusWidget == this && !YieldKeyboardFocus())
+			{
 				Ui.KeyboardFocusWidget = null;
+				Game.Renderer.Window.SetTextInputActive(false);
+			}
 		}
 
 		public virtual string GetCursor(int2 pos) { return defaultCursor; }

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -355,6 +355,7 @@ namespace OpenRA.Platforms.Default
 
 			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();
+			SetTextInputActive(false);
 		}
 
 		static byte[] DoublePixelData(byte[] data, Size size)
@@ -439,6 +440,19 @@ namespace OpenRA.Platforms.Default
 					SDL.SDL_WarpMouseInWindow(window, lockedMousePosition.Value.X, lockedMousePosition.Value.Y);
 
 				lockedMousePosition = null;
+			}
+		}
+
+		public void SetTextInputActive(bool active)
+		{
+			VerifyThreadAffinity();
+			if (active)
+			{
+				SDL.SDL_StartTextInput();
+			}
+			else
+			{
+				SDL.SDL_StopTextInput();
 			}
 		}
 


### PR DESCRIPTION
This pull request changes the IME text input behavior to be disabled by default. It is only activated when a widget that requires keyboard input gains focus.

**Key behavior changes**

- IME text input is initially turned off during game startup
- When a widget takes keyboard focus the text input is enabled
- When a widget yields keyboard focus the text input is disabled

**Why this is beneficial**

This prevents accidental IME activation when pressing Shift followed by other keys during gameplay, while still allowing text input to work correctly in UI elements that need keyboard focus.

The two screenshots show the input method's key settings and the in-game steps that trigger the input method, respectively. To illustrate the issue more clearly, I recorded a short video. You can see that initially I could use the E and R keys to switch tabs, but after using Shift to plan the path, pressing E and R triggers the input method.

<img width="899" height="699" alt="微软拼音输入法按键设置" src="https://github.com/user-attachments/assets/d46caec2-0570-456e-bc8a-4bca94533b75" />

<img width="1920" height="1080" alt="游戏内触发输入法" src="https://github.com/user-attachments/assets/f1a35222-cbb4-4def-b9f2-b3cc8fea88af" />

https://github.com/user-attachments/assets/46378e8d-ad43-4ce6-ab48-7b431515643e