### PR TITLE
Add version control browser URL

### DIFF
--- a/packaging/linux/openra.metainfo.xml.in
+++ b/packaging/linux/openra.metainfo.xml.in
@@ -48,6 +48,7 @@
     <color type="primary" scheme_preference="dark">#1a191e</color>
   </branding>
   <url type="homepage">https://www.openra.net</url>
+  <url type="vcs-browser">https://github.com/OpenRA/OpenRA</url>
   <url type="bugtracker">https://github.com/OpenRA/OpenRA/issues</url>
   <url type="donation">https://www.patreon.com/orahosting</url>
   <update_contact>paul_at_chote.net</update_contact>


### PR DESCRIPTION
https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url strongly suggests it for Open Source projects and I also saw its linter spit out warnings when you don't.