### PR TITLE
Include the GeoIP database in the source tarball

### DIFF
--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -24,6 +24,8 @@ make version VERSION="${TAG}"
 # Use the amend flag (r) to prevent each call erasing the output from earlier calls.
 rm "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" || :
 git ls-tree HEAD --name-only -r -z | xargs -0 tar vrf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
+./fetch-geoip.sh
+tar -rvf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar" IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 bzip2 "${OUTPUTDIR}/OpenRA-${TAG}-source.tar"
 
 popd > /dev/null


### PR DESCRIPTION
This is otherwise a pain point for packaging because it requires an internet connection to download it before a build that it is often offline for security reasons. If downloaded in advance by the packaging system with a checksum, this will then fail next month because the file is updated.