### PR TITLE
Fix server-side map pool loading

### DIFF
--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -93,22 +93,20 @@ namespace OpenRA
 				}
 			}
 
-			if (t.IsGenericType &&
+			if ((t.IsGenericType &&
 				(t.GetGenericTypeDefinition() == typeof(List<>) ||
-				t.GetGenericTypeDefinition() == typeof(HashSet<>) ||
-				t.GetGenericTypeDefinition()
-					.BaseTypes()
+				t.GetGenericTypeDefinition() == typeof(HashSet<>))) ||
+				t.BaseTypes()
 					.Select(bt => bt.IsGenericType ? bt.GetGenericTypeDefinition() : null)
-					.Any(bt => bt == typeof(FrozenSet<>))))
+					.Any(bt => bt == typeof(FrozenSet<>)))
 				return ((System.Collections.IEnumerable)v).Cast<object>().Select(FormatValue).JoinWith(", ");
 
 			// This is only for documentation generation
-			if (t.IsGenericType &&
-				(t.GetGenericTypeDefinition() == typeof(Dictionary<,>) ||
-				t.GetGenericTypeDefinition()
-					.BaseTypes()
+			if ((t.IsGenericType &&
+				t.GetGenericTypeDefinition() == typeof(Dictionary<,>)) ||
+				t.BaseTypes()
 					.Select(bt => bt.IsGenericType ? bt.GetGenericTypeDefinition() : null)
-					.Any(bt => bt == typeof(FrozenDictionary<,>))))
+					.Any(bt => bt == typeof(FrozenDictionary<,>)))
 			{
 				var result = new StringBuilder();
 				var dict = (System.Collections.IDictionary)v;

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -283,7 +283,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				if (streams.Count == 0)
-					return CryptoUtil.SHA1Hash([]);
+					return CryptoUtil.SHA1Hash(Array.Empty<byte>());
 
 				var merged = streams[0];
 				for (var i = 1; i < streams.Count; i++)

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -223,8 +223,9 @@ namespace OpenRA
 		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids,
 			Action<MapPreview> mapDetailsReceived = null, Action<MapPreview> mapQueryFailed = null)
 		{
-			var queryUids = uids.Distinct()
-				.Where(uid => uid != null)
+			var distinctUids = uids.Distinct().Where(uid => uid != null).ToList();
+
+			var queryUids = distinctUids
 				.Select(uid => previews[uid])
 				.Where(p => p.Status == MapStatus.Unavailable)
 				.Select(p => p.Uid)
@@ -238,9 +239,36 @@ namespace OpenRA
 				var client = HttpClientFactory.Create();
 				var stringPool = new HashSet<string>(); // Reuse common strings in YAML
 
-				// Limit each query to 50 maps at a time to avoid request size limits
-				foreach (var batchUids in queryUids.Chunk(50))
+				// Limit each query to 50 maps at a time to avoid request size limits.
+				// Use manual chunking instead of Enumerable.Chunk to avoid potential
+				// runtime bugs (see #22506).
+				const int BatchSize = 50;
+				for (var i = 0; i < queryUids.Count; i += BatchSize)
 				{
+					var batchSize = Math.Min(BatchSize, queryUids.Count - i);
+					var batchUids = new List<string>(batchSize);
+					for (var j = 0; j < batchSize; j++)
+					{
+						var uid = queryUids[i + j];
+
+						// Map UIDs are SHA-1 hashes (40 lowercase hex characters).
+						// Skip any UID that doesn't match this format to prevent
+						// Corrupted data from reaching the remote query URL (#22506).
+						if (uid.Length != 40 || !uid.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+						{
+							Log.Write("debug", $"MapCache: skipping invalid map UID '{uid}'");
+							var p = previews[uid];
+							if (p.Status == MapStatus.Searching)
+								p.CompleteRemoteSearch(null, mapQueryFailed);
+							continue;
+						}
+
+						batchUids.Add(uid);
+					}
+
+					if (batchUids.Count == 0)
+						continue;
+
 					var url = repositoryUrl + "hash/" + string.Join(",", batchUids) + "/yaml";
 					using (new PerfTimer("RemoteMapDetails"))
 					{


### PR DESCRIPTION
Fixes #22506.

FieldSaver.FormatValue serializes FrozenSet<string> (used for the server map pool) for network transmission via SyncMapPool. In .NET 8, ToFrozenSet() returns instances of internal non-generic types (e.g. LengthBucketsFrozenSet). The existing type check:

    if (t.IsGenericType && t.GetGenericTypeDefinition().BaseTypes()...)

failed for non-generic runtime types because t.IsGenericType was false. The value fell through to the TypeConverter, which returned the literal string "(Collection)" instead of the comma-separated UID list. This corrupted string was sent to all clients via SyncMapPool, which then queried the Resource Center for a map with UID "(Collection)".

Changes:
- FieldSaver: Check t.BaseTypes() directly for FrozenSet<> (and FrozenDictionary<,>) instead of going through t.GetGenericTypeDefinition().BaseTypes(), so non-generic runtime types like LengthBucketsFrozenSet are correctly handled.
- MapCache: Replace Enumerable.Chunk(50) with a manual for-loop to avoid edge cases in .NET 8 Chunk. Validate UIDs are 40-char lowercase hex (SHA-1) before querying; invalid UIDs are logged and skipped, and their map previews are marked failed to prevent a stuck Searching state.
- Map: Fix ambiguous SHA1Hash([]) call between byte[] and string overloads.

Tested with make test on all four default mods and manually validated to patched server map pools work again. Verified FormatValue now correctly serializes non-empty FrozenSets to comma-separated UIDs instead of "(Collection)".

--

The bug was introduced in commit 797c71e500 (Nov 7, 2025) - "Add FieldLoader/Saver support for ImmutableArray, FrozenSet, FrozenDictionary". It is not present in the latest full release (release-20250330). It only exists in the current playtest/dev branch (playtest-20260222).

The FrozenSet<> type check in FieldSaver.FormatValue uses t.GetGenericTypeDefinition().BaseTypes(), which requires t to be generic. This works for EmptyFrozenSet<T> (generic) but fails for .NET 8 non-empty runtime type LengthBucketsFrozenSet (non-generic). The value then falls through to the TypeConverter, which returns the literal string "(Collection)".