### PR TITLE
Fix crash in CopySourceAction

### DIFF
--- a/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
+++ b/OpenRA.Mods.Common/Installer/SourceActions/CopySourceAction.cs
@@ -28,7 +28,13 @@ namespace OpenRA.Mods.Common.Installer
 				var targetPath = Platform.ResolvePath(node.Key);
 				if (File.Exists(targetPath))
 				{
-					Log.Write("install", "Ignoring installed file " + targetPath);
+					Log.Write("install", $"Ignoring installed file: {targetPath}");
+					continue;
+				}
+
+				if (!File.Exists(sourcePath))
+				{
+					Log.Write("install", $"File not found: {sourcePath}");
 					continue;
 				}
 


### PR DESCRIPTION
As title says. While technically source with missing files can be considered corrupted, in some cases it might make sense to just log missing files and continue installation.