### PR TITLE
MapPreviewWidget: show team number instead of spawn letter on map preview when spawn and team are both selected.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -220,10 +220,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 					WidgetUtils.DrawSprite(sprite, (pos - offset).ToVector2());
 
-					var number = Convert.ToChar('A' + spawnPoints.IndexOf(p)).ToString();
-					var textOffset = spawnFont.Measure(number) / 2 + spawnLabelOffset;
+					var spawnLabelText = occupied && occupant.Team > 0 ? occupant.Team.ToStringInvariant() :
+						Convert.ToChar('A' + spawnPoints.IndexOf(p)).ToString();
 
-					spawnFont.DrawTextWithContrast(number, (pos - textOffset).ToVector2(), spawnColor, spawnContrastColor, 1);
+					var textOffset = spawnFont.Measure(spawnLabelText) / 2 + spawnLabelOffset;
+					spawnFont.DrawTextWithContrast(spawnLabelText, (pos - textOffset).ToVector2(), spawnColor, spawnContrastColor, 1);
 				}
 			}
 		}


### PR DESCRIPTION
Show team number instead of spawn letter on map preview when spawn and team are both selected.

My first pull request. This fixes the time consuming issue of having to mouse over all the spawns in the map preview before starting every game. Now you can check the teams quickly, while only needing to mouse over spawns that may be overlapping each other.

I used AI but it is just a simple AND check of the spawn letter and team number selection. The spawn letters are still displayed by default on the map preview if the team number is not selected.

Potential issue is if a player loads a huge map with spawns that are out of order and plays with many bots, it may be difficult to find the bot that is on the wrong team/spawn since the tooltip does not show the spawn letter, and bots share the same name.