### PR TITLE
Use time instead of cost to calculate progress bars

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -79,10 +79,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var current = queue.AllQueued().Where(i => i.Started).MinByOrDefault(i => i.RemainingTime);
 			if (current == null)
 				value = 0;
-			else if (current.TotalCost <= 0)
+			else if (current.TotalTime <= 0)
 				value = 1;
 			else
-				value = 1 - (float)current.RemainingCost / current.TotalCost;
+				value = 1 - (float)current.RemainingTime / current.TotalTime;
 		}
 
 		float ISelectionBar.GetValue()


### PR DESCRIPTION
This fixes progress bars being always 100% when the PayUpFront option is used for production queues.