### PR TITLE
[Feature] Auto-prune old replays

### DIFF
--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Network
 		BinaryWriter writer;
 		readonly Func<string> chooseFilename;
 		MemoryStream preStartBuffer = new();
+		string replayDir;
 
 		static bool IsGameStart(byte[] data)
 		{
@@ -46,6 +47,7 @@ namespace OpenRA.Network
 			var filename = chooseFilename();
 			var mod = Game.ModData.Manifest;
 			var dir = Path.Combine(Platform.SupportDir, "Replays", mod.Id, mod.Metadata.Version);
+			replayDir = dir;
 
 			if (!Directory.Exists(dir))
 				Directory.CreateDirectory(dir);
@@ -114,6 +116,36 @@ namespace OpenRA.Network
 
 			preStartBuffer?.Dispose();
 			writer.Close();
+
+			if (replayDir != null)
+				PruneOldReplays(replayDir);
+		}
+
+		static void PruneOldReplays(string dir)
+		{
+			var maxReplayCount = Game.Settings.Game.MaxReplayCount;
+			if (maxReplayCount <= 0)
+				return;
+
+			var directoryInfo = new DirectoryInfo(dir);
+			if (!directoryInfo.Exists)
+				return;
+
+			var oldReplays = directoryInfo.EnumerateFiles("*.orarep")
+				.OrderByDescending(f => f.CreationTimeUtc)
+				.Skip(maxReplayCount);
+
+			foreach (var replay in oldReplays)
+			{
+				try
+				{
+					replay.Delete();
+				}
+				catch (Exception e)
+				{
+					Log.Write("debug", $"Failed to delete old replay '{replay.Name}': {e.Message}");
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Network
 			if (!directoryInfo.Exists)
 				return;
 
-			var oldReplays = directoryInfo.EnumerateFiles("*.orarep")
+			var oldReplays = directoryInfo.GetFiles("*.orarep")
 				.OrderByDescending(f => f.LastWriteTimeUtc)
 				.Skip(maxReplayCount);
 

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Network
 				return;
 
 			var oldReplays = directoryInfo.EnumerateFiles("*.orarep")
-				.OrderByDescending(f => f.CreationTimeUtc)
+				.OrderByDescending(f => f.LastWriteTimeUtc)
 				.Skip(maxReplayCount);
 
 			foreach (var replay in oldReplays)

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -12,6 +12,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Security;
+using System.Threading.Tasks;
 using OpenRA.FileFormats;
 
 namespace OpenRA.Network
@@ -118,7 +120,10 @@ namespace OpenRA.Network
 			writer.Close();
 
 			if (replayDir != null)
-				PruneOldReplays(replayDir);
+			{
+				// PERF: Push I/O work to a background.
+				_ = Task.Run(() => PruneOldReplays(replayDir));
+			}
 		}
 
 		static void PruneOldReplays(string dir)
@@ -141,9 +146,17 @@ namespace OpenRA.Network
 				{
 					replay.Delete();
 				}
-				catch (Exception e)
+				catch (IOException e)
 				{
-					Log.Write("debug", $"Failed to delete old replay '{replay.Name}': {e.Message}");
+					Log.Write("debug", $"File in use or I/O error deleting replay '{replay.Name}': {e.Message}");
+				}
+				catch (UnauthorizedAccessException e)
+				{
+					Log.Write("debug", $"Permission denied deleting replay '{replay.Name}': {e.Message}");
+				}
+				catch (SecurityException e)
+				{
+					Log.Write("debug", $"Security error deleting replay '{replay.Name}': {e.Message}");
 				}
 			}
 		}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -335,6 +335,9 @@ namespace OpenRA
 
 		public bool HideReplayChat = false;
 
+		[Desc("Maximum number of replays to keep per mod/version. Oldest replays beyond this count are deleted on startup. 0 disables pruning.")]
+		public int MaxReplayCount = 0;
+
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
 		public TargetLinesType TargetLines = TargetLinesType.Manual;
 		public bool UsePlayerStanceColors = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/GamePlaySettingsLogic.cs
@@ -57,7 +57,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		[FluentReference]
 		const string AutoSaveMaxFileNumber = "auto-save-max-file-number";
+
+		[FluentReference]
+		const string MaxReplayCountDisabled = "max-replay-count.disabled";
+
+		[FluentReference]
+		const string MaxReplayCountOptions = "max-replay-count.options";
+
 		readonly int[] autoSaveSeconds = [0, 10, 30, 45, 60, 120, 180, 300, 600];
+		readonly int[] maxReplayCountOptions = [0, 10, 50, 100];
 
 		readonly int[] autoSaveFileNumbers = [3, 5, 10, 20, 50, 100];
 		readonly AutoSaveSettings autoSaveSettings;
@@ -208,6 +216,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			autoSaveNoDropDown.GetText = () => FluentProvider.GetMessage(AutoSaveMaxFileNumber, "saves", autoSaveSettings.AutoSaveMaxFileCount);
 			autoSaveNoDropDown.IsDisabled = () => autoSaveSettings.AutoSaveInterval <= 0;
 
+			// Setup dropdown for replay limit.
+			var maxReplayCountDropDown = panel.Get<DropDownButtonWidget>("MAX_REPLAY_COUNT_DROP_DOWN");
+			maxReplayCountDropDown.OnMouseDown = _ => ShowMaxReplayCountDropdown(maxReplayCountDropDown, maxReplayCountOptions);
+			maxReplayCountDropDown.GetText = () => GetMessageForMaxReplayCount(gameSettings.MaxReplayCount);
+
 			SettingsUtils.AdjustSettingsScrollPanelLayout(scrollPanel);
 
 			return () =>
@@ -228,6 +241,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				playerSettings.Color = defaultPlayerSettings.Color;
 				autoSaveSettings.AutoSaveInterval = defaultAutoSaveSettings.AutoSaveInterval;
 				autoSaveSettings.AutoSaveMaxFileCount = defaultAutoSaveSettings.AutoSaveMaxFileCount;
+				gameSettings.MaxReplayCount = defaultGameSettings.MaxReplayCount;
 				gameSettings.HideReplayChat = defaultGameSettings.HideReplayChat;
 			};
 		}
@@ -289,11 +303,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			lastState = state;
 		}
 
+		void ShowMaxReplayCountDropdown(DropDownButtonWidget dropdown, IEnumerable<int> options)
+		{
+			ScrollItemWidget SetupItem(int o, ScrollItemWidget itemTemplate)
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => gameSettings.MaxReplayCount == o,
+					() =>
+					{
+						gameSettings.MaxReplayCount = o;
+						gameSettings.Save();
+					});
+
+				var deviceLabel = item.Get<LabelWidget>("LABEL");
+				deviceLabel.GetText = () => GetMessageForMaxReplayCount(o);
+
+				return item;
+			}
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options, SetupItem);
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			Game.LocalPlayerProfile.OnStateChanged -= UpdateForumAuthFields;
 			base.Dispose(disposing);
 		}
+
+		static string GetMessageForMaxReplayCount(int value) =>
+			value <= 0
+				? FluentProvider.GetMessage(MaxReplayCountDisabled)
+				: FluentProvider.GetMessage(MaxReplayCountOptions, "replays", value);
 
 		static string GetMessageForAutoSaveInterval(int value) =>
 			value switch

--- a/mods/cnc/chrome/settings-gameplay.yaml
+++ b/mods/cnc/chrome/settings-gameplay.yaml
@@ -207,6 +207,25 @@ Container@GAMEPLAY_PANEL:
 									Font: Regular
 				Container@ROW:
 					Width: PARENT_WIDTH - 24
+					Height: 50
+					Children:
+						Container@MAX_REPLAY_COUNT_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								LabelForInput@MAX_REPLAY_COUNT_DROP_DOWN_LABEL:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: label-max-replay-count
+									For: MAX_REPLAY_COUNT_DROP_DOWN
+								DropDownButton@MAX_REPLAY_COUNT_DROP_DOWN:
+									Y: 25
+									Width: PARENT_WIDTH
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
 						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -686,6 +686,7 @@ label-restart-required-container-audio-desc = Device changes will be applied aft
 label-gameplay-section-header = Gameplay
 label-auto-save-interval = Auto-save frequency:
 label-auto-save-max-file-number = Auto-save limit:
+label-max-replay-count = Replay limit:
 checkbox-hide-replay-chat-container = Hide Chat in Replays
 
 label-forum-profile-section-header = OpenRA Forum Account

--- a/mods/common/chrome/settings-gameplay.yaml
+++ b/mods/common/chrome/settings-gameplay.yaml
@@ -207,6 +207,24 @@ Container@GAMEPLAY_PANEL:
 					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
+						Container@MAX_REPLAY_COUNT_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Label@MAX_REPLAY_COUNT_DROP_DOWN_LABEL:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: label-max-replay-count
+								DropDownButton@MAX_REPLAY_COUNT_DROP_DOWN:
+									Y: 25
+									Width: PARENT_WIDTH
+									Height: 25
+									Font: Regular
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 50
+					Children:
 						Container@HIDE_REPLAY_CHAT_CHECKBOX_CONTAINER:
 							X: 10
 							Width: PARENT_WIDTH / 2 - 10

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -636,6 +636,7 @@ label-restart-required-container-audio-desc = Device changes will be applied aft
 label-gameplay-section-header = Gameplay
 label-auto-save-interval = Auto-save frequency:
 label-auto-save-max-file-number = Auto-save limit:
+label-max-replay-count = Replay limit:
 checkbox-hide-replay-chat-container = Hide Chat in Replays
 
 label-forum-profile-section-header = OpenRA Forum Account

--- a/mods/common/fluent/common.ftl
+++ b/mods/common/fluent/common.ftl
@@ -390,6 +390,14 @@ auto-save-interval =
 
 auto-save-max-file-number = { $saves } saves
 
+max-replay-count =
+    .disabled = None
+    .options =
+        { $replays ->
+            [one] 1 replay
+           *[other] { $replays } replays
+        }
+
 ## InputSettingsLogic
 options-mouse-scroll-type =
     .disabled = Disabled


### PR DESCRIPTION
Ability to enable auto cleaning of older replays during start of the game.

Motivation:
Keep ability to check recent matches, without need to think about regular cleanup and the UI filled with replays which comes as side effect.


<img width="1117" height="525" alt="image" src="https://github.com/user-attachments/assets/ba28c533-6f87-40fc-8bfb-e37af348e844" />


