### PR TITLE
Add slider for mouse panning speed and extends edge scrolling slider range

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -326,6 +326,7 @@ namespace OpenRA
 		public MouseControlStyle MouseControlStyle = MouseControlStyle.Modern;
 		public MouseScrollType MouseScroll = MouseScrollType.Joystick;
 		public float ViewportEdgeScrollStep = 30f;
+		public float ViewportMousePanSpeed = 1.65f;
 		public float UIScrollSpeed = 50f;
 		public float ZoomSpeed = 0.04f;
 		public int SelectionDeadzone = 24;

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -66,6 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SettingsUtils.BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gameSettings, "LockMouseWindow");
 			SettingsUtils.BindSliderPref(panel, "ZOOMSPEED_SLIDER", gameSettings, "ZoomSpeed");
 			SettingsUtils.BindSliderPref(panel, "SCROLLSPEED_SLIDER", gameSettings, "ViewportEdgeScrollStep");
+			SettingsUtils.BindSliderPref(panel, "MOUSE_PAN_SPEED_SLIDER", gameSettings, "ViewportMousePanSpeed");
 			SettingsUtils.BindSliderPref(panel, "UI_SCROLLSPEED_SLIDER", gameSettings, "UIScrollSpeed");
 
 			var mouseControlDropdown = panel.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
@@ -154,6 +155,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				gameSettings.ZoomModifier = defaultGameSettings.ZoomModifier;
 
 				panel.Get<SliderWidget>("SCROLLSPEED_SLIDER").Value = gameSettings.ViewportEdgeScrollStep;
+				panel.Get<SliderWidget>("MOUSE_PAN_SPEED_SLIDER").Value = gameSettings.ViewportMousePanSpeed;
 				panel.Get<SliderWidget>("UI_SCROLLSPEED_SLIDER").Value = gameSettings.UIScrollSpeed;
 
 				MakeMouseFocusSettingsLive(gameSettings);

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -186,8 +186,8 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (IsJoystickScrolling)
 			{
-				// Base the JoystickScrolling speed on the Scroll Speed slider
-				var rate = 0.01f * Game.Settings.Game.ViewportEdgeScrollStep;
+				// Base the JoystickScrolling speed on the Mouse Pan Speed slider
+				var rate = 0.3f * Game.Settings.Game.ViewportMousePanSpeed;
 
 				var scroll = (joystickScrollEnd.Value - joystickScrollStart.Value).ToFloat2() * rate;
 				worldRenderer.Viewport.Scroll(scroll, false);
@@ -335,7 +335,7 @@ namespace OpenRA.Mods.Common.Widgets
 				{
 					isStandardScrolling = true;
 					var d = scrollType == MouseScrollType.Inverted ? -1 : 1;
-					worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location) * d, false);
+					worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location).ToFloat2() * Game.Settings.Game.ViewportMousePanSpeed * d, false);
 					return true;
 				}
 				else if (mi.Event == MouseInputEvent.Up)

--- a/mods/cnc/chrome/settings-input.yaml
+++ b/mods/cnc/chrome/settings-input.yaml
@@ -323,11 +323,26 @@ Container@INPUT_PANEL:
 									Height: 20
 									Ticks: 7
 									MinimumValue: 10
-									MaximumValue: 50
+									MaximumValue: 150
 				Container@ROW:
 					Width: PARENT_WIDTH - 24
 					Height: 45
 					Children:
+						Container@MOUSE_PAN_SPEED_SLIDER_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Label@MOUSE_PAN_SPEED_SPEED_LABEL:
+									Width: PARENT_WIDTH
+									Height: 20
+									Text: label-mouse-pan-speed-slider-container
+								Slider@MOUSE_PAN_SPEED_SLIDER:
+									Y: 20
+									Width: PARENT_WIDTH
+									Height: 20
+									Ticks: 7
+									MinimumValue: 1
+									MaximumValue: 3
 						Container@ZOOMSPEED_SLIDER_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -749,7 +749,8 @@ label-zoom-modifier-container = Zoom Modifier:
 checkbox-alternate-scroll-container = Alternate Mouse Panning
 checkbox-lockmouse-container = Lock Mouse to Window
 label-mouse-scroll-type-container = Pan Behaviour:
-label-scrollspeed-slider-container-scroll-speed = Pan Speed:
+label-scrollspeed-slider-container-scroll-speed = Edge Pan Speed:
+label-mouse-pan-speed-slider-container = Mouse Pan Speed:
 label-zoomspeed-slider-container-zoom-speed = Zoom Speed:
 label-ui-scrollspeed-slider-container-scroll-speed = UI Scroll Speed:
 

--- a/mods/common/chrome/settings-input.yaml
+++ b/mods/common/chrome/settings-input.yaml
@@ -323,11 +323,26 @@ Container@INPUT_PANEL:
 									Height: 20
 									Ticks: 7
 									MinimumValue: 10
-									MaximumValue: 50
+									MaximumValue: 150
 				Container@ROW:
 					Width: PARENT_WIDTH - 24
 					Height: 50
 					Children:
+						Container@MOUSE_PAN_SPEED_SLIDER_CONTAINER:
+							X: 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Label@MOUSE_PAN_SPEED_LABEL:
+									Width: PARENT_WIDTH
+									Height: 20
+									Text: label-mouse-pan-speed-slider-container
+								Slider@MOUSE_PAN_SPEED_SLIDER:
+									Y: 20
+									Width: PARENT_WIDTH
+									Height: 20
+									Ticks: 7
+									MinimumValue: 1
+									MaximumValue: 3
 						Container@ZOOMSPEED_SLIDER_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -700,7 +700,8 @@ label-zoom-modifier-container = Zoom Modifier:
 checkbox-alternate-scroll-container = Alternate Mouse Panning
 checkbox-lockmouse-container = Lock Mouse to Window
 label-mouse-scroll-type-container = Pan Behaviour:
-label-scrollspeed-slider-container-scroll-speed = Pan Speed:
+label-scrollspeed-slider-container-scroll-speed = Edge Pan Speed:
+label-mouse-pan-speed-slider-container = Mouse Pan Speed:
 label-zoomspeed-slider-container-zoom-speed = Zoom Speed:
 label-ui-scrollspeed-slider-container-scroll-speed = UI Scroll Speed:
 


### PR DESCRIPTION
Fixes #22521 
Hey,
I've added a slider in Input settings to control mouse panning speed, because default one is too slow in my opinion.
I've calibrated current default value (1.65) to match mouse movement in such a way, that map moves under the mouse exactly with mouse movement, not slower or faster.
Also increased range of edge scroll speed slider, because I've seen many people (including me) complain about slow speed.

Changelog message: * added slider for mouse panning speed and increased edge scroll speed slider range