### PR TITLE
Docking: use forward path search (1->N) when finding closest dock

### DIFF
--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -406,9 +406,9 @@ namespace OpenRA.Mods.Common.Traits
 					.GroupBy(dock => clientActor.World.Map.CellContaining(dock.Trait.DockPosition))
 					.ToDictionary(group => group.Key, group => group.First());
 
-				// Start a search from each docks position:
-				var path = mobile.PathFinder.FindPathToTargetCell(
-					clientActor, lookup.Keys, clientActor.Location, BlockedByActor.None,
+				// Start a search from each client actor:
+				var path = mobile.PathFinder.FindPathToTargetCells(
+					clientActor, clientActor.Location, lookup.Keys, BlockedByActor.None,
 					location =>
 					{
 						if (!lookup.TryGetValue(location, out var dock))
@@ -420,7 +420,7 @@ namespace OpenRA.Mods.Common.Traits
 					});
 
 				if (path.Count > 0)
-					return lookup[path[^1]];
+					return lookup[path[0]];
 			}
 			else
 			{


### PR DESCRIPTION
`DockExts.ClosestDock()` uses conceptually incorrect pathfinding method for finding path to closest valid/suitable dock. This can cause issues, if the dock location of picked dock is unreachable.

### Example in OpenE2140

Resource trucks get stuck and refuse to even start moving to Refinery, if the docking cell of the nearest `DockHost` is not reachable (an impassable rocks in this case):

https://github.com/user-attachments/assets/7761e809-a03a-46cd-a0f9-af0fe789f0e1

`FindPathToTargetCell` (i.e. find path from **multiple sources** to **one target**) considers source reachable even if the source cell itself is not passable (for the actor), but adjacent cell is (which is our case). Which means `ClosestDock()` is trying to find path **from docking cells** of the docks to `IDockClient`.

So in the case above, while the `DockHost` north of the Refinery's conveyor belt is blocked by rocks, adjacent cells are reachable for the truck, so pathfinder picks path to this cell as shortest one.

This PR uses pathfinder's `FindPathToTargetCells()` instead, which finds path from **one source** (`IDockClient`) to **multiple targets** (docking locations of docks). The same rule applies, so the pathfinding fails, if **target** is not reachable. In our case the docking cell (target) is blocked by terrain, so pathfinder rejects this path and chooses different target cell (i.e. different docking cell).


https://github.com/user-attachments/assets/9092712a-6a69-4224-a9b3-25746966dc9a

### Official mods
This cannot happen in official mods, because unlike in OpenE2140, the docking locations on `DockHost` buildings in official mods (like Refinery) are within building's footprint (and thus can't get obstructed like in the case above).
