### PR TITLE
Revert "Avoid occasional 'busy wait' for next render time in main loop"

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -862,45 +862,33 @@ namespace OpenRA
 
 					var haveSomeTimeUntilNextLogic = now < nextLogic;
 					var isTimeToRender = now >= nextRender;
-					if (!Renderer.WindowIsSuspended)
+					if (!Renderer.WindowIsSuspended && ((isTimeToRender && haveSomeTimeUntilNextLogic) || forceRender))
 					{
-						if (isTimeToRender || forceRender)
-						{
-							if (haveSomeTimeUntilNextLogic || forceRender)
-								RenderTick();
+						nextRender = now + renderInterval;
 
-							nextRender = now + renderInterval;
+						// Pick the minimum allowed FPS (the lower between 'minReplayFPS'
+						// and the user's max frame rate) and convert it to maximum time
+						// allowed between screen updates.
+						// We do this before rendering to include the time rendering takes
+						// in this interval.
+						var maxRenderInterval = Math.Max(1000 / MinReplayFps, renderInterval);
+						forcedNextRender = now + maxRenderInterval;
 
-							// Pick the minimum allowed FPS (the lower between 'minReplayFPS'
-							// and the user's max frame rate) and convert it to maximum time
-							// allowed between screen updates.
-							// We do this before rendering to include the time rendering takes
-							// in this interval.
-							var maxRenderInterval = Math.Max(1000 / MinReplayFps, renderInterval);
-							forcedNextRender = now + maxRenderInterval;
-
-							renderBeforeNextTick = false;
-						}
+						RenderTick();
+						renderBeforeNextTick = false;
 					}
-					else
+
+					// Simulate a render tick if it was time to render but we skip actually rendering
+					if (Renderer.WindowIsSuspended && isTimeToRender)
 					{
-						// Simulate a render tick if it was time to render but we skip actually rendering
-						if (isTimeToRender || forceRender)
-						{
-							// Make sure that nextUpdate is set to a proper minimum interval
-							nextRender = now + renderInterval;
+						// Make sure that nextUpdate is set to a proper minimum interval
+						nextRender = now + renderInterval;
 
-							// Still process SDL events to allow a restore to come through
-							Renderer.Window.PumpInput(new NullInputHandler());
+						// Still process SDL events to allow a restore to come through
+						Renderer.Window.PumpInput(new NullInputHandler());
 
-							// Ensure that we still logic tick despite not rendering
-							renderBeforeNextTick = false;
-						}
-						else
-						{
-							// Avoid busy wait.
-							Thread.Sleep((int)(nextRender - now));
-						}
+						// Ensure that we still logic tick despite not rendering
+						renderBeforeNextTick = false;
 					}
 				}
 				else


### PR DESCRIPTION
This commit broke the minimum FPS logic for playing back replays at max speed, causing the issues reported on Discord about "freezes" when watching replays (technically not a freeze: the replay continues to tick, but isn't rendering).