### PR TITLE
Round viewport rendering to integer (screen-space) pixels.

### DIFF
--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -260,6 +260,13 @@ namespace OpenRA
 				// We need to add 1 to scroll in order to handle interpixel 0-0.99 fractionalOffset.
 				var s = new Size(vw / WorldDownscaleFactor + 1, vh / WorldDownscaleFactor + 1);
 				var fractionalOffset = centerLocation - viewportLocation;
+
+				// If scaling by an integer factor (including 1:1) we must round the offset
+				// to an integer number of screen-space pixels to preserve sharp pixel edges
+				var renderScale = screenSprite.Size.X / (s.Width - 1f);
+				if (float.IsInteger(renderScale))
+					fractionalOffset = (fractionalOffset * renderScale).Round() / renderScale;
+
 				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, s), 0, fractionalOffset, TextureChannel.RGBA);
 			}
 


### PR DESCRIPTION
Fixes the complaints of "fuzzy rendering" when using "Furthest" zoom on low-DPI displays. Fix also applies to other dpi/zoom combinations where there is an integer scaling from world pixels to screen pixels, but tends to be more subtle there.

Simplest testcase is to log the `renderScale` and `fractionalOffset` values, and zooming in on screenshots to demonstrate fuzzy/sharp pixel borders.

Before (400% scaling):
<img width="640" height="753" alt="Screenshot 2026-07-10 at 20 36 54" src="https://github.com/user-attachments/assets/6fabbf90-92c0-48b4-8b44-49168d276e44" />

After:
<img width="593" height="696" alt="Screenshot 2026-07-10 at 20 37 07" src="https://github.com/user-attachments/assets/118cad2c-31af-43a5-aa79-0268b671f06a" />
