### PR TITLE
Add Sungrid Protocol design blueprint and Phase 0 docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md — Navigation map for Sungrid Protocol
+
+This repo is large (a full game engine fork) and most of it is upstream OpenRA, not Sungrid Protocol content. Read this first before exploring the tree.
+
+## What this repo is
+
+`richardkfm/sungrid-protocol` is a **direct fork of the OpenRA engine repository** (default branch `bleed`) — not the lightweight [OpenRAModSDK](https://github.com/OpenRA/OpenRAModSDK) template. Sungrid Protocol, a solarpunk reinterpretation of the classic Red Alert RTS formula, is being built as a new mod (`mods/sungrid`) inside this engine tree, forked from the stock `mods/ra` mod. See `docs/ARCHITECTURE.md` for the full rationale on why this structure was chosen over migrating to the Mod SDK pattern.
+
+## Directory map
+
+**Upstream engine — do not modify casually.** Treat any change here as requiring explicit justification against a named friction point in `docs/ARCHITECTURE.md`:
+- `OpenRA.Game/`, `OpenRA.Mods.Common/`, `OpenRA.Mods.Cnc/`, `OpenRA.Mods.D2k/`, `OpenRA.Platforms.Default/`, `OpenRA.Server/`, `OpenRA.Test/`, `OpenRA.Utility/`, `OpenRA.Launcher/`, `OpenRA.WindowsLauncher/`
+
+**Mod/content territory — where Sungrid Protocol work actually happens:**
+- `mods/ra` — stock upstream Red Alert mod, kept unmodified as a reference template. Do not edit; fork from it instead.
+- `mods/cnc`, `mods/d2k`, `mods/ts` — other stock upstream mods, not otherwise relevant to Sungrid Protocol work.
+- `mods/sungrid` — **the Sungrid Protocol mod.** Does not exist yet as of this writing (repo is at Phase 0, docs-only). Will be created in Phase 1 by forking `mods/ra`. This is where nearly all future rules/YAML, sequences, maps, and mod-specific C# traits will live.
+
+**Design docs:**
+- `docs/BLUEPRINT.md` — master document, full project blueprint in one place.
+- `docs/VISION.md` — design pillars, tone, what differentiates Sungrid Protocol from vanilla RA.
+- `docs/ROADMAP.md` — phase-by-phase plan (0 through 6+) with deliverables, exit criteria, explicit non-goals.
+- `docs/ARCHITECTURE.md` — OpenRA technical strategy, data-driven vs. engine-level split, known friction points.
+- `docs/GAME_MODES.md` — full spec for the Grid Reserve economic victory mode.
+- `docs/BUILDINGS.md` — the 10-building initial roster, categorized and staged.
+- `docs/ART_DIRECTION.md` — solarpunk tone/visual guardrails.
+- `docs/CONTRIBUTING.md` — Sungrid-specific workflow (branches, labels, RFCs, PR checklist). Root `CONTRIBUTING.md` is upstream OpenRA's C# style guide and still applies to engine-level changes.
+- `docs/LICENSE_NOTES.md` — GPLv3 inheritance, EA non-affiliation, original-asset licensing notes.
+
+## Project goals and principles (condensed from `docs/VISION.md`)
+
+1. Classic RTS legibility first — theme never overrides silhouette/UI readability.
+2. Solarpunk as a lens that changes gameplay (power management, recycling, grid defense), not just reskinned names.
+3. Spend vs. save is a first-class strategic decision (this is what Grid Reserve is for).
+4. Pressure never disappears — scouting, harassment, raiding, and map control stay relevant in every mode, including the economic one.
+5. Data-driven before engine-driven — YAML/Lua first, new C# only when provably necessary.
+6. Small, reversible phases — every phase ships something playable and can be rolled back cleanly.
+7. Destruction victory stays intact — Grid Reserve is additive and optional, never a replacement.
+8. 3+ players is the target for new social/economic mechanics — diplomacy and shared-resource systems are deliberately deferred until this is validated.
+
+## Key architecture decisions already made
+
+- Fork `mods/ra` → `mods/sungrid` inside this engine repo, instead of migrating to a separate OpenRAModSDK-based repo (see `docs/ARCHITECTURE.md` for the trade-off).
+- Data-driven-first: buildings/units/rules go through YAML composing existing OpenRA traits wherever possible; new C# traits are reserved for things YAML genuinely can't express (currently: only the Grid Reserve vault/win-condition mechanic).
+- Destruction victory is the permanent default; Grid Reserve is a toggleable lobby option.
+- "Grid Reserve" is the recommended/working name for the economic victory mode (see `docs/GAME_MODES.md` for the other 4 candidates that were considered).
+- Diplomacy, alliance mechanics, and shared/pooled resources are explicitly out of scope until Phase 3-5 playtests justify them (see Phase 6+ in `docs/ROADMAP.md`).
+
+## Current status
+
+This PR (branch `claude/sungrid-protocol-roadmap-83d92w`) is a **docs-only Phase 0 bootstrap** — it adds the design doc set, this navigation file, and a reframed `README.md`. No `mods/sungrid` content exists yet. Next work is tracked in the first 10 GitHub issues opened alongside this PR, covering Phase 0 GitHub setup and Phase 1-3 engineering work (mod scaffolding, CI, baseline content, Grid Reserve implementation).
+
+## Working conventions
+
+- Don't touch upstream `OpenRA.*` engine directories unless a friction point in `docs/ARCHITECTURE.md` says it's required.
+- Prefer YAML/Lua trait composition in `mods/sungrid` over new C# traits; if a new trait seems necessary, check it against the "New C# traits" row in `docs/ARCHITECTURE.md` first.
+- Keep commits/PRs scoped to one phase/issue at a time — see `docs/CONTRIBUTING.md` for the full PR checklist and label taxonomy.
+- Never push directly to `bleed`; always branch + PR.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository is a fork of the OpenRA engine (see [Technical Architecture](doc
 * [`docs/ART_DIRECTION.md`](docs/ART_DIRECTION.md) — tone and visual direction.
 * [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — branch strategy, labels, RFC process, PR checklist, release strategy (Sungrid-specific — for engine-level C# style, see the root [`CONTRIBUTING.md`](CONTRIBUTING.md)).
 * [`docs/LICENSE_NOTES.md`](docs/LICENSE_NOTES.md) — license inheritance and EA non-affiliation.
+* [`docs/BACKLOG.md`](docs/BACKLOG.md) — first 10 engineering issues, held here because GitHub Issues is currently disabled on this repo; import as real issues once it's enabled.
 * [`CLAUDE.md`](CLAUDE.md) — navigation map for AI-assisted development sessions in this repo.
 
 ## Play

--- a/README.md
+++ b/README.md
@@ -1,60 +1,46 @@
-# OpenRA
+# Sungrid Protocol
 
-A Libre/Free Real Time Strategy game engine supporting early Westwood classics.
+A solarpunk reinterpretation of the classic Red Alert RTS formula — renewable power, smart grids, drone logistics, and resilient settlements, built on the [OpenRA](https://www.openra.net) engine. Still a real RTS: base building, unit counters, scouting, raiding, and map control are all intact. The first big design departure is an optional **economic victory mode** ("Grid Reserve") that makes saving money a real alternative win path, alongside the classic destruction victory.
 
-* Website: [https://www.openra.net](https://www.openra.net)
-* Chat: [#openra on Libera](ircs://irc.libera.chat:6697/openra) ([web](https://web.libera.chat/#openra)) or [Discord](https://discord.openra.net) ![Discord Badge](https://discordapp.com/api/guilds/153649279762694144/widget.png)
-* Repository: [https://github.com/OpenRA/OpenRA](https://github.com/OpenRA/OpenRA) ![Continuous Integration](https://github.com/OpenRA/OpenRA/workflows/Continuous%20Integration/badge.svg)
+This repository is a fork of the OpenRA engine (see [Technical Architecture](docs/ARCHITECTURE.md) for why, and the trade-offs of that choice). Sungrid Protocol content lives in `mods/sungrid` once Phase 1 scaffolding lands (see [Roadmap](docs/ROADMAP.md)) — as of this writing, that directory does not exist yet; this repo is at the Phase 0 documentation-bootstrap stage.
 
-Please read the [FAQ](https://github.com/OpenRA/OpenRA/wiki/FAQ) in our [Wiki](https://github.com/OpenRA/OpenRA/wiki) and report problems at [https://github.com/OpenRA/OpenRA/issues](https://github.com/OpenRA/OpenRA/issues).
+## Start here
 
-Join the [Forum](https://forum.openra.net/) for discussion.
+* [`docs/BLUEPRINT.md`](docs/BLUEPRINT.md) — the full project blueprint: vision, technical strategy, phased roadmap, MVP definition, economic victory mode spec, building plan, and GitHub workflow, all in one place.
+* [`docs/VISION.md`](docs/VISION.md) — design pillars and what differentiates Sungrid Protocol from vanilla Red Alert-style play.
+* [`docs/ROADMAP.md`](docs/ROADMAP.md) — phase-by-phase deliverables, exit criteria, and explicit non-goals.
+* [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — how this is structured as an OpenRA mod, and what's data-driven vs. engine-level.
+* [`docs/GAME_MODES.md`](docs/GAME_MODES.md) — full spec for the Grid Reserve economic victory mode.
+* [`docs/BUILDINGS.md`](docs/BUILDINGS.md) — the initial building roster.
+* [`docs/ART_DIRECTION.md`](docs/ART_DIRECTION.md) — tone and visual direction.
+* [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) — branch strategy, labels, RFC process, PR checklist, release strategy (Sungrid-specific — for engine-level C# style, see the root [`CONTRIBUTING.md`](CONTRIBUTING.md)).
+* [`docs/LICENSE_NOTES.md`](docs/LICENSE_NOTES.md) — license inheritance and EA non-affiliation.
+* [`CLAUDE.md`](CLAUDE.md) — navigation map for AI-assisted development sessions in this repo.
 
 ## Play
 
-Distributed mods include a reimagining of
+Not yet playable as a distinct mod — see the roadmap. Once Phase 1 lands, Sungrid Protocol will launch as its own entry in the OpenRA mod chooser alongside the stock mods included in this fork (Red Alert, Tiberian Dawn, Dune 2000), which remain present as unmodified reference/upstream content.
 
-* Command & Conquer: Red Alert
-* Command & Conquer: Tiberian Dawn
-* Dune 2000
+EA has not endorsed and does not support this product. See [`docs/LICENSE_NOTES.md`](docs/LICENSE_NOTES.md) for the full non-affiliation and licensing notes.
 
-EA has not endorsed and does not support this product.
+## Building the engine
 
-Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-game) Guide to win multiplayer matches.
+This repo is a full OpenRA engine checkout. See [`INSTALL.md`](INSTALL.md) for environment setup and the [OpenRA Compiling guide](https://github.com/OpenRA/OpenRA/wiki/Compiling) for engine build instructions — these are unchanged from upstream OpenRA.
 
 ## Contribute
 
-* Please read [INSTALL.md](https://github.com/OpenRA/OpenRA/blob/bleed/INSTALL.md) and [Compiling](https://github.com/OpenRA/OpenRA/wiki/Compiling) on how to set up an OpenRA development environment.
-* See [Hacking](https://github.com/OpenRA/OpenRA/wiki/Hacking) for a (now very outdated) overview of the engine.
-* Read and follow our [Code of Conduct](https://github.com/OpenRA/OpenRA/blob/bleed/CODE_OF_CONDUCT.md).
-* To get your patches merged, please adhere to the [Contributing](https://github.com/OpenRA/OpenRA/blob/bleed/CONTRIBUTING.md) guidelines.
+* Read [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) first for Sungrid Protocol's workflow (branches, labels, RFCs, PR checklist).
+* Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+* Engine-level C# contributions still follow the upstream [`CONTRIBUTING.md`](CONTRIBUTING.md) style guide.
 
-## Mapping
+## Upstream OpenRA
 
-* We offer a [Mapping](https://github.com/OpenRA/OpenRA/wiki/Mapping) Tutorial as you can change gameplay drastically with custom rules.
-* For scripted mission have a look at the [Lua API](https://docs.openra.net/en/release/lua/).
-* If you want to share your maps with the community, upload them at the [OpenRA Resource Center](https://resource.openra.net).
-
-## Modding
-
-* Download a copy of the [OpenRA Mod SDK](https://github.com/OpenRA/OpenRAModSDK) to start your own mod.
-* Check the [Modding Guide](https://github.com/OpenRA/OpenRA/wiki/Modding-Guide) to create your own classic RTS.
-* There exists an auto-generated [Trait documentation](https://docs.openra.net/en/latest/release/traits/) to get started with yaml files.
-* Some hints on how to create new OpenRA compatible [Pixelart](https://github.com/OpenRA/OpenRA/wiki/Pixelart).
-* Upload total conversions at [our Mod DB profile](https://www.moddb.com/games/openra/mods).
-
-## Support
-
-* Sponsor a [mirror server](https://github.com/OpenRA/OpenRAWebsiteV3/tree/master/packages) if you have some bandwidth to spare.
-* You can immediately set up a [Dedicated](https://github.com/OpenRA/OpenRA/wiki/Dedicated-Server) Game Server.
+Sungrid Protocol builds on the OpenRA engine and community tooling. If you're looking for the original OpenRA project (Red Alert, Tiberian Dawn, and Dune 2000 mods): [https://github.com/OpenRA/OpenRA](https://github.com/OpenRA/OpenRA), [https://www.openra.net](https://www.openra.net), [Discord](https://discord.openra.net).
 
 ## License
-Copyright (c) OpenRA Developers and Contributors
-This file is part of OpenRA, which is free software. It is made
-available to you under the terms of the GNU General Public License
+
+Copyright (c) OpenRA Developers and Contributors, and Sungrid Protocol Contributors.
+This project is free software, available under the terms of the GNU General Public License
 as published by the Free Software Foundation, either version 3 of
 the License, or (at your option) any later version. For more
-information, see [COPYING](https://github.com/OpenRA/OpenRA/blob/bleed/COPYING).
-
-# Sponsors
-Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+information, see [COPYING](COPYING) and [`docs/LICENSE_NOTES.md`](docs/LICENSE_NOTES.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,58 @@
+# Sungrid Protocol — Technical Architecture
+
+## Repo structure decision
+
+`richardkfm/sungrid-protocol` is currently a **direct fork of the OpenRA engine repository itself** (default branch `bleed`), containing the full engine source tree (`OpenRA.Game/`, `OpenRA.Mods.Common/`, `OpenRA.Mods.Cnc/`, `OpenRA.Mods.D2k/`, `OpenRA.Platforms.Default/`, `OpenRA.Server/`, `OpenRA.Test/`, `OpenRA.Utility/`) plus the stock mods (`mods/ra`, `mods/cnc`, `mods/d2k`, `mods/ts`), all unmodified from upstream. This is **not** the lightweight [OpenRAModSDK](https://github.com/OpenRA/OpenRAModSDK) repo, which normally treats the engine as a downloaded dependency and keeps a mod's repo small.
+
+**Decision: keep this repo as the full engine fork, and build Sungrid Protocol as a new mod directory (`mods/sungrid`) forked from `mods/ra`, rather than migrating to a separate OpenRAModSDK-based repo.**
+
+Rationale:
+- Zero migration risk — restructuring into the SDK pattern now would burn Phase 0 time on infrastructure instead of content, with no gameplay payoff.
+- `mods/ra` is a complete, working reference implementation sitting right next to where the new mod will live — the fastest possible starting point.
+- The full engine tree is already available in-repo if a Phase 3+ friction point genuinely requires an engine-level (not mod-level) change — no separate checkout needed.
+- Trade-off accepted: this repo is heavier than a typical mod repo, and pulling upstream OpenRA engine updates later means merging against a full engine tree rather than bumping a dependency version. This is an acceptable cost given the "fastest realistic route to a playable prototype" priority; it can be revisited post-MVP if upstream sync pain becomes real.
+
+## Data-driven vs. engine-level split
+
+| Layer | Examples | Default assumption |
+|---|---|---|
+| YAML rules (`mods/sungrid/rules/*.yaml`) | Buildings, units, weapons, tech tree, costs, power values | **Always try this first.** This is how OpenRA mods normally differentiate from each other. |
+| Sequences/art config | Sprite sheets, palettes, UI chrome layout | Data-driven; new art is a content/pipeline problem, not a code problem. |
+| Lua map/mission scripting | AI hints, scripted triggers, campaign logic | Data-driven; used for Phase 4 AI behavior tuning. |
+| Existing C# traits, recombined | `Power`, `Cargo`, `Reservable`, `AttackBase`, `Selectable`, `Health`, etc. applied to new units/buildings via YAML | Data-driven — this covers the large majority of Phase 2 and Phase 5 building work (Solar Array is just `Power` with a new sprite; Drone Bay is largely `Cargo`/`Reservable` composition). |
+| New C# traits | Grid Reserve deposit/withdrawal tracking, hold-to-win countdown, HUD reserve bar | **Engine-level, but scoped and additive.** Only Phase 3 is expected to need genuinely new trait code. |
+| Core engine changes (`OpenRA.Game`, netcode, renderer) | — | **Avoid entirely if possible.** Nothing in the current roadmap is expected to require this. If a friction point below turns out to force it, that's a stop-and-reassess moment, not a "just do it" moment. |
+
+The rule of thumb: if it can be expressed as YAML composing existing traits, it's data-driven and low-risk. If it needs new *game state that OpenRA's existing traits don't track* (like a locked, non-spendable currency pool with a countdown), it needs a new trait — but that trait should be small, additive, and not modify how existing modes/traits behave.
+
+## Fastest path to a playable prototype
+
+1. Fork `mods/ra` → `mods/sungrid` (copy, rename mod id/metadata, no rule changes). Verify it launches and plays identically to RA under the new mod id. This is all of Phase 1.
+2. Layer in Phase 2's reflavored buildings via YAML only — no new traits, no new art pipeline yet (recolor/retexture existing sprites). Verify nothing regresses.
+3. Only then start Phase 3's Grid Reserve trait work, since it's the one piece that can't be done purely in YAML.
+
+This sequencing means there is a genuinely playable (if visually undifferentiated) build after Phase 1, well before any new C# code is written — which de-risks the whole project against "big rewrite that never ships."
+
+## Biggest technical unknowns / friction points
+
+1. **Win-condition hook for Grid Reserve.** OpenRA's `MissionObjectives`/conquest-victory framework is built around elimination-style conditions. A hold-a-threshold-with-a-countdown win condition needs a new trait that plugs into that framework cleanly, is deterministic (OpenRA is lockstep-networked — any new state must replicate identically across all clients), and doesn't desync in multiplayer. This is the single highest-risk technical item in the whole roadmap and should get a design spike (small prototype, 1v1 only) before Phase 3 is considered "in progress" for real.
+2. **HUD/scoreboard additions.** New UI elements (Reserve bars, Lockdown countdown, minimap reveal) go through OpenRA's `ChromeLayout` YAML + widget system. Feasible, but budget real time for it — UI work in OpenRA's widget system is more verbose than it looks.
+3. **Deterministic economy state.** The Vault's deposit/decay/reveal logic must be replayable and lockstep-safe like all other OpenRA game state (no floating point drift, no client-only randomness). Model it the same way existing `PlayerResources`/`Silo`-style traits already do.
+4. **Asset pipeline for new art.** Phase 5's original art pass needs a decided pixel-art/sprite pipeline (palette, resolution, animation frame conventions) consistent with `docs/ART_DIRECTION.md` before more than one artist (human or AI-assisted) touches it, or assets won't compose visually.
+5. **AI script depth.** OpenRA's built-in AI is script-driven (Lua) and not naturally aware of custom win conditions. Phase 4's "AI understands Grid Reserve" deliverable is bounded on purpose (see Phase 4 risk note in `docs/ROADMAP.md`) because teaching the stock AI genuinely good judgment about a brand-new mechanic is open-ended.
+
+## What this repo will look like after Phase 1
+
+```
+mods/
+  ra/            # unmodified upstream reference, kept for diffing
+  sungrid/       # new: Sungrid Protocol mod (forked from ra)
+    mod.yaml
+    rules/
+    sequences/
+    maps/
+    chrome/
+    ...
+```
+
+Upstream engine directories (`OpenRA.Game/`, `OpenRA.Mods.*/`, etc.) are expected to stay untouched through at least Phase 5. If a future phase needs an engine change, it should be a small, clearly-justified diff reviewed with the same scrutiny as any upstream OpenRA contribution — not a place to accumulate hacks.

--- a/docs/ART_DIRECTION.md
+++ b/docs/ART_DIRECTION.md
@@ -1,0 +1,31 @@
+# Sungrid Protocol — Art Direction
+
+## Tone
+
+Lush eco-solarpunk. Renewable power, smart grids, drone logistics, and resilient settlements — hopeful and strategic, not utopian or goofy. This is still a real RTS: the world should look like people building something worth defending, under genuine pressure, not a post-scarcity diorama with no stakes.
+
+## Guardrails
+
+- **Not utopian.** Bases should show wear, improvisation, and defense — sandbags next to solar panels, drone bays bolted onto salvaged structure, not pristine architecture-magazine renders.
+- **Not goofy.** No cartoon mascots, no winking irony. The Cryptominer building (morally ambiguous legacy tech repurposed under solar power) is the tone reference: interesting, slightly uneasy, not a joke.
+- **Still a Cold-War-adjacent conflict, re-skinned.** Military tension, scouting, raiding, and destruction are real and visible — weapons and defensive structures should read as dangerous, not decorative.
+
+## Readability rules (non-negotiable, ties to Design Pillar 1)
+
+- Every unit and building must have a distinct, readable silhouette at standard RTS zoom — theme never overrides legibility.
+- Faction/player color must remain the dominant, unambiguous ownership signal (team-color accents on structures/units), consistent with classic RA-style UI conventions.
+- Health/status bars, selection indicators, and UI chrome keep OpenRA's existing conventions until there's a specific, tested reason to deviate — familiarity is a feature for genre-literate players.
+
+## Palette direction
+
+- **Base palette:** greens (living systems, recycling, foliage reclaiming industrial space), warm solar-panel blues/blacks, sun-gold accents for "active/powered" states.
+- **Military/industrial counterpoint:** desaturated grays and rust for legacy infrastructure (Cryptominer, salvaged structures) to visually separate "old world tech" from "new grid tech" without needing a second faction yet.
+- **Danger/alert states:** reserve existing RTS conventions (red/amber) for low power, under-attack, and Grid Reserve Lockdown countdown states — don't reinvent alert color language.
+
+## Faction visual differentiation (Phase 5+)
+
+Until a second faction is scoped, "faction flavor" means making the single Sungrid Protocol roster visually cohesive and distinct from vanilla RA/Allies/Soviets — not inventing a second full art set. Notes for whenever a second faction is justified: differentiate through material and infrastructure philosophy (e.g. decentralized/drone-based vs. centralized/hardened grid) rather than through tone shifts — both factions should still read as "this world," not swap into a different genre.
+
+## Asset pipeline (Phase 5 planning note)
+
+Before more than one contributor (human or AI-assisted) produces art, lock: sprite resolution and frame conventions matching OpenRA's existing pixel-art pipeline, a shared base palette file, and a naming/sequence convention consistent with `mods/ra`'s existing structure so new sequences drop into the engine's existing tooling without custom loader work. This is a data/content-pipeline decision, not a code decision — see `docs/ARCHITECTURE.md` friction point #4.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,195 @@
+# Sungrid Protocol — Phase 0/1/2/3 Issue Backlog
+
+GitHub Issues are currently **disabled** on this repository, so these could not be opened as actual GitHub issues (attempted via the API, got `410 Issues has been disabled in this repository`). This file holds the exact content, ready to paste in as-is once Issues is enabled (repo Settings → Features → Issues), or to import via `gh issue create` / the GitHub UI.
+
+Once Issues is enabled, these can be created in order and this file can be trimmed down to just a pointer, or deleted.
+
+---
+
+### 1. Scaffold mods/sungrid from mods/ra template
+
+**Labels:** `phase:1`, `type:content`, `good-first-issue`
+
+**Phase:** 1 — Baseline playable shell (see `docs/ROADMAP.md`)
+
+**Purpose:** Create the Sungrid Protocol mod directory by forking the stock `mods/ra` mod. No rule changes yet — this is pure plumbing to get a mod identity that boots.
+
+**Scope:**
+- Copy `mods/ra` → `mods/sungrid`.
+- Update `mod.yaml` metadata: mod id, title, description, version, icon placeholder.
+- No changes to units/buildings/rules YAML in this issue.
+
+**Dependencies:** Depends on the Phase 0 docs PR (`docs/ARCHITECTURE.md`, `docs/ROADMAP.md`) being merged, since it defines this exact approach.
+
+**Definition of done:** `mods/sungrid` exists, builds, and appears as its own distinct entry (not "Red Alert") in the OpenRA mod chooser.
+
+---
+
+### 2. Verify baseline playable shell (skirmish vs. AI)
+
+**Labels:** `phase:1`, `type:content`
+
+**Phase:** 1 — Baseline playable shell (see `docs/ROADMAP.md`)
+
+**Purpose:** Prove the forked `mods/sungrid` mod is genuinely playable before any content work starts, per the "fastest path to a playable prototype" sequencing in `docs/ARCHITECTURE.md`.
+
+**Scope:**
+- Launch `mods/sungrid`.
+- Play a full skirmish match against the built-in AI.
+- Confirm destruction victory/defeat triggers correctly.
+- Confirm no crashes and assets load correctly under the new mod id.
+
+**Dependencies:** Blocked by #1 "Scaffold mods/sungrid from mods/ra template."
+
+**Definition of done:** A complete skirmish match can be played start-to-finish with a normal win/loss result and no crashes.
+
+---
+
+### 3. Set up CI build for the Sungrid mod
+
+**Labels:** `phase:0`, `type:engine`
+
+**Phase:** 0/1 — Bootstrap / Baseline playable shell
+
+**Purpose:** Catch broken mod builds automatically instead of relying on manual verification, per `docs/CONTRIBUTING.md`'s PR checklist ("builds cleanly").
+
+**Scope:**
+- Extend the existing engine CI workflow to also build/validate `mods/sungrid`.
+- Fail CI if the mod fails to build or its `mod.yaml`/rules fail to parse.
+
+**Dependencies:** Blocked by #1.
+
+**Definition of done:** A PR that intentionally breaks `mods/sungrid` fails CI; a healthy PR passes.
+
+---
+
+### 4. Add Solar Array + Battery Bank building stubs
+
+**Labels:** `phase:2`, `type:content`, `area:energy`
+
+**Phase:** 2 — First solarpunk content layer (see `docs/ROADMAP.md`, `docs/BUILDINGS.md`)
+
+**Purpose:** First visible solarpunk content pass, entirely data-driven.
+
+**Scope:**
+- Solar Array: reflavor of the power plant (`Power` trait, new name/sequence, placeholder or recolored art is fine).
+- Battery Bank: reflavor of the silo/storage building as **placeholder economy only** — this is not yet the Grid Reserve Vault mechanic (that's issue #6/#7).
+- No new C# traits.
+
+**Dependencies:** Blocked by #2.
+
+**Definition of done:** Both buildings are buildable in a skirmish match, function correctly (power generation / storage), and don't regress the Phase 1 baseline.
+
+---
+
+### 5. Add Recycling Depot (salvage-based economy building)
+
+**Labels:** `phase:2`, `type:content`, `area:economy`
+
+**Phase:** 2 — First solarpunk content layer (see `docs/ROADMAP.md`, `docs/BUILDINGS.md`)
+
+**Purpose:** Second economy stream rewarding map control and battlefield cleanup, per the Recycling Depot spec in `docs/BUILDINGS.md`.
+
+**Scope:**
+- Refinery-adjacent building that reclaims Credits from destroyed units/buildings (wrecks).
+- Data-driven where possible; flag in the PR if wreck-salvage genuinely requires new trait logic (see `docs/ARCHITECTURE.md` friction points).
+
+**Dependencies:** Blocked by #2.
+
+**Definition of done:** Buildable, and produces Credits from battlefield wreckage during a test skirmish match.
+
+---
+
+### 6. RFC: Grid Reserve trait design
+
+**Labels:** `phase:3`, `type:design`, `area:grid-reserve`, `risk:scope-trap`
+
+**Phase:** 3 — Economic victory mode MVP (see `docs/GAME_MODES.md`, `docs/ARCHITECTURE.md`)
+
+**Purpose:** This is the project's first genuinely new C# system and its highest-risk technical item (deterministic/lockstep-safe custom win condition). Per `docs/CONTRIBUTING.md`'s RFC workflow, design it in an issue before writing implementation code.
+
+**Scope:**
+- Concrete trait design for the Vault building: deposit tracking (irreversible, per-tick rate cap), per-Vault capacity cap, destruction-drain behavior (~50% Reserve loss + attacker Credit reward), and the hold-to-win "Grid Lockdown" countdown hook into OpenRA's `MissionObjectives`/win-condition framework.
+- Explicit check for multiplayer lockstep determinism (no floating point drift, no client-only randomness).
+- Update `docs/GAME_MODES.md` and/or `docs/ARCHITECTURE.md` in this issue/PR if the concrete design diverges from the current spec.
+
+**Dependencies:** Blocked by #2. Should ideally follow #4/#5 so there's a stable content base to build on, but is not strictly blocked by them.
+
+**Definition of done:** RFC issue resolved with a design that's been sanity-checked against OpenRA's existing win-condition/resource trait patterns; docs updated to match; ready to hand to an implementation issue.
+
+---
+
+### 7. Implement Grid Reserve Vault trait + win condition
+
+**Labels:** `phase:3`, `type:engine`, `area:grid-reserve`
+
+**Phase:** 3 — Economic victory mode MVP (see `docs/GAME_MODES.md`)
+
+**Purpose:** Implement the resolved RFC — the actual Grid Reserve mechanic that makes the economic victory mode exist.
+
+**Scope:**
+- Vault building trait (deposit/capacity/destruction-drain) per the resolved RFC.
+- Win-condition trait for the Grid Lockdown countdown (start on reaching target, cancel/reset if Reserve drops below target).
+- Lobby toggle for the mode; destruction victory remains available and unaffected when toggled off.
+
+**Dependencies:** Blocked by #6.
+
+**Definition of done:** A 1v1 local test match can be won via Grid Reserve end-to-end (deposit → reach target → hold Lockdown → win), and destruction victory still works normally when the mode is toggled off.
+
+---
+
+### 8. Add Grid Reserve HUD/scoreboard elements
+
+**Labels:** `phase:3`, `type:engine`, `area:grid-reserve`
+
+**Phase:** 3 — Economic victory mode MVP (see `docs/GAME_MODES.md`)
+
+**Purpose:** Make Grid Reserve legible and dramatic to play, not just functional — the countdown broadcast and minimap reveal are core anti-turtle mechanics, not cosmetic.
+
+**Scope:**
+- Per-player Reserve bar with numeric current/target in the sidebar/scoreboard.
+- Broadcast banner + audio cue to all players when a Lockdown countdown starts or cancels.
+- Minimap reveal of a player's Vault locations once their Reserve hits 50% of target.
+- End-of-match scoreboard showing final Reserve totals for all players regardless of win condition used.
+
+**Dependencies:** Blocked by #7.
+
+**Definition of done:** All four HUD elements are visible, correctly triggered, and verified in a test match.
+
+---
+
+### 9. 3-4 player Grid Reserve playtest + balance pass
+
+**Labels:** `phase:3`, `phase:4`, `type:content`, `area:grid-reserve`, `risk:scope-trap`
+
+**Phase:** 3/4 — Grid Reserve MVP / Playtest Hardening (see `docs/GAME_MODES.md`)
+
+**Purpose:** Grid Reserve's entire value proposition depends on turtling being a losing strategy. This issue exists specifically to stress-test that, not just general balance — see "Top 3 scope traps" #2 in `docs/BLUEPRINT.md`.
+
+**Scope:**
+- Run structured 3-player and 4-player matches with Grid Reserve enabled.
+- Specifically probe: can a player win by hiding and never engaging? Does a Vault raid meaningfully disrupt a leader's Lockdown countdown in practice?
+- Tune Reserve targets, decay rate, deposit caps, and minimap reveal threshold from `docs/GAME_MODES.md` based on results; update the doc if numbers change.
+
+**Dependencies:** Blocked by #8.
+
+**Definition of done:** At least one recorded match is won via Grid Reserve with a documented instance of a Vault raid affecting the outcome; no playtest match is won by a strategy reviewers would describe as "just hide and wait."
+
+---
+
+### 10. Set up first external playtest build/packaging
+
+**Labels:** `phase:4`, `phase:5`, `type:content`
+
+**Phase:** 4/5 prep — Playtest Hardening / Faction Flavor (see MVP definition in `docs/BLUEPRINT.md` section 4)
+
+**Purpose:** Get a build that a non-team playtester can install and run unassisted — this is the concrete "ready for first public testers" gate.
+
+**Scope:**
+- Package a distributable build of `mods/sungrid` (installer or archive, per platform as feasible).
+- Write minimal install/run instructions for testers.
+- Dry-run the install process on a machine that isn't the founder's dev environment.
+
+**Dependencies:** Blocked by #9. Should also follow enough of Phase 5's building roster to be worth external testing (see `docs/ROADMAP.md`), but packaging work itself can start in parallel.
+
+**Definition of done:** A non-team playtester successfully installs the build and completes a full match unassisted.

--- a/docs/BLUEPRINT.md
+++ b/docs/BLUEPRINT.md
@@ -1,0 +1,208 @@
+# Sungrid Protocol — Development Blueprint
+
+This is the master planning document for Sungrid Protocol. It's written for a solo technical founder executing with Claude Code assistance, optimized for the fastest realistic route to a playable prototype on the OpenRA engine. Companion docs go deeper on individual topics and are linked throughout; this document is the one to read start-to-finish.
+
+---
+
+## 1. Project summary
+
+Sungrid Protocol is a solarpunk reinterpretation of the classic Red Alert RTS formula, built on OpenRA. It combines readable classic RTS gameplay with renewable-energy and eco-infrastructure themes, real strategic/military tension, and a new economic victory mode that changes spending incentives.
+
+**Design pillars** (full detail in [`VISION.md`](VISION.md)):
+
+1. Classic RTS legibility first — theme never overrides silhouette/UI readability.
+2. Solarpunk as a lens, not a coat of paint — it changes what players *do* (power management, recycling, grid defense), not just what things are named.
+3. Spend vs. save is a first-class strategic decision, contested the same way territory is.
+4. Pressure never disappears — scouting, harassment, raiding, and map control stay relevant in every mode, including the economic one.
+5. Data-driven before engine-driven — YAML/Lua first, new C# only when provably necessary.
+6. Small, reversible phases — every phase ships something playable and can be rolled back cleanly.
+7. Destruction victory stays intact — the economic mode is additive and optional, never a replacement.
+8. 3+ players is the design target for new modes — diplomacy and betrayal only get interesting with three or more seats.
+
+**What makes it different from vanilla Red Alert-style play:** vanilla RA-style games have exactly one win condition (elimination) and a single spendable resource with no strategic "hold" option. Sungrid Protocol adds a second, legitimate path to victory built around *not* spending — while making the act of hoarding itself a raid target, so turtling remains exposed rather than becoming a passive-win strategy. See the full comparison table in [`VISION.md`](VISION.md).
+
+---
+
+## 2. Technical strategy for OpenRA
+
+Full detail in [`ARCHITECTURE.md`](ARCHITECTURE.md). Summary:
+
+**Repo structure.** This repo (`richardkfm/sungrid-protocol`) is currently a direct fork of the full OpenRA engine (branch `bleed`), not the lightweight OpenRAModSDK template. **Decision: keep it that way, and build Sungrid Protocol as a new `mods/sungrid` directory forked from the existing `mods/ra` reference mod**, rather than migrating to a separate SDK-based repo. This avoids burning Phase 0 time on infrastructure migration with zero gameplay payoff, and `mods/ra` is a ready-made, working starting point sitting right next to where the new mod will live. Trade-off: this repo is heavier than a typical mod repo and pulling upstream engine updates later means merging against a full engine tree — acceptable given the priority on speed to prototype.
+
+**Data-driven vs. engine-level.** Buildings, units, weapons, costs, and tech tree are YAML in `mods/sungrid/rules/*.yaml`, composing existing OpenRA traits (`Power`, `Cargo`, `Reservable`, `AttackBase`, `Health`, etc.) — this covers nearly the entire building roster. New C# trait work is reserved for the one thing YAML genuinely can't express: the Grid Reserve vault/deposit/hold-to-win mechanic (Phase 3). Core engine changes (`OpenRA.Game`, netcode, renderer) are avoided entirely unless a named friction point forces it.
+
+**Fastest path to a playable prototype:** (1) fork `mods/ra` → `mods/sungrid`, verify it boots and plays identically under the new mod id — no rule changes yet; (2) layer in reflavored buildings via YAML only, still no new traits; (3) only then start the Grid Reserve trait work, since it's the one piece that can't be done in pure YAML. This means a genuinely playable build exists after step 1, before any new C# code is written.
+
+**Biggest technical unknowns:**
+1. The Grid Reserve win-condition hook — needs to plug into OpenRA's elimination-oriented `MissionObjectives` framework with a hold-a-threshold-with-countdown condition that stays deterministic/lockstep-safe in multiplayer. Highest-risk item in the roadmap; merits a small 1v1 design spike before Phase 3 is considered "in progress."
+2. New HUD/scoreboard elements via OpenRA's `ChromeLayout`/widget system — feasible but more verbose than it looks; budget real time.
+3. Keeping the new Vault/Reserve state deterministic and replay-safe like existing `PlayerResources`/`Silo`-style traits.
+4. Locking an art/sprite pipeline before more than one contributor touches assets (Phase 5).
+5. OpenRA's stock AI (Lua-scripted) has no native awareness of custom win conditions — "AI understands Grid Reserve" is intentionally bounded to "doesn't ignore it," not "plays it well" (Phase 4).
+
+---
+
+## 3. Phased roadmap
+
+Full detail — objective, why, deliverables, code scope, data/content scope, testing scope, milestone, exit criteria, biggest risk, explicit non-goals — for every phase lives in [`ROADMAP.md`](ROADMAP.md). Summary table:
+
+| Phase | Objective | Milestone | Exit criteria (short) |
+|---|---|---|---|
+| 0 | Repository bootstrap and architecture setup | `P0: Bootstrap` | Docs, labels, milestones, first issues all in place |
+| 1 | Baseline playable shell on OpenRA | `P1: Baseline Shell` | `mods/sungrid` (forked from `mods/ra`) launches and plays a full skirmish |
+| 2 | First solarpunk content layer | `P2: First Content Pass` | 3+ new/reflavored buildings playable without regressions |
+| 3 | Economic victory mode MVP | `P3: Grid Reserve MVP` | 3+ player match winnable via Grid Reserve, toggle works, a raid demonstrably disrupts a leader |
+| 4 | UI, balance, AI, multiplayer iteration | `P4: Playtest Hardening` | External testers complete a full multiplayer match with no desyncs/crashes |
+| 5 | Expanded buildings / faction flavor / polish | `P5: Faction Flavor` | Full 10-building roster balanced, distinct visual identity — this is the MVP release point |
+| 6+ | Diplomacy / shared-resource systems (conditional) | `P6: Diplomacy (conditional)` | Only starts if Phase 3-5 playtests show sustained demand |
+
+---
+
+## 4. MVP definition
+
+**Essential features for the smallest external-playtestable MVP:**
+- A launchable `mods/sungrid` mod, distinct from stock `mods/ra`, with its own identity in the OpenRA mod chooser.
+- The full 10-building roster from [`BUILDINGS.md`](BUILDINGS.md), balanced enough for a complete match.
+- Classic destruction victory, fully working, as the default mode.
+- Grid Reserve economic victory mode, toggleable, balanced against real playtests (see [`GAME_MODES.md`](GAME_MODES.md)).
+- A functional (not necessarily strong) skirmish AI that doesn't actively ignore Grid Reserve.
+- Stable multiplayer (dedicated server or lobby-hosted) for 2-6 players without desyncs.
+- A distinct, coherent visual identity — not necessarily fully custom art, but not a recolored RA reskin either.
+
+**Intentionally excluded from MVP:** a second faction, campaign/story missions, diplomacy or alliance mechanics, shared/pooled Reserve, spectator tooling beyond the basic scoreboard, competitive-strength AI.
+
+**What players should be able to experience:** a complete, replayable RTS match — scout, expand, build an economy and a base, fight or raid opponents, and win either by elimination or by banking and defending enough Grid Reserve to trigger and hold a Lockdown countdown — in a setting that visibly reads as lush eco-solarpunk rather than a Red Alert reskin.
+
+**"Ready for first public testers" means:** Phase 5's exit criteria are met (full roster, balanced, visually distinct), Phase 4's multiplayer stability bar is cleared, and at least one internal/closed playtest of 3+ players has completed a Grid Reserve win without anyone describing the winning strategy as "just hide and wait."
+
+---
+
+## 5. Economic victory mode: Grid Reserve
+
+Full spec in [`GAME_MODES.md`](GAME_MODES.md). Summary:
+
+**Recommended name:** **Grid Reserve** (candidates considered: Energy Surplus, Sunbank Protocol, Reserve Threshold, Solvency Protocol).
+
+**Mechanic:** A new **Vault** building converts spendable Credits into a locked, non-spendable **Reserve** pool. Deposits are irreversible and rate-capped per tick. Each Vault has a capacity cap, forcing multiple exposed Vaults to reach a real target. Destroying an enemy Vault drains ~50% of its Reserve and rewards the attacker — this is what keeps harassment and raiding relevant under this mode.
+
+**Win condition:** reaching the map's Reserve target triggers a broadcast **Grid Lockdown** countdown (60-120s); holding Reserve at/above target for the full countdown wins; dropping below target (e.g., a Vault is destroyed) cancels the countdown.
+
+**Example targets** (medium map): ~15,000/player baseline, roughly a 5% per-player discount at higher counts — e.g. 30,000 (2p), 40,000 (3p), 48,000 (4p), 63,000 (6p) on a medium map; see the full size × player-count table in `GAME_MODES.md`.
+
+**HUD/scoreboard:** per-player Reserve bar with numeric target, broadcast banner/audio on Lockdown start/cancel, minimap reveal of Vault locations once a player hits 50% of target, end-of-match scoreboard showing final Reserve for all players.
+
+**Anti-stalemate:** "Grid Decay" slowly drains all players' Reserve if nobody triggers a Lockdown within a time window, forcing the race to resolve.
+
+**Anti-turtle:** 50% minimap reveal, per-Vault capacity caps forcing exposure, no combat/defensive synergy granted by Vaults, deposit-rate caps preventing last-second panic-banking.
+
+**Why harassment/map pressure remain relevant:** the mode redirects what's worth attacking (Vaults) rather than removing the incentive to attack — a large undefended Reserve is a bigger prize than a player who spent everything on units.
+
+**Why 3+ players:** in 1v1, hoarding is a pure two-body optimization race identical in shape to destruction play. With 3+, a leading hoarder becomes the shared target of the whole table once revealed — dogpile dynamics, opportunistic raiding, and kingmaking only exist with three or more seats.
+
+**Deferred to later revisions:** diplomacy-gated Vault protection, shared/pooled Reserve between allies, alliance-split victory, per-faction Reserve bonuses, spectator tooling beyond the basic scoreboard.
+
+---
+
+## 6. Building plan
+
+Full detail — fantasy, gameplay purpose, prerequisites, likely counters, implementation complexity, MVP staging — for all 10 buildings lives in [`BUILDINGS.md`](BUILDINGS.md). Categorized summary:
+
+| Building | Category | Staging | Complexity |
+|---|---|---|---|
+| Solar Array | Energy | MVP (Phase 2) | Low |
+| Battery Bank (Vault) | Energy / Economy | MVP (Phase 3) | High |
+| Recycling Depot | Economy | MVP (Phase 2) | Medium |
+| Cryptominer | Economy | Mid-term (Phase 5) | Medium |
+| Datacenter for AI | Economy / Intelligence | Mid-term (Phase 5) | Medium |
+| Drone Bay | Logistics | Mid-term (Phase 5) | Medium-High |
+| Grid Defense Turret | Defense | Mid-term (Phase 5) | Medium |
+| Smart Grid Relay | Energy / Logistics | Later | Medium |
+| Resilience Shelter | Defense | Later | Medium |
+| Sensor Array | Intelligence | Later | Low |
+
+---
+
+## 7. GitHub execution model
+
+Full detail in [`CONTRIBUTING.md`](CONTRIBUTING.md). Summary:
+
+- **Repo structure:** upstream engine (`OpenRA.*`) untouched by default; `mods/ra` etc. as unmodified references; `mods/sungrid` as the active mod; `docs/` for design docs.
+- **Branch strategy:** `bleed` is the protected integration branch; short-lived `feature/*`/`claude/*` branches per issue; no direct pushes to `bleed`.
+- **Milestones:** one per roadmap phase (`P0: Bootstrap` through `P6: Diplomacy (conditional)`).
+- **Label taxonomy:** `phase:0`-`phase:6`, `type:design`/`content`/`engine`/`docs`/`bug`, `area:economy`/`energy`/`defense`/`intelligence`/`logistics`/`grid-reserve`, `risk:scope-trap`, `good-first-issue`.
+- **RFC workflow:** any `type:engine` change, or any change to a rule already documented in `GAME_MODES.md`/`BUILDINGS.md`, gets a `type:design` issue first; docs update in the same PR as (or immediately before) the implementation.
+- **PR checklist:** linked issue + milestone; RFC linked if engine-level; docs updated if a documented rule changed; manually playtested; no untouched-directory violations; builds cleanly.
+- **Release strategy:** internal builds off `bleed` per phase exit criteria; first public-facing tag at the Phase 5/MVP point.
+- **Changelog:** starts at Phase 1 (first playable build), one plain-language entry per merged PR, grouped by phase.
+- **Contributor onboarding:** README → VISION → ROADMAP → ARCHITECTURE → pick an issue matching the current milestone.
+- **Claude Code usage:** default to `mods/sungrid/` and `docs/`; treat any `OpenRA.*` engine diff as requiring explicit justification; prefer YAML/Lua over new C# traits; never push directly to `bleed`; keep sessions scoped to one issue/phase item.
+
+---
+
+## 8. Documentation plan
+
+| File | Purpose | Core sections |
+|---|---|---|
+| `README.md` | Front door for the repo | Project summary, quick links to all docs, play/build instructions, license |
+| `VISION.md` | Why this project exists and what makes it different | Design pillars, tone, vanilla-RA comparison table, explicit non-goals |
+| `ROADMAP.md` | Phase-by-phase execution plan | Per-phase objective/deliverables/scope/exit criteria/risk/non-goals table |
+| `ARCHITECTURE.md` | Technical strategy | Repo structure decision, data-driven vs. engine-level split, fastest path to prototype, named friction points |
+| `GAME_MODES.md` | Economic victory mode spec | Naming, mechanic, win condition, target tables, HUD, anti-stalemate/turtle rules, why 3+ players |
+| `BUILDINGS.md` | Content roster | Per-building fantasy/purpose/prereqs/counters/complexity/staging, categorized |
+| `ART_DIRECTION.md` | Visual/tone direction | Tone, guardrails, readability rules, palette, asset pipeline notes |
+| `CONTRIBUTING.md` (docs/) | Sungrid-specific contributor workflow | Repo structure, branches, milestones, labels, RFC process, PR checklist, release/changelog, Claude Code usage |
+| `LICENSE_NOTES.md` | Licensing clarity | GPLv3 inheritance, EA non-affiliation, original-asset licensing, open decisions |
+| `CLAUDE.md` (root) | AI-session navigation map | What this repo is, directory map, doc index, principles, current status, working conventions |
+| `BLUEPRINT.md` (this file) | Single-read master plan | All of the above, condensed and cross-linked |
+
+---
+
+## 9. First 10 GitHub issues
+
+See the issues opened alongside this PR for the live versions; summarized here for reference:
+
+1. **Scaffold `mods/sungrid` from `mods/ra` template** — Phase 1. Fork the mod directory, update `mod.yaml` metadata (id/title/icon), no rule changes. *Depends on: this docs PR merged.* *DoD: mod appears in the OpenRA mod chooser under its own name.*
+2. **Verify baseline playable shell** — Phase 1. Launch `mods/sungrid`, play a full skirmish vs. AI, confirm destruction win/loss works. *Depends on: #1.* *DoD: a complete match can be played start-to-finish with no crashes.*
+3. **Set up CI build for the Sungrid mod** — Phase 0/1. Extend existing CI workflow to build/validate `mods/sungrid`. *Depends on: #1.* *DoD: CI fails on a broken mod build.*
+4. **Add Solar Array + Battery Bank building stubs** — Phase 2. YAML-only reflavor of the power plant and silo-equivalent; Battery Bank here is placeholder economy only, not yet the Grid Reserve Vault. *Depends on: #2.* *DoD: both buildable and functional in a skirmish.*
+5. **Add Recycling Depot** — Phase 2. Refinery-adjacent economy building with a salvage-based income stream. *Depends on: #2.* *DoD: buildable, produces Credits from battlefield wreckage in a test match.*
+6. **RFC: Grid Reserve trait design** — Phase 3, `type:design`. Design the Vault deposit/capacity/decay/win-condition trait before writing it. *Depends on: #2.* *DoD: RFC issue resolved, `GAME_MODES.md`/`ARCHITECTURE.md` updated if the design shifts from the current spec.*
+7. **Implement Grid Reserve Vault trait + win condition** — Phase 3, `type:engine`. The actual C# implementation per the resolved RFC. *Depends on: #6.* *DoD: a 1v1 match can be won via Grid Reserve in a local test.*
+8. **Add Grid Reserve HUD/scoreboard elements** — Phase 3. Reserve bars, Lockdown broadcast, minimap reveal at 50%. *Depends on: #7.* *DoD: all HUD elements visible and correct in a test match.*
+9. **3-4 player Grid Reserve playtest + balance pass** — Phase 3/4. Structured playtest specifically probing turtle strategies and raid disruption of Lockdown countdowns. *Depends on: #8.* *DoD: at least one match won via Grid Reserve with a documented Vault raid affecting the outcome.*
+10. **Set up first external playtest build/packaging** — Phase 4/5 prep. Package a build testers can install and run, with basic instructions. *Depends on: #9.* *DoD: a non-team playtester successfully installs and completes a match unassisted.*
+
+---
+
+## 10. Next 3 Claude Code prompts
+
+After this planning PR merges, these are the next three prompts to run, in order:
+
+1. *"Fork `mods/ra` into a new `mods/sungrid` mod: copy the directory, update `mod.yaml` (id, title, description, icon path) to Sungrid Protocol branding, and make no other rule changes. Verify it builds and appears as a separate entry in the OpenRA mod chooser. This is issue #1/#2 from `docs/BLUEPRINT.md` section 9."*
+2. *"In `mods/sungrid`, add Solar Array (power plant reflavor), Battery Bank (silo reflavor, placeholder economy only — not yet the Grid Reserve Vault), and Recycling Depot (refinery-adjacent salvage income) as YAML-only content changes composing existing OpenRA traits. No new C# code. Playtest a skirmish to confirm no regressions to the baseline shell. This is issues #4/#5 from `docs/BLUEPRINT.md` section 9."*
+3. *"Write the Grid Reserve RFC (issue #6): a concrete C# trait design for the Vault building — deposit/withdrawal-forbidden state, per-tick deposit rate cap, per-Vault capacity cap, destruction-drain behavior, and the hold-to-win Lockdown countdown hook into OpenRA's win-condition framework — checked specifically for lockstep-determinism in multiplayer. Update `docs/GAME_MODES.md` and `docs/ARCHITECTURE.md` if the concrete design differs from the current spec, before any implementation code is written."*
+
+---
+
+## A. Recommended MVP scope
+
+The full 10-building roster, both victory modes (destruction default, Grid Reserve toggleable), a functional (not strong) AI, stable 2-6 player multiplayer, and a visually distinct (not necessarily fully custom-art) solarpunk identity. See section 4 above for the full breakdown.
+
+## B. Recommended Phase 0 checklist
+
+- [x] Write and merge the full `docs/` design doc set (`VISION`, `ROADMAP`, `ARCHITECTURE`, `GAME_MODES`, `BUILDINGS`, `ART_DIRECTION`, `CONTRIBUTING`, `LICENSE_NOTES`, `BLUEPRINT`) and `CLAUDE.md`.
+- [x] Reframe root `README.md` around Sungrid Protocol while preserving OpenRA attribution/license requirements.
+- [ ] Create GitHub milestones `P0`-`P6` matching `ROADMAP.md`.
+- [ ] Create the label taxonomy from `docs/CONTRIBUTING.md`.
+- [ ] Open the first 10 issues (section 9 above).
+- [ ] Merge this PR to `bleed`.
+
+## C. Top 3 scope traps to avoid
+
+1. **Pulling Phase 6 (diplomacy/shared-resource systems) forward.** It's the single biggest risk to the schedule — it's genuinely interesting but has no natural stopping point and isn't validated by any playtest data yet. Don't start it until Phase 3-5 explicitly justify it.
+2. **Under-scoping Grid Reserve's anti-turtle mechanics.** If the mode ships without real exposure (minimap reveal, capacity caps, no defensive synergy), the "optimal" strategy becomes hiding in a corner — which directly kills the project's core thesis. This gets dedicated playtesting attention, not just code review.
+3. **Producing custom art before mechanics are validated.** Phase 2's content pass should ship on recolored/placeholder art; committing to a full asset pipeline (Phase 5) before Grid Reserve and the core building set have survived real playtests risks expensive rework.
+
+## D. Single next action
+
+Merge this docs PR, then run Claude Code prompt #1 from section 10: fork `mods/ra` into `mods/sungrid` and get a genuinely playable (if unstyled) build launching under its own mod identity. Everything else in the roadmap is downstream of that one step existing and working.

--- a/docs/BUILDINGS.md
+++ b/docs/BUILDINGS.md
@@ -1,0 +1,105 @@
+# Sungrid Protocol — Building Plan
+
+Ten buildings, staged across the roadmap in `docs/ROADMAP.md`. Treat every fantasy/name here as a strong starting point, not a locked final design — expect iteration once these hit a playtest.
+
+## Category map
+
+| Category | Buildings |
+|---|---|
+| Energy | Solar Array, Battery Bank (Vault), Smart Grid Relay |
+| Economy | Recycling Depot, Cryptominer, Datacenter for AI |
+| Defense | Grid Defense Turret, Resilience Shelter |
+| Intelligence | Sensor Array, Datacenter for AI (dual-category) |
+| Logistics | Drone Bay |
+
+## Building details
+
+### 1. Solar Array
+- **Category:** Energy
+- **Fantasy:** A field of tracking solar panels feeding the base grid — the visual signature of the faction's power economy.
+- **Gameplay purpose:** Direct replacement for the classic power plant; primary power-generation building.
+- **Prerequisites:** Construction Yard.
+- **Likely counters:** Airstrikes/artillery targeting exposed power infrastructure (same counterplay as classic RA power plants — low armor, high strategic value).
+- **Implementation complexity:** Low — existing `Power` trait, reflavored art/sequence.
+- **Staging:** MVP (Phase 2).
+
+### 2. Battery Bank (Vault)
+- **Category:** Energy / Economy
+- **Fantasy:** Grid-scale battery storage that can be permanently committed to the settlement's long-term reserve rather than drawn back down.
+- **Gameplay purpose:** The deposit structure for the Grid Reserve economic victory mode (see `docs/GAME_MODES.md`) — converts spendable Credits into locked, irreversible Reserve.
+- **Prerequisites:** Solar Array (requires an established power economy first), Refinery-equivalent economy building.
+- **Likely counters:** Direct assault/raiding once Reserve inside is worth stealing-by-destruction; artillery and air harassment are effective since Vaults have no inherent defensive synergy.
+- **Implementation complexity:** High — this is the one building that needs new C# trait work (deposit tracking, capacity, destruction-drain, Lockdown countdown hook).
+- **Staging:** MVP (Phase 3) — required for the economic victory mode to exist at all.
+
+### 3. Recycling Depot
+- **Category:** Economy
+- **Fantasy:** A circular-economy facility that reclaims scrap from destroyed units/buildings (yours and the battlefield's) and converts it back into usable Credits.
+- **Gameplay purpose:** Refinery-adjacent economy building; gives a second, salvage-based income stream that rewards map control and post-battle cleanup over pure resource-field control.
+- **Prerequisites:** Construction Yard, Solar Array.
+- **Likely counters:** Denying the player battlefield access (so there's nothing to salvage), direct destruction like any economy building.
+- **Implementation complexity:** Medium — likely reuses/extends existing salvage-adjacent traits (there is prior art in OpenRA mods for wreck-harvesting mechanics) rather than needing wholly new systems.
+- **Staging:** MVP (Phase 2).
+
+### 4. Cryptominer
+- **Category:** Economy
+- **Fantasy:** Repurposed compute infrastructure grinding through proof-of-work for a legacy financial network — a deliberately morally ambiguous building in an eco-solarpunk setting (cheap power in, real money out, but it's not "clean" the way Solar Array is).
+- **Gameplay purpose:** A high power-draw, high-Credit-output economy building — trades grid stability (drains power hard) for economic upside, creating a real tension with the Solar Array/power budget.
+- **Prerequisites:** Solar Array (needs power headroom to be worth building), Tech Center-equivalent.
+- **Likely counters:** Power denial (destroy Solar Arrays and the Cryptominer goes offline or throttles), it's a high-value/low-defense target for raids given its output.
+- **Implementation complexity:** Medium — power-draw-scaled income likely needs a small custom trait (existing `Power`/economy traits don't natively support "income that scales with available power headroom"), but no win-condition-level complexity.
+- **Staging:** Mid-term (Phase 5).
+
+### 5. Datacenter for AI
+- **Category:** Economy / Intelligence
+- **Fantasy:** Racks of compute serving the faction's logistics AI and battlefield analytics — the "brains" behind smart-grid coordination.
+- **Gameplay purpose:** Dual-purpose building — modest passive Credit/tech bonus plus an intelligence effect (e.g. periodic radar pulse or unit-vision bonus), tying economic investment to information advantage rather than pure output.
+- **Prerequisites:** Tech Center-equivalent, Solar Array.
+- **Likely counters:** High-value raid target once its intelligence bonus is felt on the battlefield; power denial reduces its effect the same way as Cryptominer.
+- **Implementation complexity:** Medium — likely composes existing intelligence/reveal traits with a standard economy trait rather than needing new systems.
+- **Staging:** Mid-term (Phase 5).
+
+### 6. Drone Bay
+- **Category:** Logistics
+- **Fantasy:** Autonomous delivery drones ferrying resources and reinforcements across contested terrain, reducing dependence on vulnerable ground supply lines.
+- **Gameplay purpose:** Logistics building enabling faster resource transport and/or rapid unit repositioning between owned structures — a mobility/economy hybrid that rewards map-spanning infrastructure over turtled play.
+- **Prerequisites:** Construction Yard, Recycling Depot or equivalent economy building.
+- **Likely counters:** Anti-air, since drone traffic is the obvious vulnerability; destroying the Drone Bay itself halts the logistics network.
+- **Implementation complexity:** Medium-High — likely composes existing `Cargo`/`Reservable`/transport traits, but genuinely novel routing behavior could push into new-trait territory; flagged as a Phase 5 friction point to scope carefully before committing.
+- **Staging:** Mid-term (Phase 5).
+
+### 7. Grid Defense Turret
+- **Category:** Defense
+- **Fantasy:** A point-defense structure drawing directly off the local grid — hits harder when the grid is healthy, weaker when power is strained.
+- **Gameplay purpose:** Standard defensive structure, but with its damage/rate-of-fire tied to the base's current power surplus — creates a direct tactical link between the energy economy and combat strength.
+- **Prerequisites:** Solar Array.
+- **Likely counters:** Power denial (destroy power plants to weaken the turret before assaulting), standard artillery/air counters to static defense.
+- **Implementation complexity:** Medium — power-scaled combat stats likely need a small custom trait extension over the stock `AttackBase`/turret traits.
+- **Staging:** Mid-term (Phase 5).
+
+### 8. Smart Grid Relay
+- **Category:** Energy / Logistics
+- **Fantasy:** A grid-balancing relay station that lets power flow between distant parts of a sprawling, decentralized base.
+- **Gameplay purpose:** Extends effective power range/pooling between disconnected base clusters, enabling more spread-out, harder-to-snipe-in-one-strike base layouts.
+- **Prerequisites:** Solar Array.
+- **Likely counters:** Destroying the Relay can fragment a spread base's power pool, so it becomes a high-value target in decentralized layouts.
+- **Implementation complexity:** Medium — depends on how OpenRA's stock power-pooling model can be extended; may require a small trait if power pooling isn't naturally range-limited today.
+- **Staging:** Later (post-Phase 5, revisit once base-spread playstyles are observed in playtests).
+
+### 9. Resilience Shelter
+- **Category:** Defense
+- **Fantasy:** A hardened civil-defense structure that keeps a settlement's core functions running under sustained attack — the "don't lose everything at once" building.
+- **Gameplay purpose:** Damage-mitigation/comeback structure — e.g. reduces splash damage to nearby structures or grants a brief repair pulse when the base takes heavy losses, softening total wipeouts without preventing them.
+- **Prerequisites:** Construction Yard, Tech Center-equivalent.
+- **Likely counters:** Alpha-strike/overwhelm tactics that outpace its mitigation window; it blunts damage, it doesn't prevent loss.
+- **Implementation complexity:** Medium — likely a conditional damage-modifier trait applied to nearby structures, similar in shape to existing aura/support-power traits.
+- **Staging:** Later (post-Phase 5).
+
+### 10. Sensor Array
+- **Category:** Intelligence
+- **Fantasy:** A distributed sensor mesh reading grid load, drone traffic, and terrain across the map — battlefield awareness as smart-grid telemetry.
+- **Gameplay purpose:** Wide-radius vision/detection building (including stealth/cloak detection if the roster ever needs it), rewarding investment in map awareness over blind aggression.
+- **Prerequisites:** Tech Center-equivalent.
+- **Likely counters:** High-value raid/airstrike target once its intelligence value is evident; doesn't defend itself.
+- **Implementation complexity:** Low — largely composes existing reveal/detector traits already in OpenRA's common mod.
+- **Staging:** Later (post-Phase 5).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Sungrid Protocol
+
+This document covers Sungrid Protocol's project workflow: branching, issues, RFCs, releases. For C# coding style on engine-level changes, see the root [`CONTRIBUTING.md`](../CONTRIBUTING.md), which is OpenRA's upstream engine contribution guide and still applies to anything touching `OpenRA.*` directories.
+
+## Repository structure
+
+```
+OpenRA.Game/, OpenRA.Mods.*/, ...   # upstream engine — avoid touching unless justified in docs/ARCHITECTURE.md
+mods/ra, mods/cnc, mods/d2k, mods/ts  # stock upstream mods — reference only, do not edit
+mods/sungrid/                       # Sungrid Protocol mod — this is where almost all work happens
+docs/                                # design docs (this file, VISION, ROADMAP, ARCHITECTURE, GAME_MODES, BUILDINGS, ART_DIRECTION, LICENSE_NOTES, BLUEPRINT)
+CLAUDE.md                            # navigation map for AI-assisted sessions
+```
+
+## Branch strategy
+
+- `bleed` — default/integration branch, always playable. Nothing merges here that doesn't at least build.
+- `claude/*` or `feature/*` — short-lived branches per issue/phase item. Named after the issue where possible (e.g. `feature/grid-reserve-vault`).
+- No direct pushes to `bleed` — everything goes through a PR, even for a solo-founder-plus-Claude workflow, so the diff history stays reviewable.
+- Tag releases off `bleed` once a phase's exit criteria (per `docs/ROADMAP.md`) are met.
+
+## Milestones
+
+One GitHub milestone per roadmap phase, named to match `docs/ROADMAP.md` exactly:
+
+`P0: Bootstrap`, `P1: Baseline Shell`, `P2: First Content Pass`, `P3: Grid Reserve MVP`, `P4: Playtest Hardening`, `P5: Faction Flavor`, `P6: Diplomacy (conditional)`.
+
+Every issue and PR should be assigned to the milestone of the phase it belongs to; an issue with no clear phase is a signal it's premature (check it against the "do NOT attempt yet" list in that phase's roadmap entry).
+
+## Label taxonomy
+
+| Label | Meaning |
+|---|---|
+| `phase:0` … `phase:6` | Which roadmap phase this belongs to |
+| `type:design` | RFC / design proposal, not yet implementation |
+| `type:content` | Data-driven YAML/art/audio work |
+| `type:engine` | New or modified C# trait / engine-level change |
+| `type:docs` | Documentation only |
+| `type:bug` | Regression or broken behavior |
+| `area:economy`, `area:energy`, `area:defense`, `area:intelligence`, `area:logistics` | Matches the building categories in `docs/BUILDINGS.md` |
+| `area:grid-reserve` | Anything touching the economic victory mode specifically |
+| `risk:scope-trap` | Flagged as touching something explicitly deferred in the roadmap — extra scrutiny before merging |
+| `good-first-issue` | Self-contained, low-context-required |
+
+## RFC / design proposal workflow
+
+Anything in the `type:engine` category, or anything that changes a rule already documented in `docs/GAME_MODES.md` or `docs/BUILDINGS.md`, gets an RFC first:
+
+1. Open an issue labeled `type:design` describing the problem, the proposed change, and which doc(s) it would update.
+2. Resolve open questions in the issue thread (or via a short doc update proposal) before writing implementation code.
+3. Once agreed, update the relevant doc (`GAME_MODES.md`, `BUILDINGS.md`, `ARCHITECTURE.md`, etc.) in the same PR as the implementation, or in a docs-only PR immediately before it — the docs should never silently drift from what's actually implemented.
+
+Pure `type:content` changes (a new building's YAML stats, a balance tweak) don't need a full RFC — a normal PR description explaining the change is enough.
+
+## PR checklist
+
+- [ ] Linked to an issue and the correct phase milestone
+- [ ] If `type:engine`: matching RFC issue linked, and the change is additive (doesn't alter unrelated existing traits/behavior)
+- [ ] If it changes a documented rule: the relevant `docs/*.md` file is updated in the same PR
+- [ ] Manually playtested (skirmish match minimum) if it touches buildable content or a game mode
+- [ ] No changes to `OpenRA.*` upstream engine directories unless explicitly justified and called out in the PR description
+- [ ] Builds cleanly (`make` / the repo's standard build command)
+
+## Release strategy
+
+- Internal/dev builds off `bleed` after every merged phase-exit-criteria milestone (see `docs/ROADMAP.md` exit criteria per phase).
+- First tagged release intended for external humans is the Phase 5 exit point — see the MVP definition in `docs/BLUEPRINT.md`.
+- Pre-MVP, tags are for the founder's/testers' own tracking (`v0.0.x-phaseN`) — not public releases.
+
+## Changelog
+
+Keep a `CHANGELOG.md` at the repo root once Phase 1 ships a playable build (not needed for Phase 0's docs-only bootstrap). One entry per merged PR, grouped by phase, written in plain language a playtester would understand (not raw commit messages).
+
+## Contributor onboarding
+
+1. Read `README.md`, then `docs/VISION.md` and `docs/ROADMAP.md` for the "why" and "what's next."
+2. Read `docs/ARCHITECTURE.md` before touching any code — it defines what's data-driven (default) vs. engine-level (exception).
+3. Pick an open issue matching the current phase's milestone; if none exist, propose one against the roadmap rather than inventing new scope.
+4. Follow the PR checklist above.
+
+## Using Claude Code safely in this repo
+
+- Default Claude Code sessions to `mods/sungrid/` and `docs/` — treat any diff touching `OpenRA.*` upstream engine directories as requiring explicit justification against a named friction point in `docs/ARCHITECTURE.md`, not a default action.
+- Prefer data-driven (YAML/Lua) changes; a Claude session proposing a new C# trait should point to which "New C# traits" row in `docs/ARCHITECTURE.md` it satisfies.
+- Never push directly to `bleed` from an automated session — always a branch + PR, even for docs.
+- Keep sessions scoped to one issue/phase item at a time; a session that starts drifting into unrelated files or future-phase content is a signal to stop and re-scope, not to keep going.

--- a/docs/GAME_MODES.md
+++ b/docs/GAME_MODES.md
@@ -1,0 +1,70 @@
+# Sungrid Protocol — Economic Victory Mode
+
+Destruction victory (eliminate all opponents) remains the default, always-available win condition. This document specifies the first alternative: an optional economic victory mode, toggleable per-lobby.
+
+## Name
+
+| Candidate | Note |
+|---|---|
+| **Grid Reserve** *(recommended)* | Reads as a bank/reserve concept, fits the smart-grid fiction, short and HUD-friendly ("Grid Reserve: 42,000 / 60,000"). |
+| Energy Surplus | Clear but undersells the "banking" mechanic. |
+| Sunbank Protocol | On-theme but slightly cute; risks tone drift toward goofy. |
+| Reserve Threshold | Descriptive but dry, weak as a lobby-facing mode name. |
+| Solvency Protocol | Strong economic framing, less solarpunk-specific. |
+
+## Core rules
+
+Grid Reserve introduces a new building type, the **Vault**, and a new per-player resource pool, **Reserve**, that is separate from ordinary spendable Credits.
+
+1. **Depositing.** Vaults convert spendable Credits into Reserve at a fixed rate, at a capped deposit rate per tick (prevents "dump the whole treasury in one safe moment"). Deposits are **irreversible** — Reserve cannot be withdrawn back into spendable Credits. This is the actual spend-vs-save decision: money in a Vault can never again buy units or defenses.
+2. **Capacity.** Each Vault has a maximum Reserve capacity. Reaching a high Reserve target requires building and defending **multiple Vaults**, which is what keeps the mode from collapsing into "build one Vault in a corner and wait."
+3. **Vulnerability.** Vaults are ordinary destructible structures. Destroying an enemy Vault drains a percentage (recommended: 50%) of the Reserve it held and grants the attacker a Credits reward proportional to the drained amount. This is the mechanism that keeps harassment and raiding relevant under this mode — a Vault is a juicier raid target than almost anything else on the map once it's carrying real Reserve.
+4. **Win condition — Grid Lockdown.** When a player's total Reserve across all their Vaults first reaches the map's Reserve target, a **Grid Lockdown countdown** (60–120 seconds, map-configurable) begins and is broadcast to all players. If the player's Reserve stays at or above the target for the full countdown, they win. If Reserve drops below target at any point during the countdown (typically because a Vault was destroyed), the countdown cancels and must be re-triggered from scratch once the target is met again.
+5. **Toggle.** Grid Reserve is a lobby option, off by default at first release, so destruction victory is never at risk of feeling deprecated.
+
+## Example Reserve targets
+
+Targets scale per player, with a modest per-player discount at higher counts so 6-player games don't take disproportionately longer to resolve than 3-player games.
+
+| Map size | 2 players | 3 players | 4 players | 6 players |
+|---|---|---|---|---|
+| Small | 20,000 | 27,000 | 32,000 | 42,000 |
+| Medium | 30,000 | 40,000 | 48,000 | 63,000 |
+| Large | 45,000 | 60,000 | 72,000 | 95,000 |
+
+(Baseline: ~15,000 Reserve per player on a medium map, roughly a 5% per-additional-player discount past the second player. These are starting points for Phase 3 playtesting, not final balance — expect them to move.)
+
+## HUD / scoreboard requirements
+
+- Per-player Reserve bar in the sidebar/scoreboard, showing current Reserve and the map's target (e.g. `Grid Reserve: 42,000 / 60,000`).
+- Broadcast banner + audio cue to **all players** when any player's Grid Lockdown countdown starts, and again if it cancels — this is the moment that should trigger table-wide attention and raids.
+- Minimap reveal: once a player's Reserve reaches **50% of target**, their Vault locations are revealed on all opponents' minimaps for the rest of the match (see anti-turtle rules below).
+- End-of-match scoreboard shows final Reserve totals for all players regardless of who won, so "who was closest" is visible even in a destruction-victory game.
+
+## Anti-stalemate rules
+
+- **Grid Decay:** if no player has triggered a Grid Lockdown countdown within a map-configured time window (recommended: 75% of the map's expected match length), all players' Reserve begins slowly decaying (recommended: 1%/minute) until someone reaches target. This prevents a mutual-turtle deadlock where nobody pushes for the win because everyone is "safely" below target.
+- Grid Decay never reduces Reserve below zero and never affects Credits — it only pressures the Reserve race to actually resolve.
+
+## Anti-turtle rules
+
+- **50% minimap reveal** (above) — you cannot bank in total secrecy once you're meaningfully ahead.
+- **Per-Vault capacity cap** — reaching a real target requires multiple exposed Vaults, not one hidden bunker.
+- **No defensive synergy** — Vaults grant no combat bonus, no repair aura, nothing that makes them worth defending *other than* the Reserve inside them. They don't anchor a defensive turtle the way a normal base does.
+- **Deposit-rate cap** — Credits can't be dumped into Reserve in one panic move when a raid is spotted inbound; hoarding has to be a sustained commitment, not a last-second reflex.
+
+## Why harassment and map pressure remain relevant
+
+Under Grid Reserve, the *thing worth attacking* is different (Vaults instead of, or in addition to, production buildings), but the incentive to scout, harass, and raid is not reduced — it's redirected. A player sitting on a large, undefended Reserve is a bigger prize than a player who spent everything on units, which keeps map control and scouting valuable exactly the way they are in a destruction-victory game.
+
+## Why this mode is strongest with 3+ players
+
+In a 1v1 match, hoarding is a pure two-body optimization race — whoever banks faster wins, and the only counterplay is "attack the other guy," which is identical to destruction-victory play. With 3 or more players, a leading hoarder becomes the shared target of the whole table: minimap reveal at 50% invites opportunistic raids from *any* opponent, not just the "designated rival," which creates dogpile dynamics, kingmaking (a weaker player choosing who to raid can decide who wins), and genuine multi-way tension that doesn't exist in 2-player games. This is also why diplomacy/alliance mechanics are deferred — they only make sense once this 3+-player dynamic is validated.
+
+## Deferred to later revisions
+
+- Diplomacy-gated Vault protection (e.g. non-aggression pacts that exempt Vaults from raids).
+- Shared or pooled Reserve between allied players.
+- Alliance-split victory (co-op win when allied players' combined Reserve hits target).
+- Per-faction Reserve mechanics or bonuses.
+- Any UI/spectator tooling beyond the basic scoreboard above.

--- a/docs/LICENSE_NOTES.md
+++ b/docs/LICENSE_NOTES.md
@@ -1,0 +1,25 @@
+# Sungrid Protocol — License Notes
+
+## Inherited license
+
+Sungrid Protocol is built directly on the OpenRA engine, which is licensed under the **GNU General Public License v3.0 or later** (see [`COPYING`](../COPYING) at the repo root). Because this repo is a fork of the OpenRA engine itself (not just a mod loaded against a separately-distributed engine binary), the entire codebase — engine and `mods/sungrid` alike — is bound by GPLv3 terms: source availability, same-license redistribution, and preservation of copyright/license notices.
+
+Practical implications:
+- Any code contributed to `mods/sungrid` or the engine tree is distributed under GPLv3, same as upstream OpenRA.
+- The [`AUTHORS`](../AUTHORS) file should continue to reflect contributors; do not remove or obscure existing OpenRA contributor attribution.
+- Do not add dependencies with licenses incompatible with GPLv3 without checking compatibility first.
+
+## EA / Command & Conquer non-affiliation
+
+OpenRA's stock mods (`mods/ra`, `mods/cnc`, `mods/d2k`) reimplement classic Westwood/EA game rules using original code, and EA has not endorsed and does not support OpenRA (this disclaimer already appears in the upstream `README.md`). Sungrid Protocol carries the same posture: it is a new, original game built on the OpenRA engine, not a Red Alert reskin distributing EA assets. As Phase 1 forks `mods/ra` into `mods/sungrid`, any placeholder content still recognizable as Red Alert-specific IP (unit names tied to the C&C universe, EA-owned imagery) should be treated as temporary scaffolding to be replaced by original Sungrid Protocol content no later than Phase 2, not shipped in a public build.
+
+## Original asset licensing (Phase 5+)
+
+Once Phase 5 starts producing original art/audio for Sungrid Protocol:
+- New art/audio assets can be licensed separately from the GPLv3 code if desired (OpenRA's own asset conventions distinguish code license from content license in places), but the choice should be made explicitly and documented here once decided — do not leave it implicit.
+- Any third-party asset (fonts, sound effects, music) brought in from outside must have a license compatible with public redistribution, with attribution recorded in this file.
+- AI-assisted art/audio generation used for prototyping should be treated as placeholder unless the specific tool/model's output terms are confirmed compatible with the project's chosen distribution license.
+
+## Open items
+
+This file will need a decision once Phase 5 art production starts: whether original Sungrid Protocol assets ship under GPLv3 (matching code) or a separate content license (e.g. CC-BY-SA, matching conventions used by some other OpenRA-based projects). Track that decision as a `type:design` RFC issue when Phase 5 begins.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,88 @@
+# Sungrid Protocol — Phased Roadmap
+
+Scope control is the whole game here. Each phase must ship something playable or reviewable, and each phase must be revertible without breaking the one before it. See `docs/BLUEPRINT.md` for the full narrative version of this table and `docs/ARCHITECTURE.md` for the technical reasoning behind the code/data split.
+
+## Phase overview
+
+| Phase | Objective | GitHub milestone |
+|---|---|---|
+| 0 | Repository bootstrap and architecture setup | `P0: Bootstrap` |
+| 1 | Baseline playable shell on OpenRA | `P1: Baseline Shell` |
+| 2 | First solarpunk content layer | `P2: First Content Pass` |
+| 3 | Economic victory mode MVP | `P3: Grid Reserve MVP` |
+| 4 | UI, balance, AI, multiplayer iteration | `P4: Playtest Hardening` |
+| 5 | Expanded buildings / faction flavor / polish | `P5: Faction Flavor` |
+| 6+ | Diplomacy / shared-resource systems (conditional) | `P6: Diplomacy (conditional)` |
+
+## Phase 0 — Repository bootstrap and architecture setup
+
+- **Why:** Nothing downstream is trustworthy if the repo structure, docs, and contribution model aren't settled first. This is also where the "full engine fork vs. Mod SDK" question gets answered once, in writing, so it never gets re-litigated per-PR.
+- **Deliverables:** `docs/` design doc set (this file and its siblings), `CLAUDE.md` navigation map, root `README.md` reframed for Sungrid Protocol, label taxonomy and milestones created in GitHub, first 10 issues opened.
+- **Code scope:** None. No `mods/sungrid` directory yet.
+- **Data/content scope:** None.
+- **Testing scope:** Docs review only — links resolve, tables render, no contradictions between docs.
+- **Exit criteria:** All docs merged to `bleed`; milestones and labels exist; contributors (even a future solo-plus-Claude workflow) can onboard from `README.md` alone.
+- **Biggest risk:** Scope creep into actually starting `mods/sungrid` before the plan is settled, which tends to produce content that has to be redone once the mod-structure decision is final.
+- **Do NOT attempt yet:** Any C# engine changes, any new traits, any art asset pipeline decisions.
+
+## Phase 1 — Baseline playable shell on OpenRA
+
+- **Why:** Prove the fork boots, plays, and can be reskinned before any new mechanic is added. This is the fastest way to a "playable" milestone and it de-risks the mod-structure decision from Phase 0.
+- **Deliverables:** `mods/sungrid` created as a fork of `mods/ra` (same rules, same units, same maps initially), mod metadata (`mod.yaml`, id, title, icon placeholder) updated, mod appears in the OpenRA mod chooser and launches to a working skirmish against the AI.
+- **Code scope:** None beyond what `mods/ra` already has. No new traits.
+- **Data/content scope:** Mod metadata only — id/title/version/icon. Unit and building YAML is untouched (still literally Red Alert content, just running under the Sungrid Protocol mod id).
+- **Testing scope:** Manual: launch the mod, start a skirmish vs. AI, confirm win/lose on destruction victory, confirm no crashes, confirm assets load.
+- **Exit criteria:** A build of the Sungrid Protocol mod can be launched, played start-to-finish against the AI, and produces a normal win/loss result.
+- **Biggest risk:** Treating this phase as "done" content-wise — it isn't, it's plumbing. It's tempting to start reskinning immediately; resist until Phase 1 is merged and stable.
+- **Do NOT attempt yet:** Any new buildings, new economy mechanics, or art replacement. This phase is a rename-and-verify pass, not a content pass.
+
+## Phase 2 — First solarpunk content layer
+
+- **Why:** This is the first phase where Sungrid Protocol starts to look and feel different from vanilla RA, entirely through data-driven YAML changes (renamed/reflavored existing structures, new low-complexity buildings).
+- **Deliverables:** Solar Array (power plant reflavor), Battery Bank (silo-style storage reflavor), Recycling Depot (refinery-adjacent reflavor), first-pass renames of core econ buildings to fit the solarpunk fiction, placeholder or lightly-modified art (existing OpenRA art recolored/retextured is acceptable here — full asset production is a later-phase concern).
+- **Code scope:** None expected; if a genuinely new mechanic turns out to need C#, it gets flagged and deferred to Phase 3+ rather than rushed here.
+- **Data/content scope:** New/edited `rules/*.yaml` entries in `mods/sungrid`, new building icons/sequences (can be placeholder), updated tech tree ordering.
+- **Testing scope:** Manual skirmish playtest confirming new buildings are buildable, produce expected effects (power, storage), and don't break the existing economy loop or AI build orders.
+- **Exit criteria:** A skirmish match is playable start-to-finish using at least 3 new/reflavored solarpunk buildings without regressions to Phase 1's baseline.
+- **Biggest risk:** Scope-creeping into full custom art production before the mechanics are validated — expensive art on unvalidated mechanics is wasted work.
+- **Do NOT attempt yet:** Cryptominer, Datacenter for AI, Drone Bay, or anything that implies new mechanics (those wait for Phase 3+ where they can justify custom traits).
+
+## Phase 3 — Economic victory mode MVP
+
+- **Why:** This is the project's first real design innovation and the reason the project exists in its current form. See `docs/GAME_MODES.md` for the full spec.
+- **Deliverables:** New "Vault" building (Grid Reserve deposit structure), a new win-condition/`MissionObjectives`-style trait implementing hold-to-win Reserve logic, HUD/scoreboard elements showing per-player Reserve progress, minimap reveal-at-threshold behavior, lobby option to enable/disable the mode (destruction victory remains the default).
+- **Code scope:** This phase is where the first real C# work happens — a new trait (or small set of traits) for tracking Reserve, handling deposits, handling the Lockdown countdown, and hooking into the existing win-condition framework. Kept as small and additive as possible; does not touch unrelated engine systems.
+- **Data/content scope:** Vault building YAML, per-map-size Reserve target config, HUD layout changes (Lua/`ChromeLayout` YAML where possible).
+- **Testing scope:** Automated where feasible (unit-test the Reserve threshold/countdown logic if it's isolated enough), plus manual 1v1 and 3-4 player matches specifically testing: reaching target, holding through Lockdown, losing Lockdown progress via vault destruction, decay/anti-stalemate behavior over a long game.
+- **Exit criteria:** A 3+ player skirmish match can be won via Grid Reserve without destroying all opponents, the mode can be toggled off to fall back to pure destruction victory, and at least one playtest match demonstrates a vault raid meaningfully disrupting a leader's countdown.
+- **Biggest risk:** Under-scoping the anti-turtle mechanics and shipping a mode where the "optimal" strategy is to hide in a corner and never fight — this is the single most damaging outcome for the project's core thesis, so it gets explicit playtesting attention, not just code review.
+- **Do NOT attempt yet:** Diplomacy-gated protection, alliance/shared-reserve mechanics, per-faction Reserve bonuses.
+
+## Phase 4 — UI, balance, AI, and multiplayer iteration
+
+- **Why:** A mode that only works when a human designer is watching isn't done. This phase is about making Grid Reserve (and the Phase 2 content) survive contact with real players and the game's AI.
+- **Deliverables:** AI skirmish scripts updated to understand Grid Reserve (build vaults, raid enemy vaults, respond to Lockdown countdowns at a basic level), balance pass on Reserve targets/decay/deposit caps from Phase 3 playtests, HUD polish, netcode/lobby-sync validation for the new traits under real multiplayer conditions (not just LAN/local).
+- **Code scope:** AI script updates (Lua), trait bugfixes/tuning found via playtests, no new major systems.
+- **Data/content scope:** Balance tuning (numbers only) across Phase 2 and Phase 3 content.
+- **Testing scope:** Structured playtests with 3-6 external testers, dedicated-server multiplayer test session, AI-vs-AI stress test for desync/crash issues.
+- **Exit criteria:** External testers can complete a full multiplayer match (destruction or Grid Reserve) without desyncs, crashes, or "obviously broken" balance complaints; AI provides a credible skirmish opponent.
+- **Biggest risk:** AI work is a classic time sink in OpenRA-style engines — cap the AI ambition at "doesn't actively ignore the new mechanic," not "plays Grid Reserve optimally."
+- **Do NOT attempt yet:** New buildings beyond balance tuning of existing ones, new victory modes, diplomacy.
+
+## Phase 5 — Expanded buildings / faction flavor / polish
+
+- **Why:** With the core loop (destruction + Grid Reserve) validated by real playtests, this phase spends effort on breadth and production values rather than new systems.
+- **Deliverables:** Remaining buildings from `docs/BUILDINGS.md` (Cryptominer, Datacenter for AI, Drone Bay, Grid Defense Turret, Smart Grid Relay, Resilience Shelter, Sensor Array), first custom art pass replacing recolored placeholders, at least one visually-distinct faction identity, sound/music pass.
+- **Code scope:** Only as required by new building mechanics (e.g. Drone Bay logistics behavior) — still preferentially data-driven via existing OpenRA traits (`Reservable`, `Cargo`, `AttackBase`, etc.) before new C#.
+- **Data/content scope:** The bulk of this phase — new building YAML, art, audio, tech tree balancing across a fuller roster.
+- **Testing scope:** Full playtest campaign across the expanded roster, regression testing that Phase 3's Grid Reserve balance still holds with more economy options available.
+- **Exit criteria:** The building roster from `docs/BUILDINGS.md` is complete and balanced, the mod has a distinct visual identity, and this is the version considered ready for wider public testing (see MVP definition in `docs/BLUEPRINT.md`).
+- **Biggest risk:** Faction flavor work has no natural stopping point — set a fixed roster (the 10 buildings already listed) and resist adding more before shipping.
+- **Do NOT attempt yet:** Second faction, campaign/story missions, diplomacy.
+
+## Phase 6+ — Diplomacy and shared-resource systems (conditional)
+
+- **Why:** Only pursued if Grid Reserve playtests show that the spend/save tension is solid and players are asking for deeper multiplayer social dynamics (alliances, betrayal, resource sharing) on top of it.
+- **Deliverables:** Not scoped yet — deliberately. This phase does not get planned in detail until Phase 3-5 data justifies it.
+- **Exit criteria for even starting this phase:** Phase 3-5 playtests show sustained 3+ player engagement with Grid Reserve and explicit tester demand for social/diplomatic mechanics.
+- **Do NOT attempt yet:** Everything. This is the phase most likely to blow up the schedule if pulled forward — see Scope Trap #1 in `docs/BLUEPRINT.md`.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,34 @@
+# Sungrid Protocol — Vision
+
+## What it is
+
+Sungrid Protocol is a solarpunk reinterpretation of the classic Red Alert RTS formula, built on the OpenRA engine. It keeps the readable, skill-testing bones of 90s RTS design — base building, unit counters, scouting, raiding, map control — and reframes the fiction and the economy around renewable power, smart grids, drone logistics, and resilient settlements. It is hopeful and strategic, not utopian or goofy: factions are still at war, resources are still contested, and losing your base still hurts.
+
+The project's first real design innovation is not the art direction, it's the **economic victory mode**: an optional win condition that makes *saving* money a legitimate alternative to spending it on offense or defense, without turning the game into a passive economy race.
+
+## Design pillars
+
+1. **Classic RTS legibility first.** Every unit, building, and system must read clearly on screen at a glance — silhouette, color, and UI legibility are not sacrificed for theme.
+2. **Solarpunk as a lens, not a coat of paint.** Renewable energy, circular economy, and smart-grid logistics should change what players *do* (power management, recycling, grid defense), not just what things are called.
+3. **Spend vs. save is a first-class decision.** The economic victory mode exists to make hoarding capital a real strategic axis, contested the same way territory is.
+4. **Pressure never disappears.** Scouting, harassment, raiding, and map control stay relevant in every mode, including the economic one — a mode that rewards passive turtling is a failed mode.
+5. **Data-driven before engine-driven.** New content ships as OpenRA YAML/Lua/mod rules wherever physically possible; engine-level C# changes are reserved for things that are provably impossible any other way.
+6. **Small reversible phases.** Every phase ships something playable and can be rolled back without breaking the previous phase's promises.
+7. **Destruction victory stays intact.** The classic "kill everyone" win condition is never removed — the economic mode is additive and optional.
+8. **3+ players is the design target for new modes.** Diplomacy, betrayal, and opportunistic raiding only get interesting with three or more seats at the table; new social mechanics are designed for that context first.
+
+## What makes it different from vanilla Red Alert-style play
+
+| Vanilla RA-style play | Sungrid Protocol |
+|---|---|
+| Ore/Tiberium-style single resource, spend it or lose tempo | Power and capital are legible, gridded systems (solar, batteries, storage) with a real "bank it" option |
+| Only win condition is elimination | Elimination **and** an optional economic victory (hold a capital threshold) |
+| Turtling is usually just slow, not punished | Turtling under the economic mode is actively exposed (visible reserves, raidable vaults, decay pressure) |
+| Tech tree is purely military escalation | Tech tree includes eco-infrastructure (recycling, batteries, drone logistics) that trades off against military tech |
+| Aesthetic: Cold War industrial/military | Aesthetic: lush eco-industrial — solar arrays, green retrofits, drone logistics, resilient settlements over ruins |
+
+## What Sungrid Protocol is explicitly not (yet)
+
+- Not a diplomacy or alliance simulator — treaties, reparations, and resource-sharing are later-phase ideas, only pursued if the economic victory mode proves itself first.
+- Not a economy-only "builder" game — combat, raiding, and destruction remain core, non-optional systems.
+- Not a new engine or a total conversion of OpenRA's renderer/netcode — we build within OpenRA's data-driven trait system as far as it will take us.


### PR DESCRIPTION
Bootstraps the project as an OpenRA-based mod: vision, technical architecture, phased roadmap, the Grid Reserve economic victory mode spec, initial building roster, art direction, contributor workflow, license notes, and a CLAUDE.md navigation map for future sessions. Reframes the root README around Sungrid Protocol while preserving OpenRA attribution and license requirements. Docs-only change; no mod code yet (mods/sungrid scaffolding is the next issue).

Thank you for your contribution to OpenRA!

Please be aware that we do not have enough project maintainers to match the rate of contributions, so it may take several days before somebody is able to respond to your Pull Request.

You can help speed up the review process by following a few steps:

* Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard).
* Write quality commit messages (see https://chris.beams.io/posts/git-commit/).
* Only commit changes that directly relate to your Pull Request.  Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
* Review the code diff view below to double check that your changes satisfy the above three points.
* Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.
* If you are changing shared mod or engine code, make sure that you have tested your changes in all four default mods.
* Respond to review comments as soon as you reasonably can.  Reviewers will usually prioritize Pull Requests that are still fresh in their minds.  Make sure to leave a comment when you push new changes, otherwise GitHub does not automatically notify reviewers!
* Leave a polite comment asking for reviews if a week or more has passed without feedback.

If you need any help you can ask on Discord (https://discord.openra.net) or in the #openra IRC channel on Libera (not as active as Discord).