### PR TITLE
Fix boolean map generator option inverted defaults

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					case MapGeneratorBooleanOption bo:
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
-							generationArgs.Options[o.Id] = bo.Default ? falseString : trueString;
+							generationArgs.Options[o.Id] = bo.Default ? trueString : falseString;
 
 						optionWidget = checkboxOptionTemplate.Clone();
 						var checkboxWidget = optionWidget.Get<CheckboxWidget>("CHECKBOX");

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -290,7 +290,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					case MapGeneratorBooleanOption bo:
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
-							generationArgs.Options[o.Id] = bo.Default ? falseString : trueString;
+							generationArgs.Options[o.Id] = bo.Default ? trueString : falseString;
 
 						optionWidget = checkboxOptionTemplate.Clone();
 						var checkboxWidget = optionWidget.Get<CheckboxWidget>("CHECKBOX");


### PR DESCRIPTION
Corrects a reversed ternary expression, which was causing boolean map generator options to take on the opposite of their default values.

Fixes #22535