### PR TITLE
Update LangVersion to C# 13.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,7 +76,7 @@ dotnet_diagnostic.IDE0290.severity = silent
 
 # IDE0330 Prefer 'System.Threading.Lock'
 #csharp_prefer_system_threading_lock = true
-dotnet_diagnostic.IDE0330.severity = silent # Requires C# 13
+dotnet_diagnostic.IDE0330.severity = warning
 
 ## Expression-bodied members
 
@@ -348,7 +348,7 @@ dotnet_diagnostic.IDE0350.severity = warning
 
 # IDE0360 Simplify property accessor
 #csharp_style_prefer_simple_property_accessors = true
-dotnet_diagnostic.IDE0360.severity = silent # Requires C# 13
+dotnet_diagnostic.IDE0360.severity = warning
 
 ## Field preferences
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
-    <LangVersion>12</LangVersion>
+    <LangVersion>13</LangVersion>
     <DebugSymbols>true</DebugSymbols>
     <EngineRootPath Condition="'$(EngineRootPath)' == ''">..</EngineRootPath>
     <OutputPath>$(EngineRootPath)/bin</OutputPath>

--- a/OpenRA.Game/FluentProvider.cs
+++ b/OpenRA.Game/FluentProvider.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Text;
+using System.Threading;
 using OpenRA.FileSystem;
 
 namespace OpenRA
@@ -19,7 +20,7 @@ namespace OpenRA
 	public static class FluentProvider
 	{
 		// Ensure thread-safety.
-		static readonly object SyncObject = new();
+		static readonly Lock SyncObject = new();
 		static FluentBundle modFluentBundle;
 		static FluentBundle mapFluentBundle;
 

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -13,12 +13,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace OpenRA.Graphics
 {
 	public sealed class TerrainSpriteLayer : IDisposable
 	{
 		// PERF: we can reuse the IndexBuffer as all layers have the same size.
+		static readonly Lock IndexBuffersLock = new();
 		static readonly ConditionalWeakTable<World, IndexBufferRc> IndexBuffers = [];
 		readonly IndexBufferRc indexBufferWrapper;
 
@@ -54,7 +56,7 @@ namespace OpenRA.Graphics
 			vertexBuffer = Game.Renderer.Context.CreateEmptyVertexBuffer<Vertex>(vertices.Length);
 
 			indexRowStride = 6 * map.MapSize.Width;
-			lock (IndexBuffers)
+			lock (IndexBuffersLock)
 			{
 				indexBufferWrapper = IndexBuffers.GetValue(world, world => new IndexBufferRc(world));
 				indexBufferWrapper.AddRef();
@@ -239,7 +241,7 @@ namespace OpenRA.Graphics
 
 			vertexBuffer.Dispose();
 
-			lock (IndexBuffers)
+			lock (IndexBuffersLock)
 				indexBufferWrapper.Dispose();
 		}
 

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -37,7 +37,7 @@ namespace OpenRA
 		readonly SheetBuilder sheetBuilder;
 		Thread previewLoaderThread;
 		bool previewLoaderThreadShutDown = true;
-		readonly object syncRoot = new();
+		readonly Lock syncRoot = new();
 		readonly Queue<MapPreview> generateMinimap = [];
 
 		public HashSet<string> StringPool { get; } = [];

--- a/OpenRA.Game/Map/MapDirectoryTracker.cs
+++ b/OpenRA.Game/Map/MapDirectoryTracker.cs
@@ -13,12 +13,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using OpenRA.FileSystem;
 
 namespace OpenRA
 {
 	public sealed class MapDirectoryTracker : IDisposable
 	{
+		readonly Lock syncObject = new();
 		readonly FileSystemWatcher watcher;
 		readonly IReadOnlyPackage package;
 		readonly MapClassification classification;
@@ -50,7 +52,7 @@ namespace OpenRA
 
 		void AddMapAction(MapAction mapAction, string fullpath, string oldFullPath = null)
 		{
-			lock (mapActionQueue)
+			lock (syncObject)
 			{
 				dirty = true;
 
@@ -76,7 +78,7 @@ namespace OpenRA
 
 		public void UpdateMaps(MapCache mapcache)
 		{
-			lock (mapActionQueue)
+			lock (syncObject)
 			{
 				if (!dirty)
 					return;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -199,7 +199,7 @@ namespace OpenRA
 			}
 		}
 
-		readonly object syncRoot = new();
+		readonly Lock syncRoot = new();
 		readonly MapCache cache;
 		readonly ModData modData;
 		IReadOnlyPackage package;

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using OpenRA.FileSystem;
 
 namespace OpenRA
@@ -109,6 +110,7 @@ namespace OpenRA
 		const int SpacesPerLevel = 4;
 		static readonly Func<string, string> StringIdentity = s => s;
 		static readonly Func<MiniYaml, MiniYaml> MiniYamlIdentity = my => my;
+		static readonly Lock ConflictScratchLock = new();
 		static readonly Dictionary<string, MiniYamlNode> ConflictScratch = [];
 
 		public readonly string Value;
@@ -561,7 +563,7 @@ namespace OpenRA
 			var resolvedExistingNodes = WeakResolveRemovals(existingNodes?.Nodes);
 			var resolvedOverrideNodes = WeakResolveRemovals(overrideNodes?.Nodes);
 
-			lock (ConflictScratch)
+			lock (ConflictScratchLock)
 			{
 				try
 				{

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
 using OpenRA.Primitives;
 
 namespace OpenRA.Network
@@ -22,6 +23,7 @@ namespace OpenRA.Network
 	sealed class SyncReport
 	{
 		const int NumSyncReports = 7;
+		static readonly Lock TypeInfoCacheLock = new();
 		static readonly Cache<Type, TypeInfo> TypeInfoCache = new(t => new TypeInfo(t));
 
 		readonly OrderManager orderManager;
@@ -33,7 +35,7 @@ namespace OpenRA.Network
 		{
 			var type = sync.GetType();
 			TypeInfo typeInfo;
-			lock (TypeInfoCache)
+			lock (TypeInfoCacheLock)
 				typeInfo = TypeInfoCache[type];
 			var values = new Values(typeInfo.Names.Length);
 			var index = 0;

--- a/OpenRA.Game/Primitives/ActionQueue.cs
+++ b/OpenRA.Game/Primitives/ActionQueue.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace OpenRA.Primitives
 {
@@ -19,13 +20,14 @@ namespace OpenRA.Primitives
 	/// </summary>
 	public class ActionQueue
 	{
+		readonly Lock syncObject = new();
 		readonly List<DelayedAction> actions = [];
 
 		public void Add(Action a, long desiredTime)
 		{
 			ArgumentNullException.ThrowIfNull(a);
 
-			lock (actions)
+			lock (syncObject)
 			{
 				var action = new DelayedAction(a, desiredTime);
 				var index = Index(action);
@@ -36,7 +38,7 @@ namespace OpenRA.Primitives
 		public void PerformActions(long currentTime)
 		{
 			DelayedAction[] pendingActions;
-			lock (actions)
+			lock (syncObject)
 			{
 				var dummyAction = new DelayedAction(null, currentTime);
 				var index = Index(dummyAction);

--- a/OpenRA.Game/Primitives/BitSet.cs
+++ b/OpenRA.Game/Primitives/BitSet.cs
@@ -12,18 +12,20 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 using BitSetIndex = System.Numerics.BigInteger;
 
 namespace OpenRA.Primitives
 {
 	static class BitSetAllocator<T> where T : class
 	{
+		static readonly Lock SyncObject = new();
 		static readonly Cache<string, BitSetIndex> Bits = new(Allocate);
 		static BitSetIndex nextBits = 1;
 
 		static BitSetIndex Allocate(string value)
 		{
-			lock (Bits)
+			lock (SyncObject)
 			{
 				var bits = nextBits;
 				nextBits <<= 1;
@@ -34,7 +36,7 @@ namespace OpenRA.Primitives
 		public static BitSetIndex GetBits(string[] values)
 		{
 			BitSetIndex bits = 0;
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var value in values)
 					bits |= Bits[value];
 
@@ -46,7 +48,7 @@ namespace OpenRA.Primitives
 			// Map strings to existing bits; do not allocate missing values new bits
 			BitSetIndex bits = 0;
 
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var value in values)
 					if (Bits.TryGetValue(value, out var valueBit))
 						bits |= valueBit;
@@ -57,7 +59,7 @@ namespace OpenRA.Primitives
 		public static IEnumerable<string> GetStrings(BitSetIndex bits)
 		{
 			var values = new List<string>();
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var kvp in Bits)
 					if ((kvp.Value & bits) != 0)
 						values.Add(kvp.Key);
@@ -68,7 +70,7 @@ namespace OpenRA.Primitives
 		public static bool BitsContainString(BitSetIndex bits, string value)
 		{
 			BitSetIndex valueBit;
-			lock (Bits)
+			lock (SyncObject)
 				if (!Bits.TryGetValue(value, out valueBit))
 					return false;
 			return (bits & valueBit) != 0;

--- a/OpenRA.Game/Primitives/LongBitSet.cs
+++ b/OpenRA.Game/Primitives/LongBitSet.cs
@@ -12,17 +12,19 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace OpenRA.Primitives
 {
 	static class LongBitSetAllocator<T> where T : class
 	{
+		static readonly Lock SyncObject = new();
 		static readonly Cache<string, long> Bits = new(Allocate);
 		static long nextBits = 1;
 
 		static long Allocate(string value)
 		{
-			lock (Bits)
+			lock (SyncObject)
 			{
 				var bits = nextBits;
 				nextBits <<= 1;
@@ -37,7 +39,7 @@ namespace OpenRA.Primitives
 		public static long GetBits(string[] values)
 		{
 			long bits = 0;
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var value in values)
 					bits |= Bits[value];
 
@@ -49,7 +51,7 @@ namespace OpenRA.Primitives
 			// Map strings to existing bits; do not allocate missing values new bits
 			long bits = 0;
 
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var value in values)
 					if (Bits.TryGetValue(value, out var valueBit))
 						bits |= valueBit;
@@ -60,7 +62,7 @@ namespace OpenRA.Primitives
 		public static IEnumerable<string> GetStrings(long bits)
 		{
 			var values = new List<string>();
-			lock (Bits)
+			lock (SyncObject)
 				foreach (var kvp in Bits)
 					if ((kvp.Value & bits) != 0)
 						values.Add(kvp.Key);
@@ -71,7 +73,7 @@ namespace OpenRA.Primitives
 		public static bool BitsContainString(long bits, string value)
 		{
 			long valueBit;
-			lock (Bits)
+			lock (SyncObject)
 				if (!Bits.TryGetValue(value, out valueBit))
 					return false;
 			return (bits & valueBit) != 0;
@@ -79,7 +81,7 @@ namespace OpenRA.Primitives
 
 		public static void Reset()
 		{
-			lock (Bits)
+			lock (SyncObject)
 			{
 				Bits.Clear();
 				nextBits = 1;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -120,6 +120,7 @@ namespace OpenRA.Server
 
 		public readonly List<Connection> Conns = [];
 
+		public readonly Lock LobbyInfoLock = new();
 		public Session LobbyInfo;
 		public ServerSettings Settings;
 		public ModData ModData;
@@ -226,7 +227,7 @@ namespace OpenRA.Server
 
 		void MapStatusChanged(string uid, Session.MapStatus status)
 		{
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				if (LobbyInfo.GlobalSettings.Map == uid)
 					LobbyInfo.GlobalSettings.MapStatus = status;
@@ -543,7 +544,7 @@ namespace OpenRA.Server
 
 				void CompleteConnection()
 				{
-					lock (LobbyInfo)
+					lock (LobbyInfoLock)
 					{
 						client.Slot = LobbyInfo.FirstEmptySlot();
 						client.IsAdmin = !LobbyInfo.Clients.Any(c => c.IsAdmin);
@@ -986,7 +987,7 @@ namespace OpenRA.Server
 
 		void InterpretServerOrder(Connection conn, Order o)
 		{
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				// Only accept handshake responses from unvalidated clients
 				// Anything else may be an attempt to exploit the server
@@ -1172,7 +1173,7 @@ namespace OpenRA.Server
 				latency < 360 ? Session.ConnectionQuality.Moderate :
 				Session.ConnectionQuality.Poor;
 
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				foreach (var c in LobbyInfo.Clients)
 					if (c.Index == conn.PlayerIndex || (c.Bot != null && c.BotControllerClientIndex == conn.PlayerIndex))
@@ -1205,7 +1206,7 @@ namespace OpenRA.Server
 
 		public void DropClient(Connection toDrop)
 		{
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				orderBuffer?.RemovePlayer(toDrop.PlayerIndex);
 				Conns.Remove(toDrop);
@@ -1274,7 +1275,7 @@ namespace OpenRA.Server
 
 		public void SyncLobbyInfo()
 		{
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				if (State == ServerState.WaitingPlayers) // Don't do this while the game is running, it breaks things!
 					DispatchServerOrdersToClients(Order.FromTargetString("SyncInfo", LobbyInfo.Serialize(), true));
@@ -1289,7 +1290,7 @@ namespace OpenRA.Server
 			if (State != ServerState.WaitingPlayers)
 				return;
 
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				// TODO: Only need to sync the specific client that has changed to avoid conflicts!
 				var clientData = LobbyInfo.Clients.ConvertAll(client => client.Serialize());
@@ -1310,7 +1311,7 @@ namespace OpenRA.Server
 			if (State != ServerState.WaitingPlayers)
 				return;
 
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				// TODO: Don't sync all the slots if just one changed!
 				var slotData = LobbyInfo.Slots.Select(slot => slot.Value.Serialize()).ToList();
@@ -1327,7 +1328,7 @@ namespace OpenRA.Server
 			if (State != ServerState.WaitingPlayers)
 				return;
 
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				var sessionData = new List<MiniYamlNode> { LobbyInfo.GlobalSettings.Serialize() };
 
@@ -1340,7 +1341,7 @@ namespace OpenRA.Server
 
 		public void StartGame()
 		{
-			lock (LobbyInfo)
+			lock (LobbyInfoLock)
 			{
 				WriteLineWithTimeStamp(FluentProvider.GetMessage(GameStarted));
 

--- a/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ModelRenderable.cs
@@ -194,13 +194,13 @@ namespace OpenRA.Mods.Cnc.Graphics
 				var c = Color.Purple;
 				var psb = renderProxy.ProjectedShadowBounds;
 
-				Game.Renderer.RgbaColorRenderer.DrawPolygon(new float2[]
-				{
+				Game.Renderer.RgbaColorRenderer.DrawPolygon(
+				[
 					wr.Viewport.WorldToViewPx(shadowOrigin + psb[1]),
 					wr.Viewport.WorldToViewPx(shadowOrigin + psb[3]),
 					wr.Viewport.WorldToViewPx(shadowOrigin + psb[0]),
 					wr.Viewport.WorldToViewPx(shadowOrigin + psb[2])
-				}, 1, c);
+				], 1, c);
 
 				// Draw bounding box
 				var draw = model.models.Where(v => v.IsVisible);
@@ -234,10 +234,10 @@ namespace OpenRA.Mods.Cnc.Graphics
 				}
 
 				// Front face
-				cr.DrawPolygon(new[] { corners[0], corners[1], corners[3], corners[2] }, width, c);
+				cr.DrawPolygon([corners[0], corners[1], corners[3], corners[2]], width, c);
 
 				// Back face
-				cr.DrawPolygon(new[] { corners[4], corners[5], corners[7], corners[6] }, width, c);
+				cr.DrawPolygon([corners[4], corners[5], corners[7], corners[6]], width, c);
 
 				// Horizontal edges
 				cr.DrawLine(corners[0], corners[4], width, c);

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -11,12 +11,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
 	sealed class CellInfoLayerPool
 	{
 		const int MaxPoolSize = 4;
+		readonly Lock poolLock = new();
 		readonly Stack<CellLayer<CellInfo>> pool = new(MaxPoolSize);
 		readonly Map map;
 
@@ -33,7 +35,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		CellLayer<CellInfo> GetLayer()
 		{
 			CellLayer<CellInfo> layer = null;
-			lock (pool)
+			lock (poolLock)
 				if (pool.Count > 0)
 					layer = pool.Pop();
 
@@ -50,7 +52,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		void ReturnLayer(CellLayer<CellInfo> layer)
 		{
-			lock (pool)
+			lock (poolLock)
 				if (pool.Count < MaxPoolSize)
 					pool.Push(layer);
 		}

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool ValidateSlotCommand(S server, Connection conn, Session.Client client, string arg, bool requiresHost)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!server.LobbyInfo.Slots.ContainsKey(arg))
 				{
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public static bool ValidateCommand(S server, Connection conn, Session.Client client, string command)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				// Kick command is always valid for the host
 				if (command.StartsWith("kick ", StringComparison.Ordinal) || command.StartsWith("vote_kick ", StringComparison.Ordinal))
@@ -245,7 +245,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static void CheckAutoStart(S server)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var nonBotPlayers = server.LobbyInfo.NonBotPlayers;
 
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool State(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!Enum.TryParse<Session.ClientState>(s, out var state))
 				{
@@ -312,7 +312,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool StartGame(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -352,7 +352,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Slot(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!server.LobbyInfo.Slots.TryGetValue(s, out var slot))
 				{
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool AllowSpectators(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (bool.TryParse(s, out server.LobbyInfo.GlobalSettings.AllowSpectators))
 				{
@@ -399,7 +399,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Specate(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (server.LobbyInfo.GlobalSettings.AllowSpectators || client.IsAdmin)
 				{
@@ -419,7 +419,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool SlotClose(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!ValidateSlotCommand(server, conn, client, s, true))
 					return false;
@@ -453,7 +453,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool SlotOpen(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!ValidateSlotCommand(server, conn, client, s, true))
 					return false;
@@ -475,7 +475,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool SlotBot(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				if (parts.Length < 3)
@@ -557,7 +557,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Map(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -574,7 +574,7 @@ namespace OpenRA.Mods.Common.Server
 				var lastMap = server.LobbyInfo.GlobalSettings.Map;
 				void SelectMap(MapPreview map)
 				{
-					lock (server.LobbyInfo)
+					lock (server.LobbyInfoLock)
 					{
 						// Make sure the map hasn't changed in the meantime
 						if (server.LobbyInfo.GlobalSettings.Map != lastMap)
@@ -682,7 +682,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Option(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -731,7 +731,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool ResetOptions(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -762,7 +762,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool AssignTeams(S server, Connection conn, Session.Client client, string raw)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -806,7 +806,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Kick(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -864,7 +864,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool VoteKick(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var split = s.Split(' ');
 				if (split.Length != 2)
@@ -920,7 +920,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool MakeAdmin(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -957,7 +957,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool MakeSpectator(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -992,7 +992,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Name(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var sanitizedName = Settings.SanitizedPlayerName(s);
 				if (sanitizedName == client.Name)
@@ -1009,7 +1009,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Faction(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseInt32Invariant(parts[0]));
@@ -1041,7 +1041,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Team(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseInt32Invariant(parts[0]));
@@ -1069,7 +1069,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Handicap(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseInt32Invariant(parts[0]));
@@ -1142,7 +1142,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool Spawn(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseInt32Invariant(parts[0]));
@@ -1197,7 +1197,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool PlayerColor(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var parts = s.Split(' ');
 				var targetClient = server.LobbyInfo.ClientWithIndex(Exts.ParseInt32Invariant(parts[0]));
@@ -1226,7 +1226,7 @@ namespace OpenRA.Mods.Common.Server
 
 		static bool SyncLobby(S server, Connection conn, Session.Client client, string s)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (!client.IsAdmin)
 				{
@@ -1307,7 +1307,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public void ServerStarted(S server)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				InitializeMapPool(server);
 
@@ -1348,7 +1348,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public static void LoadMapSettings(S server, Session.Global gs, MapPreview map)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var options = map.PlayerActorInfo.TraitInfos<ILobbyOptions>()
 					.Concat(map.WorldActorInfo.TraitInfos<ILobbyOptions>())
@@ -1384,7 +1384,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public static Color SanitizePlayerColor(S server, Color askedColor, int playerIndex, Connection connectionToEcho = null)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				var colorManager = server.ModData.DefaultRules.Actors[SystemActors.World].TraitInfo<IColorPickerManagerInfo>();
 				var askColor = askedColor;
@@ -1410,7 +1410,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public void ClientJoined(S server, Connection conn)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				if (server.MapPool != null)
 					server.SendOrderTo(conn, "SyncMapPool", FieldSaver.FormatValue(server.MapPool));
@@ -1425,7 +1425,7 @@ namespace OpenRA.Mods.Common.Server
 
 		void INotifyServerEmpty.ServerEmpty(S server)
 		{
-			lock (server.LobbyInfo)
+			lock (server.LobbyInfoLock)
 			{
 				// Expire any temporary bans
 				server.TempBans.Clear();

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -14,6 +14,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using BeaconLib;
 using OpenRA.Network;
@@ -63,6 +64,7 @@ namespace OpenRA.Mods.Common.Server
 
 		volatile bool isBusy;
 		readonly Queue<string> masterServerMessages = [];
+		readonly Lock masterServerMessagesLock = new();
 
 		public void Tick(S server)
 		{
@@ -90,7 +92,7 @@ namespace OpenRA.Mods.Common.Server
 			}
 
 			if (server.Settings.AdvertiseOnline)
-				lock (masterServerMessages)
+				lock (masterServerMessagesLock)
 					while (masterServerMessages.Count > 0)
 						server.SendFluentMessage(masterServerMessages.Dequeue());
 		}
@@ -170,7 +172,7 @@ namespace OpenRA.Mods.Common.Server
 						}
 
 						isInitialPing = false;
-						lock (masterServerMessages)
+						lock (masterServerMessagesLock)
 						{
 							masterServerMessages.Enqueue(Connected);
 							if (errorCode != 0)
@@ -192,7 +194,7 @@ namespace OpenRA.Mods.Common.Server
 				catch (Exception ex)
 				{
 					Log.Write("server", ex.ToString());
-					lock (masterServerMessages)
+					lock (masterServerMessagesLock)
 						masterServerMessages.Enqueue(Error);
 				}
 

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Server
 
 				// Ignore client timeout in singleplayer games to make debugging easier
 				var nonBotClientCount = 0;
-				lock (server.LobbyInfo)
+				lock (server.LobbyInfoLock)
 					nonBotClientCount = server.LobbyInfo.NonBotClients.Count();
 
 				if (nonBotClientCount >= 2 || server.Type == ServerType.Dedicated)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using AI.Fuzzy.Library;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
@@ -110,6 +111,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			"then AttackOrFlee is Flee"
 		], null, null);
 
+		readonly Lock fuzzyEngineLock = new();
 		readonly MamdaniFuzzySystem fuzzyEngine = new();
 
 		public AttackOrFleeFuzzy(
@@ -117,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			IEnumerable<string> rulesForInjuredOwnHealth,
 			IEnumerable<string> rulesForNeadDeadOwnHealth)
 		{
-			lock (fuzzyEngine)
+			lock (fuzzyEngineLock)
 			{
 				var playerHealthFuzzy = new FuzzyVariable("OwnHealth", 0.0, 100.0);
 				playerHealthFuzzy.Terms.Add(new FuzzyTerm("NearDead", new TrapezoidMembershipFunction(0, 0, 20, 40)));
@@ -166,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			double attackChance;
 			var inputValues = new Dictionary<FuzzyVariable, double>();
-			lock (fuzzyEngine)
+			lock (fuzzyEngineLock)
 			{
 				inputValues.Add(fuzzyEngine.InputByName("OwnHealth"), NormalizedHealth(ownUnits, 100));
 				inputValues.Add(fuzzyEngine.InputByName("EnemyHealth"), NormalizedHealth(enemyUnits, 100));

--- a/OpenRA.Mods.Common/Widgets/Logic/CommandHistory.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CommandHistory.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
@@ -17,7 +18,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		const int MaxHistorySize = 50;
 		static CommandHistory instance;
-		static readonly object LockObject = new();
+		static readonly Lock LockObject = new();
 		readonly List<string> history = [];
 		int currentIndex = -1;
 

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -546,6 +546,7 @@ namespace OpenRA.Platforms.Default
 	sealed class OpenAlAsyncLoadSound : OpenAlSound
 	{
 		static readonly byte[] SilentData = new byte[2];
+		readonly Lock syncObject = new();
 		readonly CancellationTokenSource cts = new();
 		readonly Task playTask;
 
@@ -597,7 +598,7 @@ namespace OpenRA.Platforms.Default
 					AL10.alSourcei(source, AL10.AL_BUFFER, (int)soundSource.Buffer);
 					silentSource.Dispose();
 
-					lock (cts)
+					lock (syncObject)
 					{
 						if (!cts.IsCancellationRequested)
 						{
@@ -648,7 +649,7 @@ namespace OpenRA.Platforms.Default
 
 		public override void Stop()
 		{
-			lock (cts)
+			lock (syncObject)
 			{
 				StopSource();
 				cts.Cancel();

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using OpenRA.Primitives;
 using SDL2;
 
@@ -29,7 +30,7 @@ namespace OpenRA.Platforms.Default
 		readonly IntPtr window;
 		bool disposed;
 
-		readonly object syncObject = new();
+		readonly Lock syncObject = new();
 		readonly Size windowSize;
 		Size surfaceSize;
 		float windowScale = 1f;

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -24,13 +24,16 @@ namespace OpenRA.Platforms.Default
 	sealed class ThreadedGraphicsContext : IGraphicsContext
 	{
 		// PERF: Maintain several object pools to reduce allocations.
+		readonly Lock vertexBufferPoolsLock = new();
 		readonly Dictionary<Type, object> vertexBufferPools = [];
+		readonly Lock messagePoolLock = new();
 		readonly Stack<Message> messagePool = [];
+		readonly object messagesMonitor = new();
 		readonly Queue<Message> messages = [];
 
 		public readonly int VertexBatchSize;
 		public readonly int IndexBatchSize;
-		readonly object syncObject = new();
+		readonly object constructorMonitor = new();
 		readonly Thread renderThread;
 		volatile ExceptionDispatchInfo messageException;
 
@@ -63,12 +66,12 @@ namespace OpenRA.Platforms.Default
 				Name = "ThreadedGraphicsContext RenderThread",
 				IsBackground = true
 			};
-			lock (syncObject)
+			lock (constructorMonitor)
 			{
 				// Start and wait for the rendering thread to have initialized before returning.
 				// Otherwise, the delegates may not have been set yet.
 				renderThread.Start(context);
-				Monitor.Wait(syncObject);
+				Monitor.Wait(constructorMonitor);
 			}
 		}
 
@@ -77,7 +80,7 @@ namespace OpenRA.Platforms.Default
 			using (var context = (Sdl2GraphicsContext)contextObject)
 			{
 				// This lock allows the constructor to block until initialization completes.
-				lock (syncObject)
+				lock (constructorMonitor)
 				{
 					context.InitializeOpenGL();
 
@@ -140,7 +143,7 @@ namespace OpenRA.Platforms.Default
 					doSetBlendMode = mode => context.SetBlendMode((BlendMode)mode);
 					doSetVSync = enabled => context.SetVSyncEnabled((bool)enabled);
 
-					Monitor.Pulse(syncObject);
+					Monitor.Pulse(constructorMonitor);
 				}
 
 				// Run a message loop.
@@ -149,14 +152,14 @@ namespace OpenRA.Platforms.Default
 				Message message;
 				while (true)
 				{
-					lock (messages)
+					lock (messagesMonitor)
 					{
 						if (messages.Count == 0)
 						{
 							if (messageException != null)
 								break;
 
-							Monitor.Wait(messages);
+							Monitor.Wait(messagesMonitor);
 						}
 
 						message = messages.Dequeue();
@@ -172,7 +175,7 @@ namespace OpenRA.Platforms.Default
 
 		internal T[] GetVertices<T>(int size)
 		{
-			lock (vertexBufferPools)
+			lock (vertexBufferPoolsLock)
 			{
 				Stack<T[]> pool;
 				if (!vertexBufferPools.TryGetValue(typeof(T), out var poolObject))
@@ -193,7 +196,7 @@ namespace OpenRA.Platforms.Default
 		internal void ReturnVertices<T>(T[] vertices)
 		{
 			if (vertices.Length == VertexBatchSize)
-				lock (vertexBufferPools)
+				lock (vertexBufferPoolsLock)
 					((Stack<T[]>)vertexBufferPools[typeof(T)]).Push(vertices);
 		}
 
@@ -283,7 +286,7 @@ namespace OpenRA.Platforms.Default
 
 				if (wasSend)
 				{
-					lock (device.messagePool)
+					lock (device.messagePoolLock)
 						device.messagePool.Push(this);
 				}
 				else
@@ -308,7 +311,7 @@ namespace OpenRA.Platforms.Default
 
 		Message GetMessage()
 		{
-			lock (messagePool)
+			lock (messagePoolLock)
 				if (messagePool.Count > 0)
 					return messagePool.Pop();
 
@@ -320,11 +323,11 @@ namespace OpenRA.Platforms.Default
 			var exception = messageException;
 			exception?.Throw();
 
-			lock (messages)
+			lock (messagesMonitor)
 			{
 				messages.Enqueue(message);
 				if (messages.Count == 1)
-					Monitor.Pulse(messages);
+					Monitor.Pulse(messagesMonitor);
 			}
 		}
 
@@ -332,7 +335,7 @@ namespace OpenRA.Platforms.Default
 		{
 			QueueMessage(message);
 			var result = message.Result();
-			lock (messagePool)
+			lock (messagePoolLock)
 				messagePool.Push(message);
 			return result;
 		}

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -1085,6 +1085,7 @@ Parent: Second
 		sealed class TestStream : Stream
 		{
 			readonly ManualResetEventSlim mres = new();
+			readonly Lock bytesLock = new();
 			readonly List<byte> bytes = [];
 			bool ended;
 
@@ -1097,7 +1098,7 @@ Parent: Second
 			public void WriteBytes(ReadOnlySpan<byte> bytes)
 			{
 				if (ended) throw new InvalidOperationException();
-				lock (this.bytes)
+				lock (bytesLock)
 				{
 					this.bytes.AddRange(bytes);
 					mres.Set();
@@ -1112,7 +1113,7 @@ Parent: Second
 				if (bytes.Count == 0)
 					mres.Wait();
 
-				lock (bytes)
+				lock (bytesLock)
 				{
 					var read = Math.Min(bytes.Count, count);
 


### PR DESCRIPTION
Now that we have moved to net 10 from net 8 (#22163), we can raise the C# version to match that supported by the net 9 runtime. We don't immediately jump to C# 14 as supported by net 10, this creates too much style churn.

This unlocks C# 13 features previously unavailable to us.
- https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history#c-version-13

Enable style rules as they don't have many violations.

See #21749 for our previous migration to C# 12.