### PR TITLE
Prefer AggregateBy/CountBy over GroupBy.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -128,10 +128,11 @@ namespace OpenRA
 
 		internal Actor(World world, string name, TypeDictionary initDict)
 		{
-			var duplicateInit = initDict.WithInterface<ISingleInstanceInit>().GroupBy(i => i.GetType())
-				.FirstOrDefault(i => i.Count() > 1);
+			var duplicateInit = initDict.WithInterface<ISingleInstanceInit>()
+				.CountBy(i => i.GetType())
+				.FirstOrDefault(i => i.Value > 1);
 
-			if (duplicateInit != null)
+			if (duplicateInit.Key != null)
 				throw new InvalidDataException($"Duplicate initializer '{duplicateInit.Key.Name}'");
 
 			var init = new ActorInitializer(this, initDict);

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -802,8 +802,8 @@ namespace OpenRA
 			(Color Left, Color Right) terrainColor = default;
 
 			var colorsByPosition = positions
-				.GroupBy(p => p.Uv)
-				.ToDictionary(g => g.Key, g => g.First().Color);
+				.AggregateBy(p => p.Uv, default(Color), (_, p) => p.Color)
+				.ToDictionary();
 			for (var y = 0; y < height; y++)
 			{
 				for (var x = 0; x < width; x++)

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			// Skip eof and zero headers
 			stream.Position += 16;
 
-			var offsets = headers.ToDictionary(h => h.FileOffset, h => h);
+			var offsets = headers.ToDictionary(h => h.FileOffset);
 			for (var i = 0; i < imageCount; i++)
 			{
 				var h = headers[i];

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -35,8 +35,8 @@ namespace OpenRA.Mods.Common.Lint
 			var worldActor = rules.Actors[SystemActors.World];
 			var locomotorNames = worldActor.TraitInfos<LocomotorInfo>().Select(li => li.Name).ToList();
 			var duplicateNames = locomotorNames
-				.GroupBy(name => name)
-				.Where(g => g.Count() > 1)
+				.CountBy(name => name)
+				.Where(g => g.Value > 1)
 				.Select(g => g.Key);
 			foreach (var duplicateName in duplicateNames)
 				emitError($"More than one Locomotor exists with the name `{duplicateName}`.");

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -94,8 +94,8 @@ namespace OpenRA.Mods.Common.Lint
 				if (playerCount > spawnPoints.Length)
 					emitError($"The map allows {playerCount} possible players, but defines only {spawnPoints.Length} spawn points.");
 
-				foreach (var spawn in spawnPoints.GroupBy(x => x))
-					if (spawn.Count() > 1)
+				foreach (var spawn in spawnPoints.CountBy(x => x))
+					if (spawn.Value > 1)
 						emitError($"Duplicate spawn point location detected at `{spawn.Key}`.");
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -33,8 +33,8 @@ namespace OpenRA.Mods.Common.Lint
 			foreach (var actorInfo in rules.Actors)
 			{
 				var duplicateNames = actorInfo.Value.TraitInfos<WithSpriteBodyInfo>()
-					.GroupBy(wsb => wsb.Name)
-					.Where(g => g.Count() > 1)
+					.CountBy(wsb => wsb.Name)
+					.Where(g => g.Value > 1)
 					.Select(g => g.Key);
 				foreach (var duplicateName in duplicateNames)
 					emitError($"Actor type `{actorInfo.Key}` has more than one *SpriteBody with Name: {duplicateName}.");

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -589,7 +589,7 @@ namespace OpenRA.Mods.Common.Server
 						server.LobbyInfo.Slots = server.Map.Players.Players
 							.Select(p => MakeSlotFromPlayerReference(p.Value))
 							.Where(ss => ss != null)
-							.ToDictionary(ss => ss.PlayerReference, ss => ss);
+							.ToDictionary(ss => ss.PlayerReference);
 
 						LoadMapSettings(server, server.LobbyInfo.GlobalSettings, server.Map);
 
@@ -1321,7 +1321,7 @@ namespace OpenRA.Mods.Common.Server
 				server.LobbyInfo.Slots = server.Map.Players.Players
 					.Select(p => MakeSlotFromPlayerReference(p.Value))
 					.Where(s => s != null)
-					.ToDictionary(s => s.PlayerReference, s => s);
+					.ToDictionary(s => s.PlayerReference);
 
 				LoadMapSettings(server, server.LobbyInfo.GlobalSettings, server.Map);
 			}
@@ -1437,7 +1437,7 @@ namespace OpenRA.Mods.Common.Server
 				server.LobbyInfo.Slots = server.Map.Players.Players
 					.Select(p => MakeSlotFromPlayerReference(p.Value))
 					.Where(ss => ss != null)
-					.ToDictionary(ss => ss.PlayerReference, ss => ss);
+					.ToDictionary(ss => ss.PlayerReference);
 			}
 		}
 

--- a/OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs
+++ b/OpenRA.Mods.Common/ServerTraits/SkirmishLogic.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Server
 				var options = server.Map.PlayerActorInfo.TraitInfos<ILobbyOptions>()
 					.Concat(server.Map.WorldActorInfo.TraitInfos<ILobbyOptions>())
 					.SelectMany(t => t.LobbyOptions(server.Map))
-					.ToDictionary(o => o.Id, o => o);
+					.ToDictionary(o => o.Id);
 
 				foreach (var optionNode in optionsNode.Value.Nodes)
 				{

--- a/OpenRA.Mods.Common/Traits/DockClientManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockClientManager.cs
@@ -403,8 +403,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// Overlapping hosts can become hidden.
 				var lookup = docks
-					.GroupBy(dock => clientActor.World.Map.CellContaining(dock.Trait.DockPosition))
-					.ToDictionary(group => group.Key, group => group.First());
+					.AggregateBy(dock => clientActor.World.Map.CellContaining(dock.Trait.DockPosition), default(TraitPair<IDockHost>), (_, dock) => dock)
+					.ToDictionary();
 
 				// Start a search from each client actor:
 				var path = mobile.PathFinder.FindPathToTargetCells(

--- a/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicParallelProductionQueue.cs
@@ -89,10 +89,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (item == null)
 				return;
 
-			var parallelBuilds = Queue.FindAll(i => !i.Paused && !i.Done)
-				.GroupBy(i => i.Item)
-				.ToList()
-				.Count - 1;
+			var parallelBuilds = Queue
+				.Where(i => !i.Paused && !i.Done)
+				.DistinctBy(i => i.Item)
+				.Count() - 1;
 
 			if (parallelBuilds > 0 && !developerMode.FastBuild)
 			{
@@ -110,11 +110,9 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// As we have progressed this actor type, we will move all queued items of this actor to the end.
-			foreach (var other in Queue.FindAll(a => a.Item == item.Item))
-			{
-				Queue.Remove(other);
-				Queue.Add(other);
-			}
+			var others = Queue.FindAll(a => a.Item == item.Item);
+			Queue.RemoveAll(a => a.Item == item.Item);
+			Queue.AddRange(others);
 		}
 
 		public override IEnumerable<ActorInfo> AllItems()
@@ -222,10 +220,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override int RemainingTimeActual(ProductionItem item)
 		{
-			var parallelBuilds = Queue.FindAll(i => !i.Paused && !i.Done)
-				.GroupBy(i => i.Item)
-				.ToList()
-				.Count;
+			var parallelBuilds = Queue
+				.Where(i => !i.Paused && !i.Done)
+				.DistinctBy(i => i.Item)
+				.Count();
 			return item.RemainingTimeActual *
 				parallelBuilds *
 				info.ParallelPenaltyBuildTimeMultipliers[Math.Min(parallelBuilds - 1, info.ParallelPenaltyBuildTimeMultipliers.Length - 1)] / 100;

--- a/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
@@ -38,11 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// As we have progressed this actor type, we will move all queued items of this actor to the end.
-			foreach (var other in Queue.FindAll(a => a.Item == item.Item))
-			{
-				Queue.Remove(other);
-				Queue.Add(other);
-			}
+			var others = Queue.FindAll(a => a.Item == item.Item);
+			Queue.RemoveAll(a => a.Item == item.Item);
+			Queue.AddRange(others);
 		}
 
 		public override bool IsProducing(ProductionItem item)
@@ -64,10 +62,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override int RemainingTimeActual(ProductionItem item)
 		{
-			var parallelBuilds = Queue.FindAll(i => !i.Paused && !i.Done)
-				.GroupBy(i => i.Item)
-				.ToList()
-				.Count;
+			var parallelBuilds = Queue
+				.Where(i => !i.Paused && !i.Done)
+				.DistinctBy(i => i.Item)
+				.Count();
 			return item.RemainingTimeActual * parallelBuilds;
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/Documentation/ExtractEmmyLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Documentation/ExtractEmmyLuaAPI.cs
@@ -283,8 +283,8 @@ namespace OpenRA.Mods.Common.UtilityCommands.Documentation
 			});
 
 			var duplicateMembers = members
-				.GroupBy(x => x.memberInfo.Name)
-				.Where(x => x.Count() > 1)
+				.CountBy(x => x.memberInfo.Name)
+				.Where(x => x.Value > 1)
 				.Select(x => x.Key)
 				.ToHashSet();
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractChromeStrings.cs
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					t => t.Name[..^6],
 					t => Utility.GetFields(t).Where(Utility.HasAttribute<FluentReferenceAttribute>).Select(f => f.Name).ToArray())
 				.Where(t => t.Value.Length > 0)
-				.ToDictionary(t => t.Key, t => t.Value);
+				.ToDictionary();
 
-			var chromeLayouts = modData.Manifest.ChromeLayout.GroupBy(c => c.Split('/')[0].Split('|')[0], c => c);
+			var chromeLayouts = modData.Manifest.ChromeLayout.GroupBy(c => c.Split('/')[0].Split('|')[0]);
 
 			foreach (var layout in chromeLayouts)
 			{

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractYamlStrings.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractYamlStrings.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					t => t.Name[..^4],
 					t => Utility.GetFields(t).Where(Utility.HasAttribute<FluentReferenceAttribute>).Select(f => f.Name).ToArray())
 				.Where(t => t.Value.Length > 0)
-				.ToDictionary(t => t.Key, t => t.Value);
+				.ToDictionary();
 
 			// Extract from a specific map.
 			if (args.Length == 2)

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -233,7 +233,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							new KeyValuePair<string, string>(
 								config.Variables[variableI],
 								config.Choices[config.Variables[variableI]][choiceI]))
-						.ToDictionary(kv => kv.Key, kv => kv.Value);
+						.ToDictionary();
 
 					var descriptionBuilder = new StringBuilder();
 					foreach (var variable in config.Variables)

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/AudioSettingsLogic.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundDevice[] devices, ScrollPanelWidget scrollPanel)
 		{
 			var i = 0;
-			var options = devices.ToDictionary(d => i++.ToStringInvariant(), d => d);
+			var options = devices.ToDictionary(d => i++.ToStringInvariant());
 
 			ScrollItemWidget SetupItem(string o, ScrollItemWidget itemTemplate)
 			{


### PR DESCRIPTION
These methods overhead the overhead of materializing a group that GroupBy requires, since they only need to store the accumulated state (a count, or the aggregation result) instead.

Simplify some ToDictionary calls, this can allow use of fast paths since an unknown lambda does not need to be invoked per element.