### PR TITLE
Documentation GHA workflow: fix job titles

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.git_tag }}
 
-      - name: Install .NET 8
+      - name: Install .NET 10
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
@@ -111,7 +111,7 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.git_tag }}
 
-      - name: Install .NET 8
+      - name: Install .NET 10
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'


### PR DESCRIPTION
PR just updates job titles in docs workflow YAML. The .NET version used is already correct (10.0).

Mistake from #22163.