### PR TITLE
Add FireWarheadsOnDeath to JFISH

### DIFF
--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -152,3 +152,5 @@ JFISH:
 		Type: Circle
 			Radius: 363
 			VerticalTopOffset: 768
+	FireWarheadsOnDeath:
+		Weapon: UnitExplode


### PR DESCRIPTION
Previously it was just vanishing. This matches TS behaviour (we seem to be a bit inconsistent when looking at `rules.ini`, but `UnitExplode` seems to be the equivalent).