### PR TITLE
Reset hidden map generator options to defaults

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -285,7 +285,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					continue;
 
 				if (!o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Lobby))
+				{
+					generationArgs.Options.Remove(o.Id);
 					continue;
+				}
 
 				Widget optionWidget = null;
 				switch (o)


### PR DESCRIPTION
This primarily fixes invalid state cached between game updates. As an example for RA, this ensures "Roads" and "Obstruct walled areas" aren't set to unconfigurable false values stuck inside settings.yaml.

This was an unresolved task in https://github.com/OpenRA/OpenRA/pull/22473#issuecomment-4963086963 that I'd meant to sort out before merging.