### PR TITLE
Validate stored or untrusted map generator options

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -484,6 +484,9 @@ namespace OpenRA
 				if (generator == null)
 					throw new Exception($"Unknown map generator type {args.Generator}");
 
+				if (!generator.ValidateArgs(modData, args))
+					throw new Exception("MapGenerationArgs validation failed");
+
 				if (!generator.TryGenerateMetadata(modData, args, out var players, out var ruleDefinitions))
 					throw new Exception("Failed to generate map metadata");
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -660,5 +660,6 @@ namespace OpenRA.Traits
 
 		Map Generate(ModData modData, MapGenerationArgs args);
 		bool TryGenerateMetadata(ModData modData, MapGenerationArgs args, out MapPlayers players, out Dictionary<string, MiniYaml> rules);
+		bool ValidateArgs(ModData modData, MapGenerationArgs args);
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MapGeneratorBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapGeneratorBase.cs
@@ -9,10 +9,12 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.MapGenerator;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -112,6 +114,104 @@ namespace OpenRA.Mods.Common.Traits
 				return FieldLoader.GetValue<int>("Players", players);
 
 			return 0;
+		}
+
+		public virtual bool ValidateArgs(ModData modData, MapGenerationArgs args)
+		{
+			return ValidateArgs(
+				modData,
+				args,
+				new Size(1000, 1000),
+				MapGeneratorOption.VisibilityFlags.Lobby);
+		}
+
+		/// <summary>
+		/// Detects incompatibilities in option choices. The method will return false if any of the following are found:
+		/// Non-default choices for hidden options, invalid choices, missing choices, choices for unrecognized options.
+		/// The map width and height must both be strictly less than sizeLimit width and height.
+		/// </summary>
+		public virtual bool ValidateArgs(
+			ModData modData,
+			MapGenerationArgs args,
+			Size sizeLimit,
+			MapGeneratorOption.VisibilityFlags visibilityRequirements)
+		{
+			var falseString = FieldSaver.FormatValue(false);
+			var trueString = FieldSaver.FormatValue(true);
+			var choices = args.Options;
+			var definitions = Options;
+			var playerCount = GetPlayerCount(args);
+			if (args.Size.Width >= sizeLimit.Width || args.Size.Height >= sizeLimit.Height)
+				return false;
+
+			if (!Tilesets.Contains(args.Tileset))
+				return false;
+
+			var terrain = modData.DefaultTerrainInfo[args.Tileset];
+
+			foreach (var definition in definitions)
+			{
+				if (!choices.TryGetValue(definition.Id, out var choice))
+					return false;
+
+				var needsDefault = !definition.Visibility.HasFlag(visibilityRequirements);
+
+				switch (definition)
+				{
+					case MapGeneratorBooleanOption d:
+					{
+						if (needsDefault && FieldSaver.FormatValue(d.Default) != choice)
+							return false;
+
+						if (choice != falseString && choice != trueString)
+							return false;
+
+						break;
+					}
+
+					case MapGeneratorIntegerOption d:
+					{
+						if (needsDefault && FieldSaver.FormatValue(d.Default) != choice)
+							return false;
+
+						if (!Exts.TryParseInt32Invariant(choice, out _))
+							return false;
+
+						break;
+					}
+
+					case MapGeneratorMultiIntegerChoiceOption d:
+					{
+						if (needsDefault && FieldSaver.FormatValue(d.Default) != choice)
+							return false;
+
+						if (!Exts.TryParseInt32Invariant(choice, out var intChoice))
+							return false;
+
+						if (!d.Choices.Contains(intChoice))
+							return false;
+
+						break;
+					}
+
+					case MapGeneratorMultiChoiceOption d:
+					{
+						if (needsDefault && d.DefaultFor(terrain, playerCount) != choice)
+							return false;
+
+						var validChoices = d.ValidChoices(terrain, playerCount);
+						if (!validChoices.Contains(choice))
+							return false;
+
+						break;
+					}
+
+					default:
+						throw new NotImplementedException($"Unhandled MapGeneratorOption type {definition.GetType().Name}");
+				}
+			}
+
+			return choices.Count == definitions.Length;
 		}
 
 		public abstract Map Generate(ModData modData, MapGenerationArgs args);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -1012,5 +1012,10 @@ namespace OpenRA.Mods.Common.Traits
 		ImmutableArray<string> Tilesets { get; }
 		ImmutableArray<MapGeneratorOption> Options { get; }
 		int GetPlayerCount(MapGenerationArgs args);
+		bool ValidateArgs(
+			ModData modData,
+			MapGenerationArgs args,
+			Size sizeLimit,
+			MapGeneratorOption.VisibilityFlags visibilityRequirements);
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapGeneratorToolLogic.cs
@@ -123,16 +123,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			foreach (var o in generator.Options)
 			{
-				if (!o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Editor))
-					continue;
-
 				Widget optionWidget = null;
+				var hidden = !o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Editor);
 				switch (o)
 				{
 					case MapGeneratorBooleanOption bo:
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = bo.Default ? trueString : falseString;
+
+						if (hidden)
+							break;
 
 						optionWidget = checkboxOptionTemplate.Clone();
 						var checkboxWidget = optionWidget.Get<CheckboxWidget>("CHECKBOX");
@@ -148,6 +149,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = FieldSaver.FormatValue(io.Default);
+
+						if (hidden)
+							break;
 
 						optionWidget = textOptionTemplate.Clone();
 						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
@@ -173,6 +177,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = FieldSaver.FormatValue(mio.Default);
+
+						if (hidden)
+							break;
 
 						optionWidget = dropdownOptionTemplate.Clone();
 						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
@@ -213,37 +220,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (!generationArgs.Options.TryGetValue(o.Id, out var option) || !validChoices.Contains(option))
 							generationArgs.Options[o.Id] = mo.DefaultFor(world.Map.Rules.TerrainInfo, playerCount);
 
-						if (mo.Label != null && validChoices.Count > 0)
+						if (hidden || mo.Label == null || validChoices.Count == 0)
+							break;
+
+						optionWidget = dropdownOptionTemplate.Clone();
+						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
+						var label = FluentProvider.GetMessage(mo.Label);
+						labelWidget.GetText = () => label;
+
+						var labelCache = new CachedTransform<string, string>(v => FluentProvider.GetMessage(mo.Choices[v].Label + ".label"));
+						var dropDownWidget = optionWidget.Get<DropDownButtonWidget>("DROPDOWN");
+						dropDownWidget.GetText = () => labelCache.Update(generationArgs.Options[o.Id]);
+						dropDownWidget.OnMouseDown = _ =>
 						{
-							optionWidget = dropdownOptionTemplate.Clone();
-							var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
-							var label = FluentProvider.GetMessage(mo.Label);
-							labelWidget.GetText = () => label;
-
-							var labelCache = new CachedTransform<string, string>(v => FluentProvider.GetMessage(mo.Choices[v].Label + ".label"));
-							var dropDownWidget = optionWidget.Get<DropDownButtonWidget>("DROPDOWN");
-							dropDownWidget.GetText = () => labelCache.Update(generationArgs.Options[o.Id]);
-							dropDownWidget.OnMouseDown = _ =>
+							ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
 							{
-								ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
-								{
-									bool IsSelected() => choice == generationArgs.Options[o.Id];
-									void OnClick() => generationArgs.Options[o.Id] = choice;
-									var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+								bool IsSelected() => choice == generationArgs.Options[o.Id];
+								void OnClick() => generationArgs.Options[o.Id] = choice;
+								var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
 
-									var itemLabel = FluentProvider.GetMessage(mo.Choices[choice].Label + ".label");
-									item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
-									if (FluentProvider.TryGetMessage(mo.Choices[choice].Label + ".description", out var desc))
-										item.GetTooltipText = () => desc;
-									else
-										item.GetTooltipText = null;
+								var itemLabel = FluentProvider.GetMessage(mo.Choices[choice].Label + ".label");
+								item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
+								if (FluentProvider.TryGetMessage(mo.Choices[choice].Label + ".description", out var desc))
+									item.GetTooltipText = () => desc;
+								else
+									item.GetTooltipText = null;
 
-									return item;
-								}
+								return item;
+							}
 
-								dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", 250, validChoices, SetupItem);
-							};
-						}
+							dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", 250, validChoices, SetupItem);
+						};
 
 						break;
 					}

--- a/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapGeneratorLogic.cs
@@ -205,6 +205,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			selectedSize = MapSizes.Keys.Skip(1).First();
+
+			if (initialGeneratedMap != null)
+			{
+				var sizeLimit = MapSizes.Last().Value.Y;
+				var valid = generator.ValidateArgs(
+					modData,
+					initialGeneratedMap,
+					new Size(sizeLimit, sizeLimit),
+					MapGeneratorOption.VisibilityFlags.Lobby);
+				if (!valid)
+					initialGeneratedMap = null;
+			}
+
 			if (initialGeneratedMap != null)
 			{
 				// Make our own copy to prevent external mutation
@@ -284,16 +297,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (o.Id == "Seed")
 					continue;
 
-				if (!o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Lobby))
-					continue;
-
 				Widget optionWidget = null;
+				var hidden = !o.Visibility.HasFlag(MapGeneratorOption.VisibilityFlags.Lobby);
 				switch (o)
 				{
 					case MapGeneratorBooleanOption bo:
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = bo.Default ? trueString : falseString;
+
+						if (hidden)
+							break;
 
 						optionWidget = checkboxOptionTemplate.Clone();
 						var checkboxWidget = optionWidget.Get<CheckboxWidget>("CHECKBOX");
@@ -313,6 +327,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = FieldSaver.FormatValue(io.Default);
 
+						if (hidden)
+							break;
+
 						optionWidget = textOptionTemplate.Clone();
 						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
 						var label = FluentProvider.GetMessage(io.Label);
@@ -322,9 +339,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						textFieldWidget.Text = generationArgs.Options[o.Id];
 						textFieldWidget.OnTextEdited = () =>
 						{
-							var valid = int.TryParse(textFieldWidget.Text, out _);
+							var valid = int.TryParse(textFieldWidget.Text, out var intValue);
 							if (valid)
-								generationArgs.Options[o.Id] = textFieldWidget.Text;
+							{
+								// Reformat the integer to improve cross-client compatibility.
+								generationArgs.Options[o.Id] = FieldSaver.FormatValue(intValue);
+							}
+
 							textFieldWidget.IsValid = () => valid;
 						};
 
@@ -338,6 +359,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						if (!generationArgs.Options.ContainsKey(o.Id))
 							generationArgs.Options[o.Id] = FieldSaver.FormatValue(mio.Default);
+
+						if (hidden)
+							break;
 
 						optionWidget = dropdownOptionTemplate.Clone();
 						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
@@ -379,42 +403,42 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (!generationArgs.Options.TryGetValue(o.Id, out var option) || !validChoices.Contains(option))
 							generationArgs.Options[o.Id] = mo.DefaultFor(selectedTerrain, playerCount);
 
-						if (mo.Label != null && validChoices.Count > 0)
+						if (hidden || mo.Label == null || validChoices.Count == 0)
+							break;
+
+						optionWidget = dropdownOptionTemplate.Clone();
+						var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
+						var label = FluentProvider.GetMessage(mo.Label);
+						labelWidget.GetText = () => label;
+
+						var labelCache = new CachedTransform<string, string>(v => FluentProvider.GetMessage(mo.Choices[v].Label + ".label"));
+						var dropDownWidget = optionWidget.Get<DropDownButtonWidget>("DROPDOWN");
+						dropDownWidget.GetText = () => labelCache.Update(generationArgs.Options[o.Id]);
+						dropDownWidget.OnMouseDown = _ =>
 						{
-							optionWidget = dropdownOptionTemplate.Clone();
-							var labelWidget = optionWidget.Get<LabelWidget>("LABEL");
-							var label = FluentProvider.GetMessage(mo.Label);
-							labelWidget.GetText = () => label;
-
-							var labelCache = new CachedTransform<string, string>(v => FluentProvider.GetMessage(mo.Choices[v].Label + ".label"));
-							var dropDownWidget = optionWidget.Get<DropDownButtonWidget>("DROPDOWN");
-							dropDownWidget.GetText = () => labelCache.Update(generationArgs.Options[o.Id]);
-							dropDownWidget.OnMouseDown = _ =>
+							ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
 							{
-								ScrollItemWidget SetupItem(string choice, ScrollItemWidget template)
+								bool IsSelected() => choice == generationArgs.Options[o.Id];
+								void OnClick()
 								{
-									bool IsSelected() => choice == generationArgs.Options[o.Id];
-									void OnClick()
-									{
-										generationArgs.Options[o.Id] = choice;
-										GenerateMap();
-									}
-
-									var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
-
-									var itemLabel = FluentProvider.GetMessage(mo.Choices[choice].Label + ".label");
-									item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
-									if (FluentProvider.TryGetMessage(mo.Choices[choice].Label + ".description", out var desc))
-										item.GetTooltipText = () => desc;
-									else
-										item.GetTooltipText = null;
-
-									return item;
+									generationArgs.Options[o.Id] = choice;
+									GenerateMap();
 								}
 
-								dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", 250, validChoices, SetupItem);
-							};
-						}
+								var item = ScrollItemWidget.Setup(template, IsSelected, OnClick);
+
+								var itemLabel = FluentProvider.GetMessage(mo.Choices[choice].Label + ".label");
+								item.Get<LabelWidget>("LABEL").GetText = () => itemLabel;
+								if (FluentProvider.TryGetMessage(mo.Choices[choice].Label + ".description", out var desc))
+									item.GetTooltipText = () => desc;
+								else
+									item.GetTooltipText = null;
+
+								return item;
+							}
+
+							dropDownWidget.ShowDropDown("LABEL_DROPDOWN_WITH_TOOLTIP_TEMPLATE", 250, validChoices, SetupItem);
+						};
 
 						break;
 					}


### PR DESCRIPTION
This adds validation to map generator args which are reloaded from settings.yaml (for singleplayer skirmish) or shared between multiplayer clients. For singleplayer, stored invalid args are discarded, avoiding stale options causing problems between game updates that alter the available options. For multiplayer, invalid args are rejected and the map is considered unavailable, reducing the scope for abuse via malicious crafted options.

For the map chooser generator UI, the hidden options logic is adjusted to ensure defaults are properly set.

Strict size limitations for multiplayer are not yet enforced.
