### PR TITLE
Translate settings panel title in reset confirmation dialog

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/SettingsLogic.cs
@@ -150,10 +150,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Settings.Save();
 				}
 
+				var panelTitle = panels[activePanel];
+				if (FluentProvider.TryGetMessage(panelTitle, out var title))
+					panelTitle = title;
+
 				ConfirmationDialogs.ButtonPrompt(modData,
 					title: ResetTitle,
 					text: ResetPrompt,
-					titleArguments: ["panel", panels[activePanel]],
+					titleArguments: ["panel", panelTitle],
 					onConfirm: Reset,
 					confirmText: ResetAccept,
 					onCancel: () => { },


### PR DESCRIPTION
Self-explanatory.

Current bleed:

<img width="379" height="161" alt="image" src="https://github.com/user-attachments/assets/88833eb8-5d44-4e84-9f3c-c7ac6094b32e" />

This PR:

<img width="373" height="153" alt="image" src="https://github.com/user-attachments/assets/22ef3872-ec70-43f8-8b41-578f13d4c352" />
