### PR TITLE
Add texture subdata uploads

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -158,6 +158,7 @@ namespace OpenRA
 	public interface ITexture : IDisposable
 	{
 		void SetData(byte[] colors, int width, int height);
+		void SetSubData(byte[] colors, int xoffset, int yoffset, int width, int height);
 		void SetFloatData(float[] data, int width, int height);
 		void SetDataFromReadBuffer(Rectangle rect);
 		byte[] GetData();

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -19,6 +19,8 @@ namespace OpenRA.Graphics
 	public sealed class Sheet : IDisposable
 	{
 		bool dirty;
+		Rectangle? dirtyRegion;
+
 		bool releaseBufferOnCommit;
 		ITexture texture;
 		byte[] data;
@@ -40,6 +42,7 @@ namespace OpenRA.Graphics
 			Size = size;
 		}
 
+		// We are just wrapping an existing texture.
 		public Sheet(SheetType type, ITexture texture)
 		{
 			Type = type;
@@ -68,7 +71,17 @@ namespace OpenRA.Graphics
 
 			if (data != null && dirty)
 			{
-				texture.SetData(data, Size.Width, Size.Height);
+				// If size of texture does not match the sheet size, the texture needs to be initialized.
+				if (dirtyRegion != null && texture.Size == Size && Size != dirtyRegion?.Size)
+				{
+					var region = dirtyRegion.Value;
+					texture.SetSubData(data, region.X, region.Y, region.Width, region.Height);
+				}
+				else
+					texture.SetData(data, Size.Width, Size.Height);
+
+				dirtyRegion = null;
+
 				dirty = false;
 				if (releaseBufferOnCommit)
 					data = null;
@@ -110,14 +123,16 @@ namespace OpenRA.Graphics
 		{
 			if (data != null)
 				return;
+
 			if (texture == null)
 				data = new byte[4 * Size.Width * Size.Height];
 			else
 				data = texture.GetData();
+
 			releaseBufferOnCommit = false;
 		}
 
-		public void CommitBufferedData()
+		public void CommitBufferedData(Rectangle region)
 		{
 			if (!Buffered)
 				throw new InvalidOperationException(
@@ -125,7 +140,17 @@ namespace OpenRA.Graphics
 					"If you need to completely replace the texture data you should set data into the texture directly. " +
 					"If you need to make only small changes to the texture data consider creating a buffered sheet instead.");
 
+			if (dirtyRegion == null)
+				dirtyRegion = region;
+			else
+				dirtyRegion = Rectangle.Union(dirtyRegion.Value, region);
+
 			dirty = true;
+		}
+
+		public void CommitBufferedData()
+		{
+			CommitBufferedData(new Rectangle(0, 0, Size.Width, Size.Height));
 		}
 
 		public void ReleaseBuffer()

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Graphics
 
 			var rect = Allocate(size, zRamp, spriteOffset);
 			Util.FastCopyIntoChannel(rect, src, type, premultiplied);
-			Current.CommitBufferedData();
+			Current.CommitBufferedData(rect.Bounds);
 			return rect;
 		}
 
@@ -100,7 +100,7 @@ namespace OpenRA.Graphics
 		{
 			var rect = Allocate(new Size(src.Width, src.Height), scale);
 			Util.FastCopyIntoSprite(rect, src);
-			Current.CommitBufferedData();
+			Current.CommitBufferedData(rect.Bounds);
 			return rect;
 		}
 

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -294,7 +294,7 @@ namespace OpenRA.Graphics
 				}
 			}
 
-			s.Sheet.CommitBufferedData();
+			s.Sheet.CommitBufferedData(s.Bounds);
 
 			return g;
 		}
@@ -412,7 +412,7 @@ namespace OpenRA.Graphics
 				}
 			}
 
-			s.Sheet.CommitBufferedData();
+			s.Sheet.CommitBufferedData(s.Bounds);
 			return s;
 		}
 

--- a/OpenRA.Game/PlayerDatabase.cs
+++ b/OpenRA.Game/PlayerDatabase.cs
@@ -54,7 +54,7 @@ namespace OpenRA
 						Game.RunAfterTick(() =>
 						{
 							Util.FastCopyIntoSprite(sprite, icon);
-							sprite.Sheet.CommitBufferedData();
+							sprite.Sheet.CommitBufferedData(sprite.Bounds);
 						});
 					}
 				}

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 			// s and t are guaranteed to use the same sheet because
 			// of the custom voxel sheet allocation implementation
-			s.Sheet.CommitBufferedData();
+			s.Sheet.CommitBufferedData(s.Bounds);
 
 			var channelP = ChannelSelect[(int)s.Channel];
 			var channelC = ChannelSelect[(int)t.Channel];

--- a/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/GeneratedMapPreviewWidget.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var spriteRect = new Rectangle(0, 0, preview.Width, preview.Height);
 			mapSprite = new Sprite(mapSheet, spriteRect, TextureChannel.RGBA);
 			OpenRA.Graphics.Util.FastCopyIntoSprite(mapSprite, preview);
-			mapSheet.CommitBufferedData();
+			mapSheet.CommitBufferedData(mapSprite.Bounds);
 
 			// Update map rect
 			var previewScale = Math.Min(RenderBounds.Width * 1f / spriteRect.Width, RenderBounds.Height * 1f / spriteRect.Height);

--- a/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/EncyclopediaLogic.cs
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				OpenRA.Graphics.Util.FastCopyIntoSprite(portraitSprite, portrait);
-				portraitSprite.Sheet.CommitBufferedData();
+				portraitSprite.Sheet.CommitBufferedData(portraitSprite.Bounds);
 			}
 
 			if (titleLabel != null)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -93,6 +93,9 @@ namespace OpenRA.Platforms.Default
 		public const int GL_SCISSOR_TEST = 0x0C11;
 
 		// Texture mapping
+		public const int GL_UNPACK_ROW_LENGTH = 0x0CF2;
+		public const int GL_UNPACK_SKIP_ROWS = 0x0CF3;
+		public const int GL_UNPACK_SKIP_PIXELS = 0x0CF4;
 		public const int GL_TEXTURE_2D = 0x0DE1;
 		public const int GL_TEXTURE_WRAP_S = 0x2802;
 		public const int GL_TEXTURE_WRAP_T = 0x2803;
@@ -283,6 +286,9 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		public delegate void PixelStorei(int paramName, int param);
+		public static PixelStorei glPixelStorei { get; private set; }
+
 		public delegate int GetIntegerv(int pname, out int param);
 		public static GetIntegerv glGetIntegerv { get; private set; }
 
@@ -451,6 +457,9 @@ namespace OpenRA.Platforms.Default
 			int x, int y, int width, int height, int border);
 		public static CopyTexImage2D glCopyTexImage2D { get; private set; }
 
+		public delegate void TexSubImage2D(int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, IntPtr pixels);
+		public static TexSubImage2D glTexSubImage2D { get; private set; }
+
 		public delegate void GetTexImage(int target, int level,
 			int format, int type, IntPtr pixels);
 		public static GetTexImage glGetTexImage { get; private set; }
@@ -506,6 +515,7 @@ namespace OpenRA.Platforms.Default
 				glGetError = Bind<GetError>("glGetError");
 				glGetStringInternal = Bind<GetString>("glGetString");
 				glGetStringiInternal = Bind<GetStringi>("glGetStringi");
+				glPixelStorei = Bind<PixelStorei>("glPixelStorei");
 				glGetIntegerv = Bind<GetIntegerv>("glGetIntegerv");
 			}
 			catch (Exception e)
@@ -617,6 +627,7 @@ namespace OpenRA.Platforms.Default
 				glBindTexture = Bind<BindTexture>("glBindTexture");
 				glActiveTexture = Bind<ActiveTexture>("glActiveTexture");
 				glTexImage2D = Bind<TexImage2D>("glTexImage2D");
+				glTexSubImage2D = Bind<TexSubImage2D>("glTexSubImage2D");
 				glCopyTexImage2D = Bind<CopyTexImage2D>("glCopyTexImage2D");
 				glTexParameteri = Bind<TexParameteri>("glTexParameteri");
 				glTexParameterf = Bind<TexParameterf>("glTexParameterf");

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -92,6 +92,34 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		void SetSubData(IntPtr data, int xoffset, int yoffset, int width, int height)
+		{
+			PrepareTexture();
+
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_ROW_LENGTH, Size.Width);
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_SKIP_PIXELS, xoffset);
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_SKIP_ROWS, yoffset);
+
+			OpenGL.glTexSubImage2D(OpenGL.GL_TEXTURE_2D, 0, xoffset, yoffset, width, height,
+				OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, data);
+
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_ROW_LENGTH, 0);
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_SKIP_PIXELS, 0);
+			OpenGL.glPixelStorei(OpenGL.GL_UNPACK_SKIP_ROWS, 0);
+
+			OpenGL.CheckGLError();
+		}
+
+		public void SetSubData(byte[] colors, int xoffset, int yoffset, int width, int height)
+		{
+			VerifyThreadAffinity();
+			unsafe
+			{
+				fixed (byte* ptr = &colors[0])
+					SetSubData(new IntPtr(ptr), xoffset, yoffset, width, height);
+			}
+		}
+
 		public void SetFloatData(float[] data, int width, int height)
 		{
 			VerifyThreadAffinity();

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -669,6 +669,8 @@ namespace OpenRA.Platforms.Default
 		readonly Func<byte[]> getData;
 		readonly Action<object> setData1;
 		readonly Func<object, object> setData2;
+		readonly Action<object> setSubData1;
+		readonly Func<object, object> setSubData2;
 		readonly Action<object> setData3;
 		readonly Func<object, object> setData4;
 		readonly Action<object> setData5;
@@ -685,6 +687,8 @@ namespace OpenRA.Platforms.Default
 			getData = texture.GetData;
 			setData1 = tuple => { var t = ((byte[], int, int))tuple; texture.SetData(t.Item1, t.Item2, t.Item3); };
 			setData2 = tuple => { setData1(tuple); return null; };
+			setSubData1 = tuple => { var t = ((byte[], int, int, int, int))tuple; texture.SetSubData(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5); };
+			setSubData2 = tuple => { setSubData1(tuple); return null; };
 			setData3 = tuple => { var t = ((float[], int, int))tuple; texture.SetFloatData(t.Item1, t.Item2, t.Item3); };
 			setData4 = tuple => { setData3(tuple); return null; };
 			setData5 = rect => texture.SetDataFromReadBuffer((Rectangle)rect);
@@ -728,6 +732,25 @@ namespace OpenRA.Platforms.Default
 				// If the length is large and would result in an array on the Large Object Heap (LOH),
 				// send a message and block to avoid LOH allocation as this requires a Gen2 collection.
 				device.Send(setData2, (colors, width, height));
+			}
+		}
+
+		public void SetSubData(byte[] colors, int xoffset, int yoffset, int width, int height)
+		{
+			// Objects 85000 bytes or more will be directly allocated in the Large Object Heap (LOH).
+			// https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/large-object-heap
+			if (colors.Length < 85000)
+			{
+				// If we are able to create a small array the GC can collect easily, post a message to avoid blocking.
+				var temp = new byte[colors.Length];
+				Array.Copy(colors, temp, temp.Length);
+				device.Post(setSubData1, (temp, xoffset, yoffset, width, height));
+			}
+			else
+			{
+				// If the length is large and would result in an array on the Large Object Heap (LOH),
+				// send a message and block to avoid LOH allocation as this requires a Gen2 collection.
+				device.Send(setSubData2, (colors, xoffset, yoffset, width, height));
 			}
 		}
 


### PR DESCRIPTION
Closes #22496

Game load times are unaffected as the first upload of a texture needs to be full. However this speeds up sheet building during gameplay.

When GPU is reading memory from CPU, a CPU core and the entire GPU are paused until the upload is finished. So minimizing uploads it incredibly important. In newer graphics API's you can avoid pausing the CPU, but GPU is still paused during data transfers and won't do any work.

This PR adds subimage loads to SheetBuilder, so things like Fonts and MapPreviews now get uploaded via subdata.

Note, currently I'm giving the pointer to the entire full image and changing the reading patern as to avoid allocations. One can just give it a block of changed memory instead. I'd imagive palette sheet uploads should also make use of subdata transfers.