### PR TITLE
Add an OutputBuffer struct.

### DIFF
--- a/OpenRA.Game/Primitives/OutputBuffer.cs
+++ b/OpenRA.Game/Primitives/OutputBuffer.cs
@@ -1,0 +1,27 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenRA.Primitives
+{
+	/// <summary>
+	/// Destination where outputs should be written.
+	/// </summary>
+	public readonly struct OutputBuffer<T>(List<T> list)
+	{
+		public static implicit operator OutputBuffer<T>(List<T> list) => new(list);
+		public void Add(T item) => list.Add(item);
+		public void AddRange(IEnumerable<T> items) => list.AddRange(items);
+		public void AddRange(params ReadOnlySpan<T> items) => list.AddRange(items);
+	}
+}

--- a/OpenRA.Game/Primitives/OutputBuffer.cs
+++ b/OpenRA.Game/Primitives/OutputBuffer.cs
@@ -23,5 +23,6 @@ namespace OpenRA.Primitives
 		public void Add(T item) => list.Add(item);
 		public void AddRange(IEnumerable<T> items) => list.AddRange(items);
 		public void AddRange(params ReadOnlySpan<T> items) => list.AddRange(items);
+		public void AddRange(T[] items) => list.AddRange(items.AsSpan());
 	}
 }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -303,7 +303,7 @@ namespace OpenRA.Traits
 
 	public interface IMapPreviewSignatureInfo : ITraitInfoInterface
 	{
-		void PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer);
+		void PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, OutputBuffer<(MPos Uv, Color Color)> cells);
 	}
 
 	public interface IOccupySpaceInfo : ITraitInfoInterface

--- a/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSVeinsRenderer.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Actor types that should be treated as veins for adjacency.")]
 		public readonly FrozenSet<string> VeinholeActors = [];
 
-		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)
+		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, OutputBuffer<(MPos Uv, Color Color)> cells)
 		{
 			var resourceLayer = ai.TraitInfoOrDefault<IResourceLayerInfo>();
 			if (resourceLayer == null)
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					// Cell contains veins
 					if (map.Resources[uv].Type == resourceIndex)
 					{
-						destinationBuffer.Add((uv, info.Color));
+						cells.Add((uv, info.Color));
 						continue;
 					}
 
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					});
 
 					if (isBorder)
-						destinationBuffer.Add((uv, info.Color));
+						cells.Add((uv, info.Color));
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Pathfinder/DensePathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/DensePathGraph.cs
@@ -10,9 +10,9 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			CVec.Directions.Exclude(new CVec(-1, -1)).ToArray(), // BR
 		];
 
-		public List<GraphConnection> GetConnections(CPos position, Func<CPos, bool> targetPredicate)
+		public void PopulateConnections(CPos position, Func<CPos, bool> targetPredicate, OutputBuffer<GraphConnection> connections)
 		{
 			var layer = position.Layer;
 			var info = this[position];
@@ -120,7 +120,6 @@ namespace OpenRA.Mods.Common.Pathfinder
 				? DirectedNeighborsConservative
 				: DirectedNeighbors)[index];
 
-			var validNeighbors = new List<GraphConnection>(directions.Length + (layer == 0 ? customMovementLayersEnabledForLocomotor : 1));
 			for (var i = 0; i < directions.Length; i++)
 			{
 				var dir = directions[i];
@@ -131,7 +130,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				var pathCost = GetPathCostToNode(position, neighbor, dir, targetPredicate);
 				if (pathCost != PathGraph.PathCostForInvalidPath &&
 					this[neighbor].Status != CellStatus.Closed)
-					validNeighbors.Add(new GraphConnection(neighbor, pathCost));
+					connections.Add(new GraphConnection(neighbor, pathCost));
 			}
 
 			if (layer == 0)
@@ -151,7 +150,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 						if (entryCost != PathGraph.MovementCostForUnreachableCell &&
 							CanEnterNode(position, layerPosition, targetPredicate) &&
 							this[layerPosition].Status != CellStatus.Closed)
-							validNeighbors.Add(new GraphConnection(layerPosition, entryCost));
+							connections.Add(new GraphConnection(layerPosition, entryCost));
 					}
 				}
 			}
@@ -164,11 +163,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 					if (exitCost != PathGraph.MovementCostForUnreachableCell &&
 						CanEnterNode(position, groundPosition, targetPredicate) &&
 						this[groundPosition].Status != CellStatus.Closed)
-						validNeighbors.Add(new GraphConnection(groundPosition, exitCost));
+						connections.Add(new GraphConnection(groundPosition, exitCost));
 				}
 			}
-
-			return validNeighbors;
 		}
 
 		bool CanEnterNode(CPos srcNode, CPos destNode, Func<CPos, bool> targetPredicate)

--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
@@ -120,7 +121,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// Abstract nodes with no connections are NOT present in the graph.
 		/// A lookup will fail, rather than return an empty list.
 		/// </summary>
-		Dictionary<CPos, List<GraphConnection>> abstractGraph;
+		Dictionary<CPos, GraphConnection[]> abstractGraph;
 
 		/// <summary>
 		/// The abstract domains are represented here.
@@ -184,11 +185,11 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		sealed class AbstractGraphWithInsertedEdges
 		{
-			readonly Dictionary<CPos, List<GraphConnection>> abstractEdges;
+			readonly Dictionary<CPos, GraphConnection[]> abstractEdges;
 			readonly Dictionary<CPos, IEnumerable<GraphConnection>> changedEdges;
 
 			public AbstractGraphWithInsertedEdges(
-				Dictionary<CPos, List<GraphConnection>> abstractEdges,
+				Dictionary<CPos, GraphConnection[]> abstractEdges,
 				IList<GraphEdge> sourceEdges,
 				GraphEdge? targetEdge,
 				Func<CPos, CPos, int> costEstimator)
@@ -233,13 +234,12 @@ namespace OpenRA.Mods.Common.Pathfinder
 				}
 			}
 
-			public List<GraphConnection> GetConnections(CPos position)
+			public void PopulateConnections(CPos position, OutputBuffer<GraphConnection> connections)
 			{
 				if (changedEdges.TryGetValue(position, out var changedEdge))
-					return changedEdge.ToList();
-				if (abstractEdges.TryGetValue(position, out var abstractEdge))
-					return abstractEdge;
-				return [];
+					connections.AddRange(changedEdge);
+				else if (abstractEdges.TryGetValue(position, out var abstractEdge))
+					connections.AddRange(abstractEdge);
 			}
 		}
 
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		}
 
 		public (
-			IReadOnlyDictionary<CPos, List<GraphConnection>> AbstractGraph,
+			IReadOnlyDictionary<CPos, GraphConnection[]> AbstractGraph,
 			IReadOnlyDictionary<CPos, uint> AbstractDomains) GetOverlayData()
 		{
 			if (costEstimator == null)
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			RebuildDirtyGrids();
 			RebuildDomains();
 			return (
-				new ReadOnlyDictionary<CPos, List<GraphConnection>>(abstractGraph),
+				new ReadOnlyDictionary<CPos, GraphConnection[]>(abstractGraph),
 				new ReadOnlyDictionary<CPos, uint>(abstractDomains));
 		}
 
@@ -453,7 +453,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		void BuildCostTable()
 		{
-			abstractGraph = new Dictionary<CPos, List<GraphConnection>>(gridXs * gridYs);
+			abstractGraph = new Dictionary<CPos, GraphConnection[]>(gridXs * gridYs);
 			var customMovementLayers = world.GetCustomMovementLayers();
 			for (var gridX = mapBounds.TopLeft.X; gridX < mapBounds.BottomRight.X; gridX += GridSize)
 				for (var gridY = mapBounds.TopLeft.Y; gridY < mapBounds.BottomRight.Y; gridY += GridSize)
@@ -466,7 +466,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// within adjacent grids on the same layer. Also determines any edges available to grids on other layers via
 		/// custom movement layers.
 		/// </summary>
-		IEnumerable<KeyValuePair<CPos, List<GraphConnection>>> GetAbstractEdgesForGrid(int gridX, int gridY, ICustomMovementLayer[] customMovementLayers)
+		IEnumerable<KeyValuePair<CPos, GraphConnection[]>> GetAbstractEdgesForGrid(int gridX, int gridY, ICustomMovementLayer[] customMovementLayers)
 		{
 			var abstractEdges = new HashSet<(CPos Src, CPos Dst)>();
 			for (byte gridLayer = 0; gridLayer < customMovementLayers.Length; gridLayer++)
@@ -573,7 +573,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				.GroupBy(edge => edge.Src)
 				.Select(group => KeyValuePair.Create(
 					group.Key,
-					group.Select(edge => new GraphConnection(edge.Dst, costEstimator(edge.Src, edge.Dst))).ToList()));
+					group.Select(edge => new GraphConnection(edge.Dst, costEstimator(edge.Src, edge.Dst))).ToArray()));
 		}
 
 		/// <summary>
@@ -814,7 +814,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			// Determine an abstract path to all sources, for use in a unidirectional search.
 			var estimatedSearchSize = (abstractGraph.Count + 2) / 8;
 			using (var reverseAbstractSearch = PathSearch.ToTargetCellOverGraph(
-				fullGraph.GetConnections, locomotor, target, target, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
+				fullGraph.PopulateConnections, locomotor, target, target, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
 			{
 				using (var fromSrc = GetLocalPathSearch(
 					self, sourcesWithPathableNodes, target, customCost, ignoreActor, check, laneBias, null, heuristicWeightPercentage,
@@ -904,13 +904,13 @@ namespace OpenRA.Mods.Common.Pathfinder
 			// Determine an abstract path in both directions, for use in a bidirectional search.
 			var estimatedSearchSize = (abstractGraph.Count + 2) / 8;
 			using (var forwardAbstractSearch = PathSearch.ToTargetCellOverGraph(
-				fullGraph.GetConnections, locomotor, source, target, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
+				fullGraph.PopulateConnections, locomotor, source, target, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
 			{
 				if (!forwardAbstractSearch.ExpandToTarget())
 					return PathFinder.NoPath;
 
 				using (var reverseAbstractSearch = PathSearch.ToTargetCellOverGraph(
-					fullGraph.GetConnections, locomotor, target, source, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
+					fullGraph.PopulateConnections, locomotor, target, source, estimatedSearchSize, pathFinderOverlay?.RecordAbstractEdges(self)))
 				{
 					reverseAbstractSearch.ExpandToTarget();
 
@@ -1062,11 +1062,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 			if (abstractDomains.Count != 0)
 				return;
 
-			List<GraphConnection> AbstractEdge(CPos abstractCell)
+			void AbstractEdge(CPos abstractCell, OutputBuffer<GraphConnection> connections)
 			{
 				if (abstractGraph.TryGetValue(abstractCell, out var abstractEdge))
-					return abstractEdge;
-				return null;
+					connections.AddRange(abstractEdge);
 			}
 
 			// As in BuildGrid, flood fill the search graph until all disjoint domains are discovered.

--- a/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/IPathGraph.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -22,12 +23,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 	public interface IPathGraph : IDisposable
 	{
 		/// <summary>
-		/// Given a source node, returns connections to all reachable destination nodes with their cost.
+		/// Given a source node, populates connections to all reachable destination nodes with their cost.
 		/// </summary>
-		/// <remarks>PERF: Returns a <see cref="List{T}"/> rather than an <see cref="IEnumerable{T}"/> as enumerating
-		/// this efficiently is important for pathfinding performance. Callers should interact with this as an
-		/// <see cref="IEnumerable{T}"/> and not mutate the result.</remarks>
-		List<GraphConnection> GetConnections(CPos source, Func<CPos, bool> targetPredicate);
+		void PopulateConnections(CPos source, Func<CPos, bool> targetPredicate, OutputBuffer<GraphConnection> connections);
 
 		/// <summary>
 		/// Gets or sets the pathfinding information for a given node.

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 			void Add(CPos source, CPos destination, int costSoFar, int estimatedRemainingCost);
 		}
 
+		const int BufferSize = 8;
+
 		// PERF: Maintain a pool of layers used for paths searches for each world. These searches are performed often
 		// so we wish to avoid the high cost of initializing a new search space every time by reusing the old ones.
 		static readonly ConditionalWeakTable<World, CellInfoLayerPool> LayerPoolTable = [];
@@ -110,7 +112,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		}
 
 		public static PathSearch ToTargetCellOverGraph(
-			Func<CPos, List<GraphConnection>> edges, Locomotor locomotor, CPos from, CPos target,
+			Action<CPos, OutputBuffer<GraphConnection>> edges, Locomotor locomotor, CPos from, CPos target,
 			int estimatedSearchSize = 0, IRecorder recorder = null)
 		{
 			var graph = new SparsePathGraph(edges, estimatedSearchSize);
@@ -244,14 +246,15 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// using the A* algorithm (A-star) and returns that node.
 		/// </summary>
 		/// <returns>The most promising node of the iteration.</returns>
-		CPos Expand()
+		CPos Expand(List<GraphConnection> buffer)
 		{
 			var currentMinNode = openQueue.Pop().Destination;
 
 			var currentInfo = Graph[currentMinNode];
 			Graph[currentMinNode] = new CellInfo(CellStatus.Closed, currentInfo.CostSoFar, currentInfo.EstimatedTotalCost, currentInfo.PreviousNode);
 
-			foreach (var connection in Graph.GetConnections(currentMinNode, TargetPredicate))
+			Graph.PopulateConnections(currentMinNode, TargetPredicate, buffer);
+			foreach (var connection in buffer)
 			{
 				// Calculate the cost up to that point
 				var costSoFarToNeighbor = currentInfo.CostSoFar + connection.Cost;
@@ -288,6 +291,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 				openQueue.Add(new GraphConnection(neighbor, estimatedTotalCostToTarget));
 			}
 
+			buffer.Clear();
+
 			return currentMinNode;
 		}
 
@@ -301,8 +306,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </remarks>
 		public bool ExpandToTarget()
 		{
+			var buffer = new List<GraphConnection>(BufferSize);
 			while (CanExpand())
-				if (TargetPredicate(Expand()))
+				if (TargetPredicate(Expand(buffer)))
 					return true;
 
 			return false;
@@ -314,9 +320,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		public List<CPos> ExpandAll()
 		{
+			var buffer = new List<GraphConnection>(BufferSize);
 			var consideredCells = new List<CPos>();
 			while (CanExpand())
-				consideredCells.Add(Expand());
+				consideredCells.Add(Expand(buffer));
 			return consideredCells;
 		}
 
@@ -326,9 +333,10 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		public List<CPos> FindPath()
 		{
+			var buffer = new List<GraphConnection>(BufferSize);
 			while (CanExpand())
 			{
-				var p = Expand();
+				var p = Expand(buffer);
 				if (TargetPredicate(p))
 					return MakePath(Graph, p);
 			}
@@ -359,17 +367,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 		/// </summary>
 		public static List<CPos> FindBidiPath(PathSearch first, PathSearch second)
 		{
+			var buffer = new List<GraphConnection>(BufferSize);
 			while (first.CanExpand() && second.CanExpand())
 			{
 				// make some progress on the first search
-				var p = first.Expand();
+				var p = first.Expand(buffer);
 				var pInfo = second.Graph[p];
 				if (pInfo.Status == CellStatus.Closed &&
 					pInfo.CostSoFar != PathGraph.PathCostForInvalidPath)
 					return MakeBidiPath(first, second, p);
 
 				// make some progress on the second search
-				var q = second.Expand();
+				var q = second.Expand(buffer);
 				var qInfo = first.Graph[q];
 				if (qInfo.Status == CellStatus.Closed &&
 					qInfo.CostSoFar != PathGraph.PathCostForInvalidPath)

--- a/OpenRA.Mods.Common/Pathfinder/SparsePathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/SparsePathGraph.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -23,18 +24,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 	/// </summary>
 	sealed class SparsePathGraph : IPathGraph
 	{
-		readonly Func<CPos, List<GraphConnection>> edges;
+		readonly Action<CPos, OutputBuffer<GraphConnection>> edges;
 		readonly Dictionary<CPos, CellInfo> info;
 
-		public SparsePathGraph(Func<CPos, List<GraphConnection>> edges, int estimatedSearchSize = 0)
+		public SparsePathGraph(Action<CPos, OutputBuffer<GraphConnection>> edges, int estimatedSearchSize = 0)
 		{
 			this.edges = edges;
 			info = new Dictionary<CPos, CellInfo>(estimatedSearchSize);
 		}
 
-		public List<GraphConnection> GetConnections(CPos position, Func<CPos, bool> targetPredicate)
+		public void PopulateConnections(CPos position, Func<CPos, bool> targetPredicate, OutputBuffer<GraphConnection> connections)
 		{
-			return edges(position) ?? [];
+			edges(position, connections);
 		}
 
 		public CellInfo this[CPos pos]

--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -26,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Overrides `Color` if both set.")]
 		public readonly string Terrain = null;
 
-		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)
+		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, OutputBuffer<(MPos Uv, Color Color)> cells)
 		{
 			Color color;
 			if (!string.IsNullOrEmpty(Terrain))
@@ -47,9 +46,9 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var ios = ai.TraitInfo<IOccupySpaceInfo>();
-			var cells = ios.OccupiedCells(ai, s.Get<LocationInit>().Value);
-			foreach (var cell in cells)
-				destinationBuffer.Add((cell.Key.ToMPos(map), color));
+			var occupiedCells = ios.OccupiedCells(ai, s.Get<LocationInit>().Value);
+			foreach (var cell in occupiedCells)
+				cells.Add((cell.Key.ToMPos(map), color));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -41,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Radar
 			modifier = self.TraitsImplementing<IRadarColorModifier>().FirstOrDefault();
 		}
 
-		public void PopulateRadarSignatureCells(Actor self, List<(CPos Cell, Color Color)> destinationBuffer)
+		public void PopulateRadarSignatureCells(Actor self, OutputBuffer<(CPos Cell, Color Color)> cells)
 		{
 			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
 			if (IsTraitDisabled || (viewer != null && !Info.ValidRelationships.HasRelationship(self.Owner.RelationshipWith(viewer))))
@@ -53,12 +52,12 @@ namespace OpenRA.Mods.Common.Traits.Radar
 
 			if (Info.UseLocation)
 			{
-				destinationBuffer.Add((self.Location, color));
+				cells.Add((self.Location, color));
 				return;
 			}
 
 			foreach (var cell in self.OccupiesSpace.OccupiedCells())
-				destinationBuffer.Add((cell.Cell, color));
+				cells.Add((cell.Cell, color));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -474,11 +474,11 @@ namespace OpenRA.Mods.Common.Traits
 			return nodes;
 		}
 
-		public void PopulateRadarSignatureCells(Actor self, List<(CPos Cell, Color Color)> destinationBuffer)
+		public void PopulateRadarSignatureCells(Actor self, OutputBuffer<(CPos Cell, Color Color)> cells)
 		{
 			foreach (var preview in cellMap.Keys)
 				foreach (var cell in OccupiedCells(preview))
-					destinationBuffer.Add((cell, preview.RadarColor));
+					cells.Add((cell, preview.RadarColor));
 		}
 
 		void INotifyActorDisposing.Disposing(Actor self)

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public (
-			IReadOnlyDictionary<CPos, List<GraphConnection>> AbstractGraph,
+			IReadOnlyDictionary<CPos, GraphConnection[]> AbstractGraph,
 			IReadOnlyDictionary<CPos, uint> AbstractDomains) GetOverlayDataForLocomotor(
 			Locomotor locomotor, BlockedByActor check)
 		{

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			return ret.ToFrozenDictionary();
 		}
 
-		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, List<(MPos Uv, Color Color)> destinationBuffer)
+		void IMapPreviewSignatureInfo.PopulateMapPreviewSignatureCells(Map map, ActorInfo ai, ActorReference s, OutputBuffer<(MPos Uv, Color Color)> cells)
 		{
 			var resourceLayer = ai.TraitInfoOrDefault<IResourceLayerInfo>();
 			if (resourceLayer == null)
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var cell = new MPos(i, j);
 					if (colors.TryGetValue(map.Resources[cell].Type, out var color))
-						destinationBuffer.Add((cell, color));
+						cells.Add((cell, color));
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -561,7 +561,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IRadarSignature
 	{
-		void PopulateRadarSignatureCells(Actor self, List<(CPos Cell, Color Color)> destinationBuffer);
+		void PopulateRadarSignatureCells(Actor self, OutputBuffer<(CPos Cell, Color Color)> cells);
 	}
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }


### PR DESCRIPTION
This allows wrapping a list to expose only the Add/AddRange methods. Used when a caller wants to provide a destination buffer for the callee to write output - but does not want the callee to have any other access to the buffer. This can be useful when the caller wants to reuse a buffer across calls to amortize allocations.