### PR TITLE
[FEATURE] Switchable default Move <--> AttackMove

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -332,6 +332,7 @@ namespace OpenRA
 		public int MouseScrollDeadzone = 8;
 
 		public bool UseAlternateScrollButton = false;
+		public bool AttackMoveIsDefault = false;
 
 		public bool HideReplayChat = false;
 

--- a/OpenRA.Mods.Common/Orders/MoveOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/MoveOrderGenerator.cs
@@ -1,0 +1,50 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	// A marker subclass of the default contextual click handler. It does not override any
+	// targeting/cursor logic - a plain click through this generator behaves in every way
+	// like a normal default click (Attack still wins on an enemy unit, Enter still wins on
+	// a garrisonable building, etc).
+	//
+	// The only purpose of having a distinct type is so that AttackMoveOrderTargeter
+	// (see AttackMove.cs) can recognise "we are currently in this mode" and bail out, letting
+	// a plain terrain click fall through to Move - exactly as if
+	// Game.Settings.Game.AttackMoveIsDefault were turned off, without actually touching that
+	// (persisted) setting.
+	public class MoveOrderGenerator : UnitOrderGenerator
+	{
+		public MoveOrderGenerator(World world)
+			: base(world) { }
+
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			// base.OrderInner is a lazily-evaluated iterator (it uses yield internally), so it
+			// does not actually run - and does not call AttackMoveOrderTargeter.CanTarget - until
+			// the returned sequence is enumerated. It must be materialised here, before
+			// CancelInputMode() below replaces world.OrderGenerator, otherwise CanTarget's check
+			// for "are we still in this mode" would already see the reverted generator and let
+			// attack-move win again.
+			var orders = base.OrderInner(world, cell, worldPixel, mi).ToList();
+
+			// Revert to the plain default generator after a single click, unless the player
+			// is queueing multiple waypoints (Shift) - matches AttackMoveOrderGenerator.
+			if (!mi.Modifiers.HasModifier(Modifiers.Shift))
+				world.CancelInputMode();
+
+			return orders;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -56,10 +56,12 @@ namespace OpenRA.Mods.Common.Traits
 	sealed class AttackMove : IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
+		readonly Actor self;
 		readonly IMove move;
 
 		public AttackMove(Actor self, AttackMoveInfo info)
 		{
+			this.self = self;
 			move = self.Trait<IMove>();
 			Info = info;
 		}
@@ -69,13 +71,14 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (Game.Settings.Game.AttackMoveIsDefault)
-					yield return new AttackMoveOrderTargeter(Info);
+					yield return new AttackMoveOrderTargeter(Info, self.World.OrderGenerator is MoveOrderGenerator);
 			}
 		}
 
 		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
 		{
-			if (order.OrderID == "AttackMove")
+			// order.OrderID may be "AttackMove" or "AssaultMove" - see AttackMoveOrderTargeter.
+			if (order is AttackMoveOrderTargeter)
 				return new Order(order.OrderID, self, target, queued);
 
 			return null;
@@ -199,18 +202,30 @@ namespace OpenRA.Mods.Common.Traits
 	sealed class AttackMoveOrderTargeter : IOrderTargeter
 	{
 		readonly AttackMoveInfo info;
+		readonly bool moveButtonActive;
 
-		public AttackMoveOrderTargeter(AttackMoveInfo info)
+		// Mutable like AttackBase's own AttackOrderTargeter.OrderID: this same targeter doubles
+		// up for AssaultMove while the repurposed Move button/hotkey is active (see CanTarget).
+		string orderID = "AttackMove";
+
+		public AttackMoveOrderTargeter(AttackMoveInfo info, bool moveButtonActive)
 		{
 			this.info = info;
+			this.moveButtonActive = moveButtonActive;
 		}
 
-		public string OrderID => "AttackMove";
+		public string OrderID => orderID;
 
-		// Below Attack's force-attack-ground priority (6) so Ctrl+click on empty
-		// ground can still force-fire, but above Move's priority (4) so a plain
-		// click defaults to attack-move instead of a plain move.
-		public int OrderPriority => 5;
+		// Normally below Attack's force-attack-ground priority (6), so Ctrl+click on empty ground
+		// still force-fires, but above Move's priority (4), so a plain click defaults to
+		// attack-move instead of a plain move.
+		//
+		// While the repurposed Move button/hotkey is active (moveButtonActive), we instead need to
+		// win over force-attack-ground, so that Ctrl+click there gives AssaultMove instead - see
+		// CanTarget below. 9 (rather than just above Attack's 6) is intentional headroom: CA's own
+		// IgnoreOutOfRangeAttackOrders trait (used by e.g. NUKC/PTNK while deployed) defaults its
+		// own override priority to 7, and we don't want an exact tie with it.
+		public int OrderPriority => moveButtonActive ? 9 : 5;
 		public bool IsQueued { get; private set; }
 
 		public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
@@ -220,28 +235,39 @@ namespace OpenRA.Mods.Common.Traits
 			if (modifiers.HasModifier(TargetModifiers.ForceMove))
 				return false;
 
-			// While the player is using the repurposed attack-move button/hotkey to force a
-			// plain default click (see MoveOrderGenerator), attack-move must not compete with it.
-			if (self.World.OrderGenerator is MoveOrderGenerator)
-				return false;
-
-			// AttackMove only overrides a plain click on empty terrain - clicking directly on
+			// AttackMove/AssaultMove only override a plain click on empty terrain - clicking directly on
 			// a unit/building is left entirely to Attack/Enter/Repair/etc.'s own targeters.
 			if (target.Type != TargetType.Terrain)
 				return false;
 
-			// AttackMove is meaningless without AutoTarget, and only makes sense if the order is accepted.
-			if (!self.Info.HasTraitInfo<AutoTargetInfo>() || !self.AcceptsOrder(OrderID))
+			// AttackMove is meaningless without AutoTarget.
+			if (!self.Info.HasTraitInfo<AutoTargetInfo>())
 				return false;
 
 			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
+			if (moveButtonActive)
+			{
+				// A plain click here must remain Move - fall through to Mobile's own
+				// (lower-priority) targeter by rejecting here.
+				if (!modifiers.HasModifier(TargetModifiers.ForceAttack))
+					return false;
+
+				orderID = "AssaultMove";
+			}
+			else
+				orderID = "AttackMove";
+
+			if (!self.AcceptsOrder(orderID))
+				return false;
+
 			var location = self.World.Map.CellContaining(target.CenterPosition);
 			var explored = self.Owner.Shroud.IsExplored(location);
+			var blocked = !self.World.Map.Contains(location) || (!explored && !info.MoveIntoShroud);
 
-			cursor = !self.World.Map.Contains(location) || (!explored && !info.MoveIntoShroud)
-				? info.AttackMoveBlockedCursor
-				: info.AttackMoveCursor;
+			cursor = orderID == "AssaultMove"
+				? (blocked ? info.AssaultMoveBlockedCursor : info.AssaultMoveCursor)
+				: (blocked ? info.AttackMoveBlockedCursor : info.AttackMoveCursor);
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -256,7 +256,18 @@ namespace OpenRA.Mods.Common.Traits
 				orderID = "AssaultMove";
 			}
 			else
+			{
+				// Ctrl+click here is meant for force-attack-ground (Attack's own priority-6
+				// targeter, evaluated before this one). If Attack itself declined - e.g. the
+				// weapon can't target terrain at all - don't silently fall back to AttackMove:
+				// that would let us out-compete other legitimate priority-5 terrain+ForceAttack
+				// targeters (e.g. CA's KeepsDistance) instead of yielding to them like we would
+				// with the setting off. Fall through instead.
+				if (modifiers.HasModifier(TargetModifiers.ForceAttack))
+					return false;
+
 				orderID = "AttackMove";
+			}
 
 			if (!self.AcceptsOrder(orderID))
 				return false;

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
-	sealed class AttackMove : IResolveOrder, IOrderVoice
+	sealed class AttackMove : IIssueOrder, IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
 		readonly IMove move;
@@ -62,6 +62,23 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			move = self.Trait<IMove>();
 			Info = info;
+		}
+
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		{
+			get
+			{
+				if (Game.Settings.Game.AttackMoveIsDefault)
+					yield return new AttackMoveOrderTargeter(Info);
+			}
+		}
+
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, in Target target, bool queued)
+		{
+			if (order.OrderID == "AttackMove")
+				return new Order(order.OrderID, self, target, queued);
+
+			return null;
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
@@ -177,5 +194,61 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public override bool ClearSelectionOnLeftClick => false;
+	}
+
+	sealed class AttackMoveOrderTargeter : IOrderTargeter
+	{
+		readonly AttackMoveInfo info;
+
+		public AttackMoveOrderTargeter(AttackMoveInfo info)
+		{
+			this.info = info;
+		}
+
+		public string OrderID => "AttackMove";
+
+		// Below Attack's force-attack-ground priority (6) so Ctrl+click on empty
+		// ground can still force-fire, but above Move's priority (4) so a plain
+		// click defaults to attack-move instead of a plain move.
+		public int OrderPriority => 5;
+		public bool IsQueued { get; private set; }
+
+		public bool CanTarget(Actor self, in Target target, ref TargetModifiers modifiers, ref string cursor)
+		{
+			// Alt (ForceMove) is the general "give me a plain move" override used throughout
+			// the game - both when held directly and via the dedicated Force Move button/hotkey.
+			if (modifiers.HasModifier(TargetModifiers.ForceMove))
+				return false;
+
+			// While the player is using the repurposed attack-move button/hotkey to force a
+			// plain default click (see MoveOrderGenerator), attack-move must not compete with it.
+			if (self.World.OrderGenerator is MoveOrderGenerator)
+				return false;
+
+			// AttackMove only overrides a plain click on empty terrain - clicking directly on
+			// a unit/building is left entirely to Attack/Enter/Repair/etc.'s own targeters.
+			if (target.Type != TargetType.Terrain)
+				return false;
+
+			// AttackMove is meaningless without AutoTarget, and only makes sense if the order is accepted.
+			if (!self.Info.HasTraitInfo<AutoTargetInfo>() || !self.AcceptsOrder(OrderID))
+				return false;
+
+			IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
+
+			var location = self.World.Map.CellContaining(target.CenterPosition);
+			var explored = self.Owner.Shroud.IsExplored(location);
+
+			cursor = !self.World.Map.Contains(location) || (!explored && !info.MoveIntoShroud)
+				? info.AttackMoveBlockedCursor
+				: info.AttackMoveCursor;
+
+			return true;
+		}
+
+		public bool TargetOverridesSelection(Actor self, in Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers)
+		{
+			return modifiers.HasModifier(TargetModifiers.ForceMove);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -22,6 +22,18 @@ namespace OpenRA.Mods.Common.Widgets
 	/// <summary>Contains all functions that are unit-specific.</summary>
 	public class CommandBarLogic : ChromeLogic
 	{
+		[FluentReference]
+		const string AttackMoveTooltip = "button-command-bar-attack-move.tooltip";
+
+		[FluentReference]
+		const string AttackMoveTooltipDesc = "button-command-bar-attack-move.tooltipdesc";
+
+		[FluentReference]
+		const string AttackMoveAsMoveTooltip = "button-command-bar-attack-move-as-move.tooltip";
+
+		[FluentReference]
+		const string AttackMoveAsMoveTooltipDesc = "button-command-bar-attack-move-as-move.tooltipdesc";
+
 		readonly World world;
 
 		int selectionHash;
@@ -52,10 +64,33 @@ namespace OpenRA.Mods.Common.Widgets
 			var attackMoveButton = widget.GetOrNull<ButtonWidget>("ATTACK_MOVE");
 			if (attackMoveButton != null)
 			{
+				// The tooltip is repurposed depending on the AttackMoveIsDefault setting (see below),
+				// so it can't be bound statically from the yaml TooltipText/TooltipDesc keys - it needs
+				// to switch between the two behaviours at runtime. The icon stays the same in both cases
+				// (there is no dedicated "Move" icon in the command-icons sprite sheet).
 				WidgetUtils.BindButtonIcon(attackMoveButton);
 
+				var attackMoveTooltip = FluentProvider.GetMessage(AttackMoveTooltip);
+				var attackMoveTooltipDesc = FluentProvider.GetMessage(AttackMoveTooltipDesc);
+				var attackMoveAsMoveTooltip = FluentProvider.GetMessage(AttackMoveAsMoveTooltip);
+				var attackMoveAsMoveTooltipDesc = FluentProvider.GetMessage(AttackMoveAsMoveTooltipDesc);
+
+				attackMoveButton.GetTooltipText = () => Game.Settings.Game.AttackMoveIsDefault
+					? attackMoveAsMoveTooltip
+					: attackMoveTooltip;
+				attackMoveButton.GetTooltipDesc = () => Game.Settings.Game.AttackMoveIsDefault
+					? attackMoveAsMoveTooltipDesc
+					: attackMoveTooltipDesc;
+
 				attackMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return attackMoveDisabled; };
-				attackMoveButton.IsHighlighted = () => world.OrderGenerator is AttackMoveOrderGenerator;
+
+				// When attack-move is the default click behaviour, this button/key is repurposed
+				// to issue a plain Move instead (AttackMoveOrderTargeter otherwise wins on a plain click -
+				// see its OrderPriority). When the player has turned that off, it keeps its original
+				// sticky attack-move-mode behaviour.
+				attackMoveButton.IsHighlighted = () => Game.Settings.Game.AttackMoveIsDefault
+					? world.OrderGenerator is MoveOrderGenerator
+					: world.OrderGenerator is AttackMoveOrderGenerator;
 
 				void Toggle(bool allowCancel)
 				{
@@ -64,6 +99,8 @@ namespace OpenRA.Mods.Common.Widgets
 						if (allowCancel)
 							world.CancelInputMode();
 					}
+					else if (Game.Settings.Game.AttackMoveIsDefault)
+						world.OrderGenerator = new MoveOrderGenerator(world);
 					else
 						world.OrderGenerator = new AttackMoveOrderGenerator(world, selectedActors);
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -324,7 +324,9 @@ namespace OpenRA.Mods.Common.Widgets
 				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld && !a.IsDead)
 				.ToArray();
 
-			attackMoveDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
+			attackMoveDisabled = Game.Settings.Game.AttackMoveIsDefault
+				? !selectedActors.Any(a => a.Info.HasTraitInfo<IMoveInfo>())
+				: !selectedActors.Any(a => a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
 			guardDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<GuardInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
 			forceMoveDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<MobileInfo>() || a.Info.HasTraitInfo<AircraftInfo>());
 			forceAttackDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<AttackBaseInfo>());

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/HotkeysSettingsLogic.cs
@@ -31,6 +31,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[FluentReference]
 		const string AnyContext = HotkeyDefinition.ContextFluentPrefix + "-any";
 
+		// The "AttackMove" hotkey is repurposed as plain Move while AttackMoveIsDefault is set (see
+		// CommandBarLogic, which does the equivalent swap for the in-game command bar tooltip) - the
+		// Hotkeys settings list needs the same swap so it doesn't keep calling it "Attack Move".
+		[FluentReference]
+		const string AttackMoveAsMoveDescription = "hotkey-description-attackmove-as-move";
+
+		static string DescriptionMessage(HotkeyDefinition hd)
+		{
+			if (hd.Name == "AttackMove" && Game.Settings.Game.AttackMoveIsDefault)
+				return FluentProvider.GetMessage(AttackMoveAsMoveDescription);
+
+			return FluentProvider.GetMessage(hd.Description);
+		}
+
 		public static IEnumerable<(string Key, FluentReferenceAttribute Reference)> DynamicFluentReferences(Dictionary<string, MiniYaml> logicArgs)
 		{
 			if (logicArgs.TryGetValue("HotkeyGroups", out var hotkeyGroupsYaml))
@@ -75,7 +89,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			key.Id = hd.Name;
 			key.IsVisible = () => true;
 
-			var desc = FluentProvider.GetMessage(hd.Description) + ":";
+			var desc = DescriptionMessage(hd) + ":";
 			key.Get<LabelWidget>("FUNCTION").GetText = () => desc;
 
 			var remapButton = key.Get<ButtonWidget>("HOTKEY");
@@ -232,7 +246,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var label = panel.Get<LabelWidget>("HOTKEY_LABEL");
 			var labelText = new CachedTransform<HotkeyDefinition, string>(
-				hd => (hd != null ? FluentProvider.GetMessage(hd.Description) : "") + ":");
+				hd => (hd != null ? DescriptionMessage(hd) : "") + ":");
 			label.IsVisible = () => selectedHotkeyDefinition != null;
 			label.GetText = () => labelText.Update(selectedHotkeyDefinition);
 
@@ -243,7 +257,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				hd != null
 					? FluentProvider.GetMessage(
 						DuplicateNotice,
-						"key", FluentProvider.GetMessage(hd.Description),
+						"key", DescriptionMessage(hd),
 						"context", FluentProvider.GetMessage(hd.Contexts.First(c => selectedHotkeyDefinition.Contexts.Contains(c))))
 					: "");
 			duplicateNotice.GetText = () => duplicateNoticeText.Update(duplicateHotkeyDefinition);

--- a/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Settings/InputSettingsLogic.cs
@@ -62,6 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var scrollPanel = panel.Get<ScrollPanelWidget>("SETTINGS_SCROLLPANEL");
 
 			SettingsUtils.BindCheckboxPref(panel, "ALTERNATE_SCROLL_CHECKBOX", gameSettings, "UseAlternateScrollButton");
+			SettingsUtils.BindCheckboxPref(panel, "ATTACKMOVE_DEFAULT_CHECKBOX", gameSettings, "AttackMoveIsDefault");
 			SettingsUtils.BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gameSettings, "ViewportEdgeScroll");
 			SettingsUtils.BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gameSettings, "LockMouseWindow");
 			SettingsUtils.BindSliderPref(panel, "ZOOMSPEED_SLIDER", gameSettings, "ZoomSpeed");
@@ -146,6 +147,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				gameSettings.MouseControlStyle = defaultGameSettings.MouseControlStyle;
 				gameSettings.MouseScroll = defaultGameSettings.MouseScroll;
 				gameSettings.UseAlternateScrollButton = defaultGameSettings.UseAlternateScrollButton;
+				gameSettings.AttackMoveIsDefault = defaultGameSettings.AttackMoveIsDefault;
 				gameSettings.LockMouseWindow = defaultGameSettings.LockMouseWindow;
 				gameSettings.ViewportEdgeScroll = defaultGameSettings.ViewportEdgeScroll;
 				gameSettings.ViewportEdgeScrollStep = defaultGameSettings.ViewportEdgeScrollStep;

--- a/mods/cnc/chrome/settings-input.yaml
+++ b/mods/cnc/chrome/settings-input.yaml
@@ -280,6 +280,19 @@ Container@INPUT_PANEL:
 					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
+						Container@ATTACKMOVE_DEFAULT_CHECKBOX_CONTAINER:
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Checkbox@ATTACKMOVE_DEFAULT_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-attackmove-default-container
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 20
+					Children:
 						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -246,6 +246,17 @@ button-command-bar-attack-move =
 
     Left-click icon then right-click on target location.
 
+button-command-bar-attack-move-as-move =
+    .tooltip = Move
+    .tooltipdesc =
+    Selected units will move to the desired location
+    without automatically engaging enemies encountered en route.
+
+    Attack Move (attacking any enemies encountered en route)
+    is the default when no key is held.
+
+    Left-click icon then right-click on target location.
+
 button-command-bar-force-move =
     .tooltip = Force Move
     .tooltipdesc =

--- a/mods/cnc/fluent/chrome.ftl
+++ b/mods/cnc/fluent/chrome.ftl
@@ -786,6 +786,7 @@ button-hotkey-remap-dialog-reset =
 ## settings-input.yaml
 label-zoom-modifier-container = Zoom Modifier:
 checkbox-alternate-scroll-container = Alternate Mouse Panning
+checkbox-attackmove-default-container = Swap default: Move / Attack Move
 checkbox-lockmouse-container = Lock Mouse to Window
 label-mouse-scroll-type-container = Pan Behaviour:
 label-scrollspeed-slider-container-scroll-speed = Pan Speed:

--- a/mods/common/chrome/settings-input.yaml
+++ b/mods/common/chrome/settings-input.yaml
@@ -280,6 +280,19 @@ Container@INPUT_PANEL:
 					Width: PARENT_WIDTH - 24
 					Height: 20
 					Children:
+						Container@ATTACKMOVE_DEFAULT_CHECKBOX_CONTAINER:
+							X: PARENT_WIDTH / 2 + 10
+							Width: PARENT_WIDTH / 2 - 20
+							Children:
+								Checkbox@ATTACKMOVE_DEFAULT_CHECKBOX:
+									Width: PARENT_WIDTH
+									Height: 20
+									Font: Regular
+									Text: checkbox-attackmove-default-container
+				Container@ROW:
+					Width: PARENT_WIDTH - 24
+					Height: 20
+					Children:
 						Container@LOCKMOUSE_CHECKBOX_CONTAINER:
 							X: PARENT_WIDTH / 2 + 10
 							Width: PARENT_WIDTH / 2 - 20

--- a/mods/common/fluent/chrome.ftl
+++ b/mods/common/fluent/chrome.ftl
@@ -287,6 +287,17 @@ button-command-bar-attack-move =
 
     Left-click icon then right-click on target location.
 
+button-command-bar-attack-move-as-move =
+    .tooltip = Move
+    .tooltipdesc =
+    Selected units will move to the desired location
+    without automatically engaging enemies encountered en route.
+
+    Attack Move (attacking any enemies encountered en route)
+    is the default when no key is held.
+
+    Left-click icon then right-click on target location.
+
 button-command-bar-guard =
     .tooltip = Guard
     .tooltipdesc =
@@ -726,6 +737,7 @@ button-hotkey-remap-dialog-reset =
 ## settings-input.yaml
 label-zoom-modifier-container = Zoom Modifier:
 checkbox-alternate-scroll-container = Alternate Mouse Panning
+checkbox-attackmove-default-container = Swap default: Move / Attack Move
 checkbox-lockmouse-container = Lock Mouse to Window
 label-mouse-scroll-type-container = Pan Behaviour:
 label-scrollspeed-slider-container-scroll-speed = Pan Speed:

--- a/mods/common/fluent/hotkeys.ftl
+++ b/mods/common/fluent/hotkeys.ftl
@@ -99,6 +99,7 @@ hotkey-description-toggleplayerstancecolor = Toggle relationship colors
 hotkey-description-takescreenshot = Take screenshot
 hotkey-description-quicksave = Quick Save
 hotkey-description-attackmove = Attack Move
+hotkey-description-attackmove-as-move = Move
 hotkey-description-stop = Stop
 hotkey-description-scatter = Scatter
 hotkey-description-deploy = Deploy


### PR DESCRIPTION
Motivation: The proportion of amove vs move is abysmal and therefore player needs to press key before mouse click almost every time (debatable, but still). Seems to be weird design, considering amount of QoL improvements OpenRA have comparing to the original games.

Intention: Allow player to use arguably most used move command - AttackMove as default Move command, without need of modifiers.

- Similiar type of QoL enhancement, like existing Alternate Mouse panning.
- To not force any of regular players change their muscle memory, default is off -> same behauviour 
- Modifiers are unchanged
- Tooltip changes according selected behauviour


https://github.com/user-attachments/assets/9d36bc5e-5610-4efc-bdda-ed90735528f9

