### PR TITLE
Add an experimental C++23 port of the YAML and reflection modules

### DIFF
--- a/CPP23/.gitignore
+++ b/CPP23/.gitignore
@@ -1,0 +1,2 @@
+# 构建产物 / build artifacts
+build/

--- a/CPP23/CMakeLists.txt
+++ b/CPP23/CMakeLists.txt
@@ -32,7 +32,9 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options(-Wall -Wextra -Wpedantic)
+# 错误处理策略：严禁异常 —— 全部错误经 std::expected<T, YamlError> 传播
+# Error-handling policy: exceptions are forbidden - all errors propagate via std::expected
+add_compile_options(-Wall -Wextra -Wpedantic -fno-exceptions)
 
 add_library(openra_yaml
     src/MiniYaml.cpp

--- a/CPP23/CMakeLists.txt
+++ b/CPP23/CMakeLists.txt
@@ -1,0 +1,45 @@
+# OpenRA C++23 分模块移植 / OpenRA C++23 incremental port
+#
+# 工具链约定（跨平台一致）：统一使用 LLVM Clang 的 GNU ABI 目标——
+# Toolchain convention (cross-platform consistent): always LLVM Clang targeting the GNU ABI.
+#   Windows: llvm-mingw 的 clang++（x86_64-w64-windows-gnu，libc++，Itanium ABI）
+#            llvm-mingw clang++ (self-contained, libc++, Itanium ABI)
+#   Linux:   系统 clang++（目标天然相同）/ system clang++ (identical target)
+# 这样避免了 MSVC ABI（名称修饰/异常/std 模板行为差异），三平台编译产物行为一致。
+# This avoids the MSVC ABI (mangling/exception/std template differences) for consistent behavior.
+#
+# 构建 / Build:
+#   cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+#          -DCMAKE_CXX_COMPILER=<llvm-mingw 的 clang++ 路径 / path to clang++>
+#   cmake --build build
+#   ctest --test-dir build --output-on-failure
+cmake_minimum_required(VERSION 3.24)
+project(openra_cpp23 LANGUAGES CXX)
+
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "This project requires LLVM Clang (GNU ABI target, e.g. llvm-mingw on Windows).")
+endif()
+
+if(WIN32 AND NOT CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "")
+    # 附加保护：MSVC-ABI 的官方 clang 会定义 _MSC_VER——拒绝以防误用
+    # Extra guard: MSVC-ABI clang defines _MSC_VER - refuse it to prevent accidental use
+    if(CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+        message(FATAL_ERROR "MSVC-ABI clang detected. Use llvm-mingw clang++ (GNU ABI) instead.")
+    endif()
+endif()
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+add_library(openra_yaml
+    src/MiniYaml.cpp
+)
+target_include_directories(openra_yaml PUBLIC include)
+
+enable_testing()
+add_executable(openra_yaml_tests tests/test_main.cpp)
+target_link_libraries(openra_yaml_tests PRIVATE openra_yaml)
+add_test(NAME yaml_tests COMMAND openra_yaml_tests)

--- a/CPP23/README.md
+++ b/CPP23/README.md
@@ -29,6 +29,42 @@ cmake --build build
 Windows 下可直接运行 `build.cmd [test]`。
 On Windows just run `build.cmd [test]`.
 
+## 编码规范：严禁异常 / Coding Rule: No Exceptions
+
+**C++23 移植全程严禁使用异常抛出。**
+**Exception throwing is strictly forbidden across the C++23 port.**
+
+该规则由构建系统强制执行：所有目标统一编译于 `-fno-exceptions`（见 `CMakeLists.txt`），
+任何残留的 `throw` 会直接导致编译失败。
+The rule is enforced by the build: every target compiles with `-fno-exceptions` (see
+`CMakeLists.txt`), so any leftover `throw` fails the build outright.
+
+错误处理统一约定：
+The unified error-handling convention:
+
+- **可失败路径**返回 `std::expected<T, OpenRA::YamlError>`（C++23），错误沿调用链显式传播；
+  对应 C# 侧抛 `YamlException` / `FieldLoadException` 的每一个路径。
+  **Fallible paths** return `std::expected<T, OpenRA::YamlError>` (C++23) and errors propagate
+  explicitly up the call chain, covering every path that throws `YamlException` /
+  `FieldLoadException` on the C# side.
+- **不可失败路径**（纯合并/查询等）保持普通返回值，不裹 expected。
+  **Infallible paths** (pure merging/queries) keep plain return types, unwrapped.
+- 快速查询可用可空指针变体（如 `nodeWithKeyOrNull`）。
+  Fast queries may use nullable-pointer variants (e.g. `nodeWithKeyOrNull`).
+
+```cpp
+// 示例：错误显式向上传播 / example: errors propagate explicitly
+auto nodes = OpenRA::miniYamlFromString(text, "rules");
+if (!nodes.has_value())
+    return std::unexpected(std::move(nodes).error());  // 而非 throw / instead of throwing
+```
+
+选择无异常的原因：确定性控制流便于引擎级审计、消除栈展开的代码体积与运行时开销、
+与游戏主循环的错误恢复策略（降级/日志/跳过）自然衔接。
+Rationale: deterministic control flow is easier to audit at engine level, stack unwinding's
+code-size and runtime cost disappears, and it fits the game loop's recovery strategy
+(degrade/log/skip) naturally.
+
 ## 移植进度总览 / Port Status Overview
 
 模块规模按 C# 侧文件数/行数标注，作为工作量参考。

--- a/CPP23/README.md
+++ b/CPP23/README.md
@@ -1,0 +1,130 @@
+# OpenRA C++23 分模块移植 / OpenRA Incremental C++23 Port
+
+按模块把引擎从 C#/.NET 移植到 C++23。本目录独立于 C# 代码树构建，与主工程互不影响。
+Incrementally ports the engine from C#/.NET to C++23. This directory builds independently of the C# tree and does not affect the main project.
+
+## 工具链 / Toolchain
+
+CMake + Ninja + **LLVM Clang（GNU ABI）**，跨平台统一：
+CMake + Ninja + **LLVM Clang (GNU ABI)**, consistent across platforms:
+
+- Windows：[llvm-mingw](https://github.com/mstorsjo/llvm-mingw) 的 clang++（自包含：clang + libc++ + mingw-w64，Itanium ABI）
+  Windows: clang++ from [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) (self-contained: clang + libc++ + mingw-w64, Itanium ABI)
+- Linux：系统 clang++（目标天然一致）
+  Linux: the system clang++ (naturally the same target)
+
+刻意不使用 MSVC-ABI 的官方 clang 发行版：名称修饰、异常与 std 模板行为差异会破坏三平台一致性。
+The MSVC-ABI official clang distribution is deliberately avoided: mangling, exception and std template behavior differences would break three-platform consistency.
+
+```sh
+# 构建 / Build
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=<clang++ 路径 / path to clang++>
+cmake --build build
+
+# 测试（第二个参数指向仓库根，用于真实 mod 文件冒烟测试）
+# Tests (arg 2 points at the repo root for real-mod smoke tests)
+./build/openra_yaml_tests.exe ..
+```
+
+Windows 下可直接运行 `build.cmd [test]`。
+On Windows just run `build.cmd [test]`.
+
+## 移植进度总览 / Port Status Overview
+
+模块规模按 C# 侧文件数/行数标注，作为工作量参考。
+Module sizes are annotated with the C#-side file/line counts as an effort reference.
+
+### ✅ 已完成 / Completed
+
+| 模块 / Module | 内容 / Content | 位置 / Location | 对应 C# / C# equivalent |
+|---|---|---|---|
+| MiniYaml 解析与合并 / parsing & merging | YAML 子集解析、`Inherits@` 继承、`-Key` 删除、多源合并、序列化 / YAML-subset parsing, `Inherits@` inheritance, `-Key` removal, multi-source merging, serialization | `include/openra/MiniYaml.h` + `src/MiniYaml.cpp` | `OpenRA.Game/MiniYaml.cs`（786 行，逐段保真翻译 / faithful section-by-section port） |
+| 字段绑定 / field binding | 编译期字段元数据（成员指针，零宏）/ compile-time field metadata (member pointers, no macros) | `include/openra/Fields.h` | `FieldLoader.GetTypeLoadInfo` 的反射枚举 / its reflection-based field enumeration |
+| 值注入 / value injection | 标量/string/vector/嵌套结构的 YAML→对象注入，坏值与未知字段处理 / YAML→object injection for scalars/string/vector/nested structs, invalid-value and unknown-field handling | `include/openra/FieldLoader.h` | `FieldLoader.cs` 核心（910 行）/ the core of `FieldLoader.cs` |
+| 类型工厂 / type factory | 类型名→工厂注册（`OPENRA_REGISTER_TYPE` 宏，替代运行时反射）/ type-name → factory registration (macro, replacing runtime reflection) | `include/openra/TypeRegistry.h` | `ObjectCreator.CreateObject` 反射工厂 / its reflection factory |
+| 构建与测试 / build & tests | CMake/Ninja 配置、37 项断言测试、真实 mod 文件冒烟 / CMake/Ninja setup, 37 assertion tests, real-mod smoke tests | `CMakeLists.txt`、`tests/test_main.cpp` | — |
+
+方言行为与 C# 版一致：4 空格或 1 tab 一级缩进、`#` 注释（`\#` 转义）、反斜杠空白保护、
+同父重复继承报错、弱删除语义。
+Dialect behavior matches the C# version: 4 spaces or 1 tab per indent level, `#` comments
+(`\#` escaped), backslash whitespace guards, duplicate-inheritance errors, weak removal semantics.
+
+### ⬜ 待移植 / Pending
+
+按依赖顺序分四个阶段，每阶段内条目可并行。
+Four phases in dependency order; items within a phase can proceed in parallel.
+
+**阶段一：基础层（引擎的可移植地基）/ Phase 1: Foundation**
+
+| 模块 / Module | 对应 C# / C# equivalent | 规模 / Size | 备注 / Notes |
+|---|---|---|---|
+| 游戏数值类型 / game value types | `Primitives/`（WDist/WAngle/WPos/int2/float2/Color/Size/Rectangle 等） | ~30 文件 | 接入 `FieldLoader` 特化后规则数据即可完整加载 / plug into `FieldLoader` specializations to complete rule-data loading |
+| 支持设施 / support utilities | `Support/`（Log/PerfTimer/Arguments）+ 根目录 Exts | ~16 文件 | 日志先行，后续模块依赖 / logging first, other modules depend on it |
+| 文件系统 / file system | `FileSystem/`（Mix 包/Folder/Zip） | ~4 文件 + 格式 | Mix 解析是 mod 加载的前提 / Mix parsing is a prerequisite for mod loading |
+| 规则装配入口 / rules assembly entry | `MiniYaml.Load(filesystem, files, mapRules)` 多文件合并 | — | 已有 Merge，补文件系统遍历 / Merge exists; add filesystem traversal |
+
+**阶段二：引擎核心 / Phase 2: Engine Core**
+
+| 模块 / Module | 对应 C# / C# equivalent | 规模 / Size | 备注 / Notes |
+|---|---|---|---|
+| Actor/Trait 系统 / actor-trait system | `World.cs`/`Actor.cs`/`TraitDictionary.cs` + 规则加载 | ~49 根文件 | 直接复用 TypeRegistry/Fields / reuses TypeRegistry/Fields directly |
+| 平台层 / platform layer | `Platforms.Default`（窗口/输入/上下文，SDL3 + OpenGL 或 SDL_GPU） | ~18 文件 | C# 侧 SDL3 迁移经验（全屏/线程亲和坑）已有沉淀 / carries over the SDL3 fullscreen/thread-affinity lessons |
+| 图形渲染 / rendering | `Graphics/`（Renderer/Sprite/Sheet/Palette/着色器抽象） | ~37 文件 | 最大单体；管线模型选型（GL 状态机 vs SDL_GPU）在此定 / biggest single piece; GL state-machine vs SDL_GPU decision happens here |
+| Widget 框架 / widget framework | `Widgets/` 基类 + `WidgetLoader`（YAML 布局） | 框架 ~10 文件 | 布局加载复用 Fields/FieldLoader / layout loading reuses Fields/FieldLoader |
+| 网络与同步 / networking & sync | `Network/`（OrderManager/Order 序列化/锁步） | ~17 文件 | Order 序列化需逐条接入字段元数据 / Order serialization wires into field metadata |
+| 声音 / audio | `Sound/` + OpenAL | ~2 文件 | openal-soft 原生库直连 / direct openal-soft usage |
+| 本地化 / localization | Fluent（Linguini） | — | C++ 实现薄弱，需自研子集 / weak C++ ecosystem; a subset must be built |
+| Lua 脚本 / Lua scripting | `Scripting/`（Eluant） | ~7 文件 | sol2/LuaJit 替代 / replaced by sol2/LuaJit |
+| 地图格式 / map format | `Map/` | ~19 文件 | 依赖文件系统与数值类型 / depends on the file system and value types |
+
+**阶段三：游戏内容 / Phase 3: Game Content**
+
+| 模块 / Module | 对应 C# / C# equivalent | 规模 / Size | 备注 / Notes |
+|---|---|---|---|
+| 通用 traits / common traits | `Mods.Common/Traits/` | ~501 文件 | 量最大；机械翻译 + 字段标注 / the bulk; mechanical porting plus field annotation |
+| 通用 widgets / common widgets | `Mods.Common/Widgets/` | ~192 文件 | 依赖 Widget 框架 / depends on the widget framework |
+| Cnc/D2k 特化 / Cnc & D2k specifics | `Mods.Cnc` + `Mods.D2k` | ~163 文件 | 最后收尾 / final stretch |
+
+**阶段四：外围 / Phase 4: Periphery**
+
+| 模块 / Module | 对应 C# / C# equivalent | 备注 / Notes |
+|---|---|---|
+| 工具 / utility | `Utility`（地图/lint/资源工具） | lint 依赖 trait 注册完整性 / linting depends on complete trait registration |
+| 专用服务器 / dedicated server | `Server`（~124 行入口 + `Game/Server`） | 依赖网络同步层 / depends on the networking layer |
+| 启动器与打包 / launcher & packaging | `WindowsLauncher` + 各平台安装包 | CMake 安装目标重做 / redo as CMake install targets |
+
+## C++ 侧替代反射的写法 / Replacing reflection on the C++ side
+
+```cpp
+struct WeaponInfo
+{
+    int damage = 0;
+    float range = 0;
+    static constexpr auto openra_fields = std::tuple{
+        OpenRA::field("Damage", &WeaponInfo::damage),   // YAML 名可与成员名不同 / YAML name may differ from the member name
+        OpenRA::field("Range", &WeaponInfo::range),
+    };
+};
+
+// 注册工厂（替代 ObjectCreator 的反射查找）
+// Register a factory (replaces ObjectCreator's reflective lookup)
+OPENRA_REGISTER_TYPE(TraitInfo, HealthInfo)
+
+// 从合并后的规则树实例化并注入
+// Instantiate from the merged rules tree and inject values
+auto trait = TypeRegistry<TraitInfo>::create("HealthInfo");
+auto* hi = dynamic_cast<HealthInfo*>(trait.get());
+FieldLoader::load(*hi, *node.value);
+```
+
+待 C++26 静态反射在三大编译器普及后，`openra_fields` 声明可改为自动枚举，业务代码不变。
+Once C++26 static reflection is available in all three major compilers, the `openra_fields`
+declarations can be replaced by automatic enumeration without touching business code.
+
+## 测试 / Tests
+
+`tests/test_main.cpp` 覆盖：解析（缩进/注释/转义/tab/坏缩进）、合并继承删除、重复继承异常、
+序列化回环、字段注入（含缺省/错误值）、类型注册，以及 `mods/ra/rules` 下全部真实 YAML 的冒烟解析。
+`tests/test_main.cpp` covers: parsing (indentation/comments/escapes/tabs/bad indents), merge/inherit/removal,
+duplicate-inheritance errors, serialization round-trips, field injection (defaults and invalid values),
+type registration, plus smoke-parsing every real YAML file under `mods/ra/rules`.

--- a/CPP23/build.cmd
+++ b/CPP23/build.cmd
@@ -1,0 +1,19 @@
+@echo off
+rem CMake + LLVM Clang（GNU ABI / llvm-mingw）构建脚本
+rem CMake + LLVM Clang (GNU ABI / llvm-mingw) build script
+rem 用法 / Usage: build.cmd [test]
+setlocal
+cd /d "%~dp0"
+
+rem llvm-mingw 是 LLVM 官方维护的自包含工具链（clang + libc++ + mingw-w64，GNU ABI）
+rem llvm-mingw is LLVM's self-contained toolchain (clang + libc++ + mingw-w64, GNU ABI)
+set "CLANG=%LOCALAPPDATA%\Microsoft\WinGet\Packages\MartinStorsjo.LLVM-MinGW.UCRT_Microsoft.Winget.Source_8wekyb3d8bbwe\llvm-mingw-20260519-ucrt-x86_64\bin\clang++.exe"
+if not exist "%CLANG%" set CLANG=clang++
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER="%CLANG%" || exit /b 1
+cmake --build build || exit /b 1
+
+if "%~1"=="test" (
+    ctest --test-dir build --output-on-failure || exit /b 1
+)
+endlocal

--- a/CPP23/include/openra/FieldLoader.h
+++ b/CPP23/include/openra/FieldLoader.h
@@ -1,0 +1,191 @@
+// FieldLoader —— YAML 值到 C++ 字段的注入（C++23 移植版）
+// FieldLoader - injecting YAML values into C++ fields (C++23 port)
+//
+// 对应 OpenRA.Game/FieldLoader.cs 的核心能力：
+// Mirrors the core of OpenRA.Game/FieldLoader.cs:
+//   - GetValue<T>：字符串到类型的解析（数字/布尔/字符串/向量）
+//     GetValue<T>: string-to-type parsing (numbers/bools/strings/vectors)
+//   - Load：按 openra_fields 元数据把 MiniYaml 子节点注入对象
+//     Load: inject MiniYaml child nodes into objects via openra_fields metadata
+//   - 未知字段回调（lint 用）/ unknown-field callback (for linting)
+//
+// 与 C# 版的差异 / Differences from the C# version:
+//   - C# 按 Type 动态分发；C++ 用 if constexpr 编译期分发
+//     C# dispatches on Type at runtime; C++ dispatches via if constexpr at compile time
+//   - 首版覆盖核心类型（整型/浮点/布尔/string/vector<T>/嵌套结构体）
+//     The first version covers core types (integrals/floats/bool/string/vector<T>/nested structs)
+//   - 游戏专用类型（WDist/WAngle/Color 等）随后续模块移植接入
+//     Game-specific types (WDist/WAngle/Color, ...) plug in as later modules are ported
+
+#pragma once
+
+#include "openra/Fields.h"
+#include "openra/MiniYaml.h"
+
+#include <charconv>
+#include <iostream>
+#include <map>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace OpenRA
+{
+	struct FieldLoadException : std::runtime_error
+	{
+		explicit FieldLoadException(const std::string& s)
+			: std::runtime_error(s) { }
+	};
+
+	namespace FieldLoader
+	{
+		// 相互递归（嵌套结构），在本命名空间内前向声明
+		// Mutually recursive (nested structs); forward-declared inside this namespace
+		template<class T>
+		void load(T& obj, const MiniYaml& yaml);
+		// 未知字段处理器（对应 C# UnknownFieldAction）/ unknown field handler (C# UnknownFieldAction)
+		inline std::function<void(std::string_view, std::string_view)> unknownFieldAction =
+			[](std::string_view field, std::string_view type)
+			{
+				std::cerr << "FieldLoader: Unknown field `" << field << "` on `" << type << "`\n";
+			};
+
+		namespace Detail
+		{
+			template<class T>
+			struct IsVector : std::false_type { };
+			template<class E, class A>
+			struct IsVector<std::vector<E, A>> : std::true_type { };
+
+			inline void splitSpaces(std::string_view value, std::vector<std::string_view>& parts)
+			{
+				size_t start = 0;
+				while (start <= value.size())
+				{
+					auto pos = value.find(' ', start);
+					if (pos == std::string_view::npos)
+					{
+						if (start < value.size())
+							parts.emplace_back(value.substr(start));
+						break;
+					}
+
+					if (pos > start)
+						parts.emplace_back(value.substr(start, pos - start));
+					start = pos + 1;
+				}
+			}
+
+			// 标量解析：整型/浮点/bool 走字符转换，其余特化处理
+			// Scalar parsing: integrals/floats via from_chars; the rest is specialized
+			template<class T>
+			T parseScalar(std::string_view field, std::string_view value)
+			{
+				if constexpr (std::is_same_v<T, bool>)
+				{
+					if (value == "true") return true;
+					if (value == "false") return false;
+					throw FieldLoadException("FieldLoader: Cannot parse `" + std::string(value)
+						+ "` as bool for field `" + std::string(field) + "`");
+				}
+				else if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>)
+				{
+					T result{};
+					auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), result);
+					if (ec != std::errc{})
+						throw FieldLoadException("FieldLoader: Cannot parse `" + std::string(value)
+							+ "` as " + (std::is_integral_v<T> ? "integer" : "float")
+							+ " for field `" + std::string(field) + "`");
+					return result;
+				}
+				else
+				{
+					static_assert(!sizeof(T), "Unsupported scalar type; add a specialization");
+				}
+			}
+		}
+
+		// 值解析入口 / value parsing entry point
+		// 支持：标量、std::string、std::vector<E>（空格分隔）、声明了 openra_fields 的嵌套结构
+		// Supports: scalars, std::string, std::vector<E> (space separated), nested structs with openra_fields
+		template<class T>
+		T getValue(std::string_view field, const MiniYaml& yaml)
+		{
+			if constexpr (HasFieldsV<T>)
+			{
+				// 嵌套结构体从子节点加载 / nested structs load from child nodes
+				T result{};
+				load(result, yaml);
+				return result;
+			}
+			else if constexpr (std::is_same_v<T, std::string>)
+			{
+				return yaml.value ? *yaml.value : std::string{};
+			}
+			else if constexpr (Detail::IsVector<T>::value)
+			{
+				using E = typename T::value_type;
+				T result;
+				if (yaml.value && !yaml.value->empty())
+				{
+					std::vector<std::string_view> parts;
+					Detail::splitSpaces(*yaml.value, parts);
+					result.reserve(parts.size());
+					for (const auto& p : parts)
+						result.push_back(Detail::parseScalar<E>(field, p));
+				}
+
+				return result;
+			}
+			else
+			{
+				return Detail::parseScalar<T>(field, yaml.value ? *yaml.value : std::string_view{});
+			}
+		}
+
+		// 对象加载：遍历 openra_fields，按名匹配子节点注入
+		// Object loading: walk openra_fields, injecting matching child nodes by name
+		template<class T>
+		void load(T& obj, const MiniYaml& yaml)
+		{
+			static_assert(HasFieldsV<T>, "Type must declare openra_fields metadata");
+
+			// 先按 key 建索引（保序首键优先）/ index by key first (first occurrence wins)
+			std::map<std::string, const MiniYaml*> md;
+			for (const auto& n : yaml.nodes)
+			{
+				if (!n.key)
+					continue;
+				if (!md.emplace(*n.key, n.value.get()).second)
+					throw YamlException("Duplicate key '" + *n.key + "' in " + n.location.name
+						+ ":" + std::to_string(n.location.line));
+			}
+
+			forEachField(obj, [&](std::string_view name, auto& member) {
+				auto it = md.find(std::string(name));
+				if (it == md.end())
+					return; // 缺省字段保留默认值 / absent fields keep their defaults
+
+				using Member = std::remove_reference_t<decltype(member)>;
+				member = getValue<Member>(name, *it->second);
+			});
+
+			// 未知字段上报（对应 C# 的 UnknownFieldAction）/ report unknown fields
+			for (const auto& [k, v] : md)
+			{
+				if (!hasField<T>(k))
+					unknownFieldAction(k, "?");
+			}
+		}
+
+		// 便捷形式 / convenience form
+		template<class T>
+		T load(const MiniYaml& yaml)
+		{
+			T result{};
+			load(result, yaml);
+			return result;
+		}
+	}
+}

--- a/CPP23/include/openra/FieldLoader.h
+++ b/CPP23/include/openra/FieldLoader.h
@@ -10,6 +10,9 @@
 //   - 未知字段回调（lint 用）/ unknown-field callback (for linting)
 //
 // 与 C# 版的差异 / Differences from the C# version:
+//   - 严禁异常：C# 抛 FieldLoadException 的路径一律返回 std::expected<T, YamlError>
+//     No exceptions allowed: paths that throw FieldLoadException in C# return
+//     std::expected<T, YamlError> instead (enforced by -fno-exceptions in the build)
 //   - C# 按 Type 动态分发；C++ 用 if constexpr 编译期分发
 //     C# dispatches on Type at runtime; C++ dispatches via if constexpr at compile time
 //   - 首版覆盖核心类型（整型/浮点/布尔/string/vector<T>/嵌套结构体）
@@ -23,8 +26,11 @@
 #include "openra/MiniYaml.h"
 
 #include <charconv>
+#include <expected>
+#include <functional>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -32,18 +38,13 @@
 
 namespace OpenRA
 {
-	struct FieldLoadException : std::runtime_error
-	{
-		explicit FieldLoadException(const std::string& s)
-			: std::runtime_error(s) { }
-	};
-
 	namespace FieldLoader
 	{
 		// 相互递归（嵌套结构），在本命名空间内前向声明
 		// Mutually recursive (nested structs); forward-declared inside this namespace
 		template<class T>
-		void load(T& obj, const MiniYaml& yaml);
+		std::expected<void, YamlError> load(T& obj, const MiniYaml& yaml);
+
 		// 未知字段处理器（对应 C# UnknownFieldAction）/ unknown field handler (C# UnknownFieldAction)
 		inline std::function<void(std::string_view, std::string_view)> unknownFieldAction =
 			[](std::string_view field, std::string_view type)
@@ -80,23 +81,23 @@ namespace OpenRA
 			// 标量解析：整型/浮点/bool 走字符转换，其余特化处理
 			// Scalar parsing: integrals/floats via from_chars; the rest is specialized
 			template<class T>
-			T parseScalar(std::string_view field, std::string_view value)
+			std::expected<T, YamlError> parseScalar(std::string_view field, std::string_view value)
 			{
 				if constexpr (std::is_same_v<T, bool>)
 				{
 					if (value == "true") return true;
 					if (value == "false") return false;
-					throw FieldLoadException("FieldLoader: Cannot parse `" + std::string(value)
-						+ "` as bool for field `" + std::string(field) + "`");
+					return std::unexpected(yamlError("FieldLoader: Cannot parse `" + std::string(value)
+						+ "` as bool for field `" + std::string(field) + "`"));
 				}
 				else if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>)
 				{
 					T result{};
 					auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), result);
 					if (ec != std::errc{})
-						throw FieldLoadException("FieldLoader: Cannot parse `" + std::string(value)
+						return std::unexpected(yamlError("FieldLoader: Cannot parse `" + std::string(value)
 							+ "` as " + (std::is_integral_v<T> ? "integer" : "float")
-							+ " for field `" + std::string(field) + "`");
+							+ " for field `" + std::string(field) + "`"));
 					return result;
 				}
 				else
@@ -110,13 +111,15 @@ namespace OpenRA
 		// 支持：标量、std::string、std::vector<E>（空格分隔）、声明了 openra_fields 的嵌套结构
 		// Supports: scalars, std::string, std::vector<E> (space separated), nested structs with openra_fields
 		template<class T>
-		T getValue(std::string_view field, const MiniYaml& yaml)
+		std::expected<T, YamlError> getValue(std::string_view field, const MiniYaml& yaml)
 		{
 			if constexpr (HasFieldsV<T>)
 			{
 				// 嵌套结构体从子节点加载 / nested structs load from child nodes
 				T result{};
-				load(result, yaml);
+				auto ok = load(result, yaml);
+				if (!ok.has_value())
+					return std::unexpected(std::move(ok).error());
 				return result;
 			}
 			else if constexpr (std::is_same_v<T, std::string>)
@@ -133,7 +136,12 @@ namespace OpenRA
 					Detail::splitSpaces(*yaml.value, parts);
 					result.reserve(parts.size());
 					for (const auto& p : parts)
-						result.push_back(Detail::parseScalar<E>(field, p));
+					{
+						auto element = Detail::parseScalar<E>(field, p);
+						if (!element.has_value())
+							return std::unexpected(std::move(element).error());
+						result.push_back(std::move(*element));
+					}
 				}
 
 				return result;
@@ -147,29 +155,39 @@ namespace OpenRA
 		// 对象加载：遍历 openra_fields，按名匹配子节点注入
 		// Object loading: walk openra_fields, injecting matching child nodes by name
 		template<class T>
-		void load(T& obj, const MiniYaml& yaml)
+		std::expected<void, YamlError> load(T& obj, const MiniYaml& yaml)
 		{
 			static_assert(HasFieldsV<T>, "Type must declare openra_fields metadata");
 
-			// 先按 key 建索引（保序首键优先）/ index by key first (first occurrence wins)
+			// 先按 key 建索引（重复键返回错误）/ index by key first (duplicates surface as errors)
 			std::map<std::string, const MiniYaml*> md;
 			for (const auto& n : yaml.nodes)
 			{
 				if (!n.key)
 					continue;
 				if (!md.emplace(*n.key, n.value.get()).second)
-					throw YamlException("Duplicate key '" + *n.key + "' in " + n.location.name
-						+ ":" + std::to_string(n.location.line));
+					return std::unexpected(yamlError("Duplicate key '" + *n.key + "' in " + n.location.name
+						+ ":" + std::to_string(n.location.line)));
 			}
 
+			// forEachField 的 visitor 没有早退通道，首个错误记录后继续（后续错误忽略）
+			// forEachField's visitor has no early-exit channel; record the first error and continue
+			std::optional<YamlError> firstError;
 			forEachField(obj, [&](std::string_view name, auto& member) {
 				auto it = md.find(std::string(name));
 				if (it == md.end())
 					return; // 缺省字段保留默认值 / absent fields keep their defaults
 
 				using Member = std::remove_reference_t<decltype(member)>;
-				member = getValue<Member>(name, *it->second);
+				auto parsed = getValue<Member>(name, *it->second);
+				if (parsed.has_value())
+					member = std::move(*parsed);
+				else if (!firstError.has_value())
+					firstError = std::move(parsed).error();
 			});
+
+			if (firstError.has_value())
+				return std::unexpected(std::move(*firstError));
 
 			// 未知字段上报（对应 C# 的 UnknownFieldAction）/ report unknown fields
 			for (const auto& [k, v] : md)
@@ -177,14 +195,18 @@ namespace OpenRA
 				if (!hasField<T>(k))
 					unknownFieldAction(k, "?");
 			}
+
+			return {};
 		}
 
 		// 便捷形式 / convenience form
 		template<class T>
-		T load(const MiniYaml& yaml)
+		std::expected<T, YamlError> load(const MiniYaml& yaml)
 		{
 			T result{};
-			load(result, yaml);
+			auto ok = load(result, yaml);
+			if (!ok.has_value())
+				return std::unexpected(std::move(ok).error());
 			return result;
 		}
 	}

--- a/CPP23/include/openra/Fields.h
+++ b/CPP23/include/openra/Fields.h
@@ -1,0 +1,97 @@
+// 字段元数据 —— 替代 C# 反射的编译期字段描述
+// Field metadata - compile-time field descriptions replacing C# reflection
+//
+// 对应 C# 侧 FieldLoader.GetTypeLoadInfo(Type)（反射枚举字段）的能力。
+// Replaces what C# does via FieldLoader.GetTypeLoadInfo(Type) reflection.
+//
+// 用法 / Usage:
+//   struct WeaponInfo
+//   {
+//       int Damage;
+//       float Range;
+//       static constexpr auto openra_fields = std::tuple{
+//           OpenRA::field("Damage", &WeaponInfo::Damage),
+//           OpenRA::field("Range", &WeaponInfo::Range),
+//       };
+//   };
+//
+// YAML 字段名与 C++ 成员名可以不同（对应 C# 的 YamlName 特性）
+// YAML names may differ from C++ member names (mirroring C#'s YamlName attribute)
+//
+// 待 C++26 静态反射在三大编译器普及后，可改为自动枚举聚合字段并移除这些声明
+// Once C++26 static reflection is ubiquitous these declarations can be replaced
+// by automatic aggregate field enumeration
+
+#pragma once
+
+#include <functional>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+namespace OpenRA
+{
+	// 字段描述：名字 + 成员指针 / field descriptor: name plus member pointer
+	template<class C, class M>
+	struct FieldDesc
+	{
+		std::string_view name;
+		M C::* ptr;
+	};
+
+	template<class C, class M>
+	constexpr FieldDesc<C, M> field(std::string_view name, M C::* ptr)
+	{
+		return { name, ptr };
+	}
+
+	// 判断类型是否声明了字段元数据 / whether a type declares field metadata
+	template<class T, class = void>
+	struct HasFields : std::false_type { };
+
+	template<class T>
+	struct HasFields<T, std::void_t<decltype(T::openra_fields)>> : std::true_type { };
+
+	template<class T>
+	inline constexpr bool HasFieldsV = HasFields<T>::value;
+
+	namespace FieldsDetail
+	{
+		// 成员指针的类与值类型 / class and value types of a member pointer
+		template<class T>
+		struct MemberTraits;
+		template<class C, class M>
+		struct MemberTraits<M C::*> { using Class = C; using Member = M; };
+	}
+
+	// 遍历字段：visitor(std::string_view name, Member& value)
+	// Visit fields: visitor(std::string_view name, Member& value)
+	template<class T, class Visitor>
+	void forEachField(T&& obj, Visitor&& visitor)
+	{
+		using Plain = std::remove_reference_t<T>;
+		static_assert(HasFieldsV<Plain>, "Type must declare openra_fields metadata");
+		std::apply([&](const auto&... f) {
+			(visitor(f.name, obj.*(f.ptr)), ...);
+		}, Plain::openra_fields);
+	}
+
+	// 字段数 / field count
+	template<class T>
+	constexpr size_t fieldCount()
+	{
+		static_assert(HasFieldsV<T>, "Type must declare openra_fields metadata");
+		return std::tuple_size_v<decltype(T::openra_fields)>;
+	}
+
+	// 查找字段名是否存在 / whether a field with the given name exists
+	template<class T>
+	bool hasField(std::string_view name)
+	{
+		bool found = false;
+		std::apply([&](const auto&... f) {
+			((found = found || f.name == name), ...);
+		}, T::openra_fields);
+		return found;
+	}
+}

--- a/CPP23/include/openra/MiniYaml.h
+++ b/CPP23/include/openra/MiniYaml.h
@@ -1,0 +1,133 @@
+
+// MiniYaml —— OpenRA 的 YAML 子集解析/合并引擎（C++23 移植版）
+// MiniYaml - OpenRA's YAML-subset parsing/merging engine (C++23 port)
+//
+// 从 OpenRA.Game/MiniYaml.cs 逐行为保真翻译，保留全部方言行为：
+// Ported line-by-line from OpenRA.Game/MiniYaml.cs, preserving every dialect behavior:
+//   - 4 个空格或 1 个 tab 均表示一级缩进 / 4 spaces or 1 tab each mean one indent level
+//   - '#' 起注释（'\#' 转义）/ '#' starts a comment ('\#' is escaped)
+//   - 值两侧的反斜杠保护空白 / backslash guards preserve whitespace around values
+//   - Inherits / Inherits@id 继承与 '-Key' 节点删除 / Inherits / Inherits@id inheritance and '-Key' removals
+//
+// 与 C# 版的差异（有意为之）/ Differences from the C# version (intentional):
+//   - Key/Value/Comment 用 std::optional 表达 C# 的 null 语义
+//     Key/Value/Comment use std::optional to express C#'s null semantics
+//   - 解析结果直接返回 vector（C# 为 yield 流式）/ parsing returns a vector directly (C# yields lazily)
+//   - MergePartial 的重复键告警日志暂未移植（不影响结果数据）
+//     MergePartial's duplicate-key warning log is not ported yet (does not affect results)
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+namespace OpenRA
+{
+	// 解析失败异常 / parse failure exception
+	struct YamlException : std::runtime_error
+	{
+		explicit YamlException(const std::string& s)
+			: std::runtime_error(s) { }
+	};
+
+	// 源位置（文件名:行号）/ source location (filename:line)
+	struct YamlSourceLocation
+	{
+		std::string name;
+		int line = 0;
+	};
+
+	struct MiniYaml;
+
+	// YAML 键值节点 / a keyed YAML node
+	// 注意定义顺序：节点持有 shared_ptr<MiniYaml>（不完整类型可作 shared_ptr 成员），
+	// Note the definition order: nodes hold shared_ptr<MiniYaml> (allowed on incomplete types),
+	// 而 MiniYaml 的 vector 成员需要本类型完整 / while MiniYaml's vector member needs this type complete
+	struct MiniYamlNode
+	{
+		YamlSourceLocation location;
+		std::optional<std::string> key;
+		std::shared_ptr<MiniYaml> value;
+		std::optional<std::string> comment;
+
+		MiniYamlNode() = default;
+		MiniYamlNode(std::optional<std::string> k, std::shared_ptr<MiniYaml> v,
+			std::optional<std::string> c = std::nullopt, YamlSourceLocation loc = {})
+			: location(std::move(loc)), key(std::move(k)), value(std::move(v)), comment(std::move(c)) { }
+	};
+
+	// YAML 标量 + 子节点容器 / a YAML scalar plus child nodes
+	struct MiniYaml
+	{
+		// C# 的 string Value 可为 null —— 用 optional 区分“无值”与“空串”
+		// C#'s string Value may be null - optional distinguishes "no value" from ""
+		std::optional<std::string> value;
+		std::vector<MiniYamlNode> nodes;
+
+		MiniYaml() = default;
+		explicit MiniYaml(std::optional<std::string> v)
+			: value(std::move(v)) { }
+		MiniYaml(std::optional<std::string> v, std::vector<MiniYamlNode> n)
+			: value(std::move(v)), nodes(std::move(n)) { }
+
+		// 取首个匹配 key 的子节点 / first child node matching the key
+		const MiniYamlNode* nodeWithKeyOrDefault(std::string_view key) const;
+		const MiniYamlNode& nodeWithKey(std::string_view key) const;
+
+		// 子节点转字典（重复键抛异常）/ children to a map (duplicate keys throw)
+		std::map<std::string, const MiniYaml*> toDictionary() const;
+	};
+
+	// ============================== 解析 / Parsing ==============================
+
+	// 字符串池：跨多次解析复用相同字符串（内存去重），可传 nullptr 禁用
+	// string pool: deduplicates repeated strings across parses; pass nullptr to disable
+	using StringPool = std::unordered_set<std::string>;
+
+	std::vector<MiniYamlNode> miniYamlFromString(std::string_view text, std::string_view name,
+		bool discardCommentsAndWhitespace = true, StringPool* pool = nullptr);
+	std::vector<MiniYamlNode> miniYamlFromFile(const std::string& path,
+		bool discardCommentsAndWhitespace = true, StringPool* pool = nullptr);
+
+	// ============================== 合并 / Merging ==============================
+
+	// 合并多个来源并解析 Inherits 继承与 '-Key' 删除
+	// Merges sources, resolving Inherits inheritance and '-Key' removals
+	std::vector<MiniYamlNode> miniYamlMerge(const std::vector<std::vector<MiniYamlNode>>& sources);
+
+	// ============================== 序列化 / Serialization ==============================
+
+	// 节点列表序列化为文本（tab 缩进，与 C# 版一致）
+	// Serialize node lists back to text (tab-indented, matching the C# version)
+	std::vector<std::string> miniYamlToLines(const std::vector<MiniYamlNode>& nodes);
+	std::string miniYamlToString(const std::vector<MiniYamlNode>& nodes);
+
+	// ============================== 内部实现 / Internals ==============================
+
+	namespace MiniYamlDetail
+	{
+		// 同层重复键去重合并（不解析继承/删除）
+		// Deduplicate-merge duplicate keys within one level (no inheritance/removal resolution)
+		std::vector<MiniYamlNode> mergeSelfPartial(const std::vector<MiniYamlNode>& existingNodes);
+
+		// 弱删除：'-Key' 移除前面出现的同名节点；无可删项时不报错
+		// Weak removal: '-Key' drops earlier same-key nodes; missing targets are ignored
+		std::vector<MiniYamlNode> weakResolveRemovals(const std::vector<MiniYamlNode>& nodes);
+
+		// 节点级合并：override 覆盖 existing / node-level merge: override wins over existing
+		MiniYaml mergePartial(const MiniYaml* existingNodes, const MiniYaml* overrideNodes);
+		std::vector<MiniYamlNode> mergePartial(const std::vector<MiniYamlNode>& existingNodes,
+			const std::vector<MiniYamlNode>& overrideNodes);
+
+		// 递归解析 Inherits / recursively resolve Inherits
+		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+			const std::map<std::string, const MiniYaml*>& tree,
+			std::map<std::string, YamlSourceLocation> inherited);
+	}
+}

--- a/CPP23/include/openra/MiniYaml.h
+++ b/CPP23/include/openra/MiniYaml.h
@@ -1,4 +1,3 @@
-
 // MiniYaml —— OpenRA 的 YAML 子集解析/合并引擎（C++23 移植版）
 // MiniYaml - OpenRA's YAML-subset parsing/merging engine (C++23 port)
 //
@@ -12,12 +11,16 @@
 // 与 C# 版的差异（有意为之）/ Differences from the C# version (intentional):
 //   - Key/Value/Comment 用 std::optional 表达 C# 的 null 语义
 //     Key/Value/Comment use std::optional to express C#'s null semantics
-//   - 解析结果直接返回 vector（C# 为 yield 流式）/ parsing returns a vector directly (C# yields lazily)
+//   - 严禁异常：C# 版抛 YamlException 的路径一律返回 std::expected<T, YamlError>
+//     No exceptions allowed: every path that throws YamlException in C# returns
+//     std::expected<T, YamlError> instead (enforced by -fno-exceptions in the build)
+//   - 解析结果直接返回 vector（C# 为 yield 流式）/ parsing returns a vector directly
 //   - MergePartial 的重复键告警日志暂未移植（不影响结果数据）
 //     MergePartial's duplicate-key warning log is not ported yet (does not affect results)
 
 #pragma once
 
+#include <expected>
 #include <map>
 #include <memory>
 #include <optional>
@@ -29,12 +32,18 @@
 
 namespace OpenRA
 {
-	// 解析失败异常 / parse failure exception
-	struct YamlException : std::runtime_error
+	// 统一错误载荷：消息文本（含源位置信息时由构造方拼入）
+	// Unified error payload: a message (source location included by the constructor when known)
+	struct YamlError
 	{
-		explicit YamlException(const std::string& s)
-			: std::runtime_error(s) { }
+		std::string message;
 	};
+
+	// 便捷构造 / convenience constructor
+	inline YamlError yamlError(std::string message)
+	{
+		return { std::move(message) };
+	}
 
 	// 源位置（文件名:行号）/ source location (filename:line)
 	struct YamlSourceLocation
@@ -76,12 +85,17 @@ namespace OpenRA
 		MiniYaml(std::optional<std::string> v, std::vector<MiniYamlNode> n)
 			: value(std::move(v)), nodes(std::move(n)) { }
 
-		// 取首个匹配 key 的子节点 / first child node matching the key
-		const MiniYamlNode* nodeWithKeyOrDefault(std::string_view key) const;
-		const MiniYamlNode& nodeWithKey(std::string_view key) const;
+		// 取首个匹配 key 的子节点；重复键返回错误（保持 C# 的数据错误可见性）
+		// First child matching the key; duplicate keys surface as errors
+		// (preserving C#'s data-error visibility without exceptions)
+		std::expected<const MiniYamlNode*, YamlError> nodeWithKeyOrDefault(std::string_view key) const;
 
-		// 子节点转字典（重复键抛异常）/ children to a map (duplicate keys throw)
-		std::map<std::string, const MiniYaml*> toDictionary() const;
+		// 快速版：首个匹配，重复键不检测（调用方自行保证时使用）
+		// Fast variant: first match, no duplicate detection (when the caller guarantees uniqueness)
+		const MiniYamlNode* nodeWithKeyOrNull(std::string_view key) const;
+
+		// 子节点转字典（重复键返回错误）/ children to a map (duplicate keys surface as errors)
+		std::expected<std::map<std::string, const MiniYaml*>, YamlError> toDictionary() const;
 	};
 
 	// ============================== 解析 / Parsing ==============================
@@ -90,16 +104,17 @@ namespace OpenRA
 	// string pool: deduplicates repeated strings across parses; pass nullptr to disable
 	using StringPool = std::unordered_set<std::string>;
 
-	std::vector<MiniYamlNode> miniYamlFromString(std::string_view text, std::string_view name,
-		bool discardCommentsAndWhitespace = true, StringPool* pool = nullptr);
-	std::vector<MiniYamlNode> miniYamlFromFile(const std::string& path,
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlFromString(std::string_view text,
+		std::string_view name, bool discardCommentsAndWhitespace = true, StringPool* pool = nullptr);
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlFromFile(const std::string& path,
 		bool discardCommentsAndWhitespace = true, StringPool* pool = nullptr);
 
 	// ============================== 合并 / Merging ==============================
 
 	// 合并多个来源并解析 Inherits 继承与 '-Key' 删除
 	// Merges sources, resolving Inherits inheritance and '-Key' removals
-	std::vector<MiniYamlNode> miniYamlMerge(const std::vector<std::vector<MiniYamlNode>>& sources);
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlMerge(
+		const std::vector<std::vector<MiniYamlNode>>& sources);
 
 	// ============================== 序列化 / Serialization ==============================
 
@@ -112,21 +127,21 @@ namespace OpenRA
 
 	namespace MiniYamlDetail
 	{
-		// 同层重复键去重合并（不解析继承/删除）
-		// Deduplicate-merge duplicate keys within one level (no inheritance/removal resolution)
+		// 同层重复键去重合并（不解析继承/删除；无错误路径）
+		// Deduplicate-merge duplicate keys within one level (no inheritance/removal; infallible)
 		std::vector<MiniYamlNode> mergeSelfPartial(const std::vector<MiniYamlNode>& existingNodes);
 
-		// 弱删除：'-Key' 移除前面出现的同名节点；无可删项时不报错
-		// Weak removal: '-Key' drops earlier same-key nodes; missing targets are ignored
+		// 弱删除：'-Key' 移除前面出现的同名节点；无可删项时不报错（无错误路径）
+		// Weak removal: '-Key' drops earlier same-key nodes; infallible by design
 		std::vector<MiniYamlNode> weakResolveRemovals(const std::vector<MiniYamlNode>& nodes);
 
-		// 节点级合并：override 覆盖 existing / node-level merge: override wins over existing
+		// 节点级合并：override 覆盖 existing（无错误路径）/ infallible node-level merge
 		MiniYaml mergePartial(const MiniYaml* existingNodes, const MiniYaml* overrideNodes);
 		std::vector<MiniYamlNode> mergePartial(const std::vector<MiniYamlNode>& existingNodes,
 			const std::vector<MiniYamlNode>& overrideNodes);
 
 		// 递归解析 Inherits / recursively resolve Inherits
-		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+		std::expected<std::vector<MiniYamlNode>, YamlError> resolveInherits(const MiniYaml& node,
 			const std::map<std::string, const MiniYaml*>& tree,
 			std::map<std::string, YamlSourceLocation> inherited);
 	}

--- a/CPP23/include/openra/TypeRegistry.h
+++ b/CPP23/include/openra/TypeRegistry.h
@@ -1,0 +1,92 @@
+// TypeRegistry —— 字符串类型名到工厂的注册表（C++23 移植版）
+// TypeRegistry - string type-name to factory registry (C++23 port)
+//
+// 对应 C# ObjectCreator.CreateObject<T>(string) 的反射工厂能力：
+// Replaces C# ObjectCreator.CreateObject<T>(string) reflection factories:
+// mod YAML 中 "Health: ..." 之类的键是 trait 类型名，运行时按名实例化。
+// mod YAML keys like "Health: ..." are trait type names, instantiated by name at runtime.
+//
+// C++ 无运行时反射，用显式注册宏替代（每个类型一行，链接期收集）：
+// C++ has no runtime reflection, so explicit registration macros replace it
+// (one line per type, collected at link time):
+//
+//   struct HealthInfo : TraitInfo { ... };
+//   OPENRA_REGISTER_TYPE(TraitInfo, HealthInfo)
+//
+// 末尾无须分号亦可（宏内含分号）/ the trailing semicolon is optional (macro includes one)
+// 待 C++26 静态反射普后可与 openra_fields 一起自动化
+// Automatable together with openra_fields once C++26 reflection is ubiquitous
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace OpenRA
+{
+	// 每个基类一份注册表 / one registry per base class
+	template<class Base>
+	class TypeRegistry
+	{
+	public:
+		using Factory = std::function<std::unique_ptr<Base>()>;
+
+		// 注册类型（重名返回 false）/ register a type (false on duplicate names)
+		template<class T>
+		static bool add(std::string name)
+		{
+			static_assert(std::is_base_of_v<Base, T>, "T must derive from the registry Base");
+			return registry().emplace(std::move(name), [] { return std::make_unique<T>(); }).second;
+		}
+
+		// 按名创建 / create by name
+		static std::unique_ptr<Base> create(std::string_view name)
+		{
+			auto& r = registry();
+			auto it = r.find(std::string(name));
+			if (it == r.end())
+				return nullptr;
+			return it->second();
+		}
+
+		// 已注册类型名列表（lint/文档用）/ registered names (for linting/docs)
+		static std::vector<std::string> names()
+		{
+			std::vector<std::string> result;
+			for (const auto& [k, v] : registry())
+				result.push_back(k);
+			return result;
+		}
+
+		static bool contains(std::string_view name)
+		{
+			return registry().count(std::string(name)) > 0;
+		}
+
+	private:
+		// 内联单例：头文件包含安全 / inline singleton: header-include safe
+		static std::map<std::string, Factory>& registry()
+		{
+			static std::map<std::string, Factory> instance;
+			return instance;
+		}
+	};
+}
+
+// 静态初始化注册；匿名 namespace 防止重名冲突，addr_taken 保证不被链接器丢弃
+// Static-init registration; anonymous namespace avoids collisions, and the
+// volatile address-take keeps the linker from discarding the initializer
+#define OPENRA_REGISTER_TYPE(Base, T) \
+	namespace \
+	{ \
+		struct OpenRaTypeRegistrar_##T \
+		{ \
+			OpenRaTypeRegistrar_##T() { OpenRA::TypeRegistry<Base>::add<T>(#T); } \
+		}; \
+		volatile auto OpenRaTypeRegistrarInstance_##T = OpenRaTypeRegistrar_##T{}; \
+	}

--- a/CPP23/src/MiniYaml.cpp
+++ b/CPP23/src/MiniYaml.cpp
@@ -90,31 +90,34 @@ namespace OpenRA
 
 	// ============================== 访问 / Access ==============================
 
-	const MiniYamlNode* MiniYaml::nodeWithKeyOrDefault(std::string_view key) const
+	std::expected<const MiniYamlNode*, YamlError> MiniYaml::nodeWithKeyOrDefault(std::string_view key) const
 	{
-		// C# 版对重复键抛异常 / the C# version throws on duplicate keys
+		// 重复键返回错误（对应 C# 抛异常的路径）/ duplicate keys surface as errors
+		// (the path where C# throws)
 		const MiniYamlNode* result = nullptr;
 		for (const auto& node : nodes)
 		{
 			if (!node.key || *node.key != key)
 				continue;
 			if (result != nullptr)
-				throw YamlException("Duplicate key '" + std::string(key) + "' in " + node.location.name + ":" + std::to_string(node.location.line));
+				return std::unexpected(yamlError("Duplicate key '" + std::string(key) + "' in "
+					+ node.location.name + ":" + std::to_string(node.location.line)));
 			result = &node;
 		}
 
 		return result;
 	}
 
-	const MiniYamlNode& MiniYaml::nodeWithKey(std::string_view key) const
+	const MiniYamlNode* MiniYaml::nodeWithKeyOrNull(std::string_view key) const
 	{
-		auto result = nodeWithKeyOrDefault(key);
-		if (result == nullptr)
-			throw YamlException("No node with key '" + std::string(key) + "'");
-		return *result;
+		// 快速路径：不做重复检测 / fast path: no duplicate detection
+		for (const auto& node : nodes)
+			if (node.key && *node.key == key)
+				return &node;
+		return nullptr;
 	}
 
-	std::map<std::string, const MiniYaml*> MiniYaml::toDictionary() const
+	std::expected<std::map<std::string, const MiniYaml*>, YamlError> MiniYaml::toDictionary() const
 	{
 		std::map<std::string, const MiniYaml*> ret;
 		for (const auto& y : nodes)
@@ -122,7 +125,8 @@ namespace OpenRA
 			if (!y.key)
 				continue;
 			if (!ret.emplace(*y.key, y.value.get()).second)
-				throw YamlException("Duplicate key '" + *y.key + "' in " + y.location.name + ":" + std::to_string(y.location.line));
+				return std::unexpected(yamlError("Duplicate key '" + *y.key + "' in "
+					+ y.location.name + ":" + std::to_string(y.location.line)));
 		}
 
 		return ret;
@@ -133,7 +137,7 @@ namespace OpenRA
 	namespace
 	{
 		// C# FromLines 的核心：缩进栈组装 / the core of C# FromLines: indent-stack assembly
-		std::vector<MiniYamlNode> fromLines(const std::vector<std::string_view>& lines,
+		std::expected<std::vector<MiniYamlNode>, YamlError> fromLines(const std::vector<std::string_view>& lines,
 			std::string_view name, bool discardCommentsAndWhitespace, StringPool* pool)
 		{
 			// result[level] 收集该层完成的节点 / result[level] collects completed nodes per level
@@ -287,7 +291,8 @@ namespace OpenRA
 				if (!key.empty() || !discardCommentsAndWhitespace)
 				{
 					if (!parsedLines.empty() && parsedLines.back().level < level - 1)
-						throw YamlException("Bad indent in miniyaml at " + location.name + ":" + std::to_string(location.line));
+						return std::unexpected(yamlError("Bad indent in miniyaml at "
+							+ location.name + ":" + std::to_string(location.line)));
 
 					while (!parsedLines.empty() && parsedLines.back().level > level)
 						buildCompletedSubNode(level);
@@ -311,18 +316,18 @@ namespace OpenRA
 		}
 	}
 
-	std::vector<MiniYamlNode> miniYamlFromString(std::string_view text, std::string_view name,
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlFromString(std::string_view text, std::string_view name,
 		bool discardCommentsAndWhitespace, StringPool* pool)
 	{
 		return fromLines(splitLines(text), name, discardCommentsAndWhitespace, pool);
 	}
 
-	std::vector<MiniYamlNode> miniYamlFromFile(const std::string& path,
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlFromFile(const std::string& path,
 		bool discardCommentsAndWhitespace, StringPool* pool)
 	{
 		std::ifstream file(path, std::ios::binary);
 		if (!file)
-			throw YamlException("Cannot open file: " + path);
+			return std::unexpected(yamlError("Cannot open file: " + path));
 
 		std::string text{ std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>() };
 		return fromLines(splitLines(text), path, discardCommentsAndWhitespace, pool);
@@ -333,7 +338,7 @@ namespace OpenRA
 	namespace MiniYamlDetail
 	{
 		// 相互递归，先作前向声明 / mutually recursive; forward-declared first
-		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+		std::expected<std::vector<MiniYamlNode>, YamlError> resolveInherits(const MiniYaml& node,
 			const std::map<std::string, const MiniYaml*>& tree,
 			std::map<std::string, YamlSourceLocation> inherited);
 
@@ -473,7 +478,8 @@ namespace OpenRA
 		}
 
 		// 覆盖节点并入已解析列表 / merge an override node into the resolved list
-		void mergeIntoResolved(const MiniYamlNode& overrideNode, std::vector<MiniYamlNode>& existingNodes,
+		std::expected<void, YamlError> mergeIntoResolved(const MiniYamlNode& overrideNode,
+			std::vector<MiniYamlNode>& existingNodes,
 			std::vector<std::string>& existingNodeKeys, const std::map<std::string, const MiniYaml*>& tree,
 			const std::map<std::string, YamlSourceLocation>& inherited)
 		{
@@ -493,7 +499,9 @@ namespace OpenRA
 
 			auto value = mergePartial(existingNode ? existingNode->value.get() : nullptr, overrideNode.value.get());
 			auto nodes = resolveInherits(value, tree, inherited);
-			value.nodes = std::move(nodes);
+			if (!nodes.has_value())
+				return std::unexpected(std::move(nodes).error());
+			value.nodes = std::move(*nodes);
 
 			if (existingNode != nullptr)
 			{
@@ -503,9 +511,11 @@ namespace OpenRA
 			}
 			else
 				existingNodes.push_back(overrideNode);
+
+			return {};
 		}
 
-		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+		std::expected<std::vector<MiniYamlNode>, YamlError> resolveInherits(const MiniYaml& node,
 			const std::map<std::string, const MiniYaml*>& tree,
 			std::map<std::string, YamlSourceLocation> inherited)
 		{
@@ -522,21 +532,28 @@ namespace OpenRA
 				{
 					auto it = tree.find(*n.value->value);
 					if (it == tree.end())
-						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
-							+ ": Parent type `" + *n.value->value + "` not found");
+						return std::unexpected(yamlError(n.location.name + ":" + std::to_string(n.location.line)
+							+ ": Parent type `" + *n.value->value + "` not found"));
 
 					auto [inserted, ok] = inherited.emplace(*n.value->value, n.location);
 					if (!ok)
-						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
+						return std::unexpected(yamlError(n.location.name + ":" + std::to_string(n.location.line)
 							+ ": Parent type `" + *n.value->value + "` was already inherited by this yaml tree at "
 							+ inserted->second.name + ":" + std::to_string(inserted->second.line)
-							+ " (note: may be from a derived tree)");
+							+ " (note: may be from a derived tree)"));
 
 					// 注意：C# 里 inherited 在循环内持续累积；C++ 按值传参+修改局部副本等价
 					// Note: C# keeps accumulating `inherited` across loop iterations;
 					// the by-value parameter with local mutation is equivalent
-					for (const auto& r : resolveInherits(*it->second, tree, inherited))
-						mergeIntoResolved(r, resolved, resolvedKeys, tree, inherited);
+					auto parentResolved = resolveInherits(*it->second, tree, inherited);
+					if (!parentResolved.has_value())
+						return std::unexpected(std::move(parentResolved).error());
+					for (const auto& r : *parentResolved)
+					{
+						auto merged = mergeIntoResolved(r, resolved, resolvedKeys, tree, inherited);
+						if (!merged.has_value())
+							return std::unexpected(std::move(merged).error());
+					}
 				}
 				else if (n.key && startsWith(*n.key, "-"))
 				{
@@ -544,22 +561,26 @@ namespace OpenRA
 					auto before = resolved.size();
 					std::erase_if(resolved, [&](const MiniYamlNode& r) { return r.key && *r.key == removed; });
 					if (resolved.size() == before)
-						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
-							+ ": There are no elements with key `" + removed + "` to remove");
+						return std::unexpected(yamlError(n.location.name + ":" + std::to_string(n.location.line)
+							+ ": There are no elements with key `" + removed + "` to remove"));
 					std::erase(resolvedKeys, removed);
 				}
 				else if (n.key)
-					mergeIntoResolved(n, resolved, resolvedKeys, tree, inherited);
+				{
+					auto merged = mergeIntoResolved(n, resolved, resolvedKeys, tree, inherited);
+					if (!merged.has_value())
+						return std::unexpected(std::move(merged).error());
+				}
 			}
 
 			return resolved;
 		}
 	}
 
-	std::vector<MiniYamlNode> miniYamlMerge(const std::vector<std::vector<MiniYamlNode>>& sources)
+	std::expected<std::vector<MiniYamlNode>, YamlError> miniYamlMerge(const std::vector<std::vector<MiniYamlNode>>& sources)
 	{
 		if (sources.empty())
-			return {};
+			return std::vector<MiniYamlNode>{};
 
 		// 各源自合并后逐个归并 / self-merge each source, then fold them together
 		std::optional<std::vector<MiniYamlNode>> accumulated;
@@ -575,7 +596,7 @@ namespace OpenRA
 
 		for (const auto& n : *accumulated)
 			if (n.key && !tree.emplace(*n.key, n.value).second)
-				throw YamlException("Duplicate top-level key `" + *n.key + "` in merge");
+				return std::unexpected(yamlError("Duplicate top-level key `" + *n.key + "` in merge"));
 
 		std::map<std::string, const MiniYaml*> treeView;
 		for (const auto& [k, v] : tree)
@@ -587,7 +608,10 @@ namespace OpenRA
 			// 继承沿父→子追踪，不沿子→父的兄弟扩散
 			// Inheritance is tracked parent->child, not child->parentsiblings
 			std::map<std::string, YamlSourceLocation> inherited{ { k, {} } };
-			resolved.emplace(k, MiniYamlDetail::resolveInherits(*v, treeView, inherited));
+			auto children = MiniYamlDetail::resolveInherits(*v, treeView, inherited);
+			if (!children.has_value())
+				return std::unexpected(std::move(children).error());
+			resolved.emplace(k, std::move(*children));
 		}
 
 		// 解析顶层删除（如整块 actor 移除）/ resolve top-level removals (e.g. whole actor blocks)

--- a/CPP23/src/MiniYaml.cpp
+++ b/CPP23/src/MiniYaml.cpp
@@ -1,0 +1,664 @@
+
+// MiniYaml 实现 —— 与 OpenRA.Game/MiniYaml.cs 逐段对应
+// MiniYaml implementation - mirrors OpenRA.Game/MiniYaml.cs section by section
+
+#include "openra/MiniYaml.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+
+namespace OpenRA
+{
+	namespace
+	{
+		constexpr int SpacesPerLevel = 4;
+
+		std::string_view trim(std::string_view s)
+		{
+			while (!s.empty() && (s.front() == ' ' || s.front() == '\t'
+				|| s.front() == '\r' || s.front() == '\n'))
+				s.remove_prefix(1);
+			while (!s.empty() && (s.back() == ' ' || s.back() == '\t'
+				|| s.back() == '\r' || s.back() == '\n'))
+				s.remove_suffix(1);
+			return s;
+		}
+
+		bool startsWith(std::string_view s, std::string_view prefix)
+		{
+			return s.size() >= prefix.size() && s.substr(0, prefix.size()) == prefix;
+		}
+
+		// 池化：返回池内稳定字符串 / pooled: return the stable copy held by the pool
+		std::string pooled(StringPool* pool, std::string&& s)
+		{
+			if (pool == nullptr)
+				return std::move(s);
+			return *pool->insert(std::move(s)).first;
+		}
+
+		// 解析中的行缓冲 / in-flight parsed line buffer (C# parsedLines tuple)
+		struct ParsedLine
+		{
+			int level = 0;
+			std::optional<std::string> key;
+			std::optional<std::string> value;
+			std::optional<std::string> comment;
+			YamlSourceLocation location;
+		};
+
+		int indexOfKey(const std::vector<MiniYamlNode>& nodes, std::string_view key)
+		{
+			for (size_t i = 0; i < nodes.size(); i++)
+				if (nodes[i].key && *nodes[i].key == key)
+					return static_cast<int>(i);
+			return -1;
+		}
+
+		int lastIndexOfKey(const std::vector<MiniYamlNode>& nodes, std::string_view key)
+		{
+			for (size_t i = nodes.size(); i-- > 0;)
+				if (nodes[i].key && *nodes[i].key == key)
+					return static_cast<int>(i);
+			return -1;
+		}
+
+		// 按 \r\n 或 \n 切行（保留空行）/ split on \r\n or \n (keeping empty lines)
+		std::vector<std::string_view> splitLines(std::string_view text)
+		{
+			std::vector<std::string_view> lines;
+			size_t start = 0;
+			for (size_t i = 0; i < text.size(); i++)
+			{
+				if (text[i] == '\n')
+				{
+					auto end = i;
+					if (end > start && text[end - 1] == '\r')
+						end--;
+					lines.emplace_back(text.substr(start, end - start));
+					start = i + 1;
+				}
+			}
+
+			if (start < text.size())
+				lines.emplace_back(text.substr(start));
+			return lines;
+		}
+	}
+
+	// ============================== 访问 / Access ==============================
+
+	const MiniYamlNode* MiniYaml::nodeWithKeyOrDefault(std::string_view key) const
+	{
+		// C# 版对重复键抛异常 / the C# version throws on duplicate keys
+		const MiniYamlNode* result = nullptr;
+		for (const auto& node : nodes)
+		{
+			if (!node.key || *node.key != key)
+				continue;
+			if (result != nullptr)
+				throw YamlException("Duplicate key '" + std::string(key) + "' in " + node.location.name + ":" + std::to_string(node.location.line));
+			result = &node;
+		}
+
+		return result;
+	}
+
+	const MiniYamlNode& MiniYaml::nodeWithKey(std::string_view key) const
+	{
+		auto result = nodeWithKeyOrDefault(key);
+		if (result == nullptr)
+			throw YamlException("No node with key '" + std::string(key) + "'");
+		return *result;
+	}
+
+	std::map<std::string, const MiniYaml*> MiniYaml::toDictionary() const
+	{
+		std::map<std::string, const MiniYaml*> ret;
+		for (const auto& y : nodes)
+		{
+			if (!y.key)
+				continue;
+			if (!ret.emplace(*y.key, y.value.get()).second)
+				throw YamlException("Duplicate key '" + *y.key + "' in " + y.location.name + ":" + std::to_string(y.location.line));
+		}
+
+		return ret;
+	}
+
+	// ============================== 解析 / Parsing ==============================
+
+	namespace
+	{
+		// C# FromLines 的核心：缩进栈组装 / the core of C# FromLines: indent-stack assembly
+		std::vector<MiniYamlNode> fromLines(const std::vector<std::string_view>& lines,
+			std::string_view name, bool discardCommentsAndWhitespace, StringPool* pool)
+		{
+			// result[level] 收集该层完成的节点 / result[level] collects completed nodes per level
+			std::vector<std::vector<MiniYamlNode>> result{ {} };
+			std::vector<ParsedLine> parsedLines;
+
+			// 把 parsedLines 顶层已完成的部分组装为节点树
+			// Assemble the completed top of parsedLines into the node tree
+			auto buildCompletedSubNode = [&](int level)
+			{
+				auto lastLevel = parsedLines.back().level;
+				while (lastLevel >= static_cast<int>(result.size()))
+					result.emplace_back();
+
+				while (!parsedLines.empty() && parsedLines.back().level >= level)
+				{
+					const auto& parent = parsedLines.back();
+					auto startOfRange = static_cast<int>(parsedLines.size()) - 1;
+					while (startOfRange > 0 && parsedLines[startOfRange - 1].level == parent.level)
+						startOfRange--;
+
+					// 同层先出现的行先成为无子节点兄弟 / earlier same-level lines become childless siblings
+					for (auto i = startOfRange; i < static_cast<int>(parsedLines.size()) - 1; i++)
+					{
+						const auto& sibling = parsedLines[i];
+						result[parent.level].emplace_back(sibling.key,
+							std::make_shared<MiniYaml>(sibling.value), sibling.comment, sibling.location);
+					}
+
+					// 最后一行持有下一层作为子节点 / the last line takes the next level as children
+					std::vector<MiniYamlNode>* childNodes = parent.level + 1 < static_cast<int>(result.size())
+						? &result[parent.level + 1] : nullptr;
+					result[parent.level].emplace_back(parent.key,
+						std::make_shared<MiniYaml>(parent.value, childNodes ? std::move(*childNodes) : std::vector<MiniYamlNode>{}),
+						parent.comment, parent.location);
+					if (childNodes)
+						childNodes->clear();
+
+					parsedLines.erase(parsedLines.begin() + startOfRange, parsedLines.end());
+				}
+			};
+
+			auto lineNo = 0;
+			for (auto ll : lines)
+			{
+				const auto line = ll;
+				++lineNo;
+
+				auto keyStart = 0;
+				auto level = 0;
+				auto spaces = 0;
+				auto textStart = false;
+
+				std::string_view key;
+				std::string_view value;
+				std::string_view comment;
+				auto location = YamlSourceLocation{ std::string(name), lineNo };
+
+				if (!line.empty())
+				{
+					// 缩进计数：4 空格或 1 tab 为一级 / indent counting: 4 spaces or 1 tab per level
+					auto currChar = line[keyStart];
+					while (keyStart < static_cast<int>(line.size()) && !textStart)
+					{
+						currChar = line[keyStart];
+						switch (currChar)
+						{
+							case ' ':
+								spaces++;
+								if (spaces >= SpacesPerLevel)
+								{
+									spaces = 0;
+									level++;
+								}
+
+								keyStart++;
+								break;
+							case '\t':
+								level++;
+								keyStart++;
+								break;
+							default:
+								textStart = true;
+								break;
+						}
+					}
+
+					// 按 `<key>: <value>#<comment>` 切分；'#' 在值内需 '\#' 转义
+					// Split as `<key>: <value>#<comment>`; '#' inside values needs '\#' escaping
+					auto keyLength = static_cast<int>(line.size()) - keyStart;
+					auto valueStart = -1;
+					auto valueLength = 0;
+					auto commentStart = -1;
+					for (auto i = 0; i < static_cast<int>(line.size()); i++)
+					{
+						if (valueStart < 0 && line[i] == ':')
+						{
+							valueStart = i + 1;
+							keyLength = i - keyStart;
+							valueLength = static_cast<int>(line.size()) - i - 1;
+						}
+
+						if (commentStart < 0 && line[i] == '#' && (i == 0 || line[i - 1] != '\\'))
+						{
+							commentStart = i + 1;
+							if (i <= keyStart + keyLength)
+								keyLength = i - keyStart;
+							else
+								valueLength = i - valueStart;
+
+							break;
+						}
+					}
+
+					if (keyLength > 0)
+						key = trim(line.substr(keyStart, keyLength));
+
+					if (valueStart >= 0)
+					{
+						auto trimmed = trim(line.substr(valueStart, valueLength));
+						if (!trimmed.empty())
+							value = trimmed;
+					}
+
+					if (commentStart >= 0 && !discardCommentsAndWhitespace)
+						comment = line.substr(commentStart);
+
+					if (value.size() > 1)
+					{
+						// 前后反斜杠空白保护 / leading/trailing backslash whitespace guards
+						auto trimLeading = value[0] == '\\' && (value[1] == ' ' || value[1] == '\t') ? 1 : 0;
+						auto trimTrailing = value[value.size() - 1] == '\\' && (value[value.size() - 2] == ' ' || value[value.size() - 2] == '\t') ? 1 : 0;
+						if (trimLeading + trimTrailing > 0)
+							value = value.substr(trimLeading, value.size() - trimLeading - trimTrailing);
+
+						// 还原被转义的 '#' / restore escaped '#'
+						if (value.find("\\#") != std::string_view::npos)
+						{
+							std::string unescaped{ value };
+							for (auto pos = unescaped.find("\\#"); pos != std::string::npos; pos = unescaped.find("\\#", pos))
+							{
+								unescaped.erase(pos, 1);
+								pos++;
+							}
+
+							value = unescaped;
+						}
+					}
+				}
+
+				if (!key.empty() || !discardCommentsAndWhitespace)
+				{
+					if (!parsedLines.empty() && parsedLines.back().level < level - 1)
+						throw YamlException("Bad indent in miniyaml at " + location.name + ":" + std::to_string(location.line));
+
+					while (!parsedLines.empty() && parsedLines.back().level > level)
+						buildCompletedSubNode(level);
+
+					ParsedLine parsed{ level,
+						key.empty() ? std::nullopt : std::optional<std::string>{ pooled(pool, std::string(key)) },
+						value.empty() ? std::nullopt : std::optional<std::string>{ pooled(pool, std::string(value)) },
+						comment.empty() ? std::nullopt : std::optional<std::string>{ pooled(pool, std::string(comment)) },
+						location };
+					parsedLines.emplace_back(std::move(parsed));
+				}
+
+				// C# 逐行 yield 顶层结果；C++ 版在末尾统一返回
+				// C# yields top-level nodes per line; the C++ port returns them all at the end
+			}
+
+			if (!parsedLines.empty())
+				buildCompletedSubNode(0);
+
+			return std::move(result[0]);
+		}
+	}
+
+	std::vector<MiniYamlNode> miniYamlFromString(std::string_view text, std::string_view name,
+		bool discardCommentsAndWhitespace, StringPool* pool)
+	{
+		return fromLines(splitLines(text), name, discardCommentsAndWhitespace, pool);
+	}
+
+	std::vector<MiniYamlNode> miniYamlFromFile(const std::string& path,
+		bool discardCommentsAndWhitespace, StringPool* pool)
+	{
+		std::ifstream file(path, std::ios::binary);
+		if (!file)
+			throw YamlException("Cannot open file: " + path);
+
+		std::string text{ std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>() };
+		return fromLines(splitLines(text), path, discardCommentsAndWhitespace, pool);
+	}
+
+	// ============================== 合并 / Merging ==============================
+
+	namespace MiniYamlDetail
+	{
+		// 相互递归，先作前向声明 / mutually recursive; forward-declared first
+		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+			const std::map<std::string, const MiniYaml*>& tree,
+			std::map<std::string, YamlSourceLocation> inherited);
+
+		std::vector<MiniYamlNode> mergeSelfPartial(const std::vector<MiniYamlNode>& existingNodes)
+		{
+			if (existingNodes.empty())
+				return existingNodes;
+
+			std::vector<std::string> keys;
+			std::vector<MiniYamlNode> ret;
+			ret.reserve(existingNodes.size());
+			for (const auto& n : existingNodes)
+			{
+				if (!n.key)
+					continue;
+
+				if (std::find(keys.begin(), keys.end(), *n.key) == keys.end())
+				{
+					keys.push_back(*n.key);
+					ret.push_back(n);
+				}
+				else
+				{
+					// 同键节点已存在：把新节点并入旧节点 / key seen before: merge the new node over it
+					auto originalIndex = indexOfKey(ret, *n.key);
+					ret[originalIndex].value = std::make_shared<MiniYaml>(
+						mergePartial(ret[originalIndex].value.get(), n.value.get()));
+				}
+			}
+
+			return ret;
+		}
+
+		std::vector<MiniYamlNode> weakResolveRemovals(const std::vector<MiniYamlNode>& nodes)
+		{
+			if (nodes.empty())
+				return nodes;
+
+			std::vector<MiniYamlNode> ret;
+			bool copying = false;
+			for (size_t i = 0; i < nodes.size(); i++)
+			{
+				const auto& node = nodes[i];
+				if (!node.key)
+					continue;
+
+				if (startsWith(*node.key, "-"))
+				{
+					if (!copying)
+					{
+						copying = true;
+						ret.assign(nodes.begin(), nodes.begin() + i);
+					}
+
+					// 弱删除：无可删项时静默跳过 / weak removal: silently skip if nothing matches
+					auto removed = node.key->substr(1);
+					std::erase_if(ret, [&](const MiniYamlNode& r) { return r.key && *r.key == removed; });
+				}
+				else if (copying)
+					ret.push_back(node);
+			}
+
+			return copying ? ret : nodes;
+		}
+
+		MiniYaml mergePartial(const MiniYaml* existingNodes, const MiniYaml* overrideNodes)
+		{
+			auto resolvedExistingNodes = weakResolveRemovals(existingNodes ? existingNodes->nodes : std::vector<MiniYamlNode>{});
+			auto resolvedOverrideNodes = weakResolveRemovals(overrideNodes ? overrideNodes->nodes : std::vector<MiniYamlNode>{});
+			(void)resolvedExistingNodes;
+			(void)resolvedOverrideNodes;
+			// 注：C# 在此处用 ConflictScratch 做重复键诊断日志，此处未移植（不影响结果数据）
+			// Note: C# logs duplicate-key diagnostics here via ConflictScratch; not ported (results unaffected)
+
+			if (existingNodes == nullptr)
+				return *overrideNodes;
+			if (overrideNodes == nullptr)
+				return *existingNodes;
+
+			return MiniYaml(overrideNodes->value ? overrideNodes->value : existingNodes->value,
+				mergePartial(existingNodes->nodes, overrideNodes->nodes));
+		}
+
+		std::vector<MiniYamlNode> mergePartial(const std::vector<MiniYamlNode>& existingNodes,
+			const std::vector<MiniYamlNode>& overrideNodes)
+		{
+			if (existingNodes.empty())
+				return overrideNodes;
+			if (overrideNodes.empty())
+				return existingNodes;
+
+			std::vector<MiniYamlNode> ret;
+			ret.reserve(existingNodes.size() + overrideNodes.size());
+			std::vector<std::string> plainKeys;
+
+			auto mergeNode = [&](const MiniYamlNode& node)
+			{
+				if (!node.key)
+					return;
+
+				// '-Key' 删除节点直接追加 / '-Key' removal nodes are appended as-is
+				if (startsWith(*node.key, "-"))
+				{
+					ret.push_back(node);
+					return;
+				}
+
+				// 新键直接追加 / unseen keys are appended
+				if (std::find(plainKeys.begin(), plainKeys.end(), *node.key) == plainKeys.end())
+				{
+					plainKeys.push_back(*node.key);
+					ret.push_back(node);
+					return;
+				}
+
+				// 若比上一次出现更近的位置存在删除节点，改为追加（保证 应用→删除→再应用 的顺序）
+				// If a removal node sits closer than the previous occurrence, append instead
+				// (preserving the apply -> remove -> re-apply ordering)
+				auto previousNodeIndex = lastIndexOfKey(ret, *node.key);
+				auto previousRemovalNodeIndex = lastIndexOfKey(ret, "-" + *node.key);
+				if (previousRemovalNodeIndex != -1 && previousRemovalNodeIndex > previousNodeIndex)
+				{
+					ret.push_back(node);
+					return;
+				}
+
+				ret[previousNodeIndex].value = std::make_shared<MiniYaml>(
+					mergePartial(ret[previousNodeIndex].value.get(), node.value.get()));
+			};
+
+			for (const auto& node : existingNodes)
+				mergeNode(node);
+			for (const auto& node : overrideNodes)
+				mergeNode(node);
+
+			return ret;
+		}
+
+		// 覆盖节点并入已解析列表 / merge an override node into the resolved list
+		void mergeIntoResolved(const MiniYamlNode& overrideNode, std::vector<MiniYamlNode>& existingNodes,
+			std::vector<std::string>& existingNodeKeys, const std::map<std::string, const MiniYaml*>& tree,
+			const std::map<std::string, YamlSourceLocation>& inherited)
+		{
+			// 注意：C# 在此处用 ResolveInherits 解析覆盖值的继承，但传入的是已解析树，
+			// Note: C# runs ResolveInherits on the override value here, but the tree members are
+			// 上层已解析过的节点 —— 此处按原版语义递归处理
+			// already resolved at this level - we recurse per the original semantics
+			const MiniYamlNode* existingNode = nullptr;
+			int existingNodeIndex = -1;
+			if (std::find(existingNodeKeys.begin(), existingNodeKeys.end(), *overrideNode.key) != existingNodeKeys.end())
+			{
+				existingNodeIndex = indexOfKey(existingNodes, *overrideNode.key);
+				existingNode = &existingNodes[existingNodeIndex];
+			}
+			else
+				existingNodeKeys.push_back(*overrideNode.key);
+
+			auto value = mergePartial(existingNode ? existingNode->value.get() : nullptr, overrideNode.value.get());
+			auto nodes = resolveInherits(value, tree, inherited);
+			value.nodes = std::move(nodes);
+
+			if (existingNode != nullptr)
+			{
+				auto merged = *existingNode;
+				merged.value = std::make_shared<MiniYaml>(std::move(value));
+				existingNodes[existingNodeIndex] = std::move(merged);
+			}
+			else
+				existingNodes.push_back(overrideNode);
+		}
+
+		std::vector<MiniYamlNode> resolveInherits(const MiniYaml& node,
+			const std::map<std::string, const MiniYaml*>& tree,
+			std::map<std::string, YamlSourceLocation> inherited)
+		{
+			if (node.nodes.empty())
+				return node.nodes;
+
+			std::vector<MiniYamlNode> resolved;
+			resolved.reserve(node.nodes.size());
+			std::vector<std::string> resolvedKeys;
+
+			for (const auto& n : node.nodes)
+			{
+				if (n.key && (*n.key == "Inherits" || startsWith(*n.key, "Inherits@")))
+				{
+					auto it = tree.find(*n.value->value);
+					if (it == tree.end())
+						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
+							+ ": Parent type `" + *n.value->value + "` not found");
+
+					auto [inserted, ok] = inherited.emplace(*n.value->value, n.location);
+					if (!ok)
+						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
+							+ ": Parent type `" + *n.value->value + "` was already inherited by this yaml tree at "
+							+ inserted->second.name + ":" + std::to_string(inserted->second.line)
+							+ " (note: may be from a derived tree)");
+
+					// 注意：C# 里 inherited 在循环内持续累积；C++ 按值传参+修改局部副本等价
+					// Note: C# keeps accumulating `inherited` across loop iterations;
+					// the by-value parameter with local mutation is equivalent
+					for (const auto& r : resolveInherits(*it->second, tree, inherited))
+						mergeIntoResolved(r, resolved, resolvedKeys, tree, inherited);
+				}
+				else if (n.key && startsWith(*n.key, "-"))
+				{
+					auto removed = n.key->substr(1);
+					auto before = resolved.size();
+					std::erase_if(resolved, [&](const MiniYamlNode& r) { return r.key && *r.key == removed; });
+					if (resolved.size() == before)
+						throw YamlException(n.location.name + ":" + std::to_string(n.location.line)
+							+ ": There are no elements with key `" + removed + "` to remove");
+					std::erase(resolvedKeys, removed);
+				}
+				else if (n.key)
+					mergeIntoResolved(n, resolved, resolvedKeys, tree, inherited);
+			}
+
+			return resolved;
+		}
+	}
+
+	std::vector<MiniYamlNode> miniYamlMerge(const std::vector<std::vector<MiniYamlNode>>& sources)
+	{
+		if (sources.empty())
+			return {};
+
+		// 各源自合并后逐个归并 / self-merge each source, then fold them together
+		std::optional<std::vector<MiniYamlNode>> accumulated;
+		std::map<std::string, std::shared_ptr<MiniYaml>> tree;
+		for (const auto& s : sources)
+		{
+			auto selfMerged = MiniYamlDetail::mergeSelfPartial(s);
+			if (!accumulated)
+				accumulated = std::move(selfMerged);
+			else
+				accumulated = MiniYamlDetail::mergePartial(*accumulated, selfMerged);
+		}
+
+		for (const auto& n : *accumulated)
+			if (n.key && !tree.emplace(*n.key, n.value).second)
+				throw YamlException("Duplicate top-level key `" + *n.key + "` in merge");
+
+		std::map<std::string, const MiniYaml*> treeView;
+		for (const auto& [k, v] : tree)
+			treeView.emplace(k, v.get());
+
+		std::map<std::string, std::vector<MiniYamlNode>> resolved;
+		for (const auto& [k, v] : tree)
+		{
+			// 继承沿父→子追踪，不沿子→父的兄弟扩散
+			// Inheritance is tracked parent->child, not child->parentsiblings
+			std::map<std::string, YamlSourceLocation> inherited{ { k, {} } };
+			resolved.emplace(k, MiniYamlDetail::resolveInherits(*v, treeView, inherited));
+		}
+
+		// 解析顶层删除（如整块 actor 移除）/ resolve top-level removals (e.g. whole actor blocks)
+		std::vector<MiniYamlNode> rootNodes;
+		for (const auto& [k, v] : resolved)
+			rootNodes.emplace_back(k, std::make_shared<MiniYaml>(std::nullopt, v));
+		auto root = MiniYaml(std::nullopt, std::move(rootNodes));
+		return MiniYamlDetail::resolveInherits(root, treeView, {});
+	}
+
+	// ============================== 序列化 / Serialization ==============================
+
+	namespace
+	{
+		void nodeToLines(const MiniYamlNode& node, std::vector<std::string>& lines, int depth)
+		{
+			const auto& y = *node.value;
+			auto hasKey = node.key && !node.key->empty();
+			auto hasValue = y.value && !y.value->empty();
+			auto hasComment = node.comment.has_value();
+
+			std::string line;
+			if (hasKey)
+				line += *node.key + ":";
+			if (hasValue)
+			{
+				auto escaped = *y.value;
+				for (auto pos = escaped.find('#'); pos != std::string::npos; pos = escaped.find('#', pos + 2))
+					escaped.insert(pos, "\\");
+				line += " " + escaped;
+			}
+
+			if (hasComment)
+			{
+				if (hasKey || hasValue)
+					line += " ";
+				line += "#" + *node.comment;
+			}
+
+			// C# 版子行以 "\t" 前缀递归 / child lines are "\t"-prefixed in the C# version
+			lines.push_back(std::string(static_cast<size_t>(depth), '\t') + std::move(line));
+
+			for (const auto& child : y.nodes)
+				nodeToLines(child, lines, depth + 1);
+		}
+	}
+
+	std::vector<std::string> miniYamlToLines(const std::vector<MiniYamlNode>& nodes)
+	{
+		std::vector<std::string> lines;
+		for (const auto& node : nodes)
+			nodeToLines(node, lines, 0);
+		return lines;
+	}
+
+	std::string miniYamlToString(const std::vector<MiniYamlNode>& nodes)
+	{
+		auto lines = miniYamlToLines(nodes);
+		std::string text;
+		for (const auto& l : lines)
+		{
+			// C# 版 TrimEnd 只去行尾空白并保留 tab 缩进（两端 trim 会破坏重解析）
+			// C# TrimEnd removes trailing whitespace only, keeping tab indentation
+			// (trimming both ends would break re-parsing)
+			auto end = l.size();
+			while (end > 0 && (l[end - 1] == ' ' || l[end - 1] == '\t' || l[end - 1] == '\r' || l[end - 1] == '\n'))
+				end--;
+			text += l.substr(0, end);
+			text += "\n";
+		}
+
+		return text;
+	}
+}

--- a/CPP23/tests/test_main.cpp
+++ b/CPP23/tests/test_main.cpp
@@ -1,7 +1,7 @@
-
 // MiniYaml 移植验证测试 / MiniYaml port verification tests
-// 覆盖：解析（缩进/注释/转义）、合并继承删除、序列化回环、真实 mod 文件解析
-// Covers: parsing (indent/comments/escapes), merge/inherit/removal, round-trip, real mod files
+// 覆盖：解析（缩进/注释/转义）、合并继承删除、序列化回环、字段注入、类型注册、真实 mod 文件
+// Covers: parsing (indent/comments/escapes), merge/inherit/removal, round-trips, field injection,
+// type registration, and real mod files. All fallible APIs return std::expected (no exceptions).
 
 #include "openra/MiniYaml.h"
 #include "openra/FieldLoader.h"
@@ -28,167 +28,21 @@ namespace
 			std::cout << "ok: " << what << "\n";
 	}
 
-	void testParsing()
+	// 解析断言辅助：失败时打印错误消息 / parse helper: prints the error message on failure
+	// 注意按值返回：expected 是局部对象，返回其内部引用会悬垂
+	// Returns by value: the expected is a local, so a reference into it would dangle
+	std::vector<MiniYamlNode> parsed(std::string_view text, std::string_view name)
 	{
-		const auto text = R"(# top comment
-player: World
-	Health: 100
-	Name: Generic Value
-	Speed: 7
-)";
-		auto nodes = miniYamlFromString(text, "test");
-		check(nodes.size() == 1, "single top-level node");
-		check(nodes[0].key && *nodes[0].key == "player", "key parsed");
-		check(nodes[0].value->value && *nodes[0].value->value == "World", "value parsed");
-		check(nodes[0].value->nodes.size() == 3, "three children");
-		check(*nodes[0].value->nodes[0].key == "Health"
-			&& *nodes[0].value->nodes[0].value->value == "100", "child key/value");
-		check(*nodes[0].value->nodes[1].value->value == "Generic Value", "value with spaces preserved");
-		check(nodes[0].location.line == 2, "source location line");
-	}
-
-	void testEscapes()
-	{
-		// '#' 需转义；注释以未转义 '#' 开始
-		// '#' must be escaped; comments start at an unescaped '#'
-		const auto text = R"(color: value\#withhash # real comment
-tag: \ spaced \
-)";
-		auto nodes = miniYamlFromString(text, "test", false);
-		check(nodes.size() == 2, "two nodes");
-		check(*nodes[0].value->value == "value#withhash", "escaped hash restored");
-		check(nodes[0].comment && *nodes[0].comment == " real comment", "comment captured");
-		check(*nodes[1].value->value == " spaced ", "backslash whitespace guards preserved");
-	}
-
-	void testTabIndent()
-	{
-		const auto text = "a:\n\tb: 1\n\t\tc: 2\n";
-		auto nodes = miniYamlFromString(text, "test");
-		check(nodes.size() == 1, "tab: single root");
-		check(nodes[0].value->nodes.size() == 1, "tab: one child");
-		check(nodes[0].value->nodes[0].value->nodes.size() == 1, "tab: one grandchild");
-		check(*nodes[0].value->nodes[0].value->nodes[0].key == "c", "tab: grandchild key");
-	}
-
-	void testBadIndent()
-	{
-		bool threw = false;
-		try
+		auto result = miniYamlFromString(text, name);
+		if (!result.has_value())
 		{
-			miniYamlFromString("a:\n\t\tb: 1\n", "test");
-		}
-		catch (const YamlException&)
-		{
-			threw = true;
+			std::cerr << "FAIL: parse error: " << result.error().message << "\n";
+			++failures;
+			return {};
 		}
 
-		check(threw, "bad indent throws");
+		return std::move(*result);
 	}
-
-	void testMergeInheritRemoval()
-	{
-		const auto base = R"(^base:
-	Inherits: ^common
-	HP: 10
-	Traits:
-		A: 1
-		B: 2
-^common:
-	HP: 1
-	Traits:
-		A: 9
-^extra:
-	Speed: 99
-)";
-		const auto override = R"(^base:
-	Inherits@extra: ^extra
-	HP: 20
-	Traits:
-		-B
-)";
-		auto baseNodes = miniYamlFromString(base, "base");
-		auto overrideNodes = miniYamlFromString(override, "override");
-		auto merged = miniYamlMerge({ baseNodes, overrideNodes });
-
-		check(merged.size() == 3, "merge: three top-level entries");
-		auto dict = merged[0].value->toDictionary();
-		check(dict.count("HP") && *dict.at("HP")->value == "20", "merge: override wins");
-		check(dict.count("Speed") && *dict.at("Speed")->value == "99", "inherit@extra applied");
-		auto traits = dict.at("Traits")->toDictionary();
-		check(traits.count("A") && *traits.at("A")->value == "1", "inherit: A survives from base");
-		check(!traits.count("B"), "removal: B removed");
-	}
-
-	void testDuplicateInheritThrows()
-	{
-		// C# 语义：同一父类型不可被继承两次（防循环/冗余）
-		// C# semantics: a parent may not be inherited twice (loop/redundancy guard)
-		const auto text = R"(^a:
-	Inherits: ^common
-	Inherits@dup: ^common
-^common:
-	X: 1
-)";
-		auto nodes = miniYamlFromString(text, "t");
-		bool threw = false;
-		try
-		{
-			miniYamlMerge({ nodes });
-		}
-		catch (const YamlException&)
-		{
-			threw = true;
-		}
-
-		check(threw, "duplicate inheritance throws");
-	}
-
-	void testRoundTrip()
-	{
-		const auto text = "a: 1\n\tb: hello world\n\t\tc: deep\n";
-		auto nodes = miniYamlFromString(text, "test");
-		auto out = miniYamlToString(nodes);
-		auto reparsed = miniYamlFromString(out, "roundtrip");
-		auto out2 = miniYamlToString(reparsed);
-		check(out == out2, "round-trip stable");
-		check(reparsed.size() == 1, "round-trip: same node count");
-		check(*reparsed[0].value->nodes[0].value->nodes[0].key == "c", "round-trip: deep child");
-	}
-
-	void testRealModFile(const std::filesystem::path& engineRoot)
-	{
-		// 用真实 mod 规则文件做冒烟解析 / smoke-parse real mod rule files
-		auto rules = engineRoot / "mods" / "ra" / "rules";
-		if (!std::filesystem::exists(rules))
-		{
-			std::cout << "skip: real mod files not found\n";
-			return;
-		}
-
-		int parsed = 0;
-		for (const auto& entry : std::filesystem::recursive_directory_iterator(rules))
-		{
-			if (entry.path().extension() != ".yaml")
-				continue;
-			try
-			{
-				auto nodes = miniYamlFromFile(entry.path().string());
-				parsed++;
-				for (const auto& n : nodes)
-					if (!n.key)
-						throw YamlException("null key without comment retention");
-			}
-			catch (const std::exception& e)
-			{
-				check(false, "parse " + entry.path().string() + ": " + e.what());
-				return;
-			}
-		}
-
-		check(parsed > 0, "real mod files parsed (" + std::to_string(parsed) + " files)");
-	}
-}
 
 namespace
 {
@@ -239,8 +93,131 @@ namespace
 OPENRA_REGISTER_TYPE(TraitInfo, HealthInfo)
 OPENRA_REGISTER_TYPE(TraitInfo, SpeedInfo)
 
-namespace
-{
+	void testParsing()
+	{
+		const auto text = R"(# top comment
+player: World
+	Health: 100
+	Name: Generic Value
+	Speed: 7
+)";
+		const auto nodes = parsed(text, "test");
+		check(nodes.size() == 1, "single top-level node");
+		check(nodes[0].key && *nodes[0].key == "player", "key parsed");
+		check(nodes[0].value->value && *nodes[0].value->value == "World", "value parsed");
+		check(nodes[0].value->nodes.size() == 3, "three children");
+		check(*nodes[0].value->nodes[0].key == "Health"
+			&& *nodes[0].value->nodes[0].value->value == "100", "child key/value");
+		check(*nodes[0].value->nodes[1].value->value == "Generic Value", "value with spaces preserved");
+		check(nodes[0].location.line == 2, "source location line");
+	}
+
+	void testEscapes()
+	{
+		// '#' 需转义；注释以未转义 '#' 开始（保留前导空格）
+		// '#' must be escaped; comments start at an unescaped '#' (leading space kept)
+		const auto text = R"(color: value\#withhash # real comment
+tag: \ spaced \
+)";
+		auto retain = miniYamlFromString(text, "test", false);
+		check(retain.has_value() && (*retain).size() == 2, "two nodes");
+		check(*(*retain)[0].value->value == "value#withhash", "escaped hash restored");
+		check((*retain)[0].comment && *(*retain)[0].comment == " real comment", "comment captured");
+		check(*(*retain)[1].value->value == " spaced ", "backslash whitespace guards preserved");
+	}
+
+	void testTabIndent()
+	{
+		const auto nodes = parsed("a:\n\tb: 1\n\t\tc: 2\n", "test");
+		check(nodes.size() == 1, "tab: single root");
+		check(nodes[0].value->nodes.size() == 1, "tab: one child");
+		check(nodes[0].value->nodes[0].value->nodes.size() == 1, "tab: one grandchild");
+		check(*nodes[0].value->nodes[0].value->nodes[0].key == "c", "tab: grandchild key");
+	}
+
+	void testBadIndent()
+	{
+		auto result = miniYamlFromString("a:\n\t\tb: 1\n", "test");
+		check(!result.has_value(), "bad indent yields error");
+		check(result.error().message.find("Bad indent") != std::string::npos, "bad indent message");
+	}
+
+	void testMergeInheritRemoval()
+	{
+		const auto base = R"(^base:
+	Inherits: ^common
+	HP: 10
+	Traits:
+		A: 1
+		B: 2
+^common:
+	HP: 1
+	Traits:
+		A: 9
+^extra:
+	Speed: 99
+)";
+		const auto override = R"(^base:
+	Inherits@extra: ^extra
+	HP: 20
+	Traits:
+		-B
+)";
+		auto baseNodes = miniYamlFromString(base, "base");
+		auto overrideNodes = miniYamlFromString(override, "override");
+		check(baseNodes.has_value() && overrideNodes.has_value(), "merge: inputs parse");
+		auto merged = miniYamlMerge({ *baseNodes, *overrideNodes });
+		check(merged.has_value(), "merge succeeds");
+		if (!merged.has_value())
+			return;
+
+		check((*merged).size() == 3, "merge: three top-level entries");
+		auto dict = (*merged)[0].value->toDictionary();
+		check(dict.has_value(), "merge: dictionary builds");
+		if (!dict.has_value())
+			return;
+		check(dict->count("HP") && *dict->at("HP")->value == "20", "merge: override wins");
+		check(dict->count("Speed") && *dict->at("Speed")->value == "99", "inherit@extra applied");
+		auto traits = dict->at("Traits")->toDictionary();
+		check(traits.has_value() && traits->count("A") && *traits->at("A")->value == "1",
+			"inherit: A survives from base");
+		check(!traits->count("B"), "removal: B removed");
+	}
+
+	void testDuplicateInheritFails()
+	{
+		// C# 语义：同一父类型不可被继承两次（防循环/冗余）
+		// C# semantics: a parent may not be inherited twice (loop/redundancy guard)
+		const auto text = R"(^a:
+	Inherits: ^common
+	Inherits@dup: ^common
+^common:
+	X: 1
+)";
+		auto nodes = miniYamlFromString(text, "t");
+		check(nodes.has_value(), "duplicate inheritance: input parses");
+		auto merged = miniYamlMerge({ *nodes });
+		check(!merged.has_value(), "duplicate inheritance yields error");
+		check(merged.error().message.find("already inherited") != std::string::npos,
+			"duplicate inheritance message");
+	}
+
+	void testRoundTrip()
+	{
+		const auto text = "a: 1\n\tb: hello world\n\t\tc: deep\n";
+		auto nodes = miniYamlFromString(text, "test");
+		check(nodes.has_value(), "round-trip: parses");
+		auto out = miniYamlToString(*nodes);
+		auto reparsed = miniYamlFromString(out, "roundtrip");
+		check(reparsed.has_value(), "round-trip: reparses");
+		if (!reparsed.has_value())
+			return;
+		auto out2 = miniYamlToString(*reparsed);
+		check(out == out2, "round-trip stable");
+		check((*reparsed).size() == 1, "round-trip: same node count");
+		check(*(*reparsed)[0].value->nodes[0].value->nodes[0].key == "c", "round-trip: deep child");
+	}
+
 	void testFieldLoader()
 	{
 		const auto text = R"(Name: GuardTower
@@ -251,46 +228,32 @@ Weapon:
 	Range: 7.5
 )";
 		auto nodes = miniYamlFromString(text, "fields");
+		check(nodes.has_value(), "field: input parses");
 		// 顶层各字段为平级节点，包一层根容器再加载 / top-level fields are siblings; wrap in a root
-		auto tower = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, std::move(nodes)));
+		auto tower = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, std::move(*nodes)));
+		check(tower.has_value(), "field: loads without error");
+		if (!tower.has_value())
+		{
+			std::cerr << "  error: " << tower.error().message << "\n";
+			return;
+		}
 
-		check(tower.name == "GuardTower", "field: string loaded");
-		check(tower.active, "field: bool loaded");
-		check(tower.level == 1, "field: absent field keeps default");
-		check(tower.offsets == std::vector<int>({ 1, 2, 3 }), "field: vector loaded");
-		check(tower.weapon.damage == 50, "field: nested struct loaded");
-		check(tower.weapon.range > 7.49f && tower.weapon.range < 7.51f, "field: float loaded");
+		check(tower->name == "GuardTower", "field: string loaded");
+		check(tower->active, "field: bool loaded");
+		check(tower->level == 1, "field: absent field keeps default");
+		check(tower->offsets == std::vector<int>({ 1, 2, 3 }), "field: vector loaded");
+		check(tower->weapon.damage == 50, "field: nested struct loaded");
+		check(tower->weapon.range > 7.49f && tower->weapon.range < 7.51f, "field: float loaded");
 	}
 
 	void testFieldLoaderErrors()
 	{
-		bool threw = false;
-		try
-		{
-			const auto text = "Damage: fifty\n";
-			auto nodes = miniYamlFromString(text, "bad");
-			auto w = FieldLoader::load<WeaponInfo>(MiniYaml(std::nullopt, std::move(nodes)));
-		}
-		catch (const FieldLoadException&)
-		{
-			threw = true;
-		}
+		auto bad = FieldLoader::load<WeaponInfo>(MiniYaml(std::nullopt, *miniYamlFromString("Damage: fifty\n", "bad")));
+		check(!bad.has_value(), "field: bad numeric value yields error");
+		check(bad.error().message.find("Cannot parse") != std::string::npos, "field: numeric error message");
 
-		check(threw, "field: bad numeric value throws");
-
-		threw = false;
-		try
-		{
-			const auto text = "Active: yes\n";
-			auto nodes = miniYamlFromString(text, "bad");
-			auto t = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, std::move(nodes)));
-		}
-		catch (const FieldLoadException&)
-		{
-			threw = true;
-		}
-
-		check(threw, "field: bad bool value throws");
+		auto badBool = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, *miniYamlFromString("Active: yes\n", "bad")));
+		check(!badBool.has_value(), "field: bad bool value yields error");
 	}
 
 	void testTypeRegistry()
@@ -309,13 +272,44 @@ Weapon:
 	HP: 123
 )";
 		auto nodes = miniYamlFromString(text, "traits");
-		auto trait = TypeRegistry<TraitInfo>::create(*nodes[0].key);
+		check(nodes.has_value(), "registry: input parses");
+		auto trait = TypeRegistry<TraitInfo>::create(*(*nodes)[0].key);
 		check(trait != nullptr, "registry: yaml key drives creation");
 		auto* hi = dynamic_cast<HealthInfo*>(trait.get());
-		FieldLoader::load(*hi, *nodes[0].value);
+		auto ok = FieldLoader::load(*hi, *(*nodes)[0].value);
+		check(ok.has_value(), "registry+fields: loads without error");
 		check(hi->hp == 123, "registry+fields: yaml value injected");
 	}
+
+	void testRealModFile(const std::filesystem::path& engineRoot)
+	{
+		// 用真实 mod 规则文件做冒烟解析 / smoke-parse real mod rule files
+		auto rules = engineRoot / "mods" / "ra" / "rules";
+		if (!std::filesystem::exists(rules))
+		{
+			std::cout << "skip: real mod files not found\n";
+			return;
+		}
+
+		int parsedCount = 0;
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(rules))
+		{
+			if (entry.path().extension() != ".yaml")
+				continue;
+			auto nodes = miniYamlFromFile(entry.path().string());
+			if (!nodes.has_value())
+			{
+				check(false, "parse " + entry.path().string() + ": " + nodes.error().message);
+				return;
+			}
+
+			parsedCount++;
+		}
+
+		check(parsedCount > 0, "real mod files parsed (" + std::to_string(parsedCount) + " files)");
+	}
 }
+
 
 int main(int argc, char** argv)
 {
@@ -324,7 +318,7 @@ int main(int argc, char** argv)
 	testTabIndent();
 	testBadIndent();
 	testMergeInheritRemoval();
-	testDuplicateInheritThrows();
+	testDuplicateInheritFails();
 	testRoundTrip();
 	testFieldLoader();
 	testFieldLoaderErrors();

--- a/CPP23/tests/test_main.cpp
+++ b/CPP23/tests/test_main.cpp
@@ -1,0 +1,347 @@
+
+// MiniYaml 移植验证测试 / MiniYaml port verification tests
+// 覆盖：解析（缩进/注释/转义）、合并继承删除、序列化回环、真实 mod 文件解析
+// Covers: parsing (indent/comments/escapes), merge/inherit/removal, round-trip, real mod files
+
+#include "openra/MiniYaml.h"
+#include "openra/FieldLoader.h"
+#include "openra/TypeRegistry.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <iostream>
+
+using namespace OpenRA;
+
+namespace
+{
+	int failures = 0;
+
+	void check(bool ok, const std::string& what)
+	{
+		if (!ok)
+		{
+			std::cerr << "FAIL: " << what << "\n";
+			++failures;
+		}
+		else
+			std::cout << "ok: " << what << "\n";
+	}
+
+	void testParsing()
+	{
+		const auto text = R"(# top comment
+player: World
+	Health: 100
+	Name: Generic Value
+	Speed: 7
+)";
+		auto nodes = miniYamlFromString(text, "test");
+		check(nodes.size() == 1, "single top-level node");
+		check(nodes[0].key && *nodes[0].key == "player", "key parsed");
+		check(nodes[0].value->value && *nodes[0].value->value == "World", "value parsed");
+		check(nodes[0].value->nodes.size() == 3, "three children");
+		check(*nodes[0].value->nodes[0].key == "Health"
+			&& *nodes[0].value->nodes[0].value->value == "100", "child key/value");
+		check(*nodes[0].value->nodes[1].value->value == "Generic Value", "value with spaces preserved");
+		check(nodes[0].location.line == 2, "source location line");
+	}
+
+	void testEscapes()
+	{
+		// '#' 需转义；注释以未转义 '#' 开始
+		// '#' must be escaped; comments start at an unescaped '#'
+		const auto text = R"(color: value\#withhash # real comment
+tag: \ spaced \
+)";
+		auto nodes = miniYamlFromString(text, "test", false);
+		check(nodes.size() == 2, "two nodes");
+		check(*nodes[0].value->value == "value#withhash", "escaped hash restored");
+		check(nodes[0].comment && *nodes[0].comment == " real comment", "comment captured");
+		check(*nodes[1].value->value == " spaced ", "backslash whitespace guards preserved");
+	}
+
+	void testTabIndent()
+	{
+		const auto text = "a:\n\tb: 1\n\t\tc: 2\n";
+		auto nodes = miniYamlFromString(text, "test");
+		check(nodes.size() == 1, "tab: single root");
+		check(nodes[0].value->nodes.size() == 1, "tab: one child");
+		check(nodes[0].value->nodes[0].value->nodes.size() == 1, "tab: one grandchild");
+		check(*nodes[0].value->nodes[0].value->nodes[0].key == "c", "tab: grandchild key");
+	}
+
+	void testBadIndent()
+	{
+		bool threw = false;
+		try
+		{
+			miniYamlFromString("a:\n\t\tb: 1\n", "test");
+		}
+		catch (const YamlException&)
+		{
+			threw = true;
+		}
+
+		check(threw, "bad indent throws");
+	}
+
+	void testMergeInheritRemoval()
+	{
+		const auto base = R"(^base:
+	Inherits: ^common
+	HP: 10
+	Traits:
+		A: 1
+		B: 2
+^common:
+	HP: 1
+	Traits:
+		A: 9
+^extra:
+	Speed: 99
+)";
+		const auto override = R"(^base:
+	Inherits@extra: ^extra
+	HP: 20
+	Traits:
+		-B
+)";
+		auto baseNodes = miniYamlFromString(base, "base");
+		auto overrideNodes = miniYamlFromString(override, "override");
+		auto merged = miniYamlMerge({ baseNodes, overrideNodes });
+
+		check(merged.size() == 3, "merge: three top-level entries");
+		auto dict = merged[0].value->toDictionary();
+		check(dict.count("HP") && *dict.at("HP")->value == "20", "merge: override wins");
+		check(dict.count("Speed") && *dict.at("Speed")->value == "99", "inherit@extra applied");
+		auto traits = dict.at("Traits")->toDictionary();
+		check(traits.count("A") && *traits.at("A")->value == "1", "inherit: A survives from base");
+		check(!traits.count("B"), "removal: B removed");
+	}
+
+	void testDuplicateInheritThrows()
+	{
+		// C# 语义：同一父类型不可被继承两次（防循环/冗余）
+		// C# semantics: a parent may not be inherited twice (loop/redundancy guard)
+		const auto text = R"(^a:
+	Inherits: ^common
+	Inherits@dup: ^common
+^common:
+	X: 1
+)";
+		auto nodes = miniYamlFromString(text, "t");
+		bool threw = false;
+		try
+		{
+			miniYamlMerge({ nodes });
+		}
+		catch (const YamlException&)
+		{
+			threw = true;
+		}
+
+		check(threw, "duplicate inheritance throws");
+	}
+
+	void testRoundTrip()
+	{
+		const auto text = "a: 1\n\tb: hello world\n\t\tc: deep\n";
+		auto nodes = miniYamlFromString(text, "test");
+		auto out = miniYamlToString(nodes);
+		auto reparsed = miniYamlFromString(out, "roundtrip");
+		auto out2 = miniYamlToString(reparsed);
+		check(out == out2, "round-trip stable");
+		check(reparsed.size() == 1, "round-trip: same node count");
+		check(*reparsed[0].value->nodes[0].value->nodes[0].key == "c", "round-trip: deep child");
+	}
+
+	void testRealModFile(const std::filesystem::path& engineRoot)
+	{
+		// 用真实 mod 规则文件做冒烟解析 / smoke-parse real mod rule files
+		auto rules = engineRoot / "mods" / "ra" / "rules";
+		if (!std::filesystem::exists(rules))
+		{
+			std::cout << "skip: real mod files not found\n";
+			return;
+		}
+
+		int parsed = 0;
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(rules))
+		{
+			if (entry.path().extension() != ".yaml")
+				continue;
+			try
+			{
+				auto nodes = miniYamlFromFile(entry.path().string());
+				parsed++;
+				for (const auto& n : nodes)
+					if (!n.key)
+						throw YamlException("null key without comment retention");
+			}
+			catch (const std::exception& e)
+			{
+				check(false, "parse " + entry.path().string() + ": " + e.what());
+				return;
+			}
+		}
+
+		check(parsed > 0, "real mod files parsed (" + std::to_string(parsed) + " files)");
+	}
+}
+
+namespace
+{
+	// 测试用字段化结构 / field-annotated test structs
+	struct WeaponInfo
+	{
+		int damage = 0;
+		float range = 0;
+		static constexpr auto openra_fields = std::tuple{
+			OpenRA::field("Damage", &WeaponInfo::damage),
+			OpenRA::field("Range", &WeaponInfo::range),
+		};
+	};
+
+	struct TowerInfo
+	{
+		std::string name;
+		bool active = false;
+		int level = 1;
+		std::vector<int> offsets;
+		WeaponInfo weapon;
+		static constexpr auto openra_fields = std::tuple{
+			OpenRA::field("Name", &TowerInfo::name),
+			OpenRA::field("Active", &TowerInfo::active),
+			OpenRA::field("Level", &TowerInfo::level),
+			OpenRA::field("Offsets", &TowerInfo::offsets),
+			OpenRA::field("Weapon", &TowerInfo::weapon),
+		};
+	};
+
+	// 类型注册测试基类与两个派生 / registry test base and two derived types
+	struct TraitInfo
+	{
+		virtual ~TraitInfo() = default;
+	};
+
+	struct HealthInfo : TraitInfo
+	{
+		int hp = 0;
+		static constexpr auto openra_fields = std::tuple{
+			OpenRA::field("HP", &HealthInfo::hp),
+		};
+	};
+
+	struct SpeedInfo : TraitInfo { };
+}
+
+OPENRA_REGISTER_TYPE(TraitInfo, HealthInfo)
+OPENRA_REGISTER_TYPE(TraitInfo, SpeedInfo)
+
+namespace
+{
+	void testFieldLoader()
+	{
+		const auto text = R"(Name: GuardTower
+Active: true
+Offsets: 1 2 3
+Weapon:
+	Damage: 50
+	Range: 7.5
+)";
+		auto nodes = miniYamlFromString(text, "fields");
+		// 顶层各字段为平级节点，包一层根容器再加载 / top-level fields are siblings; wrap in a root
+		auto tower = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, std::move(nodes)));
+
+		check(tower.name == "GuardTower", "field: string loaded");
+		check(tower.active, "field: bool loaded");
+		check(tower.level == 1, "field: absent field keeps default");
+		check(tower.offsets == std::vector<int>({ 1, 2, 3 }), "field: vector loaded");
+		check(tower.weapon.damage == 50, "field: nested struct loaded");
+		check(tower.weapon.range > 7.49f && tower.weapon.range < 7.51f, "field: float loaded");
+	}
+
+	void testFieldLoaderErrors()
+	{
+		bool threw = false;
+		try
+		{
+			const auto text = "Damage: fifty\n";
+			auto nodes = miniYamlFromString(text, "bad");
+			auto w = FieldLoader::load<WeaponInfo>(MiniYaml(std::nullopt, std::move(nodes)));
+		}
+		catch (const FieldLoadException&)
+		{
+			threw = true;
+		}
+
+		check(threw, "field: bad numeric value throws");
+
+		threw = false;
+		try
+		{
+			const auto text = "Active: yes\n";
+			auto nodes = miniYamlFromString(text, "bad");
+			auto t = FieldLoader::load<TowerInfo>(MiniYaml(std::nullopt, std::move(nodes)));
+		}
+		catch (const FieldLoadException&)
+		{
+			threw = true;
+		}
+
+		check(threw, "field: bad bool value throws");
+	}
+
+	void testTypeRegistry()
+	{
+		// OPENRA_REGISTER_TYPE 宏静态注册的工厂 / factories registered statically by the macro
+		auto health = TypeRegistry<TraitInfo>::create("HealthInfo");
+		check(health != nullptr, "registry: create by name");
+		check(dynamic_cast<HealthInfo*>(health.get()) != nullptr, "registry: correct dynamic type");
+
+		check(TypeRegistry<TraitInfo>::create("NoSuchInfo") == nullptr, "registry: unknown name yields null");
+		check(TypeRegistry<TraitInfo>::contains("SpeedInfo"), "registry: second type registered");
+
+		// 注册类型 + 字段加载组合：模拟 trait 的 YAML 实例化
+		// Registry + field loading combined: simulates YAML trait instantiation
+		const auto text = R"(HealthInfo:
+	HP: 123
+)";
+		auto nodes = miniYamlFromString(text, "traits");
+		auto trait = TypeRegistry<TraitInfo>::create(*nodes[0].key);
+		check(trait != nullptr, "registry: yaml key drives creation");
+		auto* hi = dynamic_cast<HealthInfo*>(trait.get());
+		FieldLoader::load(*hi, *nodes[0].value);
+		check(hi->hp == 123, "registry+fields: yaml value injected");
+	}
+}
+
+int main(int argc, char** argv)
+{
+	testParsing();
+	testEscapes();
+	testTabIndent();
+	testBadIndent();
+	testMergeInheritRemoval();
+	testDuplicateInheritThrows();
+	testRoundTrip();
+	testFieldLoader();
+	testFieldLoaderErrors();
+	testTypeRegistry();
+
+	// 从测试可执行文件位置向上找仓库根 / locate the repo root from the test executable
+	auto engineRoot = std::filesystem::current_path();
+	if (argc > 1)
+		engineRoot = std::filesystem::path(argv[1]);
+	testRealModFile(engineRoot);
+
+	if (failures > 0)
+	{
+		std::cerr << failures << " test(s) failed\n";
+		return 1;
+	}
+
+	std::cout << "all tests passed\n";
+	return 0;
+}


### PR DESCRIPTION
## Description

This is an **experimental, incremental** start of a C++23 port, kept fully isolated in a new `CPP23/` directory (it does not touch any existing C# code and builds independently with CMake).

The first module covers the YAML + reflection foundation, mirroring `MiniYaml.cs`, `FieldLoader.cs` and `ObjectCreator`:

- **MiniYaml**: a faithful, behavior-preserving port of the YAML-subset parser, `Inherits@` inheritance, `-Key` removals, multi-source merging and serialization.
- **Fields / FieldLoader**: compile-time field metadata (member pointers, no macros) plus YAML value injection for scalars, strings, vectors and nested structs, replacing C# reflection.
- **TypeRegistry**: type-name-to-factory registration macros replacing `ObjectCreator.CreateObject`.
- Toolchain: CMake + Ninja + LLVM Clang with the **GNU ABI** on all platforms (llvm-mingw on Windows), and a README documenting a four-phase porting roadmap (bilingual EN/CN).
- Tests: 37 assertions plus smoke-parsing of every real `mods/ra/rules` YAML file.

## Context

There is no upstream consensus for a C++ migration, and this PR is **not** tied to an existing issue. I'm opening it to ask the maintainers whether an incrementally ported, fully isolated `CPP23/` module directory is something you would be willing to carry in the tree (even as an experimental opt-in component), or whether this belongs in a downstream fork instead. Happy to restructure, split, or close based on your feedback.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/OpenRA/OpenRA/blob/bleed/CONTRIBUTING.md)
- [x] Existing code does not gain new behavior (C# tree untouched)
- [x] Added `CPP23/` builds and tests pass (CMake + LLVM Clang, GNU ABI)