### PR TITLE
Restore FPS when replay ends.

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -211,7 +211,7 @@ namespace OpenRA.Network
 				if (World.IsLoadingGameSave)
 					return 1;
 
-				if (World.IsReplay)
+				if (World.IsReplay && !IsOutOfSync && NetFrameNumber < ((ReplayConnection)Connection).TickCount)
 					return World.ReplayTimestep;
 
 				if (tickScale != 1f)


### PR DESCRIPTION
Whilst a replay is running, we allow the world to run at a fast tick rate, down to a minimum 10 FPS. Once the replay finishes, previously we did not restore the usual framerate. Now, we will detect the replay completing to restore normal framerate - this mirrors the same check in ReplayControlBarLogic for disabling replay controls.

Fixes #22199