### PR TITLE
Parse from spans, not strings.

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -482,57 +482,83 @@ namespace OpenRA
 			return result;
 		}
 
-		public static byte ParseByteInvariant(string s)
+		public static byte ParseByteInvariant(ReadOnlySpan<char> s)
 		{
 			return byte.Parse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
 		}
 
-		public static ushort ParseUshortInvariant(string s)
+		public static ushort ParseUInt16Invariant(ReadOnlySpan<char> s)
 		{
 			return ushort.Parse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
 		}
 
-		public static short ParseInt16Invariant(string s)
+		public static short ParseInt16Invariant(ReadOnlySpan<char> s)
 		{
 			return short.Parse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
 		}
 
-		public static int ParseInt32Invariant(string s)
+		public static int ParseInt32Invariant(ReadOnlySpan<char> s)
 		{
 			return int.Parse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
 		}
 
-		public static float ParseFloatOrPercentInvariant(string s)
+		public static long ParseInt64Invariant(ReadOnlySpan<char> s)
 		{
-			var f = float.Parse(s.Replace("%", ""), NumberStyles.Float, NumberFormatInfo.InvariantInfo);
-			return f * (s.Contains('%') ? 0.01f : 1f);
+			return long.Parse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo);
 		}
 
-		public static bool TryParseByteInvariant(string s, out byte i)
+		public static float ParseFloatOrPercentInvariant(ReadOnlySpan<char> s)
+		{
+			var raw = s;
+			var mult = 1f;
+			if (s.Contains('%'))
+			{
+				raw = s.ToString().Replace("%", "");
+				mult = 0.01f;
+			}
+
+			var f = float.Parse(raw, NumberStyles.Float, NumberFormatInfo.InvariantInfo);
+			return f * mult;
+		}
+
+		public static bool TryParseByteInvariant(ReadOnlySpan<char> s, out byte i)
 		{
 			return byte.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
 		}
 
-		public static bool TryParseUshortInvariant(string s, out ushort i)
+		public static bool TryParseUInt16Invariant(ReadOnlySpan<char> s, out ushort i)
 		{
 			return ushort.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
 		}
 
-		public static bool TryParseInt32Invariant(string s, out int i)
+		public static bool TryParseInt16Invariant(ReadOnlySpan<char> s, out short i)
+		{
+			return short.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
+		}
+
+		public static bool TryParseInt32Invariant(ReadOnlySpan<char> s, out int i)
 		{
 			return int.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
 		}
 
-		public static bool TryParseInt64Invariant(string s, out long i)
+		public static bool TryParseInt64Invariant(ReadOnlySpan<char> s, out long i)
 		{
 			return long.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
 		}
 
-		public static bool TryParseFloatOrPercentInvariant(string s, out float f)
+		public static bool TryParseFloatOrPercentInvariant(ReadOnlySpan<char> s, out float f)
 		{
-			if (float.TryParse(s?.Replace("%", ""), NumberStyles.Float, NumberFormatInfo.InvariantInfo, out f))
+			var raw = s;
+			var mult = 1f;
+			if (s.Contains('%'))
 			{
-				f *= s.Contains('%') ? 0.01f : 1f;
+				raw = s.ToString().Replace("%", "");
+				mult = 0.01f;
+			}
+
+			if (float.TryParse(raw, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out f))
+			{
+				f *= mult;
 				return true;
 			}
 
@@ -614,25 +640,25 @@ namespace OpenRA
 			return default;
 		}
 
-		public static LineSplitEnumerator SplitLines(this string str, char separator)
+		public static SplitEnumerator Split(this ReadOnlySpan<char> str, char separator)
 		{
-			return new LineSplitEnumerator(str.AsSpan(), separator);
+			return new SplitEnumerator(str, separator);
 		}
 	}
 
-	public ref struct LineSplitEnumerator
+	public ref struct SplitEnumerator
 	{
 		ReadOnlySpan<char> str;
 		readonly char separator;
 
-		public LineSplitEnumerator(ReadOnlySpan<char> str, char separator)
+		public SplitEnumerator(ReadOnlySpan<char> str, char separator)
 		{
 			this.str = str;
 			this.separator = separator;
 			Current = default;
 		}
 
-		public readonly LineSplitEnumerator GetEnumerator() => this;
+		public readonly SplitEnumerator GetEnumerator() => this;
 
 		public bool MoveNext()
 		{

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -49,11 +49,14 @@ namespace OpenRA
 			}
 		}
 
-		public static Func<string, Type, string, object> InvalidValueAction = (s, t, f) =>
-			throw new YamlException($"FieldLoader: Cannot parse `{s}` into `{f}.{t}`");
+		public delegate object InvalidValueActionDelegate(ReadOnlySpan<char> value, Type fieldType, string fieldName);
+		public delegate void UnknownFieldActionDelegate(string fieldName);
 
-		public static Action<string, Type> UnknownFieldAction = (s, f) =>
-			throw new NotImplementedException($"FieldLoader: Missing field `{s}` on `{f.Name}`");
+		public static InvalidValueActionDelegate InvalidValueAction = (value, fieldType, fieldName) =>
+			throw new YamlException($"FieldLoader: Cannot parse `{value}` into field `{fieldName}` of type `{fieldType}`");
+
+		public static UnknownFieldActionDelegate UnknownFieldAction = (fieldName) =>
+			throw new NotImplementedException($"FieldLoader: Missing field `{fieldName}`");
 
 		static readonly ConcurrentCache<Type, FieldLoadInfo[]> TypeLoadInfo =
 			new(BuildTypeLoadInfo);
@@ -62,12 +65,16 @@ namespace OpenRA
 		static readonly ConcurrentCache<string, IntegerExpression> IntegerExpressionCache =
 			new(expression => new IntegerExpression(expression));
 
-		static readonly FrozenDictionary<Type, Func<string, Type, string, object>> TypeParsers =
-			new Dictionary<Type, Func<string, Type, string, object>>
+		delegate object ParseValueDelegate(string fieldName, Type fieldType, YamlValue value);
+		delegate object ParseNodesDelegate(string fieldName, Type fieldType, ImmutableArray<MiniYamlNode> nodes);
+
+		static readonly FrozenDictionary<Type, ParseValueDelegate> TypeParsers =
+			new Dictionary<Type, ParseValueDelegate>
 			{
-				{ typeof(int), ParseInt },
+				{ typeof(byte), ParseByte },
 				{ typeof(ushort), ParseUShort },
-				{ typeof(long), ParseLong },
+				{ typeof(short), ParseShort },
+				{ typeof(int), ParseInt },
 				{ typeof(float), ParseFloat },
 				{ typeof(decimal), ParseDecimal },
 				{ typeof(string), ParseString },
@@ -96,17 +103,22 @@ namespace OpenRA
 				{ typeof(DateTime), ParseDateTime }
 			}.ToFrozenDictionary();
 
-		static readonly FrozenDictionary<Type, Func<string, Type, string, MiniYaml, object>> GenericTypeParsers =
-			new Dictionary<Type, Func<string, Type, string, MiniYaml, object>>
+		static readonly FrozenDictionary<Type, ParseValueDelegate> GenericTypeValueParsers =
+			new Dictionary<Type, ParseValueDelegate>
 			{
 				{ typeof(HashSet<>), ParseHashSetOrList },
 				{ typeof(List<>), ParseHashSetOrList },
-				{ typeof(Dictionary<,>), ParseDictionary },
 				{ typeof(ImmutableArray<>), ParseImmutableArray },
 				{ typeof(FrozenSet<>), ParseFrozenSet },
-				{ typeof(FrozenDictionary<,>), ParseFrozenDictionary },
 				{ typeof(BitSet<>), ParseBitSet },
 				{ typeof(Nullable<>), ParseNullable },
+			}.ToFrozenDictionary();
+
+		static readonly FrozenDictionary<Type, ParseNodesDelegate> GenericTypeNodesParsers =
+			new Dictionary<Type, ParseNodesDelegate>
+			{
+				{ typeof(Dictionary<,>), ParseDictionary },
+				{ typeof(FrozenDictionary<,>), ParseFrozenDictionary },
 			}.ToFrozenDictionary();
 
 		static readonly object BoxedTrue = true;
@@ -131,457 +143,513 @@ namespace OpenRA
 				m.Name == nameof(FrozenDictionary.ToFrozenDictionary) &&
 				m.GetParameters().Length == 2);
 
-		static object ParseInt(string fieldName, Type fieldType, string value)
+		static object ParseByte(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Exts.TryParseInt32Invariant(value, out var res))
+			if (Exts.TryParseByteInvariant(value.Span, out var res))
+				return res;
+			return InvalidValueAction(value.Span, fieldType, fieldName);
+		}
+
+		static object ParseUShort(string fieldName, Type fieldType, YamlValue value)
+		{
+			if (Exts.TryParseUInt16Invariant(value.Span, out var res))
+				return res;
+			return InvalidValueAction(value.Span, fieldType, fieldName);
+		}
+
+		static object ParseShort(string fieldName, Type fieldType, YamlValue value)
+		{
+			if (Exts.TryParseInt16Invariant(value.Span, out var res))
+				return res;
+			return InvalidValueAction(value.Span, fieldType, fieldName);
+		}
+
+		static object ParseInt(string fieldName, Type fieldType, YamlValue value)
+		{
+			if (Exts.TryParseInt32Invariant(value.Span, out var res))
 			{
 				if (res >= 0 && res < BoxedInts.Length)
 					return BoxedInts[res];
 				return res;
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseUShort(string fieldName, Type fieldType, string value)
+		static object ParseFloat(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Exts.TryParseUshortInvariant(value, out var res))
+			if (Exts.TryParseFloatOrPercentInvariant(value.Span, out var res))
 				return res;
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseLong(string fieldName, Type fieldType, string value)
+		static object ParseDecimal(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Exts.TryParseInt64Invariant(value, out var res))
-				return res;
-			return InvalidValueAction(value, fieldType, fieldName);
+			var raw = value.Span;
+			var mult = 1m;
+			if (value.Span.Contains('%'))
+			{
+				raw = value.ToString().Replace("%", "");
+				mult = 0.01m;
+			}
+
+			if (decimal.TryParse(raw, NumberStyles.Float, NumberFormatInfo.InvariantInfo, out var res))
+				return res * mult;
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseFloat(string fieldName, Type fieldType, string value)
+		static object ParseString(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Exts.TryParseFloatOrPercentInvariant(value, out var res))
-				return res;
-			return InvalidValueAction(value, fieldType, fieldName);
+			return value.ToString();
 		}
 
-		static object ParseDecimal(string fieldName, Type fieldType, string value)
+		static object ParseColor(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null && decimal.TryParse(value.Replace("%", ""), NumberStyles.Float, NumberFormatInfo.InvariantInfo, out var res))
-				return res * (value.Contains('%') ? 0.01m : 1m);
-			return InvalidValueAction(value, fieldType, fieldName);
-		}
-
-		static object ParseString(string fieldName, Type fieldType, string value)
-		{
-			return value;
-		}
-
-		static object ParseColor(string fieldName, Type fieldType, string value)
-		{
-			if (Color.TryParse(value, out var color))
+			if (Color.TryParse(value.Span, out var color))
 				return color;
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseHotkey(string fieldName, Type fieldType, string value)
+		static object ParseHotkey(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Hotkey.TryParse(value, out var res))
+			if (Hotkey.TryParse(value.Span, out var res))
 				return res;
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseHotkeyReference(string fieldName, Type fieldType, string value)
+		static object ParseHotkeyReference(string fieldName, Type fieldType, YamlValue value)
 		{
-			return Game.ModData.Hotkeys[value];
+			return Game.ModData.Hotkeys[value.ToString()];
 		}
 
-		static object ParseWDist(string fieldName, Type fieldType, string value)
+		static object ParseWDist(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (WDist.TryParse(value, out var res))
+			if (WDist.TryParse(value.Span, out var res))
 				return res;
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseWVec(string fieldName, Type fieldType, string value)
+		static object ParseWVec(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 3
-					&& WDist.TryParse(parts[0], out var rx)
-					&& WDist.TryParse(parts[1], out var ry)
-					&& WDist.TryParse(parts[2], out var rz))
+				Span<Range> ranges = stackalloc Range[4];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 3
+					&& WDist.TryParse(value.Span[ranges[0]], out var rx)
+					&& WDist.TryParse(value.Span[ranges[1]], out var ry)
+					&& WDist.TryParse(value.Span[ranges[2]], out var rz))
 					return new WVec(rx, ry, rz);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseWVecArray(string fieldName, Type fieldType, string value)
+		static object ParseWVecArray(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-				if (parts.Length % 3 != 0)
-					return InvalidValueAction(value, fieldType, fieldName);
-
-				var vecs = new WVec[parts.Length / 3];
-
-				for (var i = 0; i < vecs.Length; ++i)
+				var res = new List<WVec>();
+				var parts = value.Span.Split(Comma);
+				Span<WDist> elements = stackalloc WDist[3];
+				var index = 0;
+				foreach (var part in parts)
 				{
-					if (WDist.TryParse(parts[3 * i], out var rx)
-						&& WDist.TryParse(parts[3 * i + 1], out var ry)
-						&& WDist.TryParse(parts[3 * i + 2], out var rz))
-						vecs[i] = new WVec(rx, ry, rz);
-					else
-						return InvalidValueAction(value, fieldType, fieldName);
+					var p = part.Trim(); // StringSplitOptions.TrimEntries
+					if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+					if (!WDist.TryParse(p, out var element))
+						return InvalidValueAction(value.Span, fieldType, fieldName);
+
+					elements[index++] = element;
+					if (index == elements.Length)
+					{
+						index = 0;
+						res.Add(new WVec(elements[0], elements[1], elements[2]));
+					}
 				}
 
-				return vecs;
+				if (index != 0)
+					return InvalidValueAction(value.Span, fieldType, fieldName);
+
+				return res.ToArray();
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseWPos(string fieldName, Type fieldType, string value)
+		static object ParseWPos(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 3
-					&& WDist.TryParse(parts[0], out var rx)
-					&& WDist.TryParse(parts[1], out var ry)
-					&& WDist.TryParse(parts[2], out var rz))
+				Span<Range> ranges = stackalloc Range[4];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 3
+					&& WDist.TryParse(value.Span[ranges[0]], out var rx)
+					&& WDist.TryParse(value.Span[ranges[1]], out var ry)
+					&& WDist.TryParse(value.Span[ranges[2]], out var rz))
 					return new WPos(rx, ry, rz);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseWAngle(string fieldName, Type fieldType, string value)
+		static object ParseWAngle(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (Exts.TryParseInt32Invariant(value, out var res))
+			if (Exts.TryParseInt32Invariant(value.Span, out var res))
 				return new WAngle(res);
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseWRot(string fieldName, Type fieldType, string value)
+		static object ParseWRot(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 3
-					&& Exts.TryParseInt32Invariant(parts[0], out var rr)
-					&& Exts.TryParseInt32Invariant(parts[1], out var rp)
-					&& Exts.TryParseInt32Invariant(parts[2], out var ry))
+				Span<Range> ranges = stackalloc Range[4];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 3
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var rr)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var rp)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[2]], out var ry))
 					return new WRot(new WAngle(rr), new WAngle(rp), new WAngle(ry));
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseCPos(string fieldName, Type fieldType, string value)
+		static object ParseCPos(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 3
-					&& Exts.TryParseInt32Invariant(parts[0], out var x)
-					&& Exts.TryParseInt32Invariant(parts[1], out var y)
-					&& Exts.TryParseByteInvariant(parts[2], out var layer))
+				Span<Range> ranges = stackalloc Range[4];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 3
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var y)
+					&& Exts.TryParseByteInvariant(value.Span[ranges[2]], out var layer))
 					return new CPos(x, y, layer);
 
-				if (parts.Length == 2
-					&& Exts.TryParseInt32Invariant(parts[0], out x)
-					&& Exts.TryParseInt32Invariant(parts[1], out y))
+				if (parts == 2
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out x)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out y))
 					return new CPos(x, y);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseCPosArray(string fieldName, Type fieldType, string value)
+		static object ParseCPosArray(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-				if (parts.Length % 2 != 0)
-					return InvalidValueAction(value, fieldType, fieldName);
-
-				var vecs = new CPos[parts.Length / 2];
-				for (var i = 0; i < vecs.Length; i++)
+				var res = new List<CPos>();
+				var parts = value.Span.Split(Comma);
+				Span<int> elements = stackalloc int[2];
+				var index = 0;
+				foreach (var part in parts)
 				{
-					if (Exts.TryParseInt32Invariant(parts[2 * i], out var rx)
-						&& Exts.TryParseInt32Invariant(parts[2 * i + 1], out var ry))
-						vecs[i] = new CPos(rx, ry);
-					else
-						return InvalidValueAction(value, fieldType, fieldName);
+					var p = part.Trim(); // StringSplitOptions.TrimEntries
+					if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+					if (!Exts.TryParseInt32Invariant(p, out var element))
+						return InvalidValueAction(value.Span, fieldType, fieldName);
+
+					elements[index++] = element;
+					if (index == elements.Length)
+					{
+						index = 0;
+						res.Add(new CPos(elements[0], elements[1]));
+					}
 				}
 
-				return vecs;
+				if (index != 0)
+					return InvalidValueAction(value.Span, fieldType, fieldName);
+
+				return res.ToArray();
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseCVec(string fieldName, Type fieldType, string value)
+		static object ParseCVec(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 2
-					&& Exts.TryParseInt32Invariant(parts[0], out var x)
-					&& Exts.TryParseInt32Invariant(parts[1], out var y))
+				Span<Range> ranges = stackalloc Range[3];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 2
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var y))
 					return new CVec(x, y);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseCVecArray(string fieldName, Type fieldType, string value)
+		static object ParseCVecArray(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-				if (parts.Length % 2 != 0)
-					return InvalidValueAction(value, fieldType, fieldName);
-
-				var vecs = new CVec[parts.Length / 2];
-				for (var i = 0; i < vecs.Length; i++)
+				var res = new List<CVec>();
+				var parts = value.Span.Split(Comma);
+				Span<int> elements = stackalloc int[2];
+				var index = 0;
+				foreach (var part in parts)
 				{
-					if (Exts.TryParseInt32Invariant(parts[2 * i], out var rx)
-						&& Exts.TryParseInt32Invariant(parts[2 * i + 1], out var ry))
-						vecs[i] = new CVec(rx, ry);
-					else
-						return InvalidValueAction(value, fieldType, fieldName);
+					var p = part.Trim(); // StringSplitOptions.TrimEntries
+					if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+					if (!Exts.TryParseInt32Invariant(p, out var element))
+						return InvalidValueAction(value.Span, fieldType, fieldName);
+
+					elements[index++] = element;
+					if (index == elements.Length)
+					{
+						index = 0;
+						res.Add(new CVec(elements[0], elements[1]));
+					}
 				}
 
-				return vecs;
+				if (index != 0)
+					return InvalidValueAction(value.Span, fieldType, fieldName);
+
+				return res.ToArray();
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseBooleanExpression(string fieldName, Type fieldType, string value)
+		static object ParseBooleanExpression(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			try
 			{
-				try
-				{
-					return BooleanExpressionCache[value];
-				}
-				catch (InvalidDataException e)
-				{
-					throw new YamlException($"FieldLoader: Cannot parse `{value}` into `{fieldName}.{fieldType}`: {e.Message}");
-				}
+				return BooleanExpressionCache[value.ToString()];
 			}
-
-			return InvalidValueAction(value, fieldType, fieldName);
+			catch (InvalidDataException e)
+			{
+				throw new YamlException($"FieldLoader: Cannot parse `{value.Span}` into field `{fieldName}` of type `{fieldType}`: {e.Message}");
+			}
 		}
 
-		static object ParseIntegerExpression(string fieldName, Type fieldType, string value)
+		static object ParseIntegerExpression(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			try
 			{
-				try
-				{
-					return IntegerExpressionCache[value];
-				}
-				catch (InvalidDataException e)
-				{
-					throw new YamlException($"FieldLoader: Cannot parse `{value}` into `{fieldName}.{fieldType}`: {e.Message}");
-				}
+				return IntegerExpressionCache[value.ToString()];
 			}
-
-			return InvalidValueAction(value, fieldType, fieldName);
+			catch (InvalidDataException e)
+			{
+				throw new YamlException($"FieldLoader: Cannot parse `{value.Span}` into field `{fieldName}` of type `{fieldType}`: {e.Message}");
+			}
 		}
 
-		static object ParseEnum(string fieldName, Type fieldType, string value)
+		static object ParseEnum(string fieldName, Type fieldType, YamlValue value)
 		{
 			// Will allow numeric values that fit the underlying type of the enum, even if they aren't defined enumeration members.
-			if (Enum.TryParse(fieldType, value, true, out var enumValue))
+			if (Enum.TryParse(fieldType, value.Span, true, out var enumValue))
 			{
 				return enumValue;
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseBool(string fieldName, Type fieldType, string value)
+		static object ParseBool(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (bool.TryParse(value, out var result))
+			if (bool.TryParse(value.Span, out var result))
 				return result ? BoxedTrue : BoxedFalse;
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseInt2Array(string fieldName, Type fieldType, string value)
+		static object ParseInt2Array(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length % 2 != 0)
-					return InvalidValueAction(value, fieldType, fieldName);
-
-				var ints = new int2[parts.Length / 2];
-
-				for (var i = 0; i < ints.Length; i++)
+				var res = new List<int2>();
+				var parts = value.Span.Split(Comma);
+				Span<int> elements = stackalloc int[2];
+				var index = 0;
+				foreach (var part in parts)
 				{
-					if (Exts.TryParseInt32Invariant(parts[2 * i], out var x)
-						&& Exts.TryParseInt32Invariant(parts[2 * i + 1], out var y))
-						ints[i] = new int2(x, y);
-					else
-						return InvalidValueAction(value, fieldType, fieldName);
+					var p = part.Trim(); // StringSplitOptions.TrimEntries
+					if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+					if (!Exts.TryParseInt32Invariant(p, out var element))
+						return InvalidValueAction(value.Span, fieldType, fieldName);
+
+					elements[index++] = element;
+					if (index == elements.Length)
+					{
+						index = 0;
+						res.Add(new int2(elements[0], elements[1]));
+					}
 				}
 
-				return ints;
+				if (index != 0)
+					return InvalidValueAction(value.Span, fieldType, fieldName);
+
+				return res.ToArray();
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseSize(string fieldName, Type fieldType, string value)
+		static object ParseSize(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 2
-					&& Exts.TryParseInt32Invariant(parts[0], out var width)
-					&& Exts.TryParseInt32Invariant(parts[1], out var height))
+				Span<Range> ranges = stackalloc Range[3];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 2
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var width)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var height))
 					return new Size(width, height);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseInt2(string fieldName, Type fieldType, string value)
+		static object ParseInt2(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 2
-					&& Exts.TryParseInt32Invariant(parts[0], out var x)
-					&& Exts.TryParseInt32Invariant(parts[1], out var y))
+				Span<Range> ranges = stackalloc Range[3];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 2
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var y))
 					return new int2(x, y);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseVector2(string fieldName, Type fieldType, string value)
+		static object ParseVector2(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 2
-					&& Exts.TryParseFloatOrPercentInvariant(parts[0], out var x)
-					&& Exts.TryParseFloatOrPercentInvariant(parts[1], out var y))
+				Span<Range> ranges = stackalloc Range[3];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 2
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[1]], out var y))
 					return new Vector2(x, y);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseVector3(string fieldName, Type fieldType, string value)
+		static object ParseVector3(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 3
-					&& Exts.TryParseFloatOrPercentInvariant(parts[0], out var x)
-					&& Exts.TryParseFloatOrPercentInvariant(parts[1], out var y)
-					&& Exts.TryParseFloatOrPercentInvariant(parts[2], out var z))
+				Span<Range> ranges = stackalloc Range[4];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 3
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[1]], out var y)
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[2]], out var z))
 					return new Vector3(x, y, z);
 
 				// z component is optional for compatibility with older Vector2 definitions
-				if (parts.Length == 2
-					&& Exts.TryParseFloatOrPercentInvariant(parts[0], out x)
-					&& Exts.TryParseFloatOrPercentInvariant(parts[1], out y))
+				if (parts == 2
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[0]], out x)
+					&& Exts.TryParseFloatOrPercentInvariant(value.Span[ranges[1]], out y))
 					return new Vector3(x, y, 0);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseRectangle(string fieldName, Type fieldType, string value)
+		static object ParseRectangle(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-				if (parts.Length == 4
-					&& Exts.TryParseInt32Invariant(parts[0], out var x)
-					&& Exts.TryParseInt32Invariant(parts[1], out var y)
-					&& Exts.TryParseInt32Invariant(parts[2], out var width)
-					&& Exts.TryParseInt32Invariant(parts[3], out var height))
+				Span<Range> ranges = stackalloc Range[5];
+				var parts = value.Span.Split(ranges, Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				if (parts == 4
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[0]], out var x)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[1]], out var y)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[2]], out var width)
+					&& Exts.TryParseInt32Invariant(value.Span[ranges[3]], out var height))
 					return new Rectangle(x, y, width, height);
 			}
 
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseDateTime(string fieldName, Type fieldType, string value)
+		static object ParseDateTime(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (DateTime.TryParseExact(value, "yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture,
+			if (DateTime.TryParseExact(value.Span, "yyyy-MM-dd HH-mm-ss", CultureInfo.InvariantCulture,
 					DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dt))
 				return dt;
-			return InvalidValueAction(value, fieldType, fieldName);
+			return InvalidValueAction(value.Span, fieldType, fieldName);
 		}
 
-		static object ParseArray(string fieldName, Type fieldType, string value)
+		static object ParseArray(string fieldName, Type fieldType, YamlValue value)
 		{
 			var elementType = fieldType.GetElementType();
 
-			if (value == null)
+			if (value.Span.IsEmpty)
 				return typeof(Array)
 					.GetMethod(nameof(Array.Empty))
 					.MakeGenericMethod(elementType)
 					.Invoke(null, null);
 
-			var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+			var objs = new List<object>();
+			var parts = value.Span.Split(Comma);
+			foreach (var part in parts)
+			{
+				var p = part.Trim(); // StringSplitOptions.TrimEntries
+				if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
 
-			var ret = Array.CreateInstance(elementType, parts.Length);
-			for (var i = 0; i < parts.Length; i++)
-				ret.SetValue(GetValue(fieldName, elementType, parts[i]), i);
+				objs.Add(GetValue(fieldName, elementType, new YamlValue(p)));
+			}
+
+			var ret = Array.CreateInstance(elementType, objs.Count);
+			for (var i = 0; i < objs.Count; i++)
+				ret.SetValue(objs[i], i);
 			return ret;
 		}
 
-		static object ParseHashSetOrList(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseHashSetOrList(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value == null)
+			if (value.Span.IsEmpty)
 				return Activator.CreateInstance(fieldType);
 
-			var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-			var set = Activator.CreateInstance(fieldType, parts.Length);
+			var set = Activator.CreateInstance(fieldType);
 			var arguments = fieldType.GetGenericArguments();
 			var addMethod = fieldType.GetMethod(nameof(List<object>.Add), arguments);
 			var addArgs = new object[1];
-			for (var i = 0; i < parts.Length; i++)
+			var parts = value.Span.Split(Comma);
+			foreach (var part in parts)
 			{
-				addArgs[0] = GetValue(fieldName, arguments[0], parts[i]);
+				var p = part.Trim(); // StringSplitOptions.TrimEntries
+				if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+				addArgs[0] = GetValue(fieldName, arguments[0], new YamlValue(p));
 				addMethod.Invoke(set, addArgs);
 			}
 
 			return set;
 		}
 
-		static object ParseDictionary(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseDictionary(string fieldName, Type fieldType, ImmutableArray<MiniYamlNode> nodes)
 		{
-			if (yaml == null)
+			if (nodes.Length == 0)
 				return Activator.CreateInstance(fieldType);
 
-			var dict = Activator.CreateInstance(fieldType, yaml.Nodes.Length);
+			var dict = Activator.CreateInstance(fieldType, nodes.Length);
 			var arguments = fieldType.GetGenericArguments();
 			var addMethod = fieldType.GetMethod(nameof(Dictionary<object, object>.Add), arguments);
 			var addArgs = new object[2];
-			foreach (var node in yaml.Nodes)
+			foreach (var node in nodes)
 			{
-				addArgs[0] = GetValue(fieldName, arguments[0], node.Key);
+				addArgs[0] = GetValue(fieldName, arguments[0], new YamlValue(node.Key));
 				addArgs[1] = GetValue(fieldName, arguments[1], node.Value);
 				addMethod.Invoke(dict, addArgs);
 			}
@@ -589,11 +657,11 @@ namespace OpenRA
 			return dict;
 		}
 
-		static object ParseImmutableArray(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseImmutableArray(string fieldName, Type fieldType, YamlValue value)
 		{
 			var typeArgs = fieldType.GenericTypeArguments;
 
-			if (value == null)
+			if (value.Span.IsEmpty)
 				return typeof(ImmutableArray<>).MakeGenericType(typeArgs)
 					.GetField(nameof(ImmutableArray<object>.Empty))
 					.GetValue(null);
@@ -615,47 +683,56 @@ namespace OpenRA
 			return toImmutableArray.Invoke(null, [array]);
 		}
 
-		static object ParseFrozenSet(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseFrozenSet(string fieldName, Type fieldType, YamlValue value)
 		{
 			var typeArgs = fieldType.GenericTypeArguments;
 
-			if (value == null)
+			if (value.Span.IsEmpty)
 				return typeof(FrozenSet<>).MakeGenericType(typeArgs)
 					.GetProperty(nameof(FrozenSet<object>.Empty))
 					.GetValue(null);
 
 			var set =
-				ParseHashSetOrList(fieldName, typeof(HashSet<>).MakeGenericType(typeArgs), value, yaml);
+				ParseHashSetOrList(fieldName, typeof(HashSet<>).MakeGenericType(typeArgs), value);
 
 			var toFrozenSet = ToFrozenSet.MakeGenericMethod(typeArgs);
 
 			return toFrozenSet.Invoke(null, [set, null]);
 		}
 
-		static object ParseFrozenDictionary(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseFrozenDictionary(string fieldName, Type fieldType, ImmutableArray<MiniYamlNode> nodes)
 		{
 			var typeArgs = fieldType.GenericTypeArguments;
 
-			if (yaml == null)
+			if (nodes.Length == 0)
 				return typeof(FrozenDictionary<,>).MakeGenericType(typeArgs)
 					.GetProperty(nameof(FrozenDictionary<object, object>.Empty))
 					.GetValue(null);
 
 			var dict =
-				ParseDictionary(fieldName, typeof(Dictionary<,>).MakeGenericType(typeArgs), value, yaml);
+				ParseDictionary(fieldName, typeof(Dictionary<,>).MakeGenericType(typeArgs), nodes);
 
 			var toFrozenDict = ToFrozenDictionary.MakeGenericMethod(typeArgs);
 
 			return toFrozenDict.Invoke(null, [dict, null]);
 		}
 
-		static object ParseBitSet(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseBitSet(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (value != null)
+			if (!value.Span.IsEmpty)
 			{
-				var parts = value.Split(Comma, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+				var values = new List<string>();
+				var parts = value.Span.Split(Comma);
+				foreach (var part in parts)
+				{
+					var p = part.Trim(); // StringSplitOptions.TrimEntries
+					if (p.IsEmpty) continue; // StringSplitOptions.RemoveEmptyEntries
+
+					values.Add(p.ToString());
+				}
+
 				var ctor = fieldType.GetConstructor([typeof(string[])]);
-				return ctor.Invoke([parts]);
+				return ctor.Invoke([values.ToArray()]);
 			}
 			else
 			{
@@ -664,9 +741,9 @@ namespace OpenRA
 			}
 		}
 
-		static object ParseNullable(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object ParseNullable(string fieldName, Type fieldType, YamlValue value)
 		{
-			if (string.IsNullOrEmpty(value))
+			if (value.Span.IsEmpty)
 				return null;
 
 			var innerType = fieldType.GetGenericArguments()[0];
@@ -745,42 +822,45 @@ namespace OpenRA
 			var field = target.GetType().GetField(key, Flags);
 			if (field != null)
 			{
-				field.SetValue(target, GetValue(field.Name, field.FieldType, value));
+				field.SetValue(target, GetValue(field.Name, field.FieldType, new YamlValue(value)));
 				return;
 			}
 
 			var prop = target.GetType().GetProperty(key, Flags);
 			if (prop != null)
 			{
-				prop.SetValue(target, GetValue(prop.Name, prop.PropertyType, value), null);
+				prop.SetValue(target, GetValue(prop.Name, prop.PropertyType, new YamlValue(value)), null);
 				return;
 			}
 
-			UnknownFieldAction(key, target.GetType());
+			UnknownFieldAction(key);
 		}
 
 		public static T GetValue<T>(string field, string value)
 		{
-			return (T)GetValue(field, typeof(T), value, null);
+			return (T)GetValue(field, typeof(T), new YamlValue(value));
 		}
 
-		static object GetValue(string fieldName, Type fieldType, string value)
+		static object GetValue(string fieldName, Type fieldType, YamlValue value)
 		{
-			return GetValue(fieldName, fieldType, value, null);
+			return GetValue(fieldName, fieldType, value, []);
 		}
 
 		static object GetValue(string fieldName, Type fieldType, MiniYaml yaml)
 		{
-			return GetValue(fieldName, fieldType, yaml.Value, yaml);
+			return GetValue(fieldName, fieldType, new YamlValue(yaml.Value), yaml.Nodes);
 		}
 
-		static object GetValue(string fieldName, Type fieldType, string value, MiniYaml yaml)
+		static object GetValue(string fieldName, Type fieldType, YamlValue value, ImmutableArray<MiniYamlNode> nodes)
 		{
-			value = value?.Trim();
+			value = value.Trim();
 			if (fieldType.IsGenericType)
 			{
-				if (GenericTypeParsers.TryGetValue(fieldType.GetGenericTypeDefinition(), out var parseFuncGeneric))
-					return parseFuncGeneric(fieldName, fieldType, value, yaml);
+				if (GenericTypeValueParsers.TryGetValue(fieldType.GetGenericTypeDefinition(), out var parseValueFuncGeneric))
+					return parseValueFuncGeneric(fieldName, fieldType, value);
+
+				if (GenericTypeNodesParsers.TryGetValue(fieldType.GetGenericTypeDefinition(), out var parseNodesFuncGeneric))
+					return parseNodesFuncGeneric(fieldName, fieldType, nodes);
 			}
 			else
 			{
@@ -799,16 +879,59 @@ namespace OpenRA
 			{
 				try
 				{
-					return conv.ConvertFromInvariantString(value);
+					return conv.ConvertFromInvariantString(value.ToString());
 				}
 				catch
 				{
-					return InvalidValueAction(value, fieldType, fieldName);
+					return InvalidValueAction(value.Span, fieldType, fieldName);
 				}
 			}
 
-			UnknownFieldAction($"[Type] {value}", fieldType);
+			UnknownFieldAction(fieldName);
 			return null;
+		}
+
+		readonly ref struct YamlValue
+		{
+			public YamlValue(string value)
+				: this(value.AsSpan())
+			{
+				this.value = value;
+			}
+
+			public YamlValue(ReadOnlySpan<char> valueSpan)
+			{
+				this.valueSpan = valueSpan;
+			}
+
+			readonly string value;
+			readonly ReadOnlySpan<char> valueSpan;
+
+			public readonly ReadOnlySpan<char> Span => valueSpan;
+
+			public readonly YamlValue Trim()
+			{
+				var trimmed = valueSpan.Trim();
+				if (trimmed != valueSpan)
+					return new YamlValue(trimmed);
+				return this;
+			}
+
+			/// <summary>
+			/// If the input came from a string, returns the original string instance. Otherwise, allocates a string from the span.
+			/// </summary>
+			public override readonly string ToString()
+			{
+				// When the source string is null, valueSpan.ToString() will return an empty string.
+				// We don't want to return an empty string, we want to return null, so special case this.
+				if (value == null && valueSpan == ReadOnlySpan<char>.Empty)
+					return null;
+
+				// If the input value came from a string, we can return it directly and avoid allocating a new one from the span.
+				// This can be quite important as MiniYaml may have de-duplicated repeated strings from config files.
+				// When we take a span over the original string, having to ToString it again recreates the duplicates, so we are keen to avoid that.
+				return value ?? valueSpan.ToString();
+			}
 		}
 
 		public sealed class FieldLoadInfo

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Graphics
 			if (string.IsNullOrEmpty(text))
 				return new int2(0, size);
 
-			var lines = text.SplitLines('\n');
+			var lines = text.AsSpan().Split('\n');
 
 			var maxWidth = 0f;
 			var rows = 0;

--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -24,23 +24,20 @@ namespace OpenRA
 		public readonly Keycode Key;
 		public readonly Modifiers Modifiers;
 
-		public static bool TryParse(string s, out Hotkey result)
+		public static bool TryParse(ReadOnlySpan<char> s, out Hotkey result)
 		{
 			result = Invalid;
-			if (s == null)
-				return false;
 
 			Span<Range> ranges = stackalloc Range[2];
-			var span = s.AsSpan();
-			var count = span.Split(ranges, ' ');
+			var count = s.Split(ranges, ' ');
 			if (count == 0)
 				return false;
 
-			if (!Enum.TryParse(span[ranges[0]], true, out Keycode key))
+			if (!Enum.TryParse(s[ranges[0]], true, out Keycode key))
 				return false;
 
 			var mods = Modifiers.None;
-			if (count == 2 && !Enum.TryParse(span[ranges[1]], true, out mods))
+			if (count == 2 && !Enum.TryParse(s[ranges[1]], true, out mods))
 				return false;
 
 			result = new Hotkey(key, mods);

--- a/OpenRA.Game/Map/TerrainInfo.cs
+++ b/OpenRA.Game/Map/TerrainInfo.cs
@@ -85,15 +85,16 @@ namespace OpenRA
 			if (definition == null)
 				return;
 
-			string[] parts;
+			var s = definition.AsSpan();
 
-			parts = definition.Split(",");
-			if (parts.Length == 8)
+			Span<Range> ranges = stackalloc Range[9];
+			var parts = s.Split(ranges, ',');
+			if (parts == 8)
 			{
 				bits = 0;
 				for (var i = 0; i < 8; i++)
 				{
-					if (!Exts.TryParseByteInvariant(parts[i], out var b))
+					if (!Exts.TryParseByteInvariant(s[ranges[i]], out var b))
 						throw new YamlException($"`{definition}` is not a valid Riser definition");
 
 					bits |= (ulong)b << (i * 8);
@@ -102,25 +103,25 @@ namespace OpenRA
 				return;
 			}
 
-			parts = definition.Split("=");
-			if (parts.Length == 2)
+			parts = s.Split(ranges, '=');
+			if (parts == 2)
 			{
-				if (!Exts.TryParseByteInvariant(parts[1], out var b))
+				if (!Exts.TryParseByteInvariant(s[ranges[1]], out var b))
 					throw new YamlException($"`{definition}` is not a valid Riser definition");
 
 				bits = b * 0x0101010101010101u;
 
 				// TODO: make stricter
-				if (!parts[0].Contains('U', StringComparison.InvariantCultureIgnoreCase))
+				if (!s[ranges[0]].Contains(['U'], StringComparison.InvariantCultureIgnoreCase))
 					bits |= 0x00_00_00_00_00_00_ff_ffu;
 
-				if (!parts[0].Contains('R', StringComparison.InvariantCultureIgnoreCase))
+				if (!s[ranges[0]].Contains(['R'], StringComparison.InvariantCultureIgnoreCase))
 					bits |= 0x00_00_00_00_ff_ff_00_00u;
 
-				if (!parts[0].Contains('D', StringComparison.InvariantCultureIgnoreCase))
+				if (!s[ranges[0]].Contains(['D'], StringComparison.InvariantCultureIgnoreCase))
 					bits |= 0x00_00_ff_ff_00_00_00_00u;
 
-				if (!parts[0].Contains('L', StringComparison.InvariantCultureIgnoreCase))
+				if (!s[ranges[0]].Contains(['L'], StringComparison.InvariantCultureIgnoreCase))
 					bits |= 0xff_ff_00_00_00_00_00_00u;
 
 				return;

--- a/OpenRA.Game/Map/TileReference.cs
+++ b/OpenRA.Game/Map/TileReference.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA
 {
 	public readonly struct TerrainTile(ushort type, byte index)
@@ -20,12 +22,13 @@ namespace OpenRA
 
 		public override string ToString() { return Type + "," + Index; }
 
-		public static bool TryParse(string s, out TerrainTile tt)
+		public static bool TryParse(ReadOnlySpan<char> s, out TerrainTile tt)
 		{
-			var split = s.Split(',');
-			if (split.Length == 2 &&
-				Exts.TryParseUshortInvariant(split[0], out var type) &&
-				Exts.TryParseByteInvariant(split[1], out var index))
+			Span<Range> ranges = stackalloc Range[3];
+			var parts = s.Split(ranges, ',');
+			if (parts == 2 &&
+				Exts.TryParseUInt16Invariant(s[ranges[0]], out var type) &&
+				Exts.TryParseByteInvariant(s[ranges[1]], out var index))
 			{
 				tt = new TerrainTile(type, index);
 				return true;

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -161,24 +161,22 @@ namespace OpenRA.Primitives
 			return (h, s, v);
 		}
 
-		public static bool TryParse(string value, out Color color)
+		public static bool TryParse(ReadOnlySpan<char> value, out Color color)
 		{
 			color = default;
-			if (value == null)
-				return false;
 
 			value = value.Trim();
 			if (value.Length != 6 && value.Length != 8)
 				return false;
 
 			byte alpha = 255;
-			if (!byte.TryParse(value.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var red)
-				|| !byte.TryParse(value.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var green)
-				|| !byte.TryParse(value.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var blue))
+			if (!byte.TryParse(value[..2], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var red)
+				|| !byte.TryParse(value.Slice(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var green)
+				|| !byte.TryParse(value.Slice(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var blue))
 				return false;
 
 			if (value.Length == 8
-				&& !byte.TryParse(value.AsSpan(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out alpha))
+				&& !byte.TryParse(value.Slice(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out alpha))
 				return false;
 
 			color = FromArgb(alpha, red, green, blue);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -16,6 +16,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -442,10 +443,10 @@ namespace OpenRA
 				var err2 = FieldLoader.InvalidValueAction;
 				try
 				{
-					FieldLoader.InvalidValueAction = (s, t, f) =>
+					FieldLoader.InvalidValueAction = (value, fieldType, fieldName) =>
 					{
-						var ret = t.GetField(f)?.GetValue(module);
-						Console.WriteLine($"FieldLoader: Cannot parse `{s}` into `{f}:{t.Name}`; substituting default `{ret}`");
+						var ret = fieldType.IsValueType ? RuntimeHelpers.GetUninitializedObject(fieldType) : null;
+						Console.WriteLine($"FieldLoader: Cannot parse `{value}` into field `{fieldName}` of type `{fieldType}`; substituting default `{ret}`");
 						return ret;
 					};
 

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -354,7 +354,7 @@ namespace OpenRA.Support
 						if (cc != CharClass.Digit)
 						{
 							if (cc != CharClass.Whitespace && cc != CharClass.Operator && cc != CharClass.Mixed)
-								throw new InvalidDataException($"Number {Exts.ParseInt32Invariant(expression[start..i])} and variable merged at index {start}");
+								throw new InvalidDataException($"Number {Exts.ParseInt32Invariant(expression.AsSpan()[start..i])} and variable merged at index {start}");
 
 							return true;
 						}

--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -59,27 +59,27 @@ namespace OpenRA
 				.Sum() / samples);
 		}
 
-		public static bool TryParse(string s, out WDist result)
+		public static bool TryParse(ReadOnlySpan<char> s, out WDist result)
 		{
 			result = Zero;
 
-			if (string.IsNullOrEmpty(s))
+			if (s.IsEmpty)
 				return false;
 
-			s = s.ToLowerInvariant();
-			var components = s.Split('c');
+			Span<Range> ranges = stackalloc Range[3];
+			var components = s.SplitAny(ranges, "cC");
 			var cell = 0;
 			int subcell;
 
-			switch (components.Length)
+			switch (components)
 			{
 				case 2:
-					if (!Exts.TryParseInt32Invariant(components[0], out cell) ||
-						!Exts.TryParseInt32Invariant(components[1], out subcell))
+					if (!Exts.TryParseInt32Invariant(s[ranges[0]], out cell) ||
+						!Exts.TryParseInt32Invariant(s[ranges[1]], out subcell))
 						return false;
 					break;
 				case 1:
-					if (!Exts.TryParseInt32Invariant(components[0], out subcell))
+					if (!Exts.TryParseInt32Invariant(s[ranges[0]], out subcell))
 						return false;
 					break;
 				default: return false;

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 
 		static int ParseGroup(Match match, string group)
 		{
-			return Exts.ParseInt32Invariant(match.Groups[group].Value);
+			return Exts.ParseInt32Invariant(match.Groups[group].ValueSpan);
 		}
 
 		public IReadOnlyList<ISpriteFrame> Frames { get; }
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 				if (prefix != framePrefix)
 					throw new InvalidDataException($"Frame prefix mismatch: `{prefix}` != `{framePrefix}`");
 
-				frameCount = Math.Max(frameCount, Exts.ParseInt32Invariant(match.Groups["frame"].Value) + 1);
+				frameCount = Math.Max(frameCount, Exts.ParseInt32Invariant(match.Groups["frame"].ValueSpan) + 1);
 			}
 
 			var frames = new ISpriteFrame[frameCount];

--- a/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
@@ -217,7 +217,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				OtherGround = my.NodeWithKeyOrDefault("OtherGround")?.Value.Nodes.Select(
 					n =>
 					{
-						if (!Exts.TryParseUshortInvariant(n.Key, out var tile))
+						if (!Exts.TryParseUInt16Invariant(n.Key, out var tile))
 							throw new YamlException($"OtherGround {n.Key} is not a ushort");
 
 						if (!Exts.TryParseInt32Invariant(n.Value.Value, out var fraction))
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				RepaintTiles = my.NodeWithKeyOrDefault("RepaintTiles")?.Value.ToDictionary(
 					k =>
 					{
-						if (Exts.TryParseUshortInvariant(k, out var tile))
+						if (Exts.TryParseUInt16Invariant(k, out var tile))
 							return tile;
 						else
 							throw new YamlException($"RepaintTile {k} is not a ushort");

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text.RegularExpressions;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.EditorBrushes;
 using OpenRA.Mods.Common.Terrain;
@@ -65,7 +64,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				if (string.IsNullOrEmpty(my.Value))
 					throw new YamlException("Missing template type");
 
-				if (!Exts.TryParseUshortInvariant(my.Value, out Type))
+				if (!Exts.TryParseUInt16Invariant(my.Value, out Type))
 					throw new YamlException($"Invalid MultiBrush Template `${my.Value}`");
 
 				FieldLoader.Load(this, my);
@@ -205,7 +204,6 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// <summary>
 		/// Point sequence, where points are -X-Y corners of template tiles.
 		/// </summary>
-		[FieldLoader.Ignore]
 		public readonly ImmutableArray<CVec> Points;
 
 		/// <summary>
@@ -222,27 +220,12 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public MultiBrushSegment(MiniYaml my)
 		{
 			FieldLoader.Load(this, my);
+
+			for (var i = 1; i < Points.Length; i++)
 			{
-				// Unlike FieldLoader.ParseInt2Array, whitespace is ignored.
-				var value = my.NodeWithKey("Points").Value.Value;
-				var parts = Regex.Replace(value, @"\s+", string.Empty)
-					.Split(',', StringSplitOptions.RemoveEmptyEntries);
-				if (parts.Length % 2 != 0)
-					FieldLoader.InvalidValueAction(value, typeof(int2[]), "Points");
-
-				var points = new CVec[parts.Length / 2];
-				for (var i = 0; i < points.Length; i++)
-				{
-					points[i] = new CVec(Exts.ParseInt32Invariant(parts[2 * i]), Exts.ParseInt32Invariant(parts[2 * i + 1]));
-					if (i > 0)
-					{
-						var step = points[i] - points[i - 1];
-						if (Math.Abs(step.X) + Math.Abs(step.Y) != 1)
-							throw new YamlException($"Points sequence {value} has non-unit steps");
-					}
-				}
-
-				Points = [.. points];
+				var step = Points[i] - Points[i - 1];
+				if (Math.Abs(step.X) + Math.Abs(step.Y) != 1)
+					throw new YamlException("Points sequence has non-unit steps");
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Traits
 				RepaintTiles = my.NodeWithKeyOrDefault("RepaintTiles")?.Value.ToDictionary(
 					k =>
 					{
-						if (Exts.TryParseUshortInvariant(k, out var tile))
+						if (Exts.TryParseUInt16Invariant(k, out var tile))
 							return tile;
 						else
 							throw new YamlException($"RepaintTile {k} is not a ushort");

--- a/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClearMapGenerator.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override Map Generate(ModData modData, MapGenerationArgs args)
 		{
 			var random = new MersenneTwister();
-			if (!Exts.TryParseUshortInvariant(GenerateParameterYaml(modData, args).NodeWithKey("Tile").Value.Value, out var tileType))
+			if (!Exts.TryParseUInt16Invariant(GenerateParameterYaml(modData, args).NodeWithKey("Tile").Value.Value, out var tileType))
 				throw new YamlException("Illegal tile type");
 
 			var terrainInfo = modData.DefaultTerrainInfo[args.Tileset];

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -313,7 +313,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				var name = kv.Key;
-				var index = Exts.ParseInt32Invariant(name[5..]);
+				var index = Exts.ParseInt32Invariant(name.AsSpan(5));
 
 				if (index >= newCount)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				// bind some nonfatal error handling into FieldLoader, so we don't just *explode*.
 				ObjectCreator.MissingTypeAction = s => EmitError($"Missing Type: {s}.");
-				FieldLoader.UnknownFieldAction = (s, f) => EmitError($"FieldLoader: Missing field `{s}` on `{f.Name}`.");
+				FieldLoader.UnknownFieldAction = (fieldName) => EmitError($"FieldLoader: Missing field `{fieldName}`");
 
 				var maps = new List<(IReadWritePackage Package, string Map)>();
 				if (args.Length < 2)

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -112,8 +112,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (server == null || !server.IsJoinable)
 				return;
 
-			var host = server.Address.Split(':')[0];
-			var port = Exts.ParseInt32Invariant(server.Address.Split(':')[1]);
+			var parts = server.Address.Split(':');
+			var host = parts[0];
+			var port = Exts.ParseInt32Invariant(parts[1]);
 
 			ConnectionLogic.Connect(new ConnectionTarget(host, port), "", OpenLobby, DoNothing);
 		}

--- a/OpenRA.Test/OpenRA.Game/FieldLoaderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/FieldLoaderTest.cs
@@ -104,27 +104,32 @@ namespace OpenRA.Test
 		[Test]
 		public void GetValue_UnknownField()
 		{
-			static void Act() => FieldLoader.GetValue<object>("field", "test");
+			static void Act() => FieldLoader.GetValue<object>("field", "  test  ");
 
-			Assert.That(Act, Throws.TypeOf<NotImplementedException>().And.Message.EqualTo("FieldLoader: Missing field `[Type] test` on `Object`"));
+			Assert.That(Act, Throws.TypeOf<NotImplementedException>()
+				.And.Message.EqualTo("FieldLoader: Missing field `field`"));
 		}
 
 		static IEnumerable<TestCaseData> GetValue_InvalidValue_TestCases()
 		{
 			return
 			[
-				new TestCaseData(null) { TypeArgs = [typeof(int)] },
-				new TestCaseData("test") { TypeArgs = [typeof(int)] },
-				new TestCaseData("1.2") { TypeArgs = [typeof(int)] },
-				new TestCaseData((int.MaxValue + 1L).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(int)] },
+				new TestCaseData(null) { TypeArgs = [typeof(byte)] },
+				new TestCaseData("test") { TypeArgs = [typeof(byte)] },
+				new TestCaseData("1.2") { TypeArgs = [typeof(byte)] },
+				new TestCaseData((byte.MaxValue + 1L).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(byte)] },
 				new TestCaseData(null) { TypeArgs = [typeof(ushort)] },
 				new TestCaseData("test") { TypeArgs = [typeof(ushort)] },
 				new TestCaseData("1.2") { TypeArgs = [typeof(ushort)] },
 				new TestCaseData((ushort.MaxValue + 1L).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(ushort)] },
-				new TestCaseData(null) { TypeArgs = [typeof(long)] },
-				new TestCaseData("test") { TypeArgs = [typeof(long)] },
-				new TestCaseData("1.2") { TypeArgs = [typeof(long)] },
-				new TestCaseData((long.MaxValue + 1UL).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(long)] },
+				new TestCaseData(null) { TypeArgs = [typeof(short)] },
+				new TestCaseData("test") { TypeArgs = [typeof(short)] },
+				new TestCaseData("1.2") { TypeArgs = [typeof(short)] },
+				new TestCaseData((short.MaxValue + 1L).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(short)] },
+				new TestCaseData(null) { TypeArgs = [typeof(int)] },
+				new TestCaseData("test") { TypeArgs = [typeof(int)] },
+				new TestCaseData("1.2") { TypeArgs = [typeof(int)] },
+				new TestCaseData((int.MaxValue + 1L).ToString(CultureInfo.InvariantCulture)) { TypeArgs = [typeof(int)] },
 				new TestCaseData(null) { TypeArgs = [typeof(float)] },
 				new TestCaseData("test") { TypeArgs = [typeof(float)] },
 				new TestCaseData("1,2") { TypeArgs = [typeof(float)] },
@@ -180,8 +185,6 @@ namespace OpenRA.Test
 				new TestCaseData("1") { TypeArgs = [typeof(CVec[])] },
 				new TestCaseData("1,test") { TypeArgs = [typeof(CVec[])] },
 				new TestCaseData("1,2,3") { TypeArgs = [typeof(CVec[])] },
-				new TestCaseData(null) { TypeArgs = [typeof(BooleanExpression)] },
-				new TestCaseData(null) { TypeArgs = [typeof(IntegerExpression)] },
 				new TestCaseData(null) { TypeArgs = [typeof(MapGridType)] },
 				new TestCaseData(null) { TypeArgs = [typeof(bool)] },
 				new TestCaseData("test") { TypeArgs = [typeof(bool)] },
@@ -224,27 +227,30 @@ namespace OpenRA.Test
 		[TestCaseSource(nameof(GetValue_InvalidValue_TestCases))]
 		public void GetValue_InvalidValue<T>(string input)
 		{
-			void Act() => FieldLoader.GetValue<T>("field", input);
+			void Act() => FieldLoader.GetValue<T>("field", $"  {input}  ");
 
-			Assert.That(Act, Throws.TypeOf<YamlException>().And.Message.EqualTo($"FieldLoader: Cannot parse `{input}` into `field.{typeof(T).FullName}`"));
+			Assert.That(Act, Throws.TypeOf<YamlException>()
+				.And.Message.EqualTo($"FieldLoader: Cannot parse `{input}` into field `field` of type `{typeof(T).FullName}`"));
 		}
 
 		[TestCase(TypeArgs = [typeof(BooleanExpression)])]
 		[TestCase(TypeArgs = [typeof(IntegerExpression)])]
 		public void GetValue_InvalidValue<T>()
 		{
-			static void Act() => FieldLoader.GetValue<T>("field", "");
+			static void Act() => FieldLoader.GetValue<T>("field", "  ");
 
-			Assert.That(Act, Throws.TypeOf<YamlException>().And.Message.EqualTo($"FieldLoader: Cannot parse `` into `field.{typeof(T).FullName}`: Empty expression"));
+			Assert.That(Act, Throws.TypeOf<YamlException>()
+				.And.Message.EqualTo($"FieldLoader: Cannot parse `` into field `field` of type `{typeof(T).FullName}`: Empty expression"));
 		}
 
 		static IEnumerable<TestCaseData> GetValue_Primitive_TestCases()
 		{
 			return
 			[
-				new TestCaseData(123),
+				new TestCaseData((byte)123),
 				new TestCaseData((ushort)123),
-				new TestCaseData(123L),
+				new TestCaseData((short)123),
+				new TestCaseData(123),
 				new TestCaseData(123.4f.ToString(CultureInfo.InvariantCulture)),
 				new TestCaseData(123m),
 				new TestCaseData("test"),
@@ -362,7 +368,7 @@ namespace OpenRA.Test
 		[Test]
 		public void GetValue_Vector3_TwoElements()
 		{
-			var actual = FieldLoader.GetValue<Vector3>("field", "123,456");
+			var actual = FieldLoader.GetValue<Vector3>("field", "  123 , 456  ");
 
 			Assert.That(actual, Is.EqualTo(new Vector3(123, 456, 0)));
 		}
@@ -587,7 +593,8 @@ namespace OpenRA.Test
 		{
 			static void Act() => FieldLoader.GetValue<sbyte>("field", "  test  ");
 
-			Assert.That(Act, Throws.TypeOf<YamlException>().And.Message.EqualTo($"FieldLoader: Cannot parse `test` into `field.{typeof(sbyte).FullName}`"));
+			Assert.That(Act, Throws.TypeOf<YamlException>()
+				.And.Message.EqualTo($"FieldLoader: Cannot parse `test` into field `field` of type `{typeof(sbyte).FullName}`"));
 		}
 
 		sealed class LoadFieldOrPropertyTarget
@@ -620,7 +627,8 @@ namespace OpenRA.Test
 			Assert.That(target.PublicIntProp, Is.EqualTo(34));
 			Assert.That(target.GetPrivateIntField(), Is.EqualTo(56));
 			Assert.That(target.GetPrivateIntProp(), Is.EqualTo(78));
-			Assert.That(Act, Throws.TypeOf<NotImplementedException>().And.Message.EqualTo("FieldLoader: Missing field `unknown` on `LoadFieldOrPropertyTarget`"));
+			Assert.That(Act, Throws.TypeOf<NotImplementedException>()
+				.And.Message.EqualTo("FieldLoader: Missing field `unknown`"));
 		}
 
 		sealed class LoadTarget
@@ -841,9 +849,8 @@ namespace OpenRA.Test
 
 			void Act() => FieldLoader.Load(target, yaml);
 
-			Assert.That(Act,
-				Throws.TypeOf<InvalidOperationException>().And
-				.Message.EqualTo("LoadUsingMissingTarget does not specify a loader function 'unknown'"));
+			Assert.That(Act, Throws.TypeOf<InvalidOperationException>()
+				.And.Message.EqualTo("LoadUsingMissingTarget does not specify a loader function 'unknown'"));
 			Assert.That(target.Int, Is.EqualTo(1));
 		}
 	}


### PR DESCRIPTION
Update various parts of the codebase to support parsing from spans, rather than strings. This allows values to be parsed directly from a text buffer in some cases, without needing to materialize an intermediate string to perform the parse.

- Numeric Parse/TryParse methods in Exts accept a span, not a string.
- Hotkey, TileReference, Color, WDist: TryParse methods accept a span, not a string.
- Riser splits into spans, rather than splitting to strings.
- Some callsites pass a span for parsing where they can instead of allocating a string.
- FieldLoader learns to use spans for extracting, splitting and parsing text values.

Additionally, FieldLoader learns dedicated parse methods for some types (byte, short) and forgets others (long). This is to provide fast paths for types used in the default mods, other types can use the TypeDescriptor fallback. Some of the action delegates in FieldLoader change to make more sense and support the parsing changes.