### PR TITLE
Continued move to frozen and immutable collections 

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -167,27 +167,45 @@ namespace OpenRA
 			return list.Find(match);
 		}
 
+		public static T Random<T>(this ReadOnlySpan<T> ts, MersenneTwister r)
+		{
+			if (ts.Length == 0)
+				throw new ArgumentException("Collection must not be empty.", nameof(ts));
+			else
+				return ts[r.Next(ts.Length)];
+		}
+
+		public static T RandomOrDefault<T>(this ReadOnlySpan<T> ts, MersenneTwister r)
+		{
+			if (ts.Length == 0)
+				return default;
+			else
+				return ts[r.Next(ts.Length)];
+		}
+
+		public static T Random<T>(this List<T> ts, MersenneTwister r) => Random<T>(CollectionsMarshal.AsSpan(ts), r);
+		public static T RandomOrDefault<T>(this List<T> ts, MersenneTwister r) => RandomOrDefault<T>(CollectionsMarshal.AsSpan(ts), r);
+		public static T Random<T>(this T[] ts, MersenneTwister r) => Random<T>(ts.AsSpan(), r);
+		public static T RandomOrDefault<T>(this T[] ts, MersenneTwister r) => RandomOrDefault<T>(ts.AsSpan(), r);
+		public static T Random<T>(this ImmutableArray<T> ts, MersenneTwister r) => Random(ts.AsSpan(), r);
+		public static T RandomOrDefault<T>(this ImmutableArray<T> ts, MersenneTwister r) => RandomOrDefault(ts.AsSpan(), r);
+
 		public static T Random<T>(this IEnumerable<T> ts, MersenneTwister r)
 		{
-			return Random(ts, r, true);
+			var xs = ts as IReadOnlyCollection<T>;
+			xs ??= ts.ToArray();
+			if (xs.Count == 0)
+				throw new ArgumentException("Collection must not be empty.", nameof(ts));
+			else
+				return xs.ElementAt(r.Next(xs.Count));
 		}
 
 		public static T RandomOrDefault<T>(this IEnumerable<T> ts, MersenneTwister r)
 		{
-			return Random(ts, r, false);
-		}
-
-		static T Random<T>(IEnumerable<T> ts, MersenneTwister r, bool throws)
-		{
 			var xs = ts as IReadOnlyCollection<T>;
-			xs ??= ts.ToList();
+			xs ??= ts.ToArray();
 			if (xs.Count == 0)
-			{
-				if (throws)
-					throw new ArgumentException("Collection must not be empty.", nameof(ts));
-				else
-					return default;
-			}
+				return default;
 			else
 				return xs.ElementAt(r.Next(xs.Count));
 		}
@@ -480,6 +498,11 @@ namespace OpenRA
 				result[i] = f(i);
 
 			return result;
+		}
+
+		public static ImmutableArray<T> MakeImmutableArray<T>(int count, Func<int, T> f)
+		{
+			return ImmutableCollectionsMarshal.AsImmutableArray(MakeArray(count, f));
 		}
 
 		public static byte ParseByteInvariant(ReadOnlySpan<char> s)

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -123,7 +123,7 @@ namespace OpenRA
 
 		static readonly object BoxedTrue = true;
 		static readonly object BoxedFalse = false;
-		static readonly object[] BoxedInts = Exts.MakeArray(33, i => (object)i);
+		static readonly ImmutableArray<object> BoxedInts = Exts.MakeImmutableArray(33, i => (object)i);
 
 		static readonly MethodInfo ToImmutableArray =
 			typeof(ImmutableArray)

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Effects;
@@ -160,7 +159,7 @@ namespace OpenRA.GameRules
 
 		static object LoadWarheads(MiniYaml yaml)
 		{
-			var retList = new List<IWarhead>();
+			var retList = ImmutableArray.CreateBuilder<IWarhead>();
 			foreach (var node in yaml.Nodes.Where(n => n.Key.StartsWith("Warhead", StringComparison.Ordinal)))
 			{
 				var ret = Game.CreateObject<IWarhead>(node.Value.Value + "Warhead");
@@ -171,7 +170,7 @@ namespace OpenRA.GameRules
 				retList.Add(ret);
 			}
 
-			return retList.ToImmutableArray();
+			return retList.DrainToImmutable();
 		}
 
 		public bool IsValidTarget(BitSet<TargetableType> targetTypes)

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using OpenRA.Primitives;
 
@@ -65,18 +64,18 @@ namespace OpenRA.Graphics
 			Buffer.BlockCopy(colors, 0, destination, destinationOffset * 4, Palette.Size * 4);
 		}
 
-		public ImmutablePalette(string filename, ImmutableArray<int> remapTransparent, ImmutableArray<int> remap)
+		public ImmutablePalette(string filename, ReadOnlySpan<int> remapTransparent, ReadOnlySpan<int> remap)
 		{
 			using (var s = File.OpenRead(filename))
 				LoadFromStream(s, remapTransparent, remap);
 		}
 
-		public ImmutablePalette(Stream s, ImmutableArray<int> remapTransparent, ImmutableArray<int> remapShadow)
+		public ImmutablePalette(Stream s, ReadOnlySpan<int> remapTransparent, ReadOnlySpan<int> remapShadow)
 		{
 			LoadFromStream(s, remapTransparent, remapShadow);
 		}
 
-		void LoadFromStream(Stream s, ImmutableArray<int> remapTransparent, ImmutableArray<int> remapShadow)
+		void LoadFromStream(Stream s, ReadOnlySpan<int> remapTransparent, ReadOnlySpan<int> remapShadow)
 		{
 			using (var reader = new BinaryReader(s))
 				for (var i = 0; i < Palette.Size; i++)

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using OpenRA.Primitives;
@@ -35,7 +36,7 @@ namespace OpenRA.Graphics
 		}
 
 		public const int SheetCount = 8;
-		static readonly string[] SheetIndexToTextureName = Exts.MakeArray(SheetCount, i => $"Texture{i}");
+		static readonly ImmutableArray<string> SheetIndexToTextureName = Exts.MakeImmutableArray(SheetCount, i => $"Texture{i}");
 		static readonly int UintSize = Marshal.SizeOf<uint>();
 
 		readonly Renderer renderer;

--- a/OpenRA.Game/Input/Keycode.cs
+++ b/OpenRA.Game/Input/Keycode.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 
 namespace OpenRA
@@ -260,7 +261,7 @@ namespace OpenRA
 	public static class KeycodeExts
 	{
 		[FluentReference(Traits.LintDictionaryReference.Values)]
-		public static readonly IReadOnlyDictionary<Keycode, string> KeycodeFluentKeys = new Dictionary<Keycode, string>()
+		public static readonly FrozenDictionary<Keycode, string> KeycodeFluentKeys = new Dictionary<Keycode, string>()
 		{
 			{ Keycode.UNKNOWN, "keycode.unknown" },
 			{ Keycode.RETURN, "keycode.return" },
@@ -500,7 +501,7 @@ namespace OpenRA
 			{ Keycode.SLEEP, "keycode.sleep" },
 			{ Keycode.MOUSE4, "keycode.mouse4" },
 			{ Keycode.MOUSE5, "keycode.mouse5" },
-		};
+		}.ToFrozenDictionary();
 
 		public static string DisplayString(Keycode k)
 		{

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -9,10 +9,9 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Traits;
 
 namespace OpenRA
@@ -204,18 +203,28 @@ namespace OpenRA
 
 		ImmutableArray<ImmutableArray<CVec>> CreateTilesByDistance()
 		{
-			var ts = new List<CVec>[MaximumTileSearchRange + 1];
-			for (var i = 0; i < MaximumTileSearchRange + 1; i++)
-				ts[i] = [];
+			var maxRangeSq = MaximumTileSearchRange * MaximumTileSearchRange;
+			var len = MaximumTileSearchRange + 1;
+
+			var ts = new ImmutableArray<CVec>.Builder[len];
+			for (var i = 0; i < len; i++)
+				ts[i] = ImmutableArray.CreateBuilder<CVec>();
 
 			for (var j = -MaximumTileSearchRange; j <= MaximumTileSearchRange; j++)
+			{
 				for (var i = -MaximumTileSearchRange; i <= MaximumTileSearchRange; i++)
-					if (MaximumTileSearchRange * MaximumTileSearchRange >= i * i + j * j)
-						ts[Exts.ISqrt(i * i + j * j, Exts.ISqrtRoundMode.Ceiling)].Add(new CVec(i, j));
+				{
+					var distSq = i * i + j * j;
+					if (maxRangeSq >= distSq)
+						ts[Exts.ISqrt(distSq, Exts.ISqrtRoundMode.Ceiling)].Add(new CVec(i, j));
+				}
+			}
 
 			// Sort each integer-distance group by the actual distance
-			foreach (var list in ts)
+			var finalArray = new ImmutableArray<CVec>[len];
+			for (var i = 0; i < len; i++)
 			{
+				var list = ts[i];
 				list.Sort((a, b) =>
 				{
 					var result = a.LengthSquared.CompareTo(b.LengthSquared);
@@ -236,9 +245,11 @@ namespace OpenRA
 
 					return a.Y.CompareTo(b.Y);
 				});
+
+				finalArray[i] = list.DrainToImmutable();
 			}
 
-			return ts.Select(list => list.ToImmutableArray()).ToImmutableArray();
+			return ImmutableCollectionsMarshal.AsImmutableArray(finalArray);
 		}
 
 		public WVec OffsetOfSubCell(SubCell subCell)

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -55,7 +54,7 @@ namespace OpenRA
 						Name = "Creeps",
 						Faction = firstFaction,
 						NonCombatant = true,
-						Enemies = Exts.MakeArray(playerCount, i => $"Multi{i}").ToImmutableArray()
+						Enemies = Exts.MakeImmutableArray(playerCount, i => $"Multi{i}")
 					}
 				}
 			};

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -16,6 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -424,14 +425,14 @@ namespace OpenRA
 				// Actor definitions may change if the map format changes
 				if (yaml.TryGetValue("Actors", out var actorDefinitions))
 				{
-					var spawns = new List<CPos>();
+					var spawns = ImmutableArray.CreateBuilder<CPos>();
 					foreach (var kv in actorDefinitions.Nodes.Where(d => d.Value.Value == "mpspawn"))
 					{
 						var s = new ActorReference(kv.Value.Value, kv.Value);
 						spawns.Add(s.Get<LocationInit>().Value);
 					}
 
-					newData.SpawnPoints = spawns.ToImmutableArray();
+					newData.SpawnPoints = spawns.DrainToImmutable();
 				}
 				else
 					newData.SpawnPoints = [];
@@ -502,7 +503,7 @@ namespace OpenRA
 				newData.SetCustomRules(modData, this, ruleDefinitions, null);
 
 				// Placeholder to satisfy server-side lint checks
-				newData.SpawnPoints = Exts.MakeArray(newData.PlayerCount, i => new CPos(i, i)).ToImmutableArray();
+				newData.SpawnPoints = Exts.MakeImmutableArray(newData.PlayerCount, i => new CPos(i, i));
 			}
 			catch (Exception e)
 			{
@@ -593,7 +594,7 @@ namespace OpenRA
 					var spawns = new CPos[r.spawnpoints.Length / 2];
 					for (var j = 0; j < r.spawnpoints.Length; j += 2)
 						spawns[j / 2] = new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]);
-					newData.SpawnPoints = spawns.ToImmutableArray();
+					newData.SpawnPoints = ImmutableCollectionsMarshal.AsImmutableArray(spawns);
 
 					newData.GridType = r.map_grid_type;
 					if (cache.LoadPreviewImages)

--- a/OpenRA.Game/Network/FluentMessage.cs
+++ b/OpenRA.Game/Network/FluentMessage.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Network
 			if (argumentsNode == null)
 				return ImmutableArray<object>.Empty;
 
-			var arguments = new List<object>(argumentsNode.Value.Nodes.Length * 2);
+			var arguments = ImmutableArray.CreateBuilder<object>(argumentsNode.Value.Nodes.Length * 2);
 			foreach (var argumentNode in argumentsNode.Value.Nodes)
 			{
 				var argument = FieldLoader.Load<FluentArgument>(argumentNode.Value);
@@ -81,7 +81,7 @@ namespace OpenRA.Network
 					arguments.Add(argument.Value);
 			}
 
-			return arguments.ToImmutableArray();
+			return arguments.DrainToImmutable();
 		}
 
 		public FluentMessage(MiniYaml yaml)

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Network
 
 		static object LoadClients(MiniYaml yaml)
 		{
-			var clients = new List<GameClient>();
+			var clients = ImmutableArray.CreateBuilder<GameClient>();
 			var clientsNode = yaml.NodeWithKeyOrDefault("Clients");
 			if (clientsNode != null)
 			{
@@ -152,7 +152,7 @@ namespace OpenRA.Network
 						clients.Add(FieldLoader.Load<GameClient>(client.Value));
 			}
 
-			return clients.ToImmutableArray();
+			return clients.DrainToImmutable();
 		}
 
 		public GameServer(MiniYaml yaml)

--- a/OpenRA.Game/Primitives/Polygon.cs
+++ b/OpenRA.Game/Primitives/Polygon.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Primitives
 			{
 				isRectangle = true;
 				BoundingRect = Rectangle.Empty;
-				Vertices = Exts.MakeArray(4, _ => int2.Zero).ToImmutableArray();
+				Vertices = Exts.MakeImmutableArray(4, _ => int2.Zero);
 			}
 		}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -10,8 +10,8 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 using System.Threading;
 using OpenRA.FileFormats;
@@ -36,7 +36,7 @@ namespace OpenRA
 		public bool WindowHasInputFocus => Window.HasInputFocus;
 		public bool WindowIsSuspended => Window.IsSuspended;
 
-		public IReadOnlyDictionary<string, SpriteFont> Fonts;
+		public FrozenDictionary<string, SpriteFont> Fonts;
 
 		internal IPlatformWindow Window { get; }
 		internal IGraphicsContext Context { get; }
@@ -135,7 +135,7 @@ namespace OpenRA
 			{
 				fontSheetBuilder?.Dispose();
 				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, modData.Manifest.RendererConstants.FontSheetSize);
-				Fonts = modData.GetOrCreate<Fonts>().FontList.ToDictionary(x => x.Key,
+				Fonts = modData.GetOrCreate<Fonts>().FontList.ToFrozenDictionary(x => x.Key,
 					x => new SpriteFont(
 						platform, x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),
 						x.Value.Size, x.Value.Ascender, Window.EffectiveWindowScale, fontSheetBuilder));

--- a/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicTilesetSpecificSpriteSequence.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 					{
 						var subStart = LoadField("Start", 0, data);
 						var subLength = LoadField("Length", 1, data);
-						frames = Exts.MakeArray(subLength, i => subStart + i).ToImmutableArray();
+						frames = Exts.MakeImmutableArray(subLength, i => subStart + i);
 					}
 
 					return [new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location)];

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpRemasteredLoader.cs
@@ -10,9 +10,10 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using ICSharpCode.SharpZipLib.Zip;
 using OpenRA.Graphics;
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			return Exts.ParseInt32Invariant(match.Groups[group].ValueSpan);
 		}
 
-		public IReadOnlyList<ISpriteFrame> Frames { get; }
+		public ImmutableArray<ISpriteFrame> Frames { get; }
 
 		public ShpRemasteredSprite(Stream stream)
 		{
@@ -115,7 +116,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 				}
 			}
 
-			Frames = frames;
+			Frames = ImmutableCollectionsMarshal.AsImmutableArray(frames);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -203,7 +204,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			}
 		}
 
-		public IReadOnlyList<ISpriteFrame> Frames { get; }
+		public ImmutableArray<ISpriteFrame> Frames { get; }
 		public readonly Size Size;
 
 		int recurseDepth = 0;
@@ -244,7 +245,7 @@ namespace OpenRA.Mods.Cnc.SpriteLoaders
 			foreach (var h in headers)
 				Decompress(h);
 
-			Frames = headers.Select(f => (ISpriteFrame)new TrimmedFrame(f)).ToArray();
+			Frames = headers.Select(f => (ISpriteFrame)new TrimmedFrame(f)).ToImmutableArray();
 		}
 
 		void Decompress(ImageHeader h)

--- a/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSMapGenerator.cs
@@ -10,9 +10,11 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Traits;
@@ -144,7 +146,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			[FieldLoader.Require]
 			public readonly int MaximumBuildings = default;
 			[FieldLoader.LoadUsing(nameof(BuildingWeightsLoader))]
-			public readonly IReadOnlyDictionary<string, int> BuildingWeights = default;
+			public readonly FrozenDictionary<string, int> BuildingWeights = default;
 			[FieldLoader.Require]
 			public readonly int CivilianBuildings = default;
 			[FieldLoader.Require]
@@ -159,21 +161,21 @@ namespace OpenRA.Mods.Cnc.Traits
 			[FieldLoader.Require]
 			public readonly ushort WaterTile = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> SegmentedBrushes;
+			public readonly ImmutableArray<MultiBrush> SegmentedBrushes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> ForestObstacles;
+			public readonly ImmutableArray<MultiBrush> ForestObstacles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> UnplayableObstacles;
+			public readonly ImmutableArray<MultiBrush> UnplayableObstacles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> CivilianBuildingsObstacles;
+			public readonly ImmutableArray<MultiBrush> CivilianBuildingsObstacles;
 			[FieldLoader.Require]
 			public readonly ushort ForestFloorTile = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<(ushort, int)> OtherGround;
+			public readonly ImmutableArray<(ushort, int)> OtherGround;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyDictionary<ushort, IReadOnlyList<MultiBrush>> RepaintTiles;
+			public readonly FrozenDictionary<ushort, ImmutableArray<MultiBrush>> RepaintTiles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<ushort> RampTiles;
+			public readonly ImmutableArray<ushort> RampTiles;
 			[FieldLoader.Ignore]
 			public readonly LatTiler LatTiler;
 			[FieldLoader.Ignore]
@@ -184,18 +186,18 @@ namespace OpenRA.Mods.Cnc.Traits
 			[FieldLoader.Ignore]
 			public readonly ResourceTypeInfo DefaultResource;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyDictionary<string, ResourceTypeInfo> ResourceSpawnSeeds;
+			public readonly FrozenDictionary<string, ResourceTypeInfo> ResourceSpawnSeeds;
 			[FieldLoader.LoadUsing(nameof(ResourceSpawnWeightsLoader))]
-			public readonly IReadOnlyDictionary<string, int> ResourceSpawnWeights = default;
+			public readonly FrozenDictionary<string, int> ResourceSpawnWeights = default;
 
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> ClearTerrain;
+			public readonly FrozenSet<byte> ClearTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> PlayableTerrain;
+			public readonly FrozenSet<byte> PlayableTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> DominantTerrain;
+			public readonly FrozenSet<byte> DominantTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> ZoneableTerrain;
+			public readonly FrozenSet<byte> ZoneableTerrain;
 			[FieldLoader.Ignore]
 			public readonly string ClearSegmentType;
 			[FieldLoader.Ignore]
@@ -224,7 +226,7 @@ namespace OpenRA.Mods.Cnc.Traits
 							throw new YamlException($"OtherGround {n.Key} has invalid fraction (should be 0 to {FractionMax})");
 
 						return (tile, fraction);
-					}).ToList();
+					})?.ToImmutableArray() ?? [];
 				RepaintTiles = my.NodeWithKeyOrDefault("RepaintTiles")?.Value.ToDictionary(
 					k =>
 					{
@@ -233,10 +235,10 @@ namespace OpenRA.Mods.Cnc.Traits
 						else
 							throw new YamlException($"RepaintTile {k} is not a ushort");
 					},
-					v => MultiBrush.LoadCollection(map, v.Value) as IReadOnlyList<MultiBrush>);
-				RepaintTiles ??= ImmutableDictionary<ushort, IReadOnlyList<MultiBrush>>.Empty;
+					v => MultiBrush.LoadCollection(map, v.Value))?.ToFrozenDictionary();
+				RepaintTiles ??= FrozenDictionary<ushort, ImmutableArray<MultiBrush>>.Empty;
 
-				RampTiles = FieldLoader.GetValue<List<ushort>>(
+				RampTiles = FieldLoader.GetValue<ImmutableArray<ushort>>(
 					nameof(RampTiles),
 					my.NodeWithKey(nameof(RampTiles)).Value.Value);
 				LatTiler = new LatTiler(my.NodeWithKey("LatTiler").Value, terrainInfo);
@@ -251,7 +253,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					ResourceSpawnSeeds = my.NodeWithKey("ResourceSpawnSeeds").Value
 						.ToDictionary(subMy => subMy.Value)
-						.ToDictionary(kv => kv.Key, kv => resourceTypes[kv.Value]);
+						.ToFrozenDictionary(kv => kv.Key, kv => resourceTypes[kv.Value]);
 				}
 				catch (KeyNotFoundException e)
 				{
@@ -269,12 +271,12 @@ namespace OpenRA.Mods.Cnc.Traits
 						break;
 				}
 
-				IReadOnlySet<byte> ParseTerrainIndexes(string key)
+				FrozenSet<byte> ParseTerrainIndexes(string key)
 				{
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
 						.Select(terrainInfo.GetTerrainIndex)
-						.ToImmutableHashSet();
+						.ToFrozenSet();
 				}
 
 				ClearTerrain = ParseTerrainIndexes("ClearTerrain");
@@ -298,7 +300,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					throw new YamlException($"Invalid Mirror value `{my.NodeWithKey("Mirror").Value.Value}`");
 			}
 
-			static IReadOnlyDictionary<string, int> BuildingWeightsLoader(MiniYaml my)
+			static FrozenDictionary<string, int> BuildingWeightsLoader(MiniYaml my)
 			{
 				return my.NodeWithKey("BuildingWeights").Value.ToDictionary(subMy =>
 					{
@@ -306,10 +308,10 @@ namespace OpenRA.Mods.Cnc.Traits
 							return f;
 						else
 							throw new YamlException($"Invalid building weight `{subMy.Value}`");
-					});
+					}).ToFrozenDictionary();
 			}
 
-			static IReadOnlyDictionary<string, int> ResourceSpawnWeightsLoader(MiniYaml my)
+			static FrozenDictionary<string, int> ResourceSpawnWeightsLoader(MiniYaml my)
 			{
 				return my.NodeWithKey("ResourceSpawnWeights").Value.ToDictionary(subMy =>
 					{
@@ -317,7 +319,7 @@ namespace OpenRA.Mods.Cnc.Traits
 							return f;
 						else
 							throw new YamlException($"Invalid resource spawn weight `{subMy.Value}`");
-					});
+					}).ToFrozenDictionary();
 			}
 		}
 
@@ -436,7 +438,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var heightMap = new RampTiler.HeightMap(map);
 
 			var coast = MatrixUtils.BordersToPoints(landPlan);
-			List<TilingPath> coastPaths;
+			ImmutableArray<TilingPath> coastPaths;
 			if (param.WaterCliffs)
 			{
 				var waterCliffZone = new Terraformer.PathPartitionZone()
@@ -473,7 +475,7 @@ namespace OpenRA.Mods.Cnc.Traits
 								param.BeachSegmentType,
 								param.BeachSegmentType)
 									.ExtendEdge(4))
-					.ToList();
+					.ToImmutableArray();
 			}
 
 			var landCoastWater = terraformer.PaintLoopsAndFill(
@@ -481,7 +483,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				coastPaths,
 				landPlan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
 				[new MultiBrush().WithTemplate(map, param.WaterTile, CVec.Zero)],
-				null,
+				default,
 				null,
 				0)
 					?? throw new MapGenerationException("Could not fit tiles for coast");
@@ -811,7 +813,7 @@ namespace OpenRA.Mods.Cnc.Traits
 						resourcePattern,
 						resourceMask,
 						param.DefaultResource,
-						resourceBiases);
+						CollectionsMarshal.AsSpan(resourceBiases));
 					terraformer.GrowResources(
 						plan,
 						typePlan,

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -51,15 +50,14 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 			Game.ModData = destModData;
 			var destPaletteInfo = destModData.DefaultRules.Actors[SystemActors.Player].TraitInfo<PlayerColorPaletteInfo>();
 			var destRemapIndex = destPaletteInfo.RemapIndex;
-			var shadowIndex = ImmutableArray<int>.Empty;
 
 			// the remap range is always 16 entries, but their location and order changes
 			for (var i = 0; i < 16; i++)
 				remap[srcRemapIndex[i]] = destRemapIndex[i];
 
 			// map everything else to the best match based on channel-wise distance
-			var srcPalette = new ImmutablePalette(args[1].Split(':')[1], [0], shadowIndex);
-			var destPalette = new ImmutablePalette(args[2].Split(':')[1], [0], shadowIndex);
+			var srcPalette = new ImmutablePalette(args[1].Split(':')[1], [0], []);
+			var destPalette = new ImmutablePalette(args[2].Split(':')[1], [0], []);
 
 			for (var i = 0; i < Palette.Size; i++)
 				if (!remap.ContainsKey(i))

--- a/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorBlit.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -92,7 +93,7 @@ namespace OpenRA.Mods.Common.EditorBrushes
 			IResourceLayer resourceLayer,
 			CellCoordsRegion region,
 			MapBlitFilters blitFilters,
-			IReadOnlySet<CPos> mask = null)
+			FrozenSet<CPos> mask = null)
 		{
 			var mapTiles = map.Tiles;
 			var mapHeight = map.Height;
@@ -313,7 +314,7 @@ namespace OpenRA.Mods.Common.EditorBrushes
 		/// be at least partially inside the CellRegion. If an actor partially lies outside of the
 		/// CellRegion, only cells within the CellRegion are included in the output set.
 		/// </summary>
-		static HashSet<CPos> GetBlitSourceMask(
+		static FrozenSet<CPos> GetBlitSourceMask(
 			EditorBlitSource blitSource,
 			CVec offset)
 		{
@@ -344,7 +345,7 @@ namespace OpenRA.Mods.Common.EditorBrushes
 					throw new ArgumentException("EditorBlitSource contains an actor entirely outside of its CellRegion");
 			}
 
-			return mask;
+			return mask.ToFrozenSet();
 		}
 
 		public void Commit() => Blit(false);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorMarkerLayerBrush.cs
@@ -241,8 +241,8 @@ namespace OpenRA.Mods.Common.Widgets
 			MarkerLayerOverlay markerLayerOverlay)
 		{
 			this.markerLayerOverlay = markerLayerOverlay;
-			tiles = markerLayerOverlay.Tiles.ToFrozenDictionary(t => t.Key, t => t.Value.ToImmutableArray());
-			var allTilesCount = tiles.Values.Sum(x => x.Length);
+			tiles = markerLayerOverlay.Tiles.ToFrozenDictionary(x => x.Key, x => x.Value.ToImmutableArray());
+			var allTilesCount = tiles.Sum(x => x.Value.Length);
 
 			Text = FluentProvider.GetMessage(ClearedAllMarkerTiles, "count", allTilesCount);
 		}

--- a/OpenRA.Mods.Common/Effects/FloatingSprite.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingSprite.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using OpenRA.Effects;
@@ -33,8 +34,8 @@ namespace OpenRA.Mods.Common.Effects
 		int ticks;
 		WAngle facing;
 
-		public FloatingSprite(Actor emitter, string image, ImmutableArray<string> sequences, string palette, bool isPlayerPalette,
-			ImmutableArray<int> lifetime, ImmutableArray<WDist> speed, ImmutableArray<WDist> gravity, int turnRate, int randomRate, WPos pos, WAngle facing,
+		public FloatingSprite(Actor emitter, string image, ReadOnlySpan<string> sequences, string palette, bool isPlayerPalette,
+			ReadOnlySpan<int> lifetime, ImmutableArray<WDist> speed, ImmutableArray<WDist> gravity, int turnRate, int randomRate, WPos pos, WAngle facing,
 			bool visibleThroughFog = false)
 		{
 			var world = emitter.World;

--- a/OpenRA.Mods.Common/FileSystem/ContentInstallerFileSystemLoader.cs
+++ b/OpenRA.Mods.Common/FileSystem/ContentInstallerFileSystemLoader.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 
 namespace OpenRA.Mods.Common.FileSystem
 {
@@ -60,11 +61,14 @@ namespace OpenRA.Mods.Common.FileSystem
 				return default(ImmutableArray<KeyValuePair<string, string>>);
 			}
 
-			var packages = new List<KeyValuePair<string, string>>(packageNode.Value.Nodes.Length);
-			foreach (var node in packageNode.Value.Nodes)
-				packages.Add(KeyValuePair.Create(node.Key, node.Value.Value));
+			var packages = new KeyValuePair<string, string>[packageNode.Value.Nodes.Length];
+			for (var i = 0; i < packageNode.Value.Nodes.Length; i++)
+			{
+				var node = packageNode.Value.Nodes[i];
+				packages[i] = KeyValuePair.Create(node.Key, node.Value.Value);
+			}
 
-			return packages.ToImmutableArray();
+			return ImmutableCollectionsMarshal.AsImmutableArray(packages);
 		}
 
 		public void Mount(Manifest manifest, OpenRA.FileSystem.FileSystem fileSystem, ObjectCreator objectCreator)

--- a/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
+++ b/OpenRA.Mods.Common/FileSystem/DefaultFileSystemLoader.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.FileSystem
@@ -33,11 +34,14 @@ namespace OpenRA.Mods.Common.FileSystem
 			if (packageNode == null)
 				return default(ImmutableArray<KeyValuePair<string, string>>);
 
-			var packages = new List<KeyValuePair<string, string>>(packageNode.Value.Nodes.Length);
-			foreach (var node in packageNode.Value.Nodes)
-				packages.Add(KeyValuePair.Create(node.Key, node.Value.Value));
+			var packages = new KeyValuePair<string, string>[packageNode.Value.Nodes.Length];
+			for (var i = 0; i < packageNode.Value.Nodes.Length; i++)
+			{
+				var node = packageNode.Value.Nodes[i];
+				packages[i] = KeyValuePair.Create(node.Key, node.Value.Value);
+			}
 
-			return packages.ToImmutableArray();
+			return ImmutableCollectionsMarshal.AsImmutableArray(packages);
 		}
 
 		public void Mount(Manifest manifest, OpenRA.FileSystem.FileSystem fileSystem, ObjectCreator objectCreator)

--- a/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Immutable;
 using System.Numerics;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -18,7 +19,9 @@ namespace OpenRA.Mods.Common.Graphics
 	public class CircleAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		const int CircleSegments = 32;
-		static readonly WVec[] FacingOffsets = Exts.MakeArray(CircleSegments, i => new WVec(1024, 0, 0).Rotate(WRot.FromFacing(i * 256 / CircleSegments)));
+		static readonly ImmutableArray<WVec> FacingOffsets = Exts.MakeImmutableArray(CircleSegments, i => new WVec(1024, 0, 0)
+			.Rotate(WRot.FromFacing(i * 256 / CircleSegments)));
+
 		readonly WDist radius;
 		readonly int width;
 		readonly Color color;

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -16,6 +16,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 
@@ -287,28 +288,43 @@ namespace OpenRA.Mods.Common.Graphics
 				return default;
 
 			// Only request the subset of frames that we actually need
-			var usedFrames = new List<int>();
+			var len = length.Value;
+			var baseCount = facings * len;
+			var totalCount = shadowStart >= 0 ? baseCount * 2 : baseCount;
+			var usedFrames = new int[totalCount];
+			var hasFrames = !frames.IsDefault;
+			var resultIndex = 0;
+
 			for (var facing = 0; facing < facings; facing++)
 			{
 				var facingInner = reverseFacings ? (facings - facing) % facings : facing;
-				for (var frame = 0; frame < length.Value; frame++)
+				if (transpose)
 				{
-					var i = transpose ? frame * facings + facingInner :
-						facingInner * stride + frame;
-
-					usedFrames.Add(frames != null ? frames[i] : start + i);
+					for (var frame = 0; frame < len; frame++)
+					{
+						var i = frame * facings + facingInner;
+						usedFrames[resultIndex++] = hasFrames ? frames[i] : start + i;
+					}
+				}
+				else
+				{
+					var baseOffset = facingInner * stride;
+					for (var frame = 0; frame < len; frame++)
+					{
+						var i = baseOffset + frame;
+						usedFrames[resultIndex++] = hasFrames ? frames[i] : start + i;
+					}
 				}
 			}
 
 			if (shadowStart >= 0)
 			{
 				var shadowOffset = shadowStart - start;
-				var frameCount = usedFrames.Count;
-				for (var i = 0; i < frameCount; i++)
-					usedFrames.Add(usedFrames[i] + shadowOffset);
+				for (var i = 0; i < baseCount; i++)
+					usedFrames[baseCount + i] = usedFrames[i] + shadowOffset;
 			}
 
-			return usedFrames.ToImmutableArray();
+			return ImmutableCollectionsMarshal.AsImmutableArray(usedFrames);
 		}
 
 		protected virtual IEnumerable<ReservationInfo> ParseFilenames(ModData modData, string tileset, ImmutableArray<int> frames, MiniYaml data, MiniYaml defaults)
@@ -337,7 +353,7 @@ namespace OpenRA.Mods.Common.Graphics
 			{
 				var subStart = LoadField("Start", 0, data);
 				var subLength = LoadField("Length", 1, data);
-				frames = Exts.MakeArray(subLength, i => subStart + i).ToImmutableArray();
+				frames = Exts.MakeImmutableArray(subLength, i => subStart + i);
 			}
 
 			yield return new ReservationInfo(filename, frames, frames, location);
@@ -505,12 +521,12 @@ namespace OpenRA.Mods.Common.Graphics
 			if (alpha != null)
 			{
 				if (alpha.Length == 1)
-					alpha = Exts.MakeArray(length.Value, _ => alpha[0]).ToImmutableArray();
+					alpha = Exts.MakeImmutableArray(length.Value, _ => alpha[0]);
 				else if (alpha.Length != length.Value)
 					throw new YamlException($"Sequence {image}.{Name} must define either 1 or {length.Value} Alpha values.");
 			}
 			else if (alphaFade)
-				alpha = Exts.MakeArray(length.Value, i => OpenRA.Graphics.Util.Lerp(1f, 0f, i / (length.Value - 1f))).ToImmutableArray();
+				alpha = Exts.MakeImmutableArray(length.Value, i => OpenRA.Graphics.Util.Lerp(1f, 0f, i / (length.Value - 1f)));
 
 			// Reindex sprites to order facings anti-clockwise and remove unused frames
 			var index = CalculateFrameIndices(start, length.Value, stride ?? length.Value, facings, default, transpose, reverseFacings, -1);

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Graphics
 					{
 						var subStart = LoadField("Start", 0, data);
 						var subLength = LoadField("Length", 1, data);
-						frames = Exts.MakeArray(subLength, i => subStart + i).ToImmutableArray();
+						frames = Exts.MakeImmutableArray(subLength, i => subStart + i);
 					}
 
 					return [new ReservationInfo(tilesetNode.Value.Value, frames, frames, tilesetNode.Location)];

--- a/OpenRA.Mods.Common/Lint/CheckInteractable.cs
+++ b/OpenRA.Mods.Common/Lint/CheckInteractable.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Lint
 
 		static bool HasInvalidBounds(ImmutableArray<WDist> bounds, Size tileSize, int tileScale)
 		{
-			if (bounds == null)
+			if (bounds.IsDefault)
 				return false;
 
 			if (bounds.Length != 2 && bounds.Length != 4)

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
@@ -24,14 +23,14 @@ namespace OpenRA.Mods.Common.Lint
 		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			var players = new MapPlayers(map.PlayerDefinitions);
-			var spawns = new List<CPos>();
+			var spawns = ImmutableArray.CreateBuilder<CPos>();
 			foreach (var kv in map.ActorDefinitions.Where(d => d.Value.Value == "mpspawn"))
 			{
 				var s = new ActorReference(kv.Value.Value, kv.Value);
 				spawns.Add(s.Get<LocationInit>().Value);
 			}
 
-			Run(emitError, emitWarning, players, map.Visibility, map.Rules.Actors[SystemActors.World], spawns.ToImmutableArray());
+			Run(emitError, emitWarning, players, map.Visibility, map.Rules.Actors[SystemActors.World], spawns.DrainToImmutable());
 		}
 
 		void ILintServerMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, MapPreview map, Ruleset mapRules)

--- a/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
+++ b/OpenRA.Mods.Common/MapGenerator/CellLayerUtils.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -594,7 +593,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			CellLayer<T> cellLayer,
 			IEnumerable<(CPos CPos, P Prop)> seeds,
 			Func<CPos, P, P?> filler,
-			ImmutableArray<CVec> spread) where P : struct
+			ReadOnlySpan<CVec> spread) where P : struct
 		{
 			var current = new List<(CPos CPos, P Prop)>();
 			var next = seeds.ToList();
@@ -624,7 +623,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			CellLayer<bool> mask,
 			CellLayer<bool> seeds,
 			Action<CPos> fillAction,
-			ImmutableArray<CVec> spread)
+			ReadOnlySpan<CVec> spread)
 		{
 			if (!AreSameShape(mask, seeds))
 				throw new ArgumentException("mask and seeds did not have same shape");

--- a/OpenRA.Mods.Common/MapGenerator/LatTiler.cs
+++ b/OpenRA.Mods.Common/MapGenerator/LatTiler.cs
@@ -9,9 +9,11 @@
 */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Support;
 
@@ -126,7 +128,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				}
 
 				Main = main?.ToImmutableHashSet();
-				Replacements = replacements.ToImmutableArray();
+				Replacements = ImmutableCollectionsMarshal.AsImmutableArray(replacements);
 			}
 
 			/// <summary>
@@ -162,7 +164,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				if (Replacements[index] == null)
 					return null;
 
-				return MultiBrush.PickAny(Replacements[index], random);
+				return MultiBrush.PickAny(Replacements[index].AsSpan(), random);
 			}
 		}
 
@@ -175,21 +177,25 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 		public LatTiler(MiniYaml my, ITemplatedTerrainInfo itti)
 		{
-			var latRules = new List<LatRule>();
-			foreach (var node in my.Nodes)
+			var nodes = my.Nodes;
+			var latRules = new LatRule[nodes.Length];
+
+			for (var i = 0; i < nodes.Length; i++)
 			{
-				var parts = node.Key.Split('@');
-				switch (parts[0])
+				var node = nodes[i];
+				var keySpan = node.Key.AsSpan();
+				var atIndex = keySpan.IndexOf('@');
+				switch (atIndex >= 0 ? keySpan[..atIndex] : keySpan)
 				{
 					case "Rule":
-						latRules.Add(new LatRule(node.Value, itti));
+						latRules[i] = new LatRule(node.Value, itti);
 						break;
 					default:
 						throw new YamlException($"Invalid LatTiler key `{node.Key}`");
 				}
 			}
 
-			this.latRules = latRules.ToImmutableArray();
+			this.latRules = ImmutableCollectionsMarshal.AsImmutableArray(latRules);
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/MapGenerator/MapGeneratorOptions.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MapGeneratorOptions.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			FieldLoader.Load(this, yaml);
 		}
 
-		public abstract IReadOnlyCollection<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount);
+		public abstract ImmutableArray<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount);
 
 		public virtual IEnumerable<string> GetFluentReferences()
 		{
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public MapGeneratorBooleanOption(string id, MiniYaml yaml)
 			: base(id, yaml) { }
 
-		public override IReadOnlyCollection<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
+		public override ImmutableArray<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
 		{
 			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(value))];
 		}
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public MapGeneratorIntegerOption(string id, MiniYaml yaml)
 			: base(id, yaml) { }
 
-		public override IReadOnlyCollection<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
+		public override ImmutableArray<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
 		{
 			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(value))];
 		}
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			return validChoices.FirstOrDefault();
 		}
 
-		public override IReadOnlyCollection<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
+		public override ImmutableArray<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
 		{
 			var validChoices = ValidChoices(terrainInfo, playerCount);
 			if (validChoices.Contains(value))
@@ -186,7 +186,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Default ??= Choices != null ? Choices[0] : 0;
 		}
 
-		public override IReadOnlyCollection<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
+		public override ImmutableArray<MiniYamlNode> GetParameters(ITerrainInfo terrainInfo, string value, int playerCount)
 		{
 			return [new MiniYamlNode(Parameter, FieldSaver.FormatValue(value))];
 		}

--- a/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
+++ b/OpenRA.Mods.Common/MapGenerator/MultiBrush.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 		public static ImmutableArray<MultiBrushInfo> ParseCollection(MiniYaml my)
 		{
-			var brushes = new List<MultiBrushInfo>();
+			var brushes = ImmutableArray.CreateBuilder<MultiBrushInfo>();
 			foreach (var node in my.Nodes)
 			{
 				switch (node.Key.Split('@')[0])
@@ -177,7 +177,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				}
 			}
 
-			return brushes.ToImmutableArray();
+			return brushes.DrainToImmutable();
 		}
 	}
 
@@ -670,7 +670,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			Map map,
 			List<ActorPlan> actorPlans,
 			CellLayer<Replaceability> replace,
-			IReadOnlyList<MultiBrush> availableBrushes,
+			ImmutableArray<MultiBrush> availableBrushes,
 			MersenneTwister random,
 			bool alwaysPreferLargerBrushes = false,
 			short? heightOffset = null)
@@ -875,15 +875,15 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>Pick a random brush from a list, respecting brush weights.</summary>
-		public static MultiBrush PickAny(IReadOnlyList<MultiBrush> brushes, MersenneTwister random)
+		public static MultiBrush PickAny(ReadOnlySpan<MultiBrush> brushes, MersenneTwister random)
 		{
-			if (brushes.Count == 0)
+			if (brushes.Length == 0)
 				throw new ArgumentException("brushes was empty");
 
-			if (brushes.Count == 1)
+			if (brushes.Length == 1)
 				return brushes[0];
 
-			var weights = new int[brushes.Count];
+			var weights = new int[brushes.Length];
 			for (var i = 0; i < weights.Length; i++)
 				weights[i] = brushes[i].Weight;
 

--- a/OpenRA.Mods.Common/MapGenerator/RampTiler.cs
+++ b/OpenRA.Mods.Common/MapGenerator/RampTiler.cs
@@ -10,10 +10,12 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Primitives;
 using OpenRA.Support;
 
@@ -401,7 +403,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 		record struct RampProperties
 		{
-			public MultiBrush[] Brushes;
+			public ImmutableArray<MultiBrush> Brushes;
 			public byte Tl;
 			public byte Tr;
 			public byte Br;
@@ -457,43 +459,50 @@ namespace OpenRA.Mods.Common.MapGenerator
 		readonly Map map;
 
 		// Contains single-tile brushes with zero height offset.
-		readonly RampProperties[] rampProperties;
+		readonly ImmutableArray<RampProperties> rampProperties;
 
 		// Lookup from a binary-concatenation of corner heights (0, 1, or 2) to ramp types.
 		// Only contains mappings for which there are brushes.
-		readonly Dictionary<int, List<byte>> rampLookup;
+		readonly FrozenDictionary<int, ImmutableArray<byte>> rampLookup;
 
 		public RampTiler(Map map, IEnumerable<ushort> rampTemplates)
 			: this(
 				map,
 				rampTemplates
 					.Select(t => new MultiBrush().WithTemplate(map, t, CVec.Zero))
-					.ToList())
+					.ToImmutableArray())
 		{ }
 
-		public RampTiler(Map map, IReadOnlyList<MultiBrush> rampBrushes)
+		public RampTiler(Map map, ImmutableArray<MultiBrush> rampBrushes)
 		{
 			this.map = map;
 			var heightStep = map.Grid.TileScale / 2;
+			var maxRamps = map.Grid.Ramps.Length;
 
-			var rampsToBrushes = new Dictionary<byte, List<MultiBrush>>();
+			// Group ramp brushes by ramp type.
+			var rampsToBrushesMap = new ImmutableArray<MultiBrush>.Builder[maxRamps];
 			foreach (var brush in rampBrushes)
 			{
-				var heightsAndRamps = brush.GetHeightsAndRamps().ToList();
-				if (heightsAndRamps.Count != 1 || heightsAndRamps[0].Height != 0)
+				var heightsAndRamps = brush.GetHeightsAndRamps();
+				using var enumerator = heightsAndRamps.GetEnumerator();
+
+				if (!enumerator.MoveNext())
 					throw new ArgumentException("brushes that are not single-tile are not supported");
 
-				var ramp = heightsAndRamps[0].Ramp;
-				if (!rampsToBrushes.ContainsKey(ramp))
-					rampsToBrushes.Add(ramp, []);
+				var (_, height, ramp) = enumerator.Current;
+				if (enumerator.MoveNext() || height != 0)
+					throw new ArgumentException("brushes that are not single-tile are not supported");
 
-				rampsToBrushes[ramp].Add(brush);
+				if (rampsToBrushesMap[ramp] == null)
+					rampsToBrushesMap[ramp] = ImmutableArray.CreateBuilder<MultiBrush>();
+
+				rampsToBrushesMap[ramp].Add(brush);
 			}
 
-			rampLookup = [];
-			rampProperties = new RampProperties[map.Grid.Ramps.Length];
-
-			for (byte ramp = 0; ramp < rampProperties.Length; ramp++)
+			// Build lookups.
+			var localRampProperties = new RampProperties[maxRamps];
+			var localRampLookup = new Dictionary<int, ImmutableArray<byte>.Builder>();
+			for (byte ramp = 0; ramp < localRampProperties.Length; ramp++)
 			{
 				var cellRamp = map.Grid.Ramps[ramp];
 				var tl = cellRamp.Corners[0].Z / heightStep;
@@ -501,24 +510,34 @@ namespace OpenRA.Mods.Common.MapGenerator
 				var br = cellRamp.Corners[2].Z / heightStep;
 				var bl = cellRamp.Corners[3].Z / heightStep;
 
-				rampProperties[ramp] = new RampProperties()
+				var brushBuilder = rampsToBrushesMap[ramp];
+				var brushes = brushBuilder != null ? brushBuilder.DrainToImmutable() : [];
+
+				localRampProperties[ramp] = new RampProperties()
 				{
-					Brushes = rampsToBrushes.GetValueOrDefault(ramp, []).ToArray(),
+					Brushes = brushes,
 					Tl = (byte)tl,
 					Tr = (byte)tr,
 					Br = (byte)br,
 					Bl = (byte)bl,
 				};
 
-				if (rampProperties[ramp].Brushes.Length > 0)
+				if (brushes.Length > 0)
 				{
 					var lookup = tl | (tr << 2) | (br << 4) | (bl << 6);
-					if (!rampLookup.ContainsKey(lookup))
-						rampLookup.Add(lookup, []);
 
-					rampLookup[lookup].Add(ramp);
+					ref var rampBuilder = ref CollectionsMarshal.GetValueRefOrAddDefault(localRampLookup, lookup, out var exists);
+					if (!exists)
+						rampBuilder = ImmutableArray.CreateBuilder<byte>();
+
+					rampBuilder.Add(ramp);
 				}
 			}
+
+			rampProperties = ImmutableCollectionsMarshal.AsImmutableArray(localRampProperties);
+			rampLookup = localRampLookup.ToFrozenDictionary(
+				kvp => kvp.Key,
+				kvp => kvp.Value.DrainToImmutable());
 		}
 
 		byte GetConnectionHeight(byte height, TerrainTileInfo info, Riser.Connection connection)
@@ -724,9 +743,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 				heights[cpos] = baseHeight;
 				ramps[cpos] =
-					validRamps.Count == 1
+					validRamps.Length == 1
 						? validRamps[0]
-						: validRamps[random.Next() % validRamps.Count];
+						: validRamps[random.Next() % validRamps.Length];
 			}
 
 			return (heights, ramps);
@@ -760,7 +779,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 					: map.Tiles.CellRegion;
 			foreach (var cpos in masked)
 			{
-				var brushes = rampProperties[ramps[cpos]].Brushes;
+				var brushes = rampProperties[ramps[cpos]].Brushes.AsSpan();
 				if (brushes.Length == 0)
 					return null;
 

--- a/OpenRA.Mods.Common/MapGenerator/Symmetry.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Symmetry.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 
@@ -261,16 +260,16 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// Rotate and mirror multiple actor plans. See RotateAndMirrorActorPlan.
 		/// </summary>
 		public static ImmutableArray<ActorPlan> RotateAndMirrorActorPlans(
-			IReadOnlyList<ActorPlan> originals,
+			ReadOnlySpan<ActorPlan> originals,
 			int rotations,
 			WMirror wmirror)
 		{
-			var projections = new List<ActorPlan>(
-				originals.Count * RotateAndMirrorProjectionCount(rotations, wmirror.ForWPos()));
+			var projections = ImmutableArray.CreateBuilder<ActorPlan>(
+				originals.Length * RotateAndMirrorProjectionCount(rotations, wmirror.ForWPos()));
 			foreach (var original in originals)
 				projections.AddRange(RotateAndMirrorActorPlan(original, rotations, wmirror));
 
-			return projections.ToImmutableArray();
+			return projections.DrainToImmutable();
 		}
 
 		/// <summary>
@@ -282,7 +281,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			int rotations,
 			WMirror wmirror)
 		{
-			var projections = new List<ActorPlan>(RotateAndMirrorProjectionCount(rotations, wmirror.ForWPos()));
+			var projections = ImmutableArray.CreateBuilder<ActorPlan>(RotateAndMirrorProjectionCount(rotations, wmirror.ForWPos()));
 			var points = RotateAndMirrorWPos(
 				original.WPosCenterLocation,
 				original.Map.Tiles,
@@ -295,7 +294,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				projections.Add(plan);
 			}
 
-			return projections.ToImmutableArray();
+			return projections.DrainToImmutable();
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
+++ b/OpenRA.Mods.Common/MapGenerator/Terraformer.cs
@@ -10,9 +10,11 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Terrain;
@@ -107,7 +109,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			BakedAdjacency,
 		}
 
-		public static (T[] Types, U[] Weights) SplitDictionary<T, U>(IReadOnlyDictionary<T, U> typeWeights)
+		public static (T[] Types, U[] Weights) SplitDictionary<T, U>(FrozenDictionary<T, U> typeWeights)
 		{
 			var types = typeWeights
 				.Select(kv => kv.Key)
@@ -353,7 +355,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// (if allowedTerrain is non-null), is free of actors, and/or is free of resources.
 		/// </summary>
 		public CellLayer<bool> CheckSpace(
-			IReadOnlySet<byte> allowedTerrain,
+			FrozenSet<byte> allowedTerrain,
 			bool checkActors = false,
 			bool checkResources = false,
 			bool checkBounds = false,
@@ -433,7 +435,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// limit the zoneable area.
 		/// </summary>
 		public CellLayer<bool> GetZoneable(
-			IReadOnlySet<byte> zoneableTerrain,
+			FrozenSet<byte> zoneableTerrain,
 			CellLayer<bool> mask = null)
 		{
 			CheckHasMapShapeOrNull(mask);
@@ -500,7 +502,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// if they are also all recessive.
 		/// </param>
 		public CellLayer<bool> FindAsymmetries(
-			IReadOnlySet<byte> dominantTerrain,
+			FrozenSet<byte> dominantTerrain,
 			bool dominantActors,
 			bool strictTerrainTypes)
 		{
@@ -558,7 +560,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 					space,
 					[(start, true)],
 					Filler,
-					spread);
+					spread.AsSpan());
 			}
 
 			foreach (var mpos in Map.AllCells.MapCoords)
@@ -849,7 +851,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			MersenneTwister random,
 			CellLayer<bool> zoneable,
 			CellLayer<int> distribution,
-			IReadOnlyDictionary<string, int> weightedActorTypes,
+			FrozenDictionary<string, int> weightedActorTypes,
 			int targetCount,
 			bool weighted,
 			WDist? actorDezoneRadius = null)
@@ -921,7 +923,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public int AddActorCluster(
 			MersenneTwister random,
 			CellLayer<bool> zoneable,
-			IReadOnlyDictionary<string, int> weightedActorTypes,
+			FrozenDictionary<string, int> weightedActorTypes,
 			int targetCount,
 			int innerReservation,
 			int minimumRadius,
@@ -983,7 +985,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public void PaintArea(
 			MersenneTwister random,
 			CellLayer<MultiBrush.Replaceability> replace,
-			IReadOnlyList<MultiBrush> brushes,
+			ImmutableArray<MultiBrush> brushes,
 			bool alwaysPreferLargerBrushes = false)
 		{
 			CheckHasMapShape(replace);
@@ -1003,7 +1005,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		public void PaintActors(
 			MersenneTwister random,
 			CellLayer<bool> mask,
-			IReadOnlyList<MultiBrush> brushes,
+			ImmutableArray<MultiBrush> brushes,
 			bool alwaysPreferLargerBrushes = false)
 		{
 			CheckHasMapShape(mask);
@@ -1033,7 +1035,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </summary>
 		public void RepaintTiles(
 			MersenneTwister random,
-			IReadOnlyDictionary<ushort, IReadOnlyList<MultiBrush>> rules)
+			FrozenDictionary<ushort, ImmutableArray<MultiBrush>> rules)
 		{
 			foreach (var (tile, collection) in rules.OrderBy(kv => kv.Key))
 			{
@@ -1237,9 +1239,9 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </param>
 		public List<TilingPath> PartitionPath(
 			int2[] path,
-			IReadOnlyList<PathPartitionZone> allZones,
+			ImmutableArray<PathPartitionZone> allZones,
 			Matrix<PathPartitionZone> zoneMask,
-			IReadOnlyList<MultiBrush> brushes,
+			ImmutableArray<MultiBrush> brushes,
 			int minimumStraight)
 		{
 			// Algorithmic Overview:
@@ -1257,7 +1259,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			//
 			// If there are multiple best solutions (with equal costs), there is a preference to
 			// solutions with more sub-paths.
-			if (allZones.Count == 0)
+			if (allZones.Length == 0)
 				throw new ArgumentException("no zones provided");
 
 			if (allZones.Count(zone => zone.RequiredSomewhere) > 1)
@@ -1303,8 +1305,8 @@ namespace OpenRA.Mods.Common.MapGenerator
 			// To optimize partition vote counting, we pre-sum all the matches for allZones[i]
 			// within zone[0..j] into partitionAcc[i][j]. This means we can quickly count the
 			// matches between a and b by subtracting partitionAcc[i][a] from partitionAcc[i][b].
-			var partitionAcc = new int[allZones.Count][];
-			for (var i = 0; i < allZones.Count; i++)
+			var partitionAcc = new int[allZones.Length][];
+			for (var i = 0; i < allZones.Length; i++)
 			{
 				partitionAcc[i] = new int[zones.Length + 1];
 				var sum = 0;
@@ -1318,7 +1320,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 
 			// This is declared outside of Vote() to avoid unnecessary re-allocations.
 			// The values are not reused across calls.
-			var voteCounts = new int[allZones.Count];
+			var voteCounts = new int[allZones.Length];
 
 			// Identifies valid zone choices in the given range and returns the cost (amount of
 			// disagreement) for the best choice(s). Optionally provides the winner(s) via the
@@ -1341,7 +1343,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				var nonWildcards = 0;
 				var best = Unsuitable;
 
-				for (var i = 0; i < allZones.Count; i++)
+				for (var i = 0; i < allZones.Length; i++)
 				{
 					int count;
 					if (to <= from)
@@ -1372,7 +1374,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 					return int.MaxValue;
 
 				if (majorities != null)
-					for (var i = 0; i < allZones.Count; i++)
+					for (var i = 0; i < allZones.Length; i++)
 						if (voteCounts[i] == best)
 							majorities.Add(allZones[i]);
 
@@ -1567,7 +1569,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				if (length + 1 == path.Length)
 					return SinglePath(fallbackPath);
 
-				var possibleZones = new List<PathPartitionZone>(allZones.Count);
+				var possibleZones = new List<PathPartitionZone>(allZones.Length);
 				Vote(from, length, true, possibleZones);
 				if (possibleZones[0] != lastZone)
 					ranges.Add((from, length, possibleZones[0]));
@@ -1637,17 +1639,17 @@ namespace OpenRA.Mods.Common.MapGenerator
 		}
 
 		/// <summary>Wrapper around PartitionPath to process multiple paths at once.</summary>
-		public List<TilingPath> PartitionPaths(
+		public ImmutableArray<TilingPath> PartitionPaths(
 			IEnumerable<int2[]> paths,
-			IReadOnlyList<PathPartitionZone> zones,
+			ImmutableArray<PathPartitionZone> zones,
 			Matrix<PathPartitionZone> partitionMask,
-			IReadOnlyList<MultiBrush> brushes,
+			ImmutableArray<MultiBrush> brushes,
 			int minStraight)
 		{
 			return paths
 				.SelectMany(path => PartitionPath(
 					path, zones, partitionMask, brushes, minStraight))
-				.ToList();
+				.ToImmutableArray();
 		}
 
 		/// <summary>
@@ -1666,17 +1668,17 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// <param name="heightOffset">Optional explicit height to paint at. Otherwise a height is picked automatically.</param>
 		public CellLayer<Side> PaintLoopsAndFill(
 			MersenneTwister random,
-			IReadOnlyList<TilingPath> tilingPaths,
+			ImmutableArray<TilingPath> tilingPaths,
 			Side fallback,
-			IReadOnlyList<MultiBrush> outside,
-			IReadOnlyList<MultiBrush> inside,
+			ImmutableArray<MultiBrush> outside,
+			ImmutableArray<MultiBrush> inside,
 			CellLayer<MultiBrush.Replaceability> replaceMask = null,
 			short? heightOffset = null)
 		{
 			CheckHasMapShapeOrNull(replaceMask);
 
-			var tilings = new MultiBrush[tilingPaths.Count];
-			for (var i = 0; i < tilingPaths.Count; i++)
+			var tilings = new MultiBrush[tilingPaths.Length];
+			for (var i = 0; i < tilingPaths.Length; i++)
 			{
 				var tiling = tilingPaths[i].Tile(random);
 				if (tiling == null)
@@ -1685,13 +1687,14 @@ namespace OpenRA.Mods.Common.MapGenerator
 				tilings[i] = tiling;
 			}
 
-			foreach (var tiling in tilings)
+			var tilingArray = ImmutableCollectionsMarshal.AsImmutableArray(tilings);
+			foreach (var tiling in tilingArray)
 				tiling.Paint(Map, ActorPlans, CPos.Zero, heightOffset, MultiBrush.Replaceability.Any, random);
 
 			if (inside == null && outside == null)
 				return null;
 
-			var sides = InsideOutside(tilings, fallback);
+			var sides = InsideOutside(tilingArray, fallback);
 
 			foreach (var (brushes, side) in new[] { (inside, Side.In), (outside, Side.Out) })
 			{
@@ -1719,13 +1722,13 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// <param name="tilings">Path tiling results which partition the space.</param>
 		/// <param name="fallback">Side to assume if no paths are contained in the map.</param>
 		public CellLayer<Side> InsideOutside(
-			IReadOnlyList<MultiBrush> tilings,
+			ImmutableArray<MultiBrush> tilings,
 			Side fallback)
 		{
 			var sides = new CellLayer<Side>(Map);
-			var tiledPoints = new CPos[tilings.Count][];
+			var tiledPoints = new CPos[tilings.Length][];
 			var tiledArea = new CellLayer<bool>(Map);
-			for (var i = 0; i < tilings.Count; i++)
+			for (var i = 0; i < tilings.Length; i++)
 			{
 				tiledPoints[i] = tilings[i].Segment.Points
 					.Select(vec => CPos.Zero + vec)
@@ -1788,7 +1791,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 				fillable,
 				fillSeeds,
 				fillAction,
-				DirectionExts.Spread4CVec);
+				DirectionExts.Spread4CVec.AsSpan());
 		}
 
 		/// <summary>
@@ -2007,12 +2010,12 @@ namespace OpenRA.Mods.Common.MapGenerator
 			CellLayer<int> pattern,
 			CellLayer<bool> mask,
 			ResourceTypeInfo defaultResource,
-			IReadOnlyList<ResourceBias> resourceBiases)
+			ReadOnlySpan<ResourceBias> resourceBiases)
 		{
 			CheckHasMapShape(pattern);
 			CheckHasMapShape(mask);
 
-			// IReadOnlyDictionary<string, ResourceTypeInfo> resourceSpawnSeeds = ...;
+			// FrozenDictionary<string, ResourceTypeInfo> resourceSpawnSeeds = ...;
 			var resourceTypes = Map.Rules.Actors[SystemActors.World]
 				.TraitInfoOrDefault<ResourceLayerInfo>()
 				.ResourceTypes

--- a/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
+++ b/OpenRA.Mods.Common/MapGenerator/TilingPath.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			}
 
 			public PermittedSegments(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<MultiBrush> all)
 			{
 				var array = all.ToImmutableArray();
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// Creates a PermittedSegments using only the given types.
 			/// </summary>
 			public static PermittedSegments FromType(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<string> types)
 				=> new(multiBrushes, FindSegments(multiBrushes, types));
 
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// at the start and end.
 			/// </summary>
 			public static PermittedSegments FromInnerAndTerminalTypes(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<string> innerTypes,
 				IEnumerable<string> terminalTypes)
 			{
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// at the start and end.
 			/// </summary>
 			public static PermittedSegments FromTypes(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<string> startTypes,
 				IEnumerable<string> innerTypes,
 				IEnumerable<string> endTypes)
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// Equivalent to FindSegments(multiBrushes, types, types, types).
 			/// </summary>
 			public static IEnumerable<MultiBrush> FindSegments(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<string> types)
 			{
 				var array = types.ToImmutableArray();
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 			/// Filter MultiBrushes to segments that use the given start, inner, and end types.
 			/// </summary>
 			public static IEnumerable<MultiBrush> FindSegments(
-				IReadOnlyList<MultiBrush> multiBrushes,
+				ImmutableArray<MultiBrush> multiBrushes,
 				IEnumerable<string> startTypes,
 				IEnumerable<string> innerTypes,
 				IEnumerable<string> endTypes)
@@ -250,7 +250,7 @@ namespace OpenRA.Mods.Common.MapGenerator
 		/// </summary>
 		public static TilingPath QuickCreate(
 			Map map,
-			IReadOnlyList<MultiBrush> brushes,
+			ImmutableArray<MultiBrush> brushes,
 			CPos[] points,
 			int maxDeviation,
 			string innerSegmentType,

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -47,7 +48,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public event Action<Actor, Actor> OnProducedInternal = (a, b) => { };
 		public event Action<Actor, Actor> OnOtherProducedInternal = (a, b) => { };
 
-		readonly List<Triggerable>[] triggerables = Exts.MakeArray(Enum.GetValues<Trigger>().Length, _ => new List<Triggerable>());
+		readonly ImmutableArray<List<Triggerable>> triggerables = Exts.MakeImmutableArray(Enum.GetValues<Trigger>().Length, _ => new List<Triggerable>());
 
 		readonly struct Triggerable : IDisposable
 		{

--- a/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/DdsLoader.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			}
 		}
 
-		public IReadOnlyList<ISpriteFrame> Frames { get; }
+		public ImmutableArray<ISpriteFrame> Frames { get; }
 
 		public DdsSprite(Stream stream)
 		{

--- a/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TgaLoader.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 			}
 		}
 
-		public IReadOnlyList<ISpriteFrame> Frames { get; }
+		public ImmutableArray<ISpriteFrame> Frames { get; }
 
 		public TgaSprite(Stream stream)
 		{

--- a/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
+++ b/OpenRA.Mods.Common/Terrain/DefaultTileCache.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -85,7 +84,7 @@ namespace OpenRA.Mods.Common.Terrain
 					}
 
 					var frameCount = terrainInfo.EnableDepth && depthFrames == null ? allFrames.Length / 2 : allFrames.Length;
-					var indices = templateInfo.Frames != null ? templateInfo.Frames : Exts.MakeArray(t.Value.TilesCount, j => j).ToImmutableArray();
+					var indices = templateInfo.Frames != null ? templateInfo.Frames : Exts.MakeImmutableArray(t.Value.TilesCount, j => j);
 
 					var start = indices.Min();
 					var end = indices.Max();

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
@@ -72,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				};
 			}
 
-			Ports = ports.ToImmutableArray();
+			Ports = ImmutableCollectionsMarshal.AsImmutableArray(ports);
 
 			base.RulesetLoaded(rules, ai);
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -54,12 +54,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		static object LoadConsiderations(MiniYaml yaml)
 		{
-			var ret = new List<Consideration>();
+			var ret = ImmutableArray.CreateBuilder<Consideration>();
 			foreach (var d in yaml.Nodes)
 				if (d.Key.Split('@')[0] == "Consideration")
 					ret.Add(new Consideration(d.Value));
 
-			return ret.ToImmutableArray();
+			return ret.DrainToImmutable();
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations.</summary>

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -26,13 +26,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		static object LoadDecisions(MiniYaml yaml)
 		{
-			var ret = new List<SupportPowerDecision>();
+			var ret = ImmutableArray.CreateBuilder<SupportPowerDecision>();
 			var decisions = yaml.NodeWithKeyOrDefault("Decisions");
 			if (decisions != null)
 				foreach (var d in decisions.Value.Nodes)
 					ret.Add(new SupportPowerDecision(d.Value));
 
-			return ret.ToImmutableArray();
+			return ret.DrainToImmutable();
 		}
 
 		public override object Create(ActorInitializer init) { return new SupportPowerBotModule(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (offset == null)
 					continue; // End piece type
 
-				neighbours[d] = GetNeighbor(offset, bridges);
+				neighbours[d] = GetNeighbor(offset.AsSpan(), bridges);
 				if (neighbours[d] != null)
 					neighbours[d].neighbours[1 - d] = this; // Save reverse lookup
 			}
@@ -188,9 +188,9 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public LegacyBridgeHut GetHut(int index) { return huts[index]; }
-		public Bridge GetNeighbor(ImmutableArray<int> offset, LegacyBridgeLayer bridges)
+		public Bridge GetNeighbor(ReadOnlySpan<int> offset, LegacyBridgeLayer bridges)
 		{
-			if (offset == null)
+			if (offset.Length < 2)
 				return null;
 
 			return bridges.GetBridge(self.Location + new CVec(offset[0], offset[1]));

--- a/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/FireProjectilesOnDeath.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.GameRules;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -48,13 +49,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.RulesetLoaded(rules, ai);
 
-			WeaponInfos = Weapons.Select(w =>
+			var localWeaponInfos = new WeaponInfo[Weapons.Length];
+			for (var i = 0; i < Weapons.Length; i++)
 			{
+				var w = Weapons[i];
 				var weaponToLower = w.ToLowerInvariant();
 				if (!rules.Weapons.TryGetValue(weaponToLower, out var weapon))
 					throw new YamlException($"Weapons Ruleset does not contain an entry '{weaponToLower}'");
-				return weapon;
-			}).ToImmutableArray();
+
+				localWeaponInfos[i] = weapon;
+			}
+
+			WeaponInfos = ImmutableCollectionsMarshal.AsImmutableArray(localWeaponInfos);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/FireWarheads.cs
+++ b/OpenRA.Mods.Common/Traits/FireWarheads.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Immutable;
-using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.GameRules;
 using OpenRA.Traits;
 
@@ -38,13 +38,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.RulesetLoaded(rules, ai);
 
-			WeaponInfos = Weapons.Select(w =>
+			var localWeaponInfos = new WeaponInfo[Weapons.Length];
+			for (var i = 0; i < Weapons.Length; i++)
 			{
+				var w = Weapons[i];
 				var weaponToLower = w.ToLowerInvariant();
 				if (!rules.Weapons.TryGetValue(weaponToLower, out var weapon))
 					throw new YamlException($"Weapons Ruleset does not contain an entry '{weaponToLower}'");
-				return weapon;
-			}).ToImmutableArray();
+
+				localWeaponInfos[i] = weapon;
+			}
+
+			WeaponInfos = ImmutableCollectionsMarshal.AsImmutableArray(localWeaponInfos);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Interactable.cs
+++ b/OpenRA.Mods.Common/Traits/Interactable.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -79,12 +80,12 @@ namespace OpenRA.Mods.Common.Traits
 				screenVertices[i] = wr.ScreenPxPosition(self.CenterPosition) + offset;
 			}
 
-			return screenVertices.ToImmutableArray();
+			return ImmutableCollectionsMarshal.AsImmutableArray(screenVertices);
 		}
 
 		Polygon Bounds(Actor self, WorldRenderer wr, ImmutableArray<WDist> bounds)
 		{
-			if (bounds == null)
+			if (bounds.IsDefault)
 				return new Polygon(AutoBounds(self, wr));
 
 			// Convert from WDist to pixels
@@ -108,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Rectangle DecorationBounds(Actor self, WorldRenderer wr)
 		{
-			return Bounds(self, wr, info.DecorationBounds != null ? info.DecorationBounds : info.Bounds).BoundingRect;
+			return Bounds(self, wr, info.DecorationBounds.IsDefault ? info.DecorationBounds : info.Bounds).BoundingRect;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
+++ b/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 		Polygon Bounds(Actor self, WorldRenderer wr, ImmutableArray<int> bounds, int height)
 		{
 			int2 left, right, top, bottom;
-			if (bounds != null)
+			if (!bounds.IsDefault)
 			{
 				// Convert from WDist to pixels
 				var offset = bounds.Length >= 4 ? new int2(bounds[2] * wr.TileSize.Width / wr.TileScale, bounds[3] * wr.TileSize.Height / wr.TileScale) : int2.Zero;

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPalette.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			var basePalette = wr.Palette(info.BasePalette).Palette;
-			var pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.Index, info.ReplaceIndex));
+			var pal = new ImmutablePalette(basePalette, new IndexedColorRemap(basePalette, info.Index.AsSpan(), info.ReplaceIndex.AsSpan()));
 			wr.AddPalette(info.Name, pal, info.AllowModifiers);
 		}
 	}
@@ -73,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Dictionary<int, int> replacements = [];
 		readonly IPalette basePalette;
 
-		public IndexedColorRemap(IPalette basePalette, ImmutableArray<int> ramp, ImmutableArray<int> remap)
+		public IndexedColorRemap(IPalette basePalette, ReadOnlySpan<int> ramp, ReadOnlySpan<int> remap)
 		{
 			this.basePalette = basePalette;
 			if (ramp.Length != remap.Length)

--- a/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/IndexedPlayerPalette.cs
@@ -65,7 +65,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.PlayerIndex.TryGetValue(playerName, out var remap))
 				pal = new ImmutablePalette(
 					basePalette,
-					new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0 ? Enumerable.Range(0, 256).ToImmutableArray() : info.RemapIndex, remap));
+					new IndexedColorRemap(basePalette, info.RemapIndex.Length == 0
+							? Enumerable.Range(0, 256).ToImmutableArray().AsSpan()
+							: info.RemapIndex.AsSpan(),
+						remap.AsSpan()));
 			else
 				pal = new ImmutablePalette(basePalette);
 

--- a/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/Palettes/PaletteFromFile.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		ImmutablePalette IProvidesCursorPaletteInfo.ReadPalette(IReadOnlyFileSystem fileSystem)
 		{
-			return new ImmutablePalette(fileSystem.Open(Filename), TransparentIndex, ShadowIndex);
+			return new ImmutablePalette(fileSystem.Open(Filename), TransparentIndex.AsSpan(), ShadowIndex.AsSpan());
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
+++ b/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
@@ -118,8 +118,8 @@ namespace OpenRA.Mods.Common.Traits
 				ticks = Util.RandomInRange(self.World.LocalRandom, Info.SpawnFrequency);
 
 				var spawnFacing = (!Info.RandomFacing && facing != null) ? facing.Facing : WAngle.FromFacing(self.World.LocalRandom.Next(256));
-				self.World.AddFrameEndTask(w => w.Add(new FloatingSprite(self, Info.Image, Info.Sequences, Info.Palette, Info.IsPlayerPalette,
-					Info.Lifetime, Info.Speed, Info.Gravity, Info.TurnRate, Info.RandomRate, self.CenterPosition + offset, spawnFacing)));
+				self.World.AddFrameEndTask(w => w.Add(new FloatingSprite(self, Info.Image, Info.Sequences.AsSpan(), Info.Palette, Info.IsPlayerPalette,
+					Info.Lifetime.AsSpan(), Info.Speed, Info.Gravity, Info.TurnRate, Info.RandomRate, self.CenterPosition + offset, spawnFacing)));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
+++ b/OpenRA.Mods.Common/Traits/World/ClassicMapGenerator.cs
@@ -14,6 +14,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Support;
@@ -137,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Require]
 			public readonly int MaximumBuildings = default;
 			[FieldLoader.LoadUsing(nameof(BuildingWeightsLoader))]
-			public readonly IReadOnlyDictionary<string, int> BuildingWeights = default;
+			public readonly FrozenDictionary<string, int> BuildingWeights = default;
 			[FieldLoader.Require]
 			public readonly int CivilianBuildings = default;
 			[FieldLoader.Require]
@@ -152,41 +153,41 @@ namespace OpenRA.Mods.Common.Traits
 			[FieldLoader.Require]
 			public readonly ushort WaterTile = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> SegmentedBrushes;
+			public readonly ImmutableArray<MultiBrush> SegmentedBrushes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> ForestObstacles;
+			public readonly ImmutableArray<MultiBrush> ForestObstacles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> UnplayableObstacles;
+			public readonly ImmutableArray<MultiBrush> UnplayableObstacles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> CivilianBuildingsObstacles;
+			public readonly ImmutableArray<MultiBrush> CivilianBuildingsObstacles;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyDictionary<ushort, IReadOnlyList<MultiBrush>> RepaintTiles;
+			public readonly FrozenDictionary<ushort, ImmutableArray<MultiBrush>> RepaintTiles;
 
 			[FieldLoader.Ignore]
 			public readonly ResourceTypeInfo DefaultResource;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyDictionary<string, ResourceTypeInfo> ResourceSpawnSeeds;
+			public readonly FrozenDictionary<string, ResourceTypeInfo> ResourceSpawnSeeds;
 			[FieldLoader.LoadUsing(nameof(ResourceSpawnWeightsLoader))]
-			public readonly IReadOnlyDictionary<string, int> ResourceSpawnWeights = default;
+			public readonly FrozenDictionary<string, int> ResourceSpawnWeights = default;
 
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> ClearTerrain;
+			public readonly FrozenSet<byte> ClearTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> PlayableTerrain;
+			public readonly FrozenSet<byte> PlayableTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> DominantTerrain;
+			public readonly FrozenSet<byte> DominantTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> ZoneableTerrain;
+			public readonly FrozenSet<byte> ZoneableTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> ClearSegmentTypes;
+			public readonly ImmutableArray<string> ClearSegmentTypes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> BeachSegmentTypes;
+			public readonly ImmutableArray<string> BeachSegmentTypes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> WaterCliffSegmentTypes;
+			public readonly ImmutableArray<string> WaterCliffSegmentTypes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> CliffSegmentTypes;
+			public readonly ImmutableArray<string> CliffSegmentTypes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<string> RoadSegmentTypes;
+			public readonly ImmutableArray<string> RoadSegmentTypes;
 
 			public Parameters(Map map, MiniYaml my)
 			{
@@ -205,8 +206,8 @@ namespace OpenRA.Mods.Common.Traits
 						else
 							throw new YamlException($"RepaintTile {k} is not a ushort");
 					},
-					v => MultiBrush.LoadCollection(map, v.Value) as IReadOnlyList<MultiBrush>);
-				RepaintTiles ??= ImmutableDictionary<ushort, IReadOnlyList<MultiBrush>>.Empty;
+					v => MultiBrush.LoadCollection(map, v.Value))?.ToFrozenDictionary();
+				RepaintTiles ??= FrozenDictionary<ushort, ImmutableArray<MultiBrush>>.Empty;
 
 				var resourceTypes = map.Rules.Actors[SystemActors.World].TraitInfoOrDefault<ResourceLayerInfo>().ResourceTypes;
 				if (!resourceTypes.TryGetValue(my.NodeWithKey("DefaultResource").Value.Value, out DefaultResource))
@@ -216,7 +217,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					ResourceSpawnSeeds = my.NodeWithKey("ResourceSpawnSeeds").Value
 						.ToDictionary(subMy => subMy.Value)
-						.ToDictionary(kv => kv.Key, kv => resourceTypes[kv.Value]);
+						.ToFrozenDictionary(kv => kv.Key, kv => resourceTypes[kv.Value]);
 				}
 				catch (KeyNotFoundException e)
 				{
@@ -234,7 +235,7 @@ namespace OpenRA.Mods.Common.Traits
 						break;
 				}
 
-				IReadOnlySet<byte> ParseTerrainIndexes(string key)
+				FrozenSet<byte> ParseTerrainIndexes(string key)
 				{
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
@@ -242,7 +243,7 @@ namespace OpenRA.Mods.Common.Traits
 						.ToFrozenSet();
 				}
 
-				IReadOnlyList<string> ParseSegmentTypes(string key)
+				ImmutableArray<string> ParseSegmentTypes(string key)
 				{
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
@@ -273,7 +274,7 @@ namespace OpenRA.Mods.Common.Traits
 					throw new YamlException($"Invalid Mirror value `{my.NodeWithKey("Mirror").Value.Value}`");
 			}
 
-			static IReadOnlyDictionary<string, int> BuildingWeightsLoader(MiniYaml my)
+			static FrozenDictionary<string, int> BuildingWeightsLoader(MiniYaml my)
 			{
 				return my.NodeWithKey("BuildingWeights").Value.ToDictionary(subMy =>
 					{
@@ -281,10 +282,10 @@ namespace OpenRA.Mods.Common.Traits
 							return f;
 						else
 							throw new YamlException($"Invalid building weight `{subMy.Value}`");
-					});
+					}).ToFrozenDictionary();
 			}
 
-			static IReadOnlyDictionary<string, int> ResourceSpawnWeightsLoader(MiniYaml my)
+			static FrozenDictionary<string, int> ResourceSpawnWeightsLoader(MiniYaml my)
 			{
 				return my.NodeWithKey("ResourceSpawnWeights").Value.ToDictionary(subMy =>
 					{
@@ -292,7 +293,7 @@ namespace OpenRA.Mods.Common.Traits
 							return f;
 						else
 							throw new YamlException($"Invalid resource spawn weight `{subMy.Value}`");
-					});
+					}).ToFrozenDictionary();
 			}
 
 			public void Validate(ITemplatedTerrainInfo terrainInfo)
@@ -536,7 +537,7 @@ namespace OpenRA.Mods.Common.Traits
 				/*bias=*/param.Water <= FractionMax / 2);
 
 			var coast = MatrixUtils.BordersToPoints(landPlan);
-			List<TilingPath> coastPaths;
+			ImmutableArray<TilingPath> coastPaths;
 			if (param.WaterRoughness > 0)
 			{
 				var beachZone = new Terraformer.PathPartitionZone()
@@ -581,7 +582,7 @@ namespace OpenRA.Mods.Common.Traits
 								param.BeachSegmentTypes[0],
 								param.BeachSegmentTypes[0])
 									.ExtendEdge(4))
-					.ToList();
+					.ToImmutableArray();
 			}
 
 			var landCoastWater = terraformer.PaintLoopsAndFill(
@@ -589,7 +590,7 @@ namespace OpenRA.Mods.Common.Traits
 				coastPaths,
 				landPlan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
 				[new MultiBrush().WithTemplate(map, param.WaterTile, CVec.Zero)],
-				null,
+				default,
 				null,
 				0)
 					?? throw new MapGenerationException("Could not fit tiles for coast");
@@ -867,7 +868,7 @@ namespace OpenRA.Mods.Common.Traits
 						resourcePattern,
 						CellLayerUtils.Intersect([playable, terraformer.CheckSpace(null, true)]),
 						param.DefaultResource,
-						resourceBiases);
+						CollectionsMarshal.AsSpan(resourceBiases));
 					terraformer.GrowResources(
 						plan,
 						typePlan,

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -280,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 			RemoveRange(PreviewsInCellRegion(region).ToArray().AsSpan());
 		}
 
-		public void RemoveRegion(CellCoordsRegion region, HashSet<CPos> mask)
+		public void RemoveRegion(CellCoordsRegion region, FrozenSet<CPos> mask)
 		{
 			RemoveRange(PreviewsInCellRegion(region).Where(p => mask.Overlaps(p.Footprint.Keys)).ToArray().AsSpan());
 		}

--- a/OpenRA.Mods.Common/Traits/World/MapGeneratorBase.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapGeneratorBase.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (optionsNode == null)
 				return ImmutableArray<MapGeneratorOption>.Empty;
 
-			var options = new List<MapGeneratorOption>();
+			var options = ImmutableArray.CreateBuilder<MapGeneratorOption>();
 			foreach (var node in optionsNode.Value.Nodes)
 			{
 				var split = node.Key.Split('@');
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 					options.Add(new MapGeneratorMultiChoiceOption(split[1], node.Value));
 			}
 
-			return options.ToImmutableArray();
+			return options.DrainToImmutable();
 		}
 
 		public static object LoadFluentReferences(MiniYaml my)

--- a/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/MarkerLayerOverlay.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public class MarkerLayer
 		{
-			public readonly Dictionary<int, CPos[]> Tiles;
+			public readonly FrozenDictionary<int, ImmutableArray<CPos>> Tiles;
 			public readonly MarkerTileMirrorMode MirrorMode;
 			public readonly int NumSides;
 			public readonly int AxisAngle;
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public MarkerLayer(MarkerLayerOverlay markerLayerOverlay)
 			{
-				Tiles = markerLayerOverlay.Tiles.ToDictionary(d => d.Key, d => d.Value.ToArray());
+				Tiles = markerLayerOverlay.Tiles.ToFrozenDictionary(d => d.Key, d => d.Value.ToImmutableArray());
 				MirrorMode = markerLayerOverlay.MirrorMode;
 				NumSides = markerLayerOverlay.NumSides;
 				AxisAngle = markerLayerOverlay.AxisAngle;
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 				NumSides = file.NumSides;
 				AxisAngle = file.AxisAngle;
 
-				SetAll(file.Tiles.ToFrozenDictionary(d => d.Key, d => d.Value.ToImmutableArray()));
+				SetAll(file.Tiles);
 			}
 			catch (Exception e)
 			{

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -227,6 +227,11 @@ namespace OpenRA.Mods.Common
 
 		public static int RandomInRange(MersenneTwister random, ImmutableArray<int> range)
 		{
+			return RandomInRange(random, range.AsSpan());
+		}
+
+		public static int RandomInRange(MersenneTwister random, ReadOnlySpan<int> range)
+		{
 			if (range.Length == 0)
 				return 0;
 
@@ -245,6 +250,11 @@ namespace OpenRA.Mods.Common
 
 		public static WDist RandomDistance(MersenneTwister random, ImmutableArray<WDist> distance)
 		{
+			return RandomDistance(random, distance.AsSpan());
+		}
+
+		public static WDist RandomDistance(MersenneTwister random, ReadOnlySpan<WDist> distance)
+		{
 			if (distance.Length == 0)
 				return WDist.Zero;
 
@@ -255,6 +265,11 @@ namespace OpenRA.Mods.Common
 		}
 
 		public static WVec RandomVector(MersenneTwister random, ImmutableArray<WVec> vector)
+		{
+			return RandomVector(random, vector.AsSpan());
+		}
+
+		public static WVec RandomVector(MersenneTwister random, ReadOnlySpan<WVec> vector)
 		{
 			if (vector.Length == 0)
 				return WVec.Zero;

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -36,16 +36,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var modData = Game.ModData = utility.ModData;
 
 			var src = args[1];
-			var shadowIndex = Array.Empty<int>();
-			if (args.Contains("--noshadow"))
-			{
-				Array.Resize(ref shadowIndex, shadowIndex.Length + 3);
-				shadowIndex[^1] = 1;
-				shadowIndex[^2] = 3;
-				shadowIndex[^3] = 4;
-			}
+			ReadOnlySpan<int> shadowIndex = args.Contains("--noshadow") ? [4, 3, 1] : [];
 
-			var palette = new ImmutablePalette(args[2], [0], shadowIndex.ToImmutableArray());
+			var palette = new ImmutablePalette(args[2], [0], shadowIndex);
 			var palColors = new Color[Palette.Size];
 			for (var i = 0; i < Palette.Size; i++)
 				palColors[i] = palette.GetColor(i);

--- a/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FuzzMapGeneratorCommand.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				long skip = 0;
 				var shard = 0;
 				var shardCount = 1;
-				var variables = new List<string>();
+				var variables = ImmutableArray.CreateBuilder<string>();
 				var choices = new Dictionary<string, ImmutableArray<string>>();
 
 				bool AddVariable(string variable, string choicesStr)
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					skip,
 					shard,
 					shardCount,
-					variables.ToImmutableArray(),
+					variables.DrainToImmutable(),
 					choices.ToFrozenDictionary());
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Warheads
 				effectiveRange = Range;
 			}
 			else
-				effectiveRange = Exts.MakeArray(Falloff.Length, i => i * Spread).ToImmutableArray();
+				effectiveRange = Exts.MakeImmutableArray(Falloff.Length, i => i * Spread);
 		}
 
 		protected override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)

--- a/OpenRA.Mods.Common/Widgets/ControlGroupsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ControlGroupsWidget.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Traits;
@@ -25,11 +26,11 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 		readonly int hotkeyCount;
 
-		HotkeyReference[] selectGroupHotkeys;
-		HotkeyReference[] createGroupHotkeys;
-		HotkeyReference[] addToGroupHotkeys;
-		HotkeyReference[] combineWithGroupHotkeys;
-		HotkeyReference[] jumpToGroupHotkeys;
+		ImmutableArray<HotkeyReference> selectGroupHotkeys;
+		ImmutableArray<HotkeyReference> createGroupHotkeys;
+		ImmutableArray<HotkeyReference> addToGroupHotkeys;
+		ImmutableArray<HotkeyReference> combineWithGroupHotkeys;
+		ImmutableArray<HotkeyReference> jumpToGroupHotkeys;
 
 		// Note: LinterHotkeyNames assumes that these are disabled by default
 		public readonly string SelectGroupKeyPrefix = null;
@@ -109,19 +110,19 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			base.Initialize(args);
 
-			selectGroupHotkeys = Exts.MakeArray(hotkeyCount,
+			selectGroupHotkeys = Exts.MakeImmutableArray(hotkeyCount,
 				i => modData.Hotkeys[SelectGroupKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
-			createGroupHotkeys = Exts.MakeArray(hotkeyCount,
+			createGroupHotkeys = Exts.MakeImmutableArray(hotkeyCount,
 				i => modData.Hotkeys[CreateGroupKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
-			addToGroupHotkeys = Exts.MakeArray(hotkeyCount,
+			addToGroupHotkeys = Exts.MakeImmutableArray(hotkeyCount,
 				i => modData.Hotkeys[AddToGroupKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
-			combineWithGroupHotkeys = Exts.MakeArray(hotkeyCount,
+			combineWithGroupHotkeys = Exts.MakeImmutableArray(hotkeyCount,
 				i => modData.Hotkeys[CombineWithGroupKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
-			jumpToGroupHotkeys = Exts.MakeArray(hotkeyCount,
+			jumpToGroupHotkeys = Exts.MakeImmutableArray(hotkeyCount,
 				i => modData.Hotkeys[JumpToGroupKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -168,7 +168,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Settings.Player.CustomColors = Game.Settings.Player.CustomColors
 						.Where(c => c != mixer.Color)
 						.Append(mixer.Color)
-						.Reverse().Take(paletteCustomRows * paletteCols).Reverse()
+						.Reverse()
+						.Take(paletteCustomRows * paletteCols)
+						.Reverse()
 						.ToImmutableArray();
 					Game.Settings.Save();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/LoadGameBrowserLogic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			public DateTime CreationTime;
 			public TimeSpan? Duration;
 			public string MapTitle;
-			public IReadOnlyList<string> Factions = [];
+			public ImmutableArray<string> Factions = [];
 			public bool Visible = true;
 			public ScrollItemWidget Item;
 		}
@@ -313,7 +314,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						Factions = save?.SlotClients.Values
 							.Select(sc => sc.Faction)
 							.Where(f => !string.IsNullOrEmpty(f))
-							.ToList() ?? []
+							.ToImmutableArray() ?? []
 					};
 
 					saves.Add(entry);

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -104,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		ProductionQueue currentQueue;
-		HotkeyReference[] hotkeys;
+		ImmutableArray<HotkeyReference> hotkeys;
 
 		public ProductionQueue CurrentQueue
 		{
@@ -174,7 +175,7 @@ namespace OpenRA.Mods.Common.Widgets
 			clock = new Animation(World, ClockAnimation);
 			cantBuild = new Animation(World, NotBuildableAnimation);
 			cantBuild.PlayFetchIndex(NotBuildableSequence, () => 0);
-			hotkeys = Exts.MakeArray(HotkeyCount,
+			hotkeys = Exts.MakeImmutableArray(HotkeyCount,
 				i => modData.Hotkeys[HotkeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
 			overlayFont = Game.Renderer.Fonts[OverlayFont];

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using OpenRA.Graphics;
@@ -62,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public SupportPowerIcon TooltipIcon { get; private set; }
 		public Func<SupportPowerIcon> GetTooltipIcon;
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
-		HotkeyReference[] hotkeys;
+		ImmutableArray<HotkeyReference> hotkeys;
 
 		Rectangle eventBounds;
 		public override Rectangle EventBounds => eventBounds;
@@ -106,7 +107,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			base.Initialize(args);
 
-			hotkeys = Exts.MakeArray(HotkeyCount,
+			hotkeys = Exts.MakeImmutableArray(HotkeyCount,
 				i => modData.Hotkeys[HotkeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
 			overlayFont = Game.Renderer.Fonts[OverlayFont];

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -99,8 +99,8 @@ namespace OpenRA.Mods.Common.Widgets
 		ScrollDirection keyboardDirections;
 		ScrollDirection edgeDirections;
 
-		HotkeyReference[] saveBookmarkHotkeys;
-		HotkeyReference[] restoreBookmarkHotkeys;
+		ImmutableArray<HotkeyReference> saveBookmarkHotkeys;
+		ImmutableArray<HotkeyReference> restoreBookmarkHotkeys;
 		WPos?[] bookmarkPositions;
 
 		[CustomLintableHotkeyNames]
@@ -155,10 +155,10 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			base.Initialize(args);
 
-			saveBookmarkHotkeys = Exts.MakeArray(BookmarkKeyCount,
+			saveBookmarkHotkeys = Exts.MakeImmutableArray(BookmarkKeyCount,
 				i => modData.Hotkeys[BookmarkSaveKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
-			restoreBookmarkHotkeys = Exts.MakeArray(BookmarkKeyCount,
+			restoreBookmarkHotkeys = Exts.MakeImmutableArray(BookmarkKeyCount,
 				i => modData.Hotkeys[BookmarkRestoreKeyPrefix + (i + 1).ToStringInvariant("D2")]);
 
 			bookmarkPositions = new WPos?[BookmarkKeyCount];

--- a/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
+++ b/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			self = init.Self;
 
-			effectiveRange = info.Range != null ? info.Range : Exts.MakeArray(info.Falloff.Length, i => i * info.Spread).ToImmutableArray();
+			effectiveRange = info.Range != null ? info.Range : Exts.MakeImmutableArray(info.Falloff.Length, i => i * info.Spread);
 		}
 
 		int GetNoisePercentageAtDistance(int distance)

--- a/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kMapGenerator.cs
@@ -12,7 +12,9 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using OpenRA.Mods.Common.MapGenerator;
 using OpenRA.Mods.Common.Terrain;
 using OpenRA.Mods.Common.Traits;
@@ -142,11 +144,11 @@ namespace OpenRA.Mods.D2k.Traits
 			[FieldLoader.Require]
 			public readonly ushort RockTile = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> PlayableTerrain;
+			public readonly FrozenSet<byte> PlayableTerrain;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> RockZoneableTerrain = default;
+			public readonly FrozenSet<byte> RockZoneableTerrain = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlySet<byte> SandZoneableTerrain = default;
+			public readonly FrozenSet<byte> SandZoneableTerrain = default;
 			[FieldLoader.Require]
 			public readonly string RockSmoothSegmentType = default;
 			[FieldLoader.Require]
@@ -158,11 +160,11 @@ namespace OpenRA.Mods.D2k.Traits
 			[FieldLoader.Require]
 			public readonly string DuneSegmentType = default;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> SegmentedBrushes;
+			public readonly ImmutableArray<MultiBrush> SegmentedBrushes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> SandDetailBrushes;
+			public readonly ImmutableArray<MultiBrush> SandDetailBrushes;
 			[FieldLoader.Ignore]
-			public readonly IReadOnlyList<MultiBrush> DuneBrushes;
+			public readonly ImmutableArray<MultiBrush> DuneBrushes;
 
 			public Parameters(Map map, MiniYaml my)
 			{
@@ -170,7 +172,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 				var terrainInfo = (ITemplatedTerrainInfo)map.Rules.TerrainInfo;
 
-				IReadOnlySet<byte> ParseTerrainIndexes(string key)
+				FrozenSet<byte> ParseTerrainIndexes(string key)
 				{
 					return my.NodeWithKey(key).Value.Value
 						.Split(',', StringSplitOptions.RemoveEmptyEntries)
@@ -298,7 +300,7 @@ namespace OpenRA.Mods.D2k.Traits
 					rockTilingRandom,
 					tilingPaths,
 					plan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
-					null,
+					default,
 					[new MultiBrush().WithTemplate(map, param.RockTile, CVec.Zero)],
 					null,
 					0)
@@ -404,12 +406,12 @@ namespace OpenRA.Mods.D2k.Traits
 								param.DuneSegmentType,
 								param.DuneSegmentType)
 									.ExtendEdge(4))
-					.ToArray();
+					.ToImmutableArray();
 				_ = terraformer.PaintLoopsAndFill(
 					duneTilingRandom,
 					tilingPaths,
 					plan[0] ? Terraformer.Side.In : Terraformer.Side.Out,
-					null,
+					default,
 					param.DuneBrushes,
 					null,
 					0)
@@ -554,7 +556,7 @@ namespace OpenRA.Mods.D2k.Traits
 						resourcePattern,
 						spiceZoneable,
 						param.Resource,
-						resourceBiases);
+						CollectionsMarshal.AsSpan(resourceBiases));
 					terraformer.GrowResources(
 						plan,
 						typePlan,


### PR DESCRIPTION
- Removing most uses of `IReadOnlySet` `IReadOnlyList`
- Removes a lot of `IReadOnlyDictionary` usecases
- Additional collections moved to immutable or frozen
- Several function signatures now using `ReadOnlySpan`
- Many functions rewritten to use `ImmutableArray.CreateBuilder` or `ImmutableCollectionsMarshal.AsImmutableArray` fo initialization