### PR TITLE
Resolve production palette icons from the owning player's faction

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -505,7 +505,12 @@ namespace OpenRA.Mods.Common.Widgets
 			DisplayedIconCount = 0;
 
 			var rb = RenderBounds;
-			var faction = producer.Trait.Faction;
+
+			// Resolve icon variants against the owning player's faction: shared units keep
+			// their own faction's cameo even when produced from a captured enemy structure.
+			// Faction-exclusive units have no player-faction image variant, so they still
+			// resolve to their default (producer faction) image via the GetImage fallback.
+			var faction = producer.Actor.Owner.Faction.InternalName;
 
 			foreach (var item in AllBuildables.Skip(IconRowOffset * Columns).Take(MaxIconRowOffset * Columns))
 			{


### PR DESCRIPTION
Fixes #22579.

## Problem

While testing the Tiberian Sun mod, a Nod player who captures a GDI production structure with an engineer sees the cameos of units and buildings available to **both** factions switch to their GDI versions in the production UI. In the original Tiberian Sun, the Nod interface keeps its own cameos for anything still available to Nod, and only introduces GDI cameos for items Nod cannot build.

## Root cause

`ProductionPaletteWidget.RefreshIcons` resolves icon variants from `producer.Trait.Faction`. After an engineer capture, `Production.Faction` stays at the **original** owner's faction, because `INotifyOwnerChanged.OnOwnerChanged` only updates it when `ProductionInfo.UpdateFactionOnOwnerChange` is set (it defaults to `false`, and no mod yaml sets it):

```csharp
void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
{
    if (Info.UpdateFactionOnOwnerChange)
        Faction = self.Owner.Faction.InternalName;
}
```

Shared units (MCV, HARV, LPST, ...) define faction-specific image variants for both sidebars (`RenderSprites.FactionImages`), so the palette resolves e.g. `mcv.gdi` instead of `mcv.nod`, mapping to `sidebar-gdi|mcvicon.shp` instead of `sidebar-nod|mcvicon.shp`.

## Fix

`RefreshIcons` now resolves the icon variants from the **owning player's** faction:

```csharp
var faction = producer.Actor.Owner.Faction.InternalName;
```

- Shared units keep their own faction's cameo when produced from a captured enemy structure (matching the original Tiberian Sun behaviour).
- Faction-exclusive units (e.g. HMEC, JUGG) have no player-faction image variant, so they still resolve to their default (producer faction) image through the `GetImage` fallback - no regression.

## Verification

Verified headlessly with a temporary `bugrepro-cameo` utility command (not part of this PR; I can submit it separately if wanted - it walks the real engine code paths against the real TS rules data, same mechanism as the existing utility commands):

```
[1] skirmish player faction: "nod"
[2] gaweap Production: Produces=[Vehicle], UpdateFactionOnOwnerChange=False
[3] production palette icon faction (post-fix) = producer.Actor.Owner.Faction = "nod"
[4] shared units resolve through the player faction:
     MCV: GetImage(...,"nod") = "mcv.nod"
     HARV: GetImage(...,"nod") = "harv.nod"
     LPST: GetImage(...,"nod") = "lpst.nod"
[5] GDI-exclusive units fall back to their default image (no regression):
     HMEC: GetImage(...,"nod") = "hmec" (pre-fix producer faction: "hmec")
     JUGG: GetImage(...,"nod") = "jugg" (pre-fix producer faction: "jugg")
[6] cameo files per variant (mods/ts/sequences/vehicles.yaml):
     mcv.gdi.icon.Filename = sidebar-gdi|mcvicon.shp
     mcv.nod.icon.Filename = sidebar-nod|mcvicon.shp
     harv.gdi.icon.Filename = sidebar-gdi|harvicon.shp
     harv.nod.icon.Filename = sidebar-nod|harvicon.shp

PASS: shared units keep their Nod cameos after the capture; GDI-exclusive units are unchanged.
```

The full test suite passes (505 passed, 0 failed).

---

### 中文说明（Chinese translation）

修复 #22579。

## 问题

在测试 Tiberian Sun 模组时发现：Nod 玩家用工程师占领 GDI 生产建筑后，生产界面中**双方**都可生产的单位和建筑的 cameo 会错误切换为 GDI 版本。原版 Tiberian Sun 中，Nod 界面对 Nod 仍然可生产的单位始终保留 Nod 版本 cameo，只有 Nod 无法生产的项目才会显示 GDI cameo。

## 根因

`ProductionPaletteWidget.RefreshIcons` 使用 `producer.Trait.Faction` 解析图标变体。工程师占领后，`Production.Faction` 仍停留在**原**拥有者的阵营，因为 `INotifyOwnerChanged.OnOwnerChanged` 仅在设置了 `ProductionInfo.UpdateFactionOnOwnerChange` 时才更新它（该字段默认为 `false`，且没有任何模组 YAML 覆盖它）：

```csharp
void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
{
    if (Info.UpdateFactionOnOwnerChange)
        Faction = self.Owner.Faction.InternalName;
}
```

共享单位（MCV、HARV、LPST 等）为两侧边栏定义了按阵营的图像变体（`RenderSprites.FactionImages`），因此生产面板解析出 `mcv.gdi` 而非 `mcv.nod`，对应 `sidebar-gdi|mcvicon.shp` 而非 `sidebar-nod|mcvicon.shp`。

## 修复

`RefreshIcons` 改为使用**拥有者玩家**的阵营解析图标变体：

```csharp
var faction = producer.Actor.Owner.Faction.InternalName;
```

- 共享单位在被占领的敌方工厂生产时保留自己阵营的 cameo（与原版 Tiberian Sun 行为一致）。
- 阵营独有单位（如 HMEC、JUGG）没有玩家阵营的图像变体，经 `GetImage` 回退机制仍解析为默认（生产者阵营）图像——无回归。

## 验证

通过一个临时的 `bugrepro-cameo` Utility 命令无头验证（不属于本 PR 的内容；如有需要可单独提交——它使用与现有 Utility 命令相同的机制，直接驱动真实引擎代码路径和真实 TS 规则数据）：

```
[1] skirmish player faction: "nod"
[2] gaweap Production: Produces=[Vehicle], UpdateFactionOnOwnerChange=False
[3] production palette icon faction (post-fix) = producer.Actor.Owner.Faction = "nod"
[4] shared units resolve through the player faction:
     MCV: GetImage(...,"nod") = "mcv.nod"
     HARV: GetImage(...,"nod") = "harv.nod"
     LPST: GetImage(...,"nod") = "lpst.nod"
[5] GDI-exclusive units fall back to their default image (no regression):
     HMEC: GetImage(...,"nod") = "hmec" (pre-fix producer faction: "hmec")
     JUGG: GetImage(...,"nod") = "jugg" (pre-fix producer faction: "jugg")
[6] cameo files per variant (mods/ts/sequences/vehicles.yaml):
     mcv.gdi.icon.Filename = sidebar-gdi|mcvicon.shp
     mcv.nod.icon.Filename = sidebar-nod|mcvicon.shp
     harv.gdi.icon.Filename = sidebar-gdi|harvicon.shp
     harv.nod.icon.Filename = sidebar-nod|harvicon.shp

PASS: 占领后共享单位保留 Nod cameo；GDI 独有单位无变化。
```

完整测试套件通过（505 项通过，0 项失败）。