### PR TITLE
Package aarch64 appimages

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -56,10 +56,39 @@ jobs:
         run: |
           gh release upload ${{ github.ref_name }} build/source/*
 
-  linux:
-    name: Linux AppImages
+  linux-x64:
+    name: Linux AppImages (x64)
     needs: create-release
     runs-on: ubuntu-22.04
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v7
+
+      - name: Install .NET 10.0
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Prepare Environment
+        run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
+
+      - name: Package AppImages
+        run: |
+          mkdir -p build/linux
+          sudo apt-get install -y desktop-file-utils
+          ./packaging/linux/buildpackage.sh "${GIT_TAG}" "${PWD}/build/linux"
+
+      - name: Upload Packages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload ${{ github.ref_name }} build/linux/*
+
+  linux-arm64:
+    name: Linux AppImages (arm64)
+    needs: create-release
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Clone Repository
         uses: actions/checkout@v7

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -36,6 +36,13 @@ elif [[ ${TAG} == pkgtest* ]]; then
 	SUFFIX="-pkgtest"
 fi
 
+ARCH=$(uname -m)
+if [[ "${ARCH}" == "aarch64" ]]; then
+	TARGETPLATFORM="linux-arm64"
+else
+	TARGETPLATFORM="linux-x64"
+fi
+
 if [ ! -d "${OUTPUTDIR}" ]; then
 	echo "Output directory '${OUTPUTDIR}' does not exist.";
 	exit 1
@@ -44,12 +51,12 @@ fi
 # Add native libraries
 echo "Downloading appimagetool"
 if command -v curl >/dev/null 2>&1; then
-	curl -s -L -O https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+	curl -s -L -O https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage
 else
-	wget -cq https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+	wget -cq https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage
 fi
 
-chmod a+x appimagetool-x86_64.AppImage
+chmod a+x appimagetool-${ARCH}.AppImage
 
 echo "Building AppImages"
 
@@ -58,14 +65,14 @@ build_appimage() {
 	DISPLAY_NAME=${2}
 	DISCORD_ID=${3}
 	APPDIR="$(pwd)/${MOD_ID}.appdir"
-	APPIMAGE="OpenRA-$(echo "${DISPLAY_NAME}" | sed 's/ /-/g')${SUFFIX}-x86_64.AppImage"
+	APPIMAGE="OpenRA-$(echo "${DISPLAY_NAME}" | sed 's/ /-/g')${SUFFIX}-${ARCH}.AppImage"
 
 	IS_D2K="False"
 	if [ "${MOD_ID}" = "d2k" ]; then
 		IS_D2K="True"
 	fi
 
-	install_assemblies "${SRCDIR}" "${APPDIR}/usr/lib/openra" "linux-x64" "True" "True" "${IS_D2K}"
+	install_assemblies "${SRCDIR}" "${APPDIR}/usr/lib/openra" "${TARGETPLATFORM}" "True" "True" "${IS_D2K}"
 	install_data "${SRCDIR}" "${APPDIR}/usr/lib/openra" "${MOD_ID}"
 	set_engine_version "${TAG}" "${APPDIR}/usr/lib/openra"
 	set_mod_version "${TAG}" "${APPDIR}/usr/lib/openra/mods/${MOD_ID}/mod.yaml" "${APPDIR}/usr/lib/openra/mods/${MOD_ID}-content/mod.yaml"
@@ -110,10 +117,10 @@ build_appimage() {
 
 	# Embed update metadata if (and only if) compiled on GitHub Actions
 	if [ -n "${GITHUB_REPOSITORY}" ]; then
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=${ARCH} ./appimagetool-${ARCH}.AppImage --no-appstream -u "zsync|https://master.openra.net/appimagecheck.zsync?mod=${MOD_ID}&channel=${UPDATE_CHANNEL}" "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 		zsyncmake -u "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/${APPIMAGE}" -o "${OUTPUTDIR}/${APPIMAGE}.zsync" "${OUTPUTDIR}/${APPIMAGE}"
 	else
-		ARCH=x86_64 ./appimagetool-x86_64.AppImage --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
+		ARCH=${ARCH} ./appimagetool-${ARCH}.AppImage --no-appstream "${APPDIR}" "${OUTPUTDIR}/${APPIMAGE}"
 	fi
 
 	rm -rf "${APPDIR}"
@@ -124,4 +131,4 @@ build_appimage "cnc" "Tiberian Dawn" "699223250181292033"
 build_appimage "d2k" "Dune 2000" "712711732770111550"
 
 # Clean up
-rm -rf appimagetool-x86_64.AppImage "${BUILTDIR}"
+rm -rf appimagetool-${ARCH}.AppImage "${BUILTDIR}"


### PR DESCRIPTION
Fixes the buildpackage.sh on my local machine, and brings release parity with macOS and Windows.

Test release: https://github.com/pchote/OpenRA/releases/tag/devtest-20260829