### PR TITLE
Fix Lua production queue selection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -125,6 +125,7 @@ Also thanks to:
     * Mustafa Alperen Seki (MustaphaTR)
     * Nathan Nichols (cracksmoka420)
     * Neil Shivkar (havok13888)
+    * Nicholas Velten
     * Nikolay Fomin (netnazgul)
     * Nooze
     * Nukem

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -138,8 +138,17 @@ namespace OpenRA.Mods.Common.Scripting
 			if (triggers.HasAnyCallbacksFor(Trigger.OnProduction))
 				return false;
 
-			var queue = queues.Where(q => actorTypes.All(t => GetBuildableInfo(t).Queue.Contains(q.Info.Type)))
-				.FirstOrDefault(q => !q.AllQueued().Any());
+			foreach (var actorType in actorTypes.Distinct())
+				GetBuildableInfo(actorType);
+
+			var queue = queues.FirstOrDefault(q =>
+			{
+				if (q.AllQueued().Any())
+					return false;
+
+				var buildableItems = q.BuildableItems().Select(a => a.Name).ToHashSet();
+				return actorTypes.All(buildableItems.Contains);
+			});
 
 			if (queue == null)
 				return false;


### PR DESCRIPTION
Fixes #22551.

## Summary
- Validate the requested actor types up front, preserving the existing Lua error behavior for invalid build targets.
- Select the first idle per-building queue that can currently build every requested actor, instead of only checking static Buildable.Queue membership.

## Changelog
- Fixed Lua ProductionQueue.Build() selecting disabled/unavailable per-building queues when a later queue can build the requested actors.

## Testing
- `make tests`
- `make check`
- In-game RA benchmark map harness:
  - Before this change: `OPENRA_PRODUCTION_QUEUE_TEST_STARTED=true`, `OPENRA_PRODUCTION_QUEUE_TEST_FAIL callback-not-called`.
  - After this change: `OPENRA_PRODUCTION_QUEUE_TEST_STARTED=true`, `OPENRA_PRODUCTION_QUEUE_TEST_PASS produced=1`.
