### PR TITLE
Fix scripted Move/AttackMove being blocked by immobile actors.

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"close enough to complete the activity.")]
 		public void AttackMove(CPos cell, int closeEnough = 0)
 		{
-			Self.QueueActivity(new AttackMoveActivity(Self, () => move.MoveTo(cell, closeEnough)));
+			Self.QueueActivity(new AttackMoveActivity(Self, () => move.MoveTo(cell, closeEnough, evaluateNearestMovableCell: true)));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"(in cells) that will be considered close enough to complete the activity.")]
 		public void Move(CPos cell, int closeEnough = 0)
 		{
-			Self.QueueActivity(new Move(Self, cell, WDist.FromCells(closeEnough)));
+			Self.QueueActivity(new Move(Self, cell, WDist.FromCells(closeEnough), evaluateNearestMovableCell: true));
 		}
 
 		[ScriptActorPropertyActivity]


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/21064

Or at least, the bug that I linked the map to reproduce if they're not the same.